### PR TITLE
fix(scale): only use periodic oledOn command to check battery level

### DIFF
--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -155,7 +155,7 @@ class DecentScale implements Scale, TransportHandoffScale {
         }
         _heartbeatTotalTicks++;
 
-        // Periodic oled-on every 2 ticks (8s) when awake
+        // Periodic battery level request every 2 ticks (8s) when awake
         if (_heartbeatTotalTicks % 2 == 0) {
           final uptimeMin = (_heartbeatTotalTicks * 4) ~/ 60;
           _log.fine(
@@ -197,7 +197,7 @@ class DecentScale implements Scale, TransportHandoffScale {
         await tare();
       }
       if (!_isSleeping) {
-        await wakeDisplay();
+        await _sendOledOn();
       }
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
@@ -292,7 +292,7 @@ class DecentScale implements Scale, TransportHandoffScale {
   }
 
   /// Causes the scale to respond with battery level, while the actual request
-  /// is to turn on the display
+  /// is to turn on the display (OledOn)
   Future<void> _requestBatteryData() async {
     final heartbeatByte = isUsingHeartBeat ? 0x01 : 0x00;
     await _writeCommand([0x0A, 0x01, 0x00, 0x00, heartbeatByte]);
@@ -300,7 +300,7 @@ class DecentScale implements Scale, TransportHandoffScale {
 
   Future<void> _sendOledOn() async {
     final heartbeatByte = isUsingHeartBeat ? 0x01 : 0x00;
-    await _writeCommand([0x0A, 0x01, 0x00, 0x00, heartbeatByte]);
+    await _requestBatteryData();
     await Future.delayed(Duration(milliseconds: 100));
     await _writeCommand([0x0A, 0x04, 0x00, 0x00, heartbeatByte]);
   }

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -162,7 +162,7 @@ class DecentScale implements Scale, TransportHandoffScale {
             "heartbeat: ${uptimeMin}m uptime, $_totalNotifications notifications",
           );
           if (!_isSleeping) {
-            await _sendOledOn();
+            await _requestBatteryData();
           }
         }
 
@@ -197,7 +197,7 @@ class DecentScale implements Scale, TransportHandoffScale {
         await tare();
       }
       if (!_isSleeping) {
-        await _sendOledOn();
+        await wakeDisplay();
       }
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
@@ -289,6 +289,13 @@ class DecentScale implements Scale, TransportHandoffScale {
     } catch (e) {
       _log.warning('Heartbeat write failed (transient): $e');
     }
+  }
+
+  /// Causes the scale to respond with battery level, while the actual request
+  /// is to turn on the display
+  Future<void> _requestBatteryData() async {
+    final heartbeatByte = isUsingHeartBeat ? 0x01 : 0x00;
+    await _writeCommand([0x0A, 0x01, 0x00, 0x00, heartbeatByte]);
   }
 
   Future<void> _sendOledOn() async {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

> **Naming:** The display name is **Decent.app**. The repo, package, and bundle ID use legacy `reaprime` / `streamline-bridge` — see the naming table in [`CLAUDE.md`](CLAUDE.md).

- Problem:
Decent.app was sending both OledOn and WakeFromSleep to HDS every 8 seconds, causing HDS FW 3.1.12 to glitch weight to 0g on each interval
- Why it matters:
Will break shots
- What changed:
Extracted OledOn to `requestBatteryLevel` and call that in the 8s interval
- What did NOT change (scope boundary):
Other HDS implementations

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs



## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

No changes

## User-Visible Changes

`None`

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — clean (no new warnings)
- [ ] `flutter test` — all pass
- [ ] `(cd packages/dye2-plugin && npm run build)` — plugin builds

### Manual verification (if applicable)

- OS / platform tested: 
macOS
- Simulated devices? (`simulate=1`): `Yes/No`
`Yes`
- Real hardware? (DE1/Bengle/scale): `Yes/No`
`No`
- What you personally verified and how:
- Edge cases checked:
