### PR TITLE
feat(skins): open external links in system browser (gh#384)

### DIFF
--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -3246,6 +3246,8 @@ http://<host>:8080/api/v1/plugins/settings.reaplugin/ui?backName=MySkin
 
 This shows "Back to MySkin" in the settings plugin's nav bar. When clicked, it navigates to `http://<host>:3000/?_=<timestamp>` (with cache busting). This allows skins to provide a "Settings" link that returns to the skin after configuration changes.
 
+**External links:** When a skin runs inside the embedded webview (mobile/desktop app), navigations to `localhost:3000` and the settings plugin load in place; any other `http`/`https` link opens in the **system browser** while the skin stays loaded. A plain `<a href="https://…">` works, but the in-app webview blocks `target="_blank"` popups (`javaScriptCanOpenWindowsAutomatically: false`), so for JS-driven links route through a delegated click handler — `window.open(url, '_blank')` with a `location.href` fallback — so the navigation reaches `shouldOverrideUrlLoading` and is handed off to the OS.
+
 **Server control endpoints:**
 
 | Method | Path | Description |

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -16,6 +16,36 @@ import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/skin_feature/simulated_webview_device.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+/// How the skin webview should treat a navigation target.
+enum SkinNavDecision {
+  /// Internal navigation — let the webview load it.
+  allow,
+
+  /// External http(s) link — open in the system browser, keep the skin loaded.
+  openExternal,
+
+  /// Anything else — refuse the navigation.
+  block,
+}
+
+/// Classifies a navigation target requested from within the skin webview.
+///
+/// Internal pages (localhost:3000 and the settings plugin) load in-place;
+/// external http/https links open in the OS browser; everything else is
+/// blocked. Pure so it can be unit-tested without a live webview.
+SkinNavDecision classifySkinNavigation(Uri? url) {
+  if (url == null) return SkinNavDecision.block;
+  final s = url.toString();
+  if (s.startsWith('http://localhost:3000') ||
+      s.contains('/api/v1/plugins/settings.reaplugin')) {
+    return SkinNavDecision.allow;
+  }
+  if (url.scheme == 'https' || url.scheme == 'http') {
+    return SkinNavDecision.openExternal;
+  }
+  return SkinNavDecision.block;
+}
+
 /// Displays the WebUI skin in a full-screen webview
 ///
 /// This view is only shown on mobile/desktop platforms (iOS, Android, macOS)
@@ -428,6 +458,20 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
     );
   }
 
