### PR TITLE
fix(#53,#421): Skale2 init sequence — LCD ON before subscribe, staggered delays, re-subscribe on wake

### DIFF
--- a/lib/src/models/device/impl/skale/skale2_scale.dart
+++ b/lib/src/models/device/impl/skale/skale2_scale.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:logging/logging.dart' as logging;
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:rxdart/subjects.dart';
@@ -36,6 +37,18 @@ class Skale2Scale implements Scale {
   final BLETransport _transport;
 
   int _batteryLevel = 0;
+
+  /// Logger for Skale2-specific warnings (e.g. button subscription failure).
+  final _log = logging.Logger('Skale2Scale');
+
+  /// Whether we have an active subscription to the weight characteristic (EF81).
+  bool _weightSubscribed = false;
+
+  /// Whether we have an active subscription to the button characteristic (EF82).
+  bool _buttonSubscribed = false;
+
+  /// Delay between init steps, matching de1app/Decenza staggered sequence.
+  static const _initStepDelay = Duration(milliseconds: 1000);
 
   Skale2Scale({required BLETransport transport})
     : _transport = transport,
@@ -73,6 +86,9 @@ class Skale2Scale implements Scale {
           .where((state) => state == ConnectionState.disconnected)
           .listen((_) {
         _connectionStateController.add(ConnectionState.disconnected);
+        // Subscriptions are lost when the BLE link drops.
+        _weightSubscribed = false;
+        _buttonSubscribed = false;
         disconnectSub?.cancel();
       });
 
@@ -103,27 +119,30 @@ class Skale2Scale implements Scale {
   DeviceType get type => DeviceType.scale;
 
   // --- Initialization ---
-
+  //
+  // Follows the de1app / Decenza staggered sequence:
+  //   1. LCD ON immediately  (0xED + 0xEC)
+  //   2. After 1s: subscribe weight notifications (EF81)
+  //   3. After 2s: subscribe button notifications (EF82)
+  //   4. After 3s: LCD ON again + set grams (0x03)
+  //
+  // The Skale2's command buffer is fragile — back-to-back operations
+  // without spacing can cause silent drops (de1app double-sends LCD ON
+  // for exactly this reason).  See GH #53 / #421.
   Future<void> _initScale() async {
-    // Subscribe to weight notifications
-    await _transport.subscribe(
-      serviceIdentifier.long,
-      weightCharacteristic.long,
-      _parseWeightNotification,
-    );
+    // 1. Turn display on and set to weight mode — BEFORE subscribing.
+    await _sendDisplayOn();
+    await _sendDisplayWeight();
 
-    // Subscribe to button notifications (optional, best-effort)
-    try {
-      await _transport.subscribe(
-        serviceIdentifier.long,
-        buttonCharacteristic.long,
-        _parseButtonNotification,
-      );
-    } catch (_) {
-      // Button characteristic may not be available on all devices
-    }
+    // 2. Subscribe to weight notifications after a settle delay.
+    await Future.delayed(_initStepDelay);
+    await _subscribeWeight();
 
-    // Read battery level from standard BLE battery service
+    // 3. Subscribe to button notifications after another delay.
+    await Future.delayed(_initStepDelay);
+    await _subscribeButton();
+
+    // Read battery level (best-effort, does not affect scale operation).
     try {
       final batteryData = await _transport.read(
         batteryService.long,
@@ -133,20 +152,46 @@ class Skale2Scale implements Scale {
         _batteryLevel = batteryData[0];
       }
     } catch (_) {
-      // Battery service may not be available
+      // Battery service may not be available.
     }
 
-    // Turn on display and set to weight mode
+    // 4. Re-send LCD ON + set grams after final delay (double-send pattern).
+    await Future.delayed(_initStepDelay);
     await _sendDisplayOn();
     await _sendDisplayWeight();
-
-    // Set scale to grams
     await _transport.write(
       serviceIdentifier.long,
       commandCharacteristic.long,
       Uint8List.fromList([0x03]),
       withResponse: false,
     );
+  }
+
+  Future<void> _subscribeWeight() async {
+    await _transport.subscribe(
+      serviceIdentifier.long,
+      weightCharacteristic.long,
+      _parseWeightNotification,
+    );
+    _weightSubscribed = true;
+  }
+
+  Future<void> _subscribeButton() async {
+    try {
+      await _transport.subscribe(
+        serviceIdentifier.long,
+        buttonCharacteristic.long,
+        _parseButtonNotification,
+      );
+      _buttonSubscribed = true;
+    } catch (e) {
+      // Button characteristic may not be available on all devices, but
+      // log a warning so the failure is visible (unlike the previous
+      // silent swallow).  This is the most likely cause of the
+      // "buttons stop working after sleep" bug — if the initial
+      // subscription silently failed, it was never retried.
+      _log.warning('Failed to subscribe to button notifications: $e');
+    }
   }
 
   // --- Commands ---
@@ -201,6 +246,20 @@ class Skale2Scale implements Scale {
   Future<void> wakeDisplay() async {
     await _sendDisplayOn();
     await _sendDisplayWeight();
+
+    // Re-subscribe to notifications if they were lost (e.g. BLE link
+    // dropped during sleep).  The Skale2 may silently lose CCCD
+    // subscriptions when its display is off — de1app handles this by
+    // re-running the full connect sequence, but we take the lighter
+    // approach of only re-subscribing what's missing.
+    if (!_weightSubscribed) {
+      _log.info('Re-subscribing to weight notifications during wake');
+      await _subscribeWeight();
+    }
+    if (!_buttonSubscribed) {
+      _log.info('Re-subscribing to button notifications during wake');
+      await _subscribeButton();
+    }
   }
 
   // --- Notification parsing ---

--- a/test/unit/models/skale2_scale_test.dart
+++ b/test/unit/models/skale2_scale_test.dart
@@ -1,0 +1,344 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/skale/skale2_scale.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Test double for [BLETransport] that records the order of all operations
+/// (writes, subscribes, reads) so tests can assert on the exact sequence.
+class _RecordableBleTransport extends BLETransport {
+  final List<String> serviceUUIDs =
+      const ['0000ff08-0000-1000-8000-00805f9b34fb'];
+
+  /// Ordered log of every operation. Each entry is a string like
+  /// `write:EF80:[0xED]`, `subscribe:EF81`, or `read:2A19`.
+  final List<String> operations = [];
+
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.disconnected);
+
+  /// Callbacks set by the last subscribe call, keyed by characteristic UUID.
+  final Map<String, void Function(Uint8List)> _notifyCallbacks = {};
+
+  _RecordableBleTransport();
+
+  @override
+  String get id => 'skale2-test-device';
+
+  @override
+  String get name => 'Test Skale2';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+
+  Future<void> emitConnectionState(ConnectionState state) async {
+    _connectionState.add(state);
+  }
+
+  @override
+  Future<ConnectionState> getConnectionState() async => _connectionState.value;
+
+  @override
+  Future<void> connect() async {
+    _connectionState.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connectionState.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<List<String>> discoverServices() async => serviceUUIDs;
+
+  @override
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {
+    final shortUuid = characteristicUUID.substring(4, 8).toLowerCase();
+    operations.add('subscribe:$shortUuid');
+    _notifyCallbacks[shortUuid] = callback;
+  }
+
+  @override
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) async {
+    final shortUuid = characteristicUUID.substring(4, 8).toLowerCase();
+    operations.add('read:$shortUuid');
+    if (shortUuid == '2a19') {
+      return Uint8List.fromList([80]); // 80% battery
+    }
+    return Uint8List(0);
+  }
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {
+    final shortUuid = characteristicUUID.substring(4, 8).toLowerCase();
+    final hexData = data.map((b) => '0x${b.toRadixString(16).toUpperCase()}').join(',');
+    operations.add('write:$shortUuid:[$hexData]');
+  }
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> dispose() async {
+    _connectionState.close();
+  }
+
+  /// Simulate a weight notification arriving from the scale.
+  void simulateWeightNotification(List<int> data) {
+    _notifyCallbacks['ef81']?.call(Uint8List.fromList(data));
+  }
+
+  /// Simulate a button notification arriving from the scale.
+  void simulateButtonNotification(List<int> data) {
+    _notifyCallbacks['ef82']?.call(Uint8List.fromList(data));
+  }
+
+  /// Whether a notification subscription is currently active for the given
+  /// characteristic (by short UUID, e.g. `ef81` or `ef82`).
+  bool isSubscribed(String shortUuid) =>
+      _notifyCallbacks.containsKey(shortUuid.toLowerCase());
+
+  /// Clear all subscriptions (simulates what happens when the BLE link drops).
+  void clearSubscriptions() {
+    _notifyCallbacks.clear();
+  }
+}
+
+void main() {
+  group('Skale2Scale initialization sequence', () {
+    late _RecordableBleTransport transport;
+    late Skale2Scale scale;
+
+    setUp(() async {
+      transport = _RecordableBleTransport();
+      scale = Skale2Scale(transport: transport);
+      await transport.emitConnectionState(ConnectionState.discovered);
+    });
+
+    test('LCD ON (0xED) is sent before subscribing to weight notifications', () async {
+      await scale.onConnect();
+
+      final lcdOnIndex = transport.operations.indexWhere(
+        (op) => op.contains('write:ef80:[0xED]'),
+      );
+      final weightSubIndex = transport.operations.indexWhere(
+        (op) => op == 'subscribe:ef81',
+      );
+
+      expect(lcdOnIndex, isNot(equals(-1)), reason: 'LCD ON should be sent');
+      expect(weightSubIndex, isNot(equals(-1)), reason: 'weight should be subscribed');
+      expect(lcdOnIndex, lessThan(weightSubIndex),
+          reason: 'LCD ON must be sent before subscribing to weight notifications');
+    });
+
+    test('LCD ON (0xEC display weight) is sent before subscribing to weight notifications', () async {
+      await scale.onConnect();
+
+      final displayWeightIndex = transport.operations.indexWhere(
+        (op) => op.contains('write:ef80:[0xEC]'),
+      );
+      final weightSubIndex = transport.operations.indexWhere(
+        (op) => op == 'subscribe:ef81',
+      );
+
+      expect(displayWeightIndex, isNot(equals(-1)), reason: 'Display weight should be sent');
+      expect(weightSubIndex, isNot(equals(-1)), reason: 'weight should be subscribed');
+      expect(displayWeightIndex, lessThan(weightSubIndex),
+          reason: 'Display weight command must be sent before subscribing to weight');
+    });
+
+    test('button notifications are subscribed after weight notifications', () async {
+      await scale.onConnect();
+
+      final weightSubIndex = transport.operations.indexWhere(
+        (op) => op == 'subscribe:ef81',
+      );
+      final buttonSubIndex = transport.operations.indexWhere(
+        (op) => op == 'subscribe:ef82',
+      );
+
+      expect(weightSubIndex, isNot(equals(-1)));
+      expect(buttonSubIndex, isNot(equals(-1)));
+      expect(weightSubIndex, lessThan(buttonSubIndex),
+          reason: 'Button subscription should come after weight subscription');
+    });
+
+    test('LCD ON is sent a second time after all subscriptions (double-send)', () async {
+      await scale.onConnect();
+
+      // Count occurrences of 0xED writes
+      final lcdOnCount = transport.operations.where(
+        (op) => op.contains('write:ef80:[0xED]'),
+      ).length;
+
+      expect(lcdOnCount, greaterThanOrEqualTo(2),
+          reason: 'LCD ON should be sent at least twice (de1app double-send pattern)');
+    });
+
+    test('grams command (0x03) is sent after the second LCD ON', () async {
+      await scale.onConnect();
+
+      final gramsIndex = transport.operations.indexWhere(
+        (op) => op.contains('write:ef80:[0x3]'),
+      );
+      // Find the second occurrence of 0xED
+      final lcdOnIndices = transport.operations
+          .asMap()
+          .entries
+          .where((e) => e.value.contains('write:ef80:[0xED]'))
+          .map((e) => e.key)
+          .toList();
+
+      expect(gramsIndex, isNot(equals(-1)), reason: 'grams command should be sent');
+      expect(lcdOnIndices.length, greaterThanOrEqualTo(2),
+          reason: 'LCD ON should be sent at least twice');
+      expect(gramsIndex, greaterThan(lcdOnIndices.last),
+          reason: 'grams command should come after the second LCD ON');
+    });
+
+    test('button notifications are not best-effort — subscription is explicit', () async {
+      await scale.onConnect();
+
+      expect(transport.isSubscribed('ef82'), isTrue,
+          reason: 'Button notifications must be subscribed, not silently skipped');
+    });
+  });
+
+  group('Skale2Scale wakeDisplay re-subscribes notifications', () {
+    late _RecordableBleTransport transport;
+    late Skale2Scale scale;
+
+    setUp(() async {
+      transport = _RecordableBleTransport();
+      scale = Skale2Scale(transport: transport);
+      await transport.emitConnectionState(ConnectionState.discovered);
+      await scale.onConnect();
+      // Clear operations log so we only see wake-time ops
+      transport.operations.clear();
+    });
+
+    test('wakeDisplay sends LCD ON (0xED) and display weight (0xEC)', () async {
+      await scale.wakeDisplay();
+
+      expect(transport.operations.any((op) => op.contains('0xED')), isTrue);
+      expect(transport.operations.any((op) => op.contains('0xEC')), isTrue);
+    });
+
+    test('wakeDisplay re-subscribes to weight notifications', () async {
+      // Simulate BLE link dropping: disconnect event resets subscription
+      // flags, then clearSubscriptions simulates the transport losing
+      // its CCCD entries.
+      await transport.emitConnectionState(ConnectionState.disconnected);
+      transport.clearSubscriptions();
+
+      await scale.wakeDisplay();
+
+      expect(transport.operations.any((op) => op == 'subscribe:ef81'), isTrue,
+          reason: 'wakeDisplay should re-subscribe to weight notifications');
+      expect(transport.isSubscribed('ef81'), isTrue,
+          reason: 'weight subscription should be active after wake');
+    });
+
+    test('wakeDisplay re-subscribes to button notifications', () async {
+      // Simulate BLE link dropping.
+      await transport.emitConnectionState(ConnectionState.disconnected);
+      transport.clearSubscriptions();
+
+      await scale.wakeDisplay();
+
+      expect(transport.operations.any((op) => op == 'subscribe:ef82'), isTrue,
+          reason: 'wakeDisplay should re-subscribe to button notifications');
+      expect(transport.isSubscribed('ef82'), isTrue,
+          reason: 'button subscription should be active after wake');
+    });
+
+    test('wakeDisplay does NOT re-subscribe if subscriptions are still active', () async {
+      // Subscriptions are still active from onConnect
+      await scale.wakeDisplay();
+
+      expect(transport.operations.any((op) => op == 'subscribe:ef81'), isFalse,
+          reason: 'wakeDisplay should not redundantly subscribe if already active');
+      expect(transport.operations.any((op) => op == 'subscribe:ef82'), isFalse,
+          reason: 'wakeDisplay should not redundantly subscribe if already active');
+    });
+  });
+
+  group('Skale2Scale timer commands', () {
+    late _RecordableBleTransport transport;
+    late Skale2Scale scale;
+
+    setUp(() async {
+      transport = _RecordableBleTransport();
+      scale = Skale2Scale(transport: transport);
+      await transport.emitConnectionState(ConnectionState.discovered);
+      await scale.onConnect();
+      transport.operations.clear();
+    });
+
+    test('startTimer sends 0xDD', () async {
+      await scale.startTimer();
+      expect(transport.operations.any((op) => op.contains('0xDD')), isTrue);
+    });
+
+    test('stopTimer sends 0xD1', () async {
+      await scale.stopTimer();
+      expect(transport.operations.any((op) => op.contains('0xD1')), isTrue);
+    });
+
+    test('resetTimer sends 0xD0', () async {
+      await scale.resetTimer();
+      expect(transport.operations.any((op) => op.contains('0xD0')), isTrue);
+    });
+  });
+
+  group('Skale2Scale weight notification parsing', () {
+    late _RecordableBleTransport transport;
+    late Skale2Scale scale;
+
+    setUp(() async {
+      transport = _RecordableBleTransport();
+      scale = Skale2Scale(transport: transport);
+      await transport.emitConnectionState(ConnectionState.discovered);
+      await scale.onConnect();
+    });
+
+    test('parses weight notification correctly', () async {
+      final completer = Completer<ScaleSnapshot>();
+
+      final sub = scale.currentSnapshot.listen((snapshot) {
+        if (!completer.isCompleted) completer.complete(snapshot);
+      });
+
+      // Simulate a weight of 100.0g
+      // rawValue = 100.0 * 2560 = 256000 = 0x0003E800
+      // little-endian: [0x00, 0xE8, 0x03, 0x00]
+      transport.simulateWeightNotification([0x00, 0xE8, 0x03, 0x00]);
+
+      final snapshot = await completer.future.timeout(
+        const Duration(seconds: 1),
+      );
+
+      expect(snapshot.weight, closeTo(100.0, 0.1));
+
+      await sub.cancel();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Cross-referenced the Skale2 BLE protocol against the canonical `de1app` (`decentespresso/de1app`, `bluetooth.tcl`). All command bytes (timer, tare, display) were already correct — the bug was in the **initialization sequence** and **wake lifecycle**.

## Root cause

`de1app` initializes the Skale2 in a staggered sequence with deliberate delays:

```
1. LCD ON immediately        (0xED + 0xEC)
2. After 1s: weight notify    (EF81)
3. After 2s: button notify    (EF82)
4. After 3s: LCD ON again + grams (0x03)
```

reaprime was doing the opposite — subscribing **before** turning the display on, with no delays, and only sending LCD ON once. The Skale2 command buffer is fragile (de1app double-sends LCD ON for exactly this reason), and the Skale2 may require the display to be initialized before accepting CCCD notification subscriptions.

Additionally, `wakeDisplay()` only sent display commands without re-subscribing to notifications. If the BLE link dropped during sleep (the Skale2 may disconnect to save power), the CCCD subscriptions were lost and never re-established — causing **buttons to stop working after the first sleep/wake cycle** (GH #421).

## Changes

### `skale2_scale.dart`

- **Reorder `_initScale()`** to match de1app staggered pattern: LCD ON → 1s delay → weight subscribe → 1s delay → button subscribe → 1s delay → LCD ON again + grams
- **Track `_weightSubscribed` / `_buttonSubscribed` flags** with reset on BLE disconnect
- **`wakeDisplay()` re-subscribes** to weight + button notifications if flags indicate they were lost
- **Button subscription logs a warning** on failure instead of silently swallowing (previous silent catch was the most likely cause of buttons never working — a failed initial subscription was never retried)

### `skale2_scale_test.dart` (new — 14 tests)

TDD: wrote failing tests first, then implemented the fix.

- Init sequence: LCD ON sent before weight subscribe, before button subscribe
- Double-send of LCD ON after all subscriptions
- Grams command (0x03) sent after second LCD ON
- Button subscription is explicit (not silently skipped)
- `wakeDisplay` re-subscribes weight + button after BLE disconnect
- `wakeDisplay` does NOT redundantly subscribe if already active
- Timer commands (start/stop/reset) send correct bytes
- Weight notification parsing

## Testing

```
flutter test test/unit/models/skale2_scale_test.dart
# 00:42 +14: All tests passed!

dart analyze lib/src/models/device/impl/skale/skale2_scale.dart test/unit/models/skale2_scale_test.dart
# No issues found!
```

Full model test suite (134 tests) also passes with no regressions.

## Closes

- #421 — Verify Skale2 implementation against canonical sources
- Partially addresses #53 — Decent Scale and Bookoo scale timer commands (Skale2 portion)