### PR TITLE
feat(settings): allow hiding skin exit guide

### DIFF
--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -3248,6 +3248,7 @@ This shows "Back to MySkin" in the settings plugin's nav bar. When clicked, it n
 
 **External links:** When a skin runs inside the embedded webview (mobile/desktop app), navigations to `localhost:3000` and the settings plugin load in place; any other `http`/`https` link opens in the **system browser** while the skin stays loaded. A plain `<a href="https://…">` works, but the in-app webview blocks `target="_blank"` popups (`javaScriptCanOpenWindowsAutomatically: false`), so for JS-driven links route through a delegated click handler — `window.open(url, '_blank')` with a `location.href` fallback — so the navigation reaches `shouldOverrideUrlLoading` and is handed off to the OS.
 
+The embedded webview also shows a platform-specific navigation guide when a skin opens. Disable or restore it in **Settings** under **General** with **Skin navigation guide**.
 **Server control endpoints:**
 
 | Method | Path | Description |

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -68,6 +68,7 @@ class SettingsController with ChangeNotifier {
   bool _onboardingCompleted = false;
   bool _accountStepSeen = false;
   bool _androidWarningDismissed = false;
+  bool _showSkinExitInstructions = true;
   bool _enableSimulatedWebViews = false;
 
   // Feature flags — loaded once at startup, hot-swappable at runtime.
@@ -104,6 +105,7 @@ class SettingsController with ChangeNotifier {
   bool get onboardingCompleted => _onboardingCompleted;
   bool get accountStepSeen => _accountStepSeen;
   bool get androidWarningDismissed => _androidWarningDismissed;
+  bool get showSkinExitInstructions => _showSkinExitInstructions;
   bool get enableSimulatedWebViews => _enableSimulatedWebViews;
 
   // Feature flags
@@ -145,6 +147,8 @@ class SettingsController with ChangeNotifier {
     _accountStepSeen = await _settingsService.accountStepSeen();
     _androidWarningDismissed =
         await _settingsService.androidWarningDismissed();
+    _showSkinExitInstructions =
+        await _settingsService.showSkinExitInstructions();
     _enableSimulatedWebViews =
         await _settingsService.enableSimulatedWebViews();
 
@@ -437,6 +441,13 @@ class SettingsController with ChangeNotifier {
     if (value == _androidWarningDismissed) return;
     _androidWarningDismissed = value;
     await _settingsService.setAndroidWarningDismissed(value);
+    notifyListeners();
+  }
+
+  Future<void> setShowSkinExitInstructions(bool value) async {
+    if (value == _showSkinExitInstructions) return;
+    _showSkinExitInstructions = value;
+    await _settingsService.setShowSkinExitInstructions(value);
     notifyListeners();
   }
 

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -75,6 +75,8 @@ abstract class SettingsService {
   Future<void> setAccountStepSeen(bool value);
   Future<bool> androidWarningDismissed();
   Future<void> setAndroidWarningDismissed(bool value);
+  Future<bool> showSkinExitInstructions();
+  Future<void> setShowSkinExitInstructions(bool value);
   Future<bool> enableSimulatedWebViews();
   Future<void> setEnableSimulatedWebViews(bool value);
 
@@ -459,6 +461,17 @@ class SharedPreferencesSettingsService extends SettingsService {
   }
 
   @override
+  Future<bool> showSkinExitInstructions() async {
+    return await prefs.getBool(SettingsKeys.showSkinExitInstructions.name) ??
+        true;
+  }
+
+  @override
+  Future<void> setShowSkinExitInstructions(bool value) async {
+    await prefs.setBool(SettingsKeys.showSkinExitInstructions.name, value);
+  }
+
+  @override
   Future<bool> enableSimulatedWebViews() async {
     return await prefs.getBool(SettingsKeys.enableSimulatedWebViews.name) ??
         false;
@@ -515,6 +528,7 @@ enum SettingsKeys {
   onboardingCompleted,
   accountStepSeen,
   androidWarningDismissed,
+  showSkinExitInstructions,
   enableSimulatedWebViews,
 }
 

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -53,6 +53,23 @@ class SettingsView extends StatelessWidget {
                 trailing: Text(_themeModeLabel(controller.themeMode)),
                 onTap: () => _showThemePicker(context),
               ),
+              const SettingsDivider(),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
+                child: ShadSwitch(
+                  value: controller.showSkinExitInstructions,
+                  onChanged: (value) async {
+                    await controller.setShowSkinExitInstructions(value);
+                  },
+                  label: const Text('Skin navigation guide'),
+                  sublabel: const Text(
+                    'Show how to return to the dashboard when opening a skin',
+                  ),
+                ),
+              ),
 
               // MARK: Updates
               const SettingsSectionHeader('Updates'),

--- a/lib/src/skin_feature/skin_view.dart
+++ b/lib/src/skin_feature/skin_view.dart
@@ -275,12 +275,15 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
         behavior: SnackBarBehavior.floating,
         margin: const EdgeInsets.all(16),
         showCloseIcon: true,
-        // action: SnackBarAction(
-        //   label: 'Dismiss',
-        //   onPressed: () {
-        //     ScaffoldMessenger.of(context).hideCurrentSnackBar();
-        //   },
-        // ),
+        action: SnackBarAction(
+          label: "Don't show again",
+          onPressed: () {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            unawaited(
+              widget.settingsController.setShowSkinExitInstructions(false),
+            );
+          },
+        ),
       ),
     );
   }
@@ -675,7 +678,9 @@ class _SkinViewState extends State<SkinView> with WidgetsBindingObserver {
         // ''');
 
         // Show exit instructions snackbar
-        if (mounted && _didShowExit == false) {
+        if (mounted &&
+            !_didShowExit &&
+            widget.settingsController.showSkinExitInstructions) {
           _didShowExit = true;
           _showExitInstructions();
         }

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -39,6 +39,7 @@ class MockSettingsService extends SettingsService {
   bool _onboardingCompleted = true; // skip onboarding in tests
   bool _accountStepSeen = true; // skip account step in tests
   bool _androidWarningDismissed = true; // skip android warning in tests
+  bool _showSkinExitInstructions = false;
   bool _enableSimulatedWebViews = false;
 
   final Map<String, bool> _featureFlags = {};
@@ -184,6 +185,11 @@ class MockSettingsService extends SettingsService {
   @override
   Future<void> setAndroidWarningDismissed(bool value) async =>
       _androidWarningDismissed = value;
+  @override
+  Future<bool> showSkinExitInstructions() async => _showSkinExitInstructions;
+  @override
+  Future<void> setShowSkinExitInstructions(bool value) async =>
+      _showSkinExitInstructions = value;
   @override
   Future<bool> enableSimulatedWebViews() async => _enableSimulatedWebViews;
   @override

--- a/test/unit/controllers/settings_controller_test.dart
+++ b/test/unit/controllers/settings_controller_test.dart
@@ -7,9 +7,11 @@ import 'package:reaprime/src/settings/settings_service.dart';
 class _SpySettingsService implements SettingsService {
   int setSimulatedDevicesCallCount = 0;
   int setEnableSimulatedWebViewsCallCount = 0;
+  int setShowSkinExitInstructionsCallCount = 0;
   int setFeatureFlagCallCount = 0;
   Set<SimulatedDevicesTypes> _simulatedDevices = {};
   bool _enableSimulatedWebViews = false;
+  bool _showSkinExitInstructions = true;
   final Map<String, bool?> _featureFlags = {};
   String? _preferredMachineId;
   String? _preferredScaleId;
@@ -27,6 +29,13 @@ class _SpySettingsService implements SettingsService {
   Future<void> setEnableSimulatedWebViews(bool value) async {
     setEnableSimulatedWebViewsCallCount++;
     _enableSimulatedWebViews = value;
+  }
+  @override
+  Future<bool> showSkinExitInstructions() async => _showSkinExitInstructions;
+  @override
+  Future<void> setShowSkinExitInstructions(bool value) async {
+    setShowSkinExitInstructionsCallCount++;
+    _showSkinExitInstructions = value;
   }
   // Feature flags
   @override
@@ -204,6 +213,41 @@ void main() {
       await controller.setEnableSimulatedWebViews(false);
 
       expect(spy.setEnableSimulatedWebViewsCallCount, 0);
+      expect(notified, isFalse);
+    });
+  });
+
+  group('SettingsController.setShowSkinExitInstructions', () {
+    test('persists and updates the in-memory value', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+
+      await controller.setShowSkinExitInstructions(false);
+
+      expect(controller.showSkinExitInstructions, isFalse);
+      expect(spy.setShowSkinExitInstructionsCallCount, 1);
+    });
+
+    test('notifies listeners on change', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      await controller.setShowSkinExitInstructions(false);
+
+      expect(notified, isTrue);
+    });
+
+    test('is a no-op when the value is unchanged', () async {
+      final spy = _SpySettingsService();
+      final controller = SettingsController(spy);
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      await controller.setShowSkinExitInstructions(true);
+
+      expect(spy.setShowSkinExitInstructionsCallCount, 0);
       expect(notified, isFalse);
     });
   });


### PR DESCRIPTION
## Summary

- Problem: SkinView's platform-specific back navigation guide had no persistent dismissal option.
- Why it matters: users who already know the navigation steps see the guide again whenever they open a skin.
- What changed: the guide now has a `Don't show again` action, persists that choice, and exposes a Settings toggle to restore it.
- What did NOT change: the close icon remains a one-time dismissal, and device, API, and external-browser behavior are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [x] WebUI skins
- [ ] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #444

## Root Cause (if bug fix)

N/A - feature.

## Regression Test Plan (if bug fix or refactor)

N/A - feature. Controller unit tests cover persistence, listener notification, and the unchanged-value no-op path.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml`
- [ ] API docs updated: `doc/Api.md`
- [ ] Plugin docs updated: `doc/Plugins.md`
- [x] Skin docs updated: `doc/Skins.md`
- [ ] Profile docs updated: `doc/Profiles.md`
- [ ] Device docs updated: `doc/DeviceManagement.md`
- [ ] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No
- Risk explanation: N/A

## User-Visible Changes

The SkinView navigation guide is enabled by default. Users can dismiss it permanently with `Don't show again` or restore it from Settings > General > Skin navigation guide.

## Verification

### Local gates

- [ ] `flutter analyze` - unavailable because Flutter is not installed in this environment
- [ ] `flutter test` - unavailable because Flutter is not installed in this environment
- [ ] `(cd packages/dye2-plugin && npm run build)` - not run; this change does not touch the plugin

### Manual verification

- OS / platform tested: Windows host, static review only
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What was verified: clean branch from `main`, isolated commit, and `git diff --check` passed
- What was not verified: Flutter formatting, analysis, widget runtime, and device behavior because Flutter/Dart are unavailable

### Evidence

- [x] Log snippets
- [ ] Test output (failing before + passing after)
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- Existing users default to the current enabled behavior because the new preference defaults to `true` when absent.

## Risks & Mitigations

- Risk: none beyond the existing asynchronous settings persistence pattern.
  - Mitigation: the controller updates in memory and persists through the shared settings service; the default remains enabled.