+  /// Launches an external link from the skin in the OS browser. Failures are
+  /// logged only — the skin stays put, so a dead link is a no-op, not a crash.
+  Future<void> _launchExternal(Uri uri) async {
+    try {
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      } else {
+        _log.warning('Cannot launch external URL: $uri');
+      }
+    } catch (e, st) {
+      _log.severe('Failed to launch external URL: $uri', e, st);
+    }
+  }
+
   Future<void> _openInExternalBrowser() async {
     final url = Uri.parse(
       'http://localhost:3000?_=${DateTime.now().millisecondsSinceEpoch}',
@@ -649,18 +693,20 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
         _log.warning('HTTP error - Status: ${errorResponse.statusCode}');
       },
       shouldOverrideUrlLoading: (controller, navigationAction) async {
-        final url = navigationAction.request.url.toString();
-
-        // Allow all navigation within localhost:3000
-        if (url.startsWith('http://localhost:3000') ||
-            url.contains('/api/v1/plugins/settings.reaplugin')) {
-          _log.fine('Allowing navigation to: $url');
-          return NavigationActionPolicy.ALLOW;
+        final uri = navigationAction.request.url;
+        switch (classifySkinNavigation(uri)) {
+          case SkinNavDecision.allow:
+            _log.fine('Allowing navigation to: $uri');
+            return NavigationActionPolicy.ALLOW;
+          case SkinNavDecision.openExternal:
+            // Open in the system browser and stay on the skin.
+            _log.info('Opening external link in system browser: $uri');
+            unawaited(_launchExternal(uri!));
+            return NavigationActionPolicy.CANCEL;
+          case SkinNavDecision.block:
+            _log.info('Blocking navigation to: $uri');
+            return NavigationActionPolicy.CANCEL;
         }
-
-        // Block external navigation
-        _log.info('Blocking navigation to: $url');
-        return NavigationActionPolicy.CANCEL;
       },
       onConsoleMessage: (controller, consoleMessage) {
         // Route to dedicated webview log service (file + stream)

--- a/test/unit/skin_feature/skin_navigation_test.dart
+++ b/test/unit/skin_feature/skin_navigation_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/skin_feature/skin_view.dart';
+
+void main() {
+  group('classifySkinNavigation', () {
+    test('allows localhost:3000 and its sub-paths', () {
+      expect(
+        classifySkinNavigation(Uri.parse('http://localhost:3000/')),
+        SkinNavDecision.allow,
+      );
+      expect(
+        classifySkinNavigation(Uri.parse('http://localhost:3000/foo?x=1')),
+        SkinNavDecision.allow,
+      );
+    });
+
+    test('allows the settings plugin path', () {
+      expect(
+        classifySkinNavigation(
+          Uri.parse('http://localhost:8080/api/v1/plugins/settings.reaplugin'),
+        ),
+        SkinNavDecision.allow,
+      );
+    });
+
+    test('opens external https links in the browser', () {
+      expect(
+        classifySkinNavigation(
+          Uri.parse('https://decentespresso.com/doc/quickstart/'),
+        ),
+        SkinNavDecision.openExternal,
+      );
+    });
+
+    test('opens external (non-localhost) http links in the browser', () {
+      expect(
+        classifySkinNavigation(Uri.parse('http://example.com/page')),
+        SkinNavDecision.openExternal,
+      );
+    });
+
+    test('blocks non-http schemes', () {
+      expect(
+        classifySkinNavigation(Uri.parse('mailto:hi@example.com')),
+        SkinNavDecision.block,
+      );
+      expect(
+        classifySkinNavigation(Uri.parse('tel:+123')),
+        SkinNavDecision.block,
+      );
+    });
+
+    test('blocks a null url', () {
+      expect(classifySkinNavigation(null), SkinNavDecision.block);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Problem:** External links in skins fail silently. The skin webview's `shouldOverrideUrlLoading` allowed only `localhost:3000` and the settings plugin path, cancelling every other navigation — so a skin's "Quickstart" link to `https://decentespresso.com/doc/quickstart/` went nowhere.
- **Why it matters:** Skins can't point users at external docs/resources; the tap just dies with no feedback.
- **What changed:** Navigation targets are now classified by a pure `classifySkinNavigation` helper. Internal pages load in place; external `http`/`https` links launch in the OS browser via `url_launcher` (already a dependency) while the skin stays loaded; everything else is still blocked.
- **What did NOT change (scope boundary):** Localhost and settings-plugin navigation behave exactly as before. No new dependency. No change to the renderer, lifecycle, or compatibility paths. `target="_blank"` popups remain disabled — skins must route JS-driven links through a delegated click handler (documented).

## Change Type (select all)

- [x] Feature
- [x] Docs

## Scope (select all touched areas)

- [x] WebUI skins
- [x] UI / Flutter widgets
- [x] Docs / specs

## Linked Issues

- Closes #384

## Root Cause (if bug fix)

N/A (feature request)

## Regression Test Plan (if bug fix or refactor)

- Coverage level:
  - [x] Unit test
- Target test or file: `test/unit/skin_feature/skin_navigation_test.dart`
- Scenario the test should lock in: localhost + settings-plugin paths → `allow`; external http/https → `openExternal`; non-http schemes and null → `block`. The navigation decision is extracted into a pure function precisely so it is testable without a live webview.

## Documentation Obligations (required)

- [x] Skin docs updated: `doc/Skins.md` — new "External links" note explaining embedded-webview behavior and the `window.open` + `location.href` fallback pattern for JS-driven links.
- [ ] N/A for the rest — no REST/WebSocket/plugin/profile/device surface changed.

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No (the app makes none itself; it hands an external URL to the OS browser via `launchUrl`, gated to `http`/`https` only)
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No
- Note: only `http`/`https` schemes are launched externally; all other schemes (`file:`, `mailto:`, custom) remain blocked, so this does not widen the in-webview navigation surface.

## User-Visible Changes

Tapping an external link in a skin now opens it in the system browser instead of doing nothing. The skin remains loaded underneath.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean: `Analyzing 2 items... No issues found! (ran in 8.5s)` (Flutter 3.44.4 / Dart 3.12.2)
- [x] `flutter test test/unit/skin_feature/skin_navigation_test.dart` — `+6: All tests passed!`

### Manual verification (if applicable)

- OS / platform tested: macOS (analyze + unit test). Live external-launch not exercised on Android/iOS/desktop in this environment.
- Simulated devices? No
- Real hardware? No
- What you personally verified: the navigation classifier via the new unit test (6 cases); static analysis clean on the changed files.
- What you did **not** verify: live `launchUrl` on a device (the original issue notes this is testable via the Quickstart button on Android/iOS).

### Evidence

```
$ flutter test test/unit/skin_feature/skin_navigation_test.dart
00:00 +1: classifySkinNavigation allows the settings plugin path
00:00 +2: classifySkinNavigation opens external https links in the browser
00:00 +3: classifySkinNavigation opens external (non-localhost) http links in the browser
00:00 +4: classifySkinNavigation blocks non-http schemes
00:00 +5: classifySkinNavigation blocks a null url
00:00 +6: All tests passed!

$ flutter analyze lib/src/skin_feature/skin_view.dart test/unit/skin_feature/skin_navigation_test.dart
Analyzing 2 items...
No issues found! (ran in 8.5s)
```

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No

## Risks & Mitigations

- Risk: a malicious/compromised skin could trigger the OS browser to open an arbitrary `http`/`https` URL.
  - Mitigation: limited to `http`/`https`; opens in the external browser (separate from the app sandbox), not in-webview; no auto-popups (`javaScriptCanOpenWindowsAutomatically: false`). Same trust level as the existing WebView2-install and settings-plugin external launches already in this file.
