### PR TITLE
Fix Decent Scale BLE lifecycle regressions

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -225,7 +225,11 @@ runs. The `EarlyConnectWatcher` does its own retry during the scan.
 
 On Apple (iOS/macOS), `getSystemDevices` is used to find the peripheral in
 the system cache. If not cached, returns null immediately (no timeout waste).
-On Android/Linux/Windows, direct `UniversalBle.connect(deviceId)` works.
+A system-connected Apple peripheral must still go through `connect()` so
+`universal_ble` attaches its native callbacks and CoreBluetooth delegate.
+This call is idempotent for an existing link and does not start a second
+physical connection. On Android/Linux/Windows, direct
+`UniversalBle.connect(deviceId)` works.
 
 The identity check happens during `onConnect()` — for machines, `v13Model`
 is read and compared against the expected `DeviceImplementation`.

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -74,7 +74,7 @@ Discovery services are responsible for scanning and creating device instances. E
 - **Platform:** All (Android, iOS, macOS, Windows, Linux)
 - **Package:** `universal_ble` (native backends on mobile/Windows/macOS; pure-Dart BlueZ backend on Linux)
 - **File:** `lib/src/services/universal_ble_discovery_service.dart`
-- **Discovery:** Unfiltered BLE scan + name-based matching (`DeviceMatcher`); also queries system/bonded devices (`getSystemDevices`) for CoreBluetooth/BlueZ. Single BLE stack on every platform since the flutter_blue_plus → universal_ble consolidation (see `doc/plans/archive/ble-universal-ble-migration/`).
+- **Discovery:** Unfiltered BLE scan + name-based matching (`DeviceMatcher`); also queries system/bonded devices (`getSystemDevices`) for CoreBluetooth/BlueZ. Apple devices returned as system-connected must still go through `connect()` so `universal_ble` attaches native callbacks and its CoreBluetooth delegate; this is idempotent and does not start a second physical connection. Single BLE stack on every platform since the flutter_blue_plus → universal_ble consolidation (see `doc/plans/archive/ble-universal-ble-migration/`).
 - **Linux/BlueZ note:** `UniversalBleTransport` applies BlueZ-specific connect handling on `Platform.isLinux` (stop scan + settle before connect to avoid `le-connection-abort-by-local`, post-connect settle, `discoverServices` retry) — without it the DE1 cold connect fails with "Failed to resolve services".
 
 #### 2. SerialService

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -101,7 +101,6 @@ class ScaleController {
     _scaleConnection = scale.connectionState.listen(_processConnection);
     _scale = scale;
     _lastConnectedDeviceId = scale.deviceId;
-    _connectionController.add(ConnectionState.connected);
   }
 
   /// Adopt a scale that has already been connected and had [onConnect]
@@ -137,7 +136,6 @@ class ScaleController {
     _scaleConnection = scale.connectionState.listen(_processConnection);
     _scale = scale;
     _lastConnectedDeviceId = scale.deviceId;
-    _connectionController.add(ConnectionState.connected);
   }
 
   void _onDisconnect() {

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/weight_flow_calculator.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/util/kalman_flow_estimator.dart';
 import 'package:reaprime/src/util/moving_average.dart';
@@ -20,6 +21,7 @@ class ScaleController {
   /// device went away. Overwritten on the next successful connect.
   String? _lastConnectedDeviceId;
   String? get lastConnectedDeviceId => _lastConnectedDeviceId;
+  final Set<String> _initializedDecentScaleIds = {};
 
   final Logger log = Logger('ScaleController');
 
@@ -98,9 +100,10 @@ class ScaleController {
     // Subscribe to connection state AFTER onConnect succeeds, so we don't
     // get poisoned by a BehaviorSubject replaying a stale 'disconnected'
     // state from before reconnection.
-    _scaleConnection = scale.connectionState.listen(_processConnection);
     _scale = scale;
     _lastConnectedDeviceId = scale.deviceId;
+    await _tareFirstDecentScaleConnection(scale);
+    _scaleConnection = scale.connectionState.listen(_processConnection);
   }
 
   /// Adopt a scale that has already been connected and had [onConnect]
@@ -133,9 +136,19 @@ class ScaleController {
       _connectionController.add(ConnectionState.disconnected);
       throw StateError('Adopted scale not connected (state: ${state.name})');
     }
-    _scaleConnection = scale.connectionState.listen(_processConnection);
     _scale = scale;
     _lastConnectedDeviceId = scale.deviceId;
+    await _tareFirstDecentScaleConnection(scale);
+    _scaleConnection = scale.connectionState.listen(_processConnection);
+  }
+
+  Future<void> _tareFirstDecentScaleConnection(Scale scale) async {
+    if (scale.implementation != DeviceImplementation.decentScale ||
+        _initializedDecentScaleIds.contains(scale.deviceId)) {
+      return;
+    }
+    await tare();
+    _initializedDecentScaleIds.add(scale.deviceId);
   }
 
   void _onDisconnect() {

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -4,7 +4,6 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/weight_flow_calculator.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/device.dart';
-import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/util/kalman_flow_estimator.dart';
 import 'package:reaprime/src/util/moving_average.dart';
@@ -21,7 +20,6 @@ class ScaleController {
   /// device went away. Overwritten on the next successful connect.
   String? _lastConnectedDeviceId;
   String? get lastConnectedDeviceId => _lastConnectedDeviceId;
-  final Set<String> _initializedDecentScaleIds = {};
 
   final Logger log = Logger('ScaleController');
 
@@ -102,7 +100,6 @@ class ScaleController {
     // state from before reconnection.
     _scale = scale;
     _lastConnectedDeviceId = scale.deviceId;
-    await _tareFirstDecentScaleConnection(scale);
     _scaleConnection = scale.connectionState.listen(_processConnection);
   }
 
@@ -138,17 +135,7 @@ class ScaleController {
     }
     _scale = scale;
     _lastConnectedDeviceId = scale.deviceId;
-    await _tareFirstDecentScaleConnection(scale);
     _scaleConnection = scale.connectionState.listen(_processConnection);
-  }
-
-  Future<void> _tareFirstDecentScaleConnection(Scale scale) async {
-    if (scale.implementation != DeviceImplementation.decentScale ||
-        _initializedDecentScaleIds.contains(scale.deviceId)) {
-      return;
-    }
-    await tare();
-    _initializedDecentScaleIds.add(scale.deviceId);
   }
 
   void _onDisconnect() {

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -133,8 +133,6 @@ class DecentScale implements Scale, TransportHandoffScale {
     // DecentScale instance — it cannot detect an already-live
     // connection created by a prior transport instance.
     final nativeState = await _device.getConnectionState();
-    final isFirstConnection =
-        _connectionStateController.value == ConnectionState.discovered;
     if (nativeState == ConnectionState.connected &&
         _connectionStateController.value == ConnectionState.connected) {
       _log.info('Already connected, skipping');
@@ -218,9 +216,6 @@ class DecentScale implements Scale, TransportHandoffScale {
         await _sendHeartBeat();
       });
       if (isUsingHeartBeat && !await _sendHeartBeat()) {
-        throw const DeviceNotConnectedException.scale();
-      }
-      if (!isUsingHeartBeat && isFirstConnection && !await _sendTare()) {
         throw const DeviceNotConnectedException.scale();
       }
       if (!_isSleeping && !await _sendOledOn()) {

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -133,6 +133,8 @@ class DecentScale implements Scale, TransportHandoffScale {
     // DecentScale instance — it cannot detect an already-live
     // connection created by a prior transport instance.
     final nativeState = await _device.getConnectionState();
+    final isFirstConnection =
+        _connectionStateController.value == ConnectionState.discovered;
     if (nativeState == ConnectionState.connected &&
         _connectionStateController.value == ConnectionState.connected) {
       _log.info('Already connected, skipping');
@@ -218,7 +220,7 @@ class DecentScale implements Scale, TransportHandoffScale {
       if (isUsingHeartBeat && !await _sendHeartBeat()) {
         throw const DeviceNotConnectedException.scale();
       }
-      if (!isUsingHeartBeat && !await _sendTare()) {
+      if (!isUsingHeartBeat && isFirstConnection && !await _sendTare()) {
         throw const DeviceNotConnectedException.scale();
       }
       if (!_isSleeping && !await _sendOledOn()) {

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -206,7 +206,7 @@ class DecentScale implements Scale, TransportHandoffScale {
               "No BLE notifications for ${_watchdogWarningTicks * 4}s "
               "(total=$_totalNotifications), re-subscribing",
             );
-            _registerNotifications();
+            _retryNotifications();
           }
         }
 
@@ -423,6 +423,18 @@ class DecentScale implements Scale, TransportHandoffScale {
     );
   }
 
+  void _retryNotifications() {
+    unawaited(
+      _registerNotifications().catchError((Object error, StackTrace stackTrace) {
+        _log.warning(
+          'BLE notification re-subscribe failed',
+          error,
+          stackTrace,
+        );
+      }),
+    );
+  }
+
   void _resetNotificationWatchdog() {
     _notificationWatchdog?.cancel();
     if (!_isSleeping && !_isDisconnecting) {
@@ -431,7 +443,7 @@ class DecentScale implements Scale, TransportHandoffScale {
           'No BLE notifications for ${_notificationWatchdogTimeout.inMilliseconds}ms '
           '(total=$_totalNotifications), re-subscribing',
         );
-        _registerNotifications();
+        _retryNotifications();
       });
     }
   }

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -458,7 +458,9 @@ class DecentScale implements Scale, TransportHandoffScale {
         _parseWeight(data);
       case 0x0A:
         // battery
-        _parseHeartbeat(data);
+        if (data.length >= 7) {
+          _parseStatusResponse(data);
+        }
     }
   }
 
@@ -477,9 +479,9 @@ class DecentScale implements Scale, TransportHandoffScale {
   }
 
   int _batteryLevel = 100;
-  void _parseHeartbeat(List<int> data) {
+  void _parseStatusResponse(List<int> data) {
     final level = data[4];
-    _log.fine("heartbeat: ${data.map((e) => e.toRadixString(16))}");
+    _log.fine("status response: ${data.map((e) => e.toRadixString(16))}");
     _batteryLevel = min(level, 100);
   }
 }

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -322,7 +322,7 @@ class DecentScale implements Scale, TransportHandoffScale {
   /// is to turn on the display (OledOn)
   Future<bool> _requestBatteryData() async {
     final heartbeatByte = isUsingHeartBeat ? 0x01 : 0x00;
-    return _writeCommand([0x0A, 0x01, 0x00, 0x00, heartbeatByte]);
+    return _writeCommand([0x0A, 0x01, 0x01, 0x00, heartbeatByte]);
   }
 
   Future<bool> _sendOledOn() async {

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -132,18 +132,15 @@ class DecentScale implements Scale, TransportHandoffScale {
     // BehaviorSubject is freshly seeded (discovered) on each new
     // DecentScale instance — it cannot detect an already-live
     // connection created by a prior transport instance.
-    final nativeState = await _device.getConnectionState();
-    if (nativeState == ConnectionState.connected &&
-        _connectionStateController.value == ConnectionState.connected) {
+    if (_connectionStateController.value == ConnectionState.connected &&
+        await _device.getConnectionState() == ConnectionState.connected) {
       _log.info('Already connected, skipping');
       return;
     }
     _connectionStateController.add(ConnectionState.connecting);
 
     try {
-      if (nativeState != ConnectionState.connected) {
-        await _device.connect();
-      }
+      await _device.connect();
 
       await subscription?.cancel();
       subscription = _device.connectionState

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -132,16 +132,20 @@ class DecentScale implements Scale, TransportHandoffScale {
     // BehaviorSubject is freshly seeded (discovered) on each new
     // DecentScale instance — it cannot detect an already-live
     // connection created by a prior transport instance.
-    final state = await _device.getConnectionState();
-    if (state == ConnectionState.connected) {
+    final nativeState = await _device.getConnectionState();
+    if (nativeState == ConnectionState.connected &&
+        _connectionStateController.value == ConnectionState.connected) {
       _log.info('Already connected, skipping');
       return;
     }
     _connectionStateController.add(ConnectionState.connecting);
 
     try {
-      await _device.connect();
+      if (nativeState != ConnectionState.connected) {
+        await _device.connect();
+      }
 
+      await subscription?.cancel();
       subscription = _device.connectionState
           .where((state) => state == ConnectionState.disconnected)
           .listen((_) {

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -197,7 +197,7 @@ class DecentScale implements Scale, TransportHandoffScale {
               "No BLE notifications for ${_watchdogDisconnectTicks * 4}s "
               "(total=$_totalNotifications, uptime=${_heartbeatTotalTicks * 4}s), disconnecting",
             );
-            disconnect();
+            unawaited(_disconnect(powerOff: false));
             return;
           } else if (_ticksSinceLastNotification >= _watchdogWarningTicks &&
               !_watchdogRetryAttempted) {

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -152,7 +152,7 @@ class DecentScale implements Scale, TransportHandoffScale {
           .where((state) => state == ConnectionState.disconnected)
           .listen((_) {
             _log.info("Transport disconnected");
-            disconnect();
+            unawaited(_disconnect(powerOff: false));
           });
 
       final services = await _device.discoverServices();
@@ -317,7 +317,7 @@ class DecentScale implements Scale, TransportHandoffScale {
         withResponse: true,
       );
       if (!sent) {
-        await disconnect();
+        await _disconnect(powerOff: false);
       }
       return sent;
     } catch (e) {

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -71,7 +71,7 @@ class DecentScale implements Scale, TransportHandoffScale {
     return Uint8List.fromList(bytes);
   }
 
-  Future<void> _writeCommand(
+  Future<bool> _writeCommand(
     List<int> commandBytes, {
     Duration? timeout,
     bool withResponse = true,
@@ -84,6 +84,7 @@ class DecentScale implements Scale, TransportHandoffScale {
         timeout: timeout,
         withResponse: withResponse,
       );
+      return true;
     } on DeviceNotConnectedException {
       _log.info('Write failed: device not connected');
       // Don't call disconnect() here — the transport already emitted
@@ -92,6 +93,7 @@ class DecentScale implements Scale, TransportHandoffScale {
       // disconnect from a write path risks a re-entrant teardown.
       // The _isDisconnecting guard would catch it, but the extra
       // log noise is confusing.
+      return false;
     }
   }
 
@@ -209,13 +211,17 @@ class DecentScale implements Scale, TransportHandoffScale {
 
         await _sendHeartBeat();
       });
-      if (isUsingHeartBeat) {
-        await _sendHeartBeat();
-      } else {
-        await tare();
+      if (isUsingHeartBeat && !await _sendHeartBeat()) {
+        throw const DeviceNotConnectedException.scale();
       }
-      if (!_isSleeping) {
-        await _sendOledOn();
+      if (!isUsingHeartBeat && !await _sendTare()) {
+        throw const DeviceNotConnectedException.scale();
+      }
+      if (!_isSleeping && !await _sendOledOn()) {
+        throw const DeviceNotConnectedException.scale();
+      }
+      if (await _device.getConnectionState() != ConnectionState.connected) {
+        throw const DeviceNotConnectedException.scale();
       }
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
@@ -285,43 +291,49 @@ class DecentScale implements Scale, TransportHandoffScale {
 
   @override
   Future<void> tare() async {
-    await _writeCommand([0x0F, 0x00, 0x00, 0x00, 0x01]);
+    await _sendTare();
   }
 
-  Future<void> _sendHeartBeat() async {
+  Future<bool> _sendTare() => _writeCommand([0x0F, 0x00, 0x00, 0x00, 0x01]);
+
+  Future<bool> _sendHeartBeat() async {
     if (!isUsingHeartBeat) {
-      return;
+      return true;
     }
     _log.finest("send hb");
     // Heartbeat ping: tells the scale the app is still alive so it won't
     // auto-sleep or disconnect. Send even when _isSleeping — without it
     // HDS firmware times out and disconnects BLE, which wakes the display.
     try {
-      await _writeCommand(
+      final sent = await _writeCommand(
         [0x0A, 0x03, 0xFF, 0xFF, 0x00],
         timeout: const Duration(seconds: 2),
         withResponse: true,
       );
-    } on DeviceNotConnectedException {
-      _log.info('Heartbeat write failed: device not connected');
-      await disconnect();
+      if (!sent) {
+        await disconnect();
+      }
+      return sent;
     } catch (e) {
       _log.warning('Heartbeat write failed (transient): $e');
+      return true;
     }
   }
 
   /// Causes the scale to respond with battery level, while the actual request
   /// is to turn on the display (OledOn)
-  Future<void> _requestBatteryData() async {
+  Future<bool> _requestBatteryData() async {
     final heartbeatByte = isUsingHeartBeat ? 0x01 : 0x00;
-    await _writeCommand([0x0A, 0x01, 0x00, 0x00, heartbeatByte]);
+    return _writeCommand([0x0A, 0x01, 0x00, 0x00, heartbeatByte]);
   }
 
-  Future<void> _sendOledOn() async {
+  Future<bool> _sendOledOn() async {
     final heartbeatByte = isUsingHeartBeat ? 0x01 : 0x00;
-    await _requestBatteryData();
+    if (!await _requestBatteryData()) {
+      return false;
+    }
     await Future.delayed(Duration(milliseconds: 100));
-    await _writeCommand([0x0A, 0x04, 0x00, 0x00, heartbeatByte]);
+    return _writeCommand([0x0A, 0x04, 0x00, 0x00, heartbeatByte]);
   }
 
   Future<void> _sendOledOff() async {

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -130,8 +130,15 @@ class UniversalBleTransport implements BLETransport {
         _connectionStateSubject.add(device.ConnectionState.disconnected);
       }
     });
-    if (_isLinux) {
+    final alreadyConnected =
+        await getConnectionState() == device.ConnectionState.connected;
+    if (alreadyConnected) {
+      _connectionStateSubject.add(device.ConnectionState.connected);
+    }
+    if (_isLinux && !alreadyConnected) {
       await _connectBlueZ();
+    }
+    if (_isLinux) {
       _startAdvertWatch();
       return;
     }
@@ -140,7 +147,7 @@ class UniversalBleTransport implements BLETransport {
     // as the BlueZ le-connection-abort-by-local mitigation above; observed
     // 2026-07-15 as repeated 10s connect timeouts to an advertising scale
     // mid-scan). The ConnectionManager retry loop restarts scanning.
-    if (_isAndroid) {
+    if (!alreadyConnected && _isAndroid) {
       try {
         _log.fine("stopping scan before connect");
         await _stopScanViaOwner();
@@ -149,17 +156,19 @@ class UniversalBleTransport implements BLETransport {
       }
       await Future.delayed(_androidPreConnectSettleDelay);
     }
-    try {
-      // 20s: connectGatt on a busy radio (live DE1 link, recent scan) can
-      // legitimately need more than 10s — fbp defaults to 35s. Must stay
-      // comfortably under ConnectionManager's 30s end-to-end guard so the
-      // richer transport-level error wins over the generic outer timeout.
-      await UniversalBle.connect(
-        _device.deviceId,
-        timeout: Duration(seconds: 20),
-      );
-    } on UniversalBleException catch (e) {
-      throw mapUniversalConnectError(e);
+    if (!alreadyConnected) {
+      try {
+        // 20s: connectGatt on a busy radio (live DE1 link, recent scan) can
+        // legitimately need more than 10s — fbp defaults to 35s. Must stay
+        // comfortably under ConnectionManager's 30s end-to-end guard so the
+        // richer transport-level error wins over the generic outer timeout.
+        await UniversalBle.connect(
+          _device.deviceId,
+          timeout: Duration(seconds: 20),
+        );
+      } on UniversalBleException catch (e) {
+        throw mapUniversalConnectError(e);
+      }
     }
     _startAdvertWatch();
 

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -130,15 +130,8 @@ class UniversalBleTransport implements BLETransport {
         _connectionStateSubject.add(device.ConnectionState.disconnected);
       }
     });
-    final alreadyConnected =
-        await getConnectionState() == device.ConnectionState.connected;
-    if (alreadyConnected) {
-      _connectionStateSubject.add(device.ConnectionState.connected);
-    }
-    if (_isLinux && !alreadyConnected) {
-      await _connectBlueZ();
-    }
     if (_isLinux) {
+      await _connectBlueZ();
       _startAdvertWatch();
       return;
     }
@@ -147,7 +140,7 @@ class UniversalBleTransport implements BLETransport {
     // as the BlueZ le-connection-abort-by-local mitigation above; observed
     // 2026-07-15 as repeated 10s connect timeouts to an advertising scale
     // mid-scan). The ConnectionManager retry loop restarts scanning.
-    if (!alreadyConnected && _isAndroid) {
+    if (_isAndroid) {
       try {
         _log.fine("stopping scan before connect");
         await _stopScanViaOwner();
@@ -156,19 +149,17 @@ class UniversalBleTransport implements BLETransport {
       }
       await Future.delayed(_androidPreConnectSettleDelay);
     }
-    if (!alreadyConnected) {
-      try {
-        // 20s: connectGatt on a busy radio (live DE1 link, recent scan) can
-        // legitimately need more than 10s — fbp defaults to 35s. Must stay
-        // comfortably under ConnectionManager's 30s end-to-end guard so the
-        // richer transport-level error wins over the generic outer timeout.
-        await UniversalBle.connect(
-          _device.deviceId,
-          timeout: Duration(seconds: 20),
-        );
-      } on UniversalBleException catch (e) {
-        throw mapUniversalConnectError(e);
-      }
+    try {
+      // 20s: connectGatt on a busy radio (live DE1 link, recent scan) can
+      // legitimately need more than 10s — fbp defaults to 35s. Must stay
+      // comfortably under ConnectionManager's 30s end-to-end guard so the
+      // richer transport-level error wins over the generic outer timeout.
+      await UniversalBle.connect(
+        _device.deviceId,
+        timeout: Duration(seconds: 20),
+      );
+    } on UniversalBleException catch (e) {
+      throw mapUniversalConnectError(e);
     }
     _startAdvertWatch();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1707,7 +1707,7 @@ packages:
     description:
       path: "."
       ref: "2.2.3"
-      resolved-ref: 6ced44211ae8e284b0c095c1a3079a27706e76f7
+      resolved-ref: "6ced44211ae8e284b0c095c1a3079a27706e76f7"
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
     version: "2.2.3"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1706,11 +1706,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2.2.2"
-      resolved-ref: f50b2f448c28088fcd7794706672159ace87f564
+      ref: "2.2.3"
+      resolved-ref: 6ced44211ae8e284b0c095c1a3079a27706e76f7
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
-    version: "2.2.2"
+    version: "2.2.3"
   universal_image:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1706,11 +1706,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0e08962b4513831002c2a197d03a8be6c1000c34"
-      resolved-ref: "0e08962b4513831002c2a197d03a8be6c1000c34"
-      url: "https://github.com/ODevStudio/universal_ble.git"
+      ref: "2.2.2"
+      resolved-ref: f50b2f448c28088fcd7794706672159ace87f564
+      url: "https://github.com/tadelv/universal_ble.git"
     source: git
-    version: "2.2.1"
+    version: "2.2.2"
   universal_image:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1706,9 +1706,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2.2.1"
-      resolved-ref: "420c771e5944cf75782e00e430ef94fa7f577165"
-      url: "https://github.com/tadelv/universal_ble.git"
+      ref: "0e08962b4513831002c2a197d03a8be6c1000c34"
+      resolved-ref: "0e08962b4513831002c2a197d03a8be6c1000c34"
+      url: "https://github.com/ODevStudio/universal_ble.git"
     source: git
     version: "2.2.1"
   universal_image:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,8 +43,8 @@ dependencies:
   equatable: ^2.0.7
   universal_ble:
     git:
-      url: https://github.com/tadelv/universal_ble.git
-      ref: 2.2.1
+      url: https://github.com/ODevStudio/universal_ble.git
+      ref: 0e08962b4513831002c2a197d03a8be6c1000c34
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,8 +43,8 @@ dependencies:
   equatable: ^2.0.7
   universal_ble:
     git:
-      url: https://github.com/ODevStudio/universal_ble.git
-      ref: 0e08962b4513831002c2a197d03a8be6c1000c34
+      url: https://github.com/tadelv/universal_ble.git
+      ref: 2.2.2
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   universal_ble:
     git:
       url: https://github.com/tadelv/universal_ble.git
-      ref: 2.2.2
+      ref: 2.2.3
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/test/services/ble/universal_ble_transport_mtu_test.dart
+++ b/test/services/ble/universal_ble_transport_mtu_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
 import 'package:universal_ble/universal_ble.dart';
 
@@ -11,6 +12,8 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   /// When true, [requestMtu] throws — simulating a stack that rejects the
   /// negotiation.
   bool throwOnRequestMtu = false;
+  BleConnectionState connectionState = BleConnectionState.connected;
+  int connectCalls = 0;
 
   @override
   Future<int> requestMtu(String deviceId, int expectedMtu) async {
@@ -53,11 +56,14 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
     bool autoConnect = false,
     ConnectionPlatformConfig? platformConfig,
   }) async {
+    connectCalls++;
+    connectionState = BleConnectionState.connected;
     updateConnection(deviceId, true);
   }
 
   @override
   Future<void> disconnect(String deviceId) async {
+    connectionState = BleConnectionState.disconnected;
     updateConnection(deviceId, false);
   }
 
@@ -112,12 +118,17 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
 
   @override
   Future<BleConnectionState> getConnectionState(String deviceId) async =>
-      BleConnectionState.connected;
+      connectionState;
 
   @override
   Future<List<BleDevice>> getSystemDevices(
     List<String>? withServices,
   ) async => [];
+
+  void emitDisconnected(String deviceId) {
+    connectionState = BleConnectionState.disconnected;
+    updateConnection(deviceId, false);
+  }
 }
 
 void main() {
@@ -187,6 +198,34 @@ void main() {
     await value.disconnect();
     await value.connect();
     expect(platform.mtuRequests, [(deviceId, 517), (deviceId, 517)]);
+    await value.dispose();
+  });
+
+  test('preconnected transport attaches without a native reconnect', () async {
+    final value = transport(android: false, linux: false);
+    final states = <device.ConnectionState>[];
+    final subscription = value.connectionState.listen(states.add);
+
+    await value.connect();
+    await Future<void>.delayed(Duration.zero);
+    expect(platform.connectCalls, 0);
+    expect(states, contains(device.ConnectionState.connected));
+
+    platform.emitDisconnected(deviceId);
+    await Future<void>.delayed(Duration.zero);
+    expect(states.last, device.ConnectionState.disconnected);
+
+    await subscription.cancel();
+    await value.dispose();
+  });
+
+  test('disconnected transport performs a native connect', () async {
+    platform.connectionState = BleConnectionState.disconnected;
+    final value = transport(android: false, linux: false);
+
+    await value.connect();
+
+    expect(platform.connectCalls, 1);
     await value.dispose();
   });
 }

--- a/test/services/ble/universal_ble_transport_mtu_test.dart
+++ b/test/services/ble/universal_ble_transport_mtu_test.dart
@@ -12,8 +12,10 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   /// When true, [requestMtu] throws — simulating a stack that rejects the
   /// negotiation.
   bool throwOnRequestMtu = false;
-  BleConnectionState connectionState = BleConnectionState.connected;
+  bool systemConnected = true;
+  bool attached = false;
   int connectCalls = 0;
+  int physicalConnectCalls = 0;
 
   @override
   Future<int> requestMtu(String deviceId, int expectedMtu) async {
@@ -57,13 +59,16 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
     ConnectionPlatformConfig? platformConfig,
   }) async {
     connectCalls++;
-    connectionState = BleConnectionState.connected;
+    attached = true;
+    if (!systemConnected) physicalConnectCalls++;
+    systemConnected = true;
     updateConnection(deviceId, true);
   }
 
   @override
   Future<void> disconnect(String deviceId) async {
-    connectionState = BleConnectionState.disconnected;
+    systemConnected = false;
+    attached = false;
     updateConnection(deviceId, false);
   }
 
@@ -71,7 +76,10 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   Future<List<BleService>> discoverServices(
     String deviceId,
     bool withDescriptors,
-  ) async => [];
+  ) async {
+    if (!attached) throw StateError('Peripheral is not attached');
+    return [];
+  }
 
   @override
   Future<void> setNotifiable(
@@ -117,8 +125,11 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   Future<void> unpair(String deviceId) async {}
 
   @override
-  Future<BleConnectionState> getConnectionState(String deviceId) async =>
-      connectionState;
+  Future<BleConnectionState> getConnectionState(String deviceId) async {
+    return systemConnected
+        ? BleConnectionState.connected
+        : BleConnectionState.disconnected;
+  }
 
   @override
   Future<List<BleDevice>> getSystemDevices(
@@ -126,7 +137,8 @@ class _MtuRecordingBlePlatform extends UniversalBlePlatform {
   ) async => [];
 
   void emitDisconnected(String deviceId) {
-    connectionState = BleConnectionState.disconnected;
+    systemConnected = false;
+    attached = false;
     updateConnection(deviceId, false);
   }
 }
@@ -201,14 +213,17 @@ void main() {
     await value.dispose();
   });
 
-  test('preconnected transport attaches without a native reconnect', () async {
+  test('system-connected transport attaches before service discovery', () async {
     final value = transport(android: false, linux: false);
     final states = <device.ConnectionState>[];
     final subscription = value.connectionState.listen(states.add);
 
     await value.connect();
+    await value.discoverServices();
     await Future<void>.delayed(Duration.zero);
-    expect(platform.connectCalls, 0);
+    expect(platform.connectCalls, 1);
+    expect(platform.physicalConnectCalls, 0);
+    expect(platform.attached, isTrue);
     expect(states, contains(device.ConnectionState.connected));
 
     platform.emitDisconnected(deviceId);
@@ -220,12 +235,13 @@ void main() {
   });
 
   test('disconnected transport performs a native connect', () async {
-    platform.connectionState = BleConnectionState.disconnected;
+    platform.systemConnected = false;
     final value = transport(android: false, linux: false);
 
     await value.connect();
 
     expect(platform.connectCalls, 1);
+    expect(platform.physicalConnectCalls, 1);
     await value.dispose();
   });
 }

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -14,24 +14,21 @@ import 'package:rxdart/subjects.dart';
 class _TrackingScale implements Scale {
   @override
   final String deviceId;
-  @override
-  final DeviceImplementation implementation;
-  _TrackingScale(
-    this.deviceId, {
-    this.implementation = DeviceImplementation.unifiedDe1,
-  });
+  _TrackingScale(this.deviceId);
 
   final _conn = BehaviorSubject<ConnectionState>.seeded(
     ConnectionState.discovered,
   );
   final _snap = BehaviorSubject<ScaleSnapshot>();
   bool disconnected = false;
-  int tareCalls = 0;
 
   @override
   String get name => deviceId;
   @override
   DeviceType get type => DeviceType.scale;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.unifiedDe1;
 
   @override
   TransportType get transportType => TransportType.unknown;
@@ -49,9 +46,7 @@ class _TrackingScale implements Scale {
   }
 
   @override
-  Future<void> tare() async {
-    tareCalls++;
-  }
+  Future<void> tare() async {}
 
   @override
   Future<void> sleepDisplay() async {}
@@ -71,8 +66,6 @@ class _TrackingScale implements Scale {
       batteryLevel: 50,
     ),
   );
-
-  void emitDisconnected() => _conn.add(ConnectionState.disconnected);
 }
 
 /// A handoff-capable scale (like the BLE Decent Scale) that records whether it
@@ -142,41 +135,6 @@ void main() {
     );
 
     await subscription.cancel();
-    controller.dispose();
-  });
-
-  test('Decent Scale tares once across rediscovered wrappers', () async {
-    final controller = ScaleController();
-    final first = _TrackingScale(
-      'decent-A',
-      implementation: DeviceImplementation.decentScale,
-    );
-    final rediscovered = _TrackingScale(
-      'decent-A',
-      implementation: DeviceImplementation.decentScale,
-    );
-
-    await controller.connectToScale(first);
-    first.emitDisconnected();
-    await Future<void>.delayed(Duration.zero);
-    await controller.connectToScale(rediscovered);
-
-    expect(first.tareCalls, 1);
-    expect(rediscovered.tareCalls, 0);
-    controller.dispose();
-  });
-
-  test('adopted Decent Scale receives the initial tare', () async {
-    final controller = ScaleController();
-    final scale = _TrackingScale(
-      'decent-A',
-      implementation: DeviceImplementation.decentScale,
-    );
-    await scale.onConnect();
-
-    await controller.adoptScale(scale);
-
-    expect(scale.tareCalls, 1);
     controller.dispose();
   });
 

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -100,6 +100,43 @@ class _FailingScale extends _TrackingScale {
 }
 
 void main() {
+  test('connect forwards connected once', () async {
+    final controller = ScaleController();
+    final scale = _TrackingScale('A');
+    final states = <ConnectionState>[];
+    final subscription = controller.connectionState.listen(states.add);
+
+    await controller.connectToScale(scale);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      states.where((state) => state == ConnectionState.connected),
+      hasLength(1),
+    );
+
+    await subscription.cancel();
+    controller.dispose();
+  });
+
+  test('adopt forwards connected once', () async {
+    final controller = ScaleController();
+    final scale = _TrackingScale('A');
+    final states = <ConnectionState>[];
+    final subscription = controller.connectionState.listen(states.add);
+    await scale.onConnect();
+
+    await controller.adoptScale(scale);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      states.where((state) => state == ConnectionState.connected),
+      hasLength(1),
+    );
+
+    await subscription.cancel();
+    controller.dispose();
+  });
+
   test('a scale whose onConnect throws surfaces as disconnected and leaks no '
       'snapshot subscription', () async {
     final controller = ScaleController();

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -14,21 +14,24 @@ import 'package:rxdart/subjects.dart';
 class _TrackingScale implements Scale {
   @override
   final String deviceId;
-  _TrackingScale(this.deviceId);
+  @override
+  final DeviceImplementation implementation;
+  _TrackingScale(
+    this.deviceId, {
+    this.implementation = DeviceImplementation.unifiedDe1,
+  });
 
   final _conn = BehaviorSubject<ConnectionState>.seeded(
     ConnectionState.discovered,
   );
   final _snap = BehaviorSubject<ScaleSnapshot>();
   bool disconnected = false;
+  int tareCalls = 0;
 
   @override
   String get name => deviceId;
   @override
   DeviceType get type => DeviceType.scale;
-
-  @override
-  DeviceImplementation get implementation => DeviceImplementation.unifiedDe1;
 
   @override
   TransportType get transportType => TransportType.unknown;
@@ -46,7 +49,10 @@ class _TrackingScale implements Scale {
   }
 
   @override
-  Future<void> tare() async {}
+  Future<void> tare() async {
+    tareCalls++;
+  }
+
   @override
   Future<void> sleepDisplay() async {}
   @override
@@ -65,6 +71,8 @@ class _TrackingScale implements Scale {
       batteryLevel: 50,
     ),
   );
+
+  void emitDisconnected() => _conn.add(ConnectionState.disconnected);
 }
 
 /// A handoff-capable scale (like the BLE Decent Scale) that records whether it
@@ -134,6 +142,41 @@ void main() {
     );
 
     await subscription.cancel();
+    controller.dispose();
+  });
+
+  test('Decent Scale tares once across rediscovered wrappers', () async {
+    final controller = ScaleController();
+    final first = _TrackingScale(
+      'decent-A',
+      implementation: DeviceImplementation.decentScale,
+    );
+    final rediscovered = _TrackingScale(
+      'decent-A',
+      implementation: DeviceImplementation.decentScale,
+    );
+
+    await controller.connectToScale(first);
+    first.emitDisconnected();
+    await Future<void>.delayed(Duration.zero);
+    await controller.connectToScale(rediscovered);
+
+    expect(first.tareCalls, 1);
+    expect(rediscovered.tareCalls, 0);
+    controller.dispose();
+  });
+
+  test('adopted Decent Scale receives the initial tare', () async {
+    final controller = ScaleController();
+    final scale = _TrackingScale(
+      'decent-A',
+      implementation: DeviceImplementation.decentScale,
+    );
+    await scale.onConnect();
+
+    await controller.adoptScale(scale);
+
+    expect(scale.tareCalls, 1);
     controller.dispose();
   });
 

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -131,6 +131,7 @@ class _RecordingBleTransport extends BLETransport {
   int disconnectCalls = 0;
   int subscribeCalls = 0;
   bool failWrites = false;
+  bool failSubscriptions = false;
 
   @override
   String get id => 'recording-decent-scale';
@@ -182,6 +183,9 @@ class _RecordingBleTransport extends BLETransport {
     void Function(Uint8List) callback,
   ) async {
     subscribeCalls++;
+    if (failSubscriptions) {
+      throw StateError('subscription failed');
+    }
     notificationCallback = callback;
   }
 
@@ -344,6 +348,30 @@ void main() {
       expect(_hasCommand(transport, 0x0A, 0x02), isFalse);
       expect(transport.disconnectCalls, 1);
       expect(states.last, ConnectionState.disconnected);
+      transport.dispose();
+    });
+  });
+
+  test('watchdog re-subscribe failures are handled', () {
+    fakeAsync((async) {
+      final transport = _RecordingBleTransport();
+      final scale = DecentScale(transport: transport);
+      var connected = false;
+      scale.onConnect().then((_) => connected = true);
+
+      async.flushMicrotasks();
+      async.elapse(const Duration(milliseconds: 100));
+      async.flushMicrotasks();
+      expect(connected, isTrue);
+      transport.failSubscriptions = true;
+
+      async.elapse(const Duration(seconds: 12));
+      async.flushMicrotasks();
+
+      expect(transport.subscribeCalls, 3);
+      expect(transport.disconnectCalls, 0);
+      scale.disconnectForHandoff();
+      async.flushMicrotasks();
       transport.dispose();
     });
   });

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -271,42 +271,57 @@ void main() {
     await transport.dispose();
   });
 
-  test('connection and rediscovery never apply transport-level tare', () async {
-    final transport = _RecordingBleTransport();
-    final scale = DecentScale(transport: transport);
+  test(
+    'connection and rediscovery use heartbeat-off LED-on without tare',
+    () async {
+      final transport = _RecordingBleTransport();
+      final scale = DecentScale(transport: transport);
 
-    await scale.onConnect();
+      await scale.onConnect();
 
-    expect(
-      _hasCommand(transport, 0x0F),
-      isFalse,
-    );
-    expect(
-      transport.writes
-          .where((data) => data[1] == 0x0A && {0x01, 0x04}.contains(data[2]))
-          .every((data) => data[5] == 0x00),
-      isTrue,
-    );
+      expect(
+        _hasCommand(transport, 0x0F),
+        isFalse,
+      );
+      expect(
+        transport.writes,
+        contains(orderedEquals([0x03, 0x0A, 0x01, 0x01, 0x00, 0x00, 0x09])),
+      );
+      expect(
+        transport.writes
+            .where((data) => data[1] == 0x0A && {0x01, 0x04}.contains(data[2]))
+            .every((data) => data[5] == 0x00),
+        isTrue,
+      );
 
-    await scale.disconnectForHandoff();
-    transport.writes.clear();
-    await scale.onConnect();
+      await scale.disconnectForHandoff();
+      transport.writes.clear();
+      await scale.onConnect();
 
-    expect(_hasCommand(transport, 0x0F), isFalse);
+      expect(_hasCommand(transport, 0x0F), isFalse);
+      expect(
+        transport.writes,
+        contains(orderedEquals([0x03, 0x0A, 0x01, 0x01, 0x00, 0x00, 0x09])),
+      );
 
-    await scale.disconnectForHandoff();
-    final rediscoveredTransport = _RecordingBleTransport(
-      nativeState: ConnectionState.connected,
-    );
-    final rediscoveredScale = DecentScale(transport: rediscoveredTransport);
-    await rediscoveredScale.onConnect();
+      await scale.disconnectForHandoff();
+      final rediscoveredTransport = _RecordingBleTransport(
+        nativeState: ConnectionState.connected,
+      );
+      final rediscoveredScale = DecentScale(transport: rediscoveredTransport);
+      await rediscoveredScale.onConnect();
 
-    expect(_hasCommand(rediscoveredTransport, 0x0F), isFalse);
+      expect(_hasCommand(rediscoveredTransport, 0x0F), isFalse);
+      expect(
+        rediscoveredTransport.writes,
+        contains(orderedEquals([0x03, 0x0A, 0x01, 0x01, 0x00, 0x00, 0x09])),
+      );
 
-    await rediscoveredScale.disconnectForHandoff();
-    await transport.dispose();
-    await rediscoveredTransport.dispose();
-  });
+      await rediscoveredScale.disconnectForHandoff();
+      await transport.dispose();
+      await rediscoveredTransport.dispose();
+    },
+  );
 
   test('notification watchdog disconnects without powering off', () {
     fakeAsync((async) {

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -190,6 +190,10 @@ class _RecordingBleTransport extends BLETransport {
     }
   }
 
+  void emitDisconnected() {
+    _connectionState.add(ConnectionState.disconnected);
+  }
+
   @override
   Future<void> dispose() async {
     await _connectionState.close();
@@ -270,6 +274,35 @@ void main() {
     await scale.disconnectForHandoff();
     await transport.dispose();
   });
+
+  test(
+    'remote disconnect is non-destructive but explicit disconnect powers off',
+    () async {
+      final remoteTransport = _RecordingBleTransport();
+      final remoteScale = DecentScale(transport: remoteTransport);
+      await remoteScale.onConnect();
+      remoteTransport.writes.clear();
+      final remoteDisconnected = remoteScale.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .first;
+
+      remoteTransport.emitDisconnected();
+      await remoteDisconnected;
+
+      expect(_hasCommand(remoteTransport, 0x0A, 0x02), isFalse);
+      await remoteTransport.dispose();
+
+      final explicitTransport = _RecordingBleTransport();
+      final explicitScale = DecentScale(transport: explicitTransport);
+      await explicitScale.onConnect();
+      explicitTransport.writes.clear();
+
+      await explicitScale.disconnect();
+
+      expect(_hasCommand(explicitTransport, 0x0A, 0x02), isTrue);
+      await explicitTransport.dispose();
+    },
+  );
 
   test(
     'disconnect() does not leak an uncaught async error when the '

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -121,6 +121,7 @@ class _RecordingBleTransport extends BLETransport {
   }) : _connectionState = BehaviorSubject.seeded(initialState);
 
   final BehaviorSubject<ConnectionState> _connectionState;
+  final writes = <Uint8List>[];
   int connectCalls = 0;
   int subscribeCalls = 0;
   bool failWrites = false;
@@ -182,6 +183,7 @@ class _RecordingBleTransport extends BLETransport {
     bool withResponse = true,
     Duration? timeout,
   }) async {
+    writes.add(Uint8List.fromList(data));
     if (failWrites) {
       _connectionState.add(ConnectionState.disconnected);
       throw const DeviceNotConnectedException.scale();
@@ -193,6 +195,17 @@ class _RecordingBleTransport extends BLETransport {
     await _connectionState.close();
   }
 }
+
+bool _hasCommand(
+  _RecordingBleTransport transport,
+  int command, [
+  int? subcommand,
+]) => transport.writes.any(
+  (data) =>
+      data.length == 7 &&
+      data[1] == command &&
+      (subcommand == null || data[2] == subcommand),
+);
 
 void main() {
   test('disconnected initialization write never publishes connected', () async {
@@ -225,6 +238,34 @@ void main() {
     expect(transport.connectCalls, 0);
     expect(transport.subscribeCalls, 1);
     expect(await scale.connectionState.first, ConnectionState.connected);
+    expect(_hasCommand(transport, 0x0F), isTrue);
+
+    await scale.disconnectForHandoff();
+    await transport.dispose();
+  });
+
+  test('first connect tares once and reconnect does not tare', () async {
+    final transport = _RecordingBleTransport();
+    final scale = DecentScale(transport: transport);
+
+    await scale.onConnect();
+
+    expect(
+      transport.writes.where((data) => data[1] == 0x0F),
+      hasLength(1),
+    );
+    expect(
+      transport.writes
+          .where((data) => data[1] == 0x0A && {0x01, 0x04}.contains(data[2]))
+          .every((data) => data[5] == 0x00),
+      isTrue,
+    );
+
+    await scale.disconnectForHandoff();
+    transport.writes.clear();
+    await scale.onConnect();
+
+    expect(_hasCommand(transport, 0x0F), isFalse);
 
     await scale.disconnectForHandoff();
     await transport.dispose();

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -117,13 +117,17 @@ class _HangingBleTransport extends _DisconnectedBleTransport {
 
 class _RecordingBleTransport extends BLETransport {
   _RecordingBleTransport({
-    ConnectionState initialState = ConnectionState.disconnected,
-  }) : _connectionState = BehaviorSubject.seeded(initialState);
+    ConnectionState nativeState = ConnectionState.disconnected,
+  }) : _nativeState = nativeState;
 
-  final BehaviorSubject<ConnectionState> _connectionState;
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+  ConnectionState _nativeState;
   final writes = <Uint8List>[];
   void Function(Uint8List)? notificationCallback;
   int connectCalls = 0;
+  int nativeConnectCalls = 0;
+  int disconnectCalls = 0;
   int subscribeCalls = 0;
   bool failWrites = false;
 
@@ -138,16 +142,22 @@ class _RecordingBleTransport extends BLETransport {
 
   @override
   Future<ConnectionState> getConnectionState() async =>
-      _connectionState.value;
+      _nativeState;
 
   @override
   Future<void> connect() async {
     connectCalls++;
+    if (_nativeState != ConnectionState.connected) {
+      nativeConnectCalls++;
+      _nativeState = ConnectionState.connected;
+    }
     _connectionState.add(ConnectionState.connected);
   }
 
   @override
   Future<void> disconnect() async {
+    disconnectCalls++;
+    _nativeState = ConnectionState.disconnected;
     _connectionState.add(ConnectionState.disconnected);
   }
 
@@ -193,6 +203,7 @@ class _RecordingBleTransport extends BLETransport {
   }
 
   void emitDisconnected() {
+    _nativeState = ConnectionState.disconnected;
     _connectionState.add(ConnectionState.disconnected);
   }
 
@@ -237,19 +248,25 @@ void main() {
     await transport.dispose();
   });
 
-  test('fresh wrapper initializes an already-connected transport', () async {
+  test('fresh wrapper attaches to an already-connected transport', () async {
     final transport = _RecordingBleTransport(
-      initialState: ConnectionState.connected,
+      nativeState: ConnectionState.connected,
     );
     final scale = DecentScale(transport: transport);
 
     await scale.onConnect();
 
-    expect(transport.connectCalls, 0);
+    expect(transport.connectCalls, 1);
+    expect(transport.nativeConnectCalls, 0);
     expect(transport.subscribeCalls, 1);
     expect(await scale.connectionState.first, ConnectionState.connected);
 
-    await scale.disconnectForHandoff();
+    final disconnected = scale.connectionState
+        .where((state) => state == ConnectionState.disconnected)
+        .first;
+    transport.emitDisconnected();
+    await disconnected;
+
     await transport.dispose();
   });
 
@@ -277,6 +294,15 @@ void main() {
     expect(_hasCommand(transport, 0x0F), isFalse);
 
     await scale.disconnectForHandoff();
+    final rediscoveredTransport = _RecordingBleTransport(
+      nativeState: ConnectionState.connected,
+    );
+    final rediscoveredScale = DecentScale(transport: rediscoveredTransport);
+    await rediscoveredScale.onConnect();
+
+    expect(_hasCommand(rediscoveredTransport, 0x0F), isFalse);
+
+    await rediscoveredScale.disconnectForHandoff();
     await transport.dispose();
   });
 

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale.dart';
@@ -304,6 +305,32 @@ void main() {
 
     await rediscoveredScale.disconnectForHandoff();
     await transport.dispose();
+    await rediscoveredTransport.dispose();
+  });
+
+  test('notification watchdog disconnects without powering off', () {
+    fakeAsync((async) {
+      final transport = _RecordingBleTransport();
+      final scale = DecentScale(transport: transport);
+      final states = <ConnectionState>[];
+      scale.connectionState.listen(states.add);
+      var connected = false;
+      scale.onConnect().then((_) => connected = true);
+
+      async.flushMicrotasks();
+      async.elapse(const Duration(milliseconds: 100));
+      async.flushMicrotasks();
+      expect(connected, isTrue);
+      transport.writes.clear();
+
+      async.elapse(const Duration(seconds: 20));
+      async.flushMicrotasks();
+
+      expect(_hasCommand(transport, 0x0A, 0x02), isFalse);
+      expect(transport.disconnectCalls, 1);
+      expect(states.last, ConnectionState.disconnected);
+      transport.dispose();
+    });
   });
 
   test(

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -122,6 +122,7 @@ class _RecordingBleTransport extends BLETransport {
 
   final BehaviorSubject<ConnectionState> _connectionState;
   final writes = <Uint8List>[];
+  void Function(Uint8List)? notificationCallback;
   int connectCalls = 0;
   int subscribeCalls = 0;
   bool failWrites = false;
@@ -170,6 +171,7 @@ class _RecordingBleTransport extends BLETransport {
     void Function(Uint8List) callback,
   ) async {
     subscribeCalls++;
+    notificationCallback = callback;
   }
 
   @override
@@ -192,6 +194,10 @@ class _RecordingBleTransport extends BLETransport {
 
   void emitDisconnected() {
     _connectionState.add(ConnectionState.disconnected);
+  }
+
+  void emitNotification(List<int> data) {
+    notificationCallback!(Uint8List.fromList(data));
   }
 
   @override
@@ -303,6 +309,33 @@ void main() {
       await explicitTransport.dispose();
     },
   );
+
+  test('status responses require seven bytes and update battery', () async {
+    final transport = _RecordingBleTransport();
+    final scale = DecentScale(transport: transport);
+    await scale.onConnect();
+
+    for (final data in [
+      [0x03, 0x0A, 0x00, 0x00],
+      [0x03, 0x0A, 0x00, 0x00, 0x01],
+      [0x03, 0x0A, 0x00, 0x00, 0x01, 0x03],
+    ]) {
+      expect(() => transport.emitNotification(data), returnsNormally);
+    }
+
+    var snapshot = scale.currentSnapshot.first;
+    transport.emitNotification([0x03, 0xCE, 0x00, 100, 0x00, 0x00, 0x00]);
+    expect((await snapshot).batteryLevel, 100);
+
+    snapshot = scale.currentSnapshot.first;
+    transport.emitNotification([0x03, 0x0A, 0x00, 0x00, 73, 0x03, 0x1D]);
+    transport.emitNotification([0x03, 0xCE, 0x00, 100, 0x00, 0x00, 0x00]);
+
+    expect((await snapshot).batteryLevel, 73);
+
+    await scale.disconnectForHandoff();
+    await transport.dispose();
+  });
 
   test(
     'disconnect() does not leak an uncaught async error when the '

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -131,6 +131,7 @@ class _RecordingBleTransport extends BLETransport {
   int disconnectCalls = 0;
   int subscribeCalls = 0;
   bool failWrites = false;
+  int? disconnectOnWrite;
   bool failSubscriptions = false;
 
   @override
@@ -201,7 +202,8 @@ class _RecordingBleTransport extends BLETransport {
     Duration? timeout,
   }) async {
     writes.add(Uint8List.fromList(data));
-    if (failWrites) {
+    if (failWrites || writes.length == disconnectOnWrite) {
+      _nativeState = ConnectionState.disconnected;
       _connectionState.add(ConnectionState.disconnected);
       throw const DeviceNotConnectedException.scale();
     }
@@ -252,6 +254,33 @@ void main() {
     await subscription.cancel();
     await transport.dispose();
   });
+
+  test(
+    'native drop on the second initialization write never publishes connected',
+    () async {
+      final transport = _RecordingBleTransport()..disconnectOnWrite = 2;
+      final scale = DecentScale(transport: transport);
+      final states = <ConnectionState>[];
+      final subscription = scale.connectionState.listen(states.add);
+
+      await expectLater(
+        scale.onConnect(),
+        throwsA(isA<DeviceNotConnectedException>()),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(transport.writes, hasLength(2));
+      expect(
+        transport.writes.first,
+        orderedEquals([0x03, 0x0A, 0x01, 0x01, 0x00, 0x00, 0x09]),
+      );
+      expect(states, isNot(contains(ConnectionState.connected)));
+      expect(await scale.connectionState.first, ConnectionState.disconnected);
+
+      await subscription.cancel();
+      await transport.dispose();
+    },
+  );
 
   test('fresh wrapper attaches to an already-connected transport', () async {
     final transport = _RecordingBleTransport(

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -116,8 +116,14 @@ class _HangingBleTransport extends _DisconnectedBleTransport {
 }
 
 class _RecordingBleTransport extends BLETransport {
-  final BehaviorSubject<ConnectionState> _connectionState =
-      BehaviorSubject.seeded(ConnectionState.disconnected);
+  _RecordingBleTransport({
+    ConnectionState initialState = ConnectionState.disconnected,
+  }) : _connectionState = BehaviorSubject.seeded(initialState);
+
+  final BehaviorSubject<ConnectionState> _connectionState;
+  int connectCalls = 0;
+  int subscribeCalls = 0;
+  bool failWrites = false;
 
   @override
   String get id => 'recording-decent-scale';
@@ -134,6 +140,7 @@ class _RecordingBleTransport extends BLETransport {
 
   @override
   Future<void> connect() async {
+    connectCalls++;
     _connectionState.add(ConnectionState.connected);
   }
 
@@ -160,7 +167,9 @@ class _RecordingBleTransport extends BLETransport {
     String serviceUUID,
     String characteristicUUID,
     void Function(Uint8List) callback,
-  ) async {}
+  ) async {
+    subscribeCalls++;
+  }
 
   @override
   Future<void> setTransportPriority(bool prioritized) async {}
@@ -173,8 +182,10 @@ class _RecordingBleTransport extends BLETransport {
     bool withResponse = true,
     Duration? timeout,
   }) async {
-    _connectionState.add(ConnectionState.disconnected);
-    throw const DeviceNotConnectedException.scale();
+    if (failWrites) {
+      _connectionState.add(ConnectionState.disconnected);
+      throw const DeviceNotConnectedException.scale();
+    }
   }
 
   @override
@@ -185,7 +196,7 @@ class _RecordingBleTransport extends BLETransport {
 
 void main() {
   test('disconnected initialization write never publishes connected', () async {
-    final transport = _RecordingBleTransport();
+    final transport = _RecordingBleTransport()..failWrites = true;
     final scale = DecentScale(transport: transport);
     final states = <ConnectionState>[];
     final subscription = scale.connectionState.listen(states.add);
@@ -200,6 +211,22 @@ void main() {
     expect(await scale.connectionState.first, ConnectionState.disconnected);
 
     await subscription.cancel();
+    await transport.dispose();
+  });
+
+  test('fresh wrapper initializes an already-connected transport', () async {
+    final transport = _RecordingBleTransport(
+      initialState: ConnectionState.connected,
+    );
+    final scale = DecentScale(transport: transport);
+
+    await scale.onConnect();
+
+    expect(transport.connectCalls, 0);
+    expect(transport.subscribeCalls, 1);
+    expect(await scale.connectionState.first, ConnectionState.connected);
+
+    await scale.disconnectForHandoff();
     await transport.dispose();
   });
 

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// Regression coverage for four Crashlytics FATAL paths that all traced
@@ -114,7 +115,94 @@ class _HangingBleTransport extends _DisconnectedBleTransport {
   }
 }
 
+class _RecordingBleTransport extends BLETransport {
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.disconnected);
+
+  @override
+  String get id => 'recording-decent-scale';
+
+  @override
+  String get name => 'Recording Decent Scale';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  Future<ConnectionState> getConnectionState() async =>
+      _connectionState.value;
+
+  @override
+  Future<void> connect() async {
+    _connectionState.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connectionState.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<List<String>> discoverServices() async => [
+    DecentScale.serviceIdentifier.long,
+  ];
+
+  @override
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) async =>
+      Uint8List(0);
+
+  @override
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {}
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {
+    _connectionState.add(ConnectionState.disconnected);
+    throw const DeviceNotConnectedException.scale();
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _connectionState.close();
+  }
+}
+
 void main() {
+  test('disconnected initialization write never publishes connected', () async {
+    final transport = _RecordingBleTransport();
+    final scale = DecentScale(transport: transport);
+    final states = <ConnectionState>[];
+    final subscription = scale.connectionState.listen(states.add);
+
+    await expectLater(
+      scale.onConnect(),
+      throwsA(isA<DeviceNotConnectedException>()),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(states, isNot(contains(ConnectionState.connected)));
+    expect(await scale.connectionState.first, ConnectionState.disconnected);
+
+    await subscription.cancel();
+    await transport.dispose();
+  });
+
   test(
     'disconnect() does not leak an uncaught async error when the '
     'power-off write throws because the device is already disconnected',

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -248,21 +248,20 @@ void main() {
     expect(transport.connectCalls, 0);
     expect(transport.subscribeCalls, 1);
     expect(await scale.connectionState.first, ConnectionState.connected);
-    expect(_hasCommand(transport, 0x0F), isTrue);
 
     await scale.disconnectForHandoff();
     await transport.dispose();
   });
 
-  test('first connect tares once and reconnect does not tare', () async {
+  test('connection and rediscovery never apply transport-level tare', () async {
     final transport = _RecordingBleTransport();
     final scale = DecentScale(transport: transport);
 
     await scale.onConnect();
 
     expect(
-      transport.writes.where((data) => data[1] == 0x0F),
-      hasLength(1),
+      _hasCommand(transport, 0x0F),
+      isFalse,
     );
     expect(
       transport.writes


### PR DESCRIPTION
## Summary

- Problem: Decent Scale initialization and BLE teardown could report false connection state, issue destructive writes after transport loss, or miss Apple system-connected peripherals.
- Why it matters: these races can leave a scale unusable, power it off during recovery, or make quick-connect fail despite an existing native link.
- What changed: hardened Decent Scale initialization/disconnect/watchdog handling, attached Apple system-connected peripherals through the normal connect path, and pinned `universal_ble` to 2.2.3.
- What did NOT change (scope boundary): no public APIs, protocol schemas, manual scale commands, or heartbeat re-enable cadence changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes N/A
- Related #423

## Root Cause (if bug fix)

- Root cause: required Decent Scale initialization writes did not propagate a disconnected-write failure, transport-loss paths reused destructive user disconnect behavior, watchdog retries could escape as uncaught futures, and fresh Apple wrappers skipped the plugin connect call needed to install native callbacks/delegates.
- Missing detection or guardrail: initialization lacked per-write success checks plus a final native-state check, disconnect paths did not distinguish transport loss from explicit power-off, short status frames were accepted, and regression coverage did not drop the native link on the second required initialization write.
- Contributing context (if known): Apple `getSystemDevices()` returns a cached connected peripheral, but the wrapper still needs `connect()` to attach native lifecycle machinery. In `universal_ble` 2.2.3 this is idempotent and does not start a second physical connection.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/models/decent_scale_disconnect_test.dart` and `test/services/ble/universal_ble_transport_mtu_test.dart`
- Scenario the test should lock in: the first Decent Scale initialization write succeeds, the native link drops during the second required write, and `DecentScale` never publishes `connected`; Apple system-connected transports still call `connect()` to attach before service discovery without a second physical connection.
- If no new test added, why not: N/A — regression coverage was added.

## Documentation Obligations (required)

- [x] API spec updated: N/A — no REST/WebSocket changes
- [x] API docs updated: N/A — no user-facing endpoint changes
- [x] Plugin docs updated: N/A — no plugin events/API changes
- [x] Skin docs updated: N/A — no skin behavior changes
- [x] Profile docs updated: N/A — no profile handling changes
- [x] Device docs updated: `doc/DeviceManagement.md` and `doc/AI_BLE_NOTES.md`
- [ ] N/A — no docs affected

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`) No
- New or changed WebSocket topics? (`Yes/No`) No
- New or changed network calls? (`Yes/No`) No
- BLE/USB surface changed? (`Yes/No`) Yes
- File system access changed? (`Yes/No`) No
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: BLE connection lifecycle and scale command sequencing changed. Risk is false state or unintended physical-device commands; mitigation is fail-closed initialization, non-destructive transport-loss teardown, an upstream version pin, and focused mock-transport regression tests.

## User-Visible Changes

- Decent Scale no longer reports connected if its native BLE link drops during required initialization.
- Transport loss and watchdog recovery no longer send the physical power-off command; explicit disconnect still does.
- Apple quick-connect can attach to an already system-connected peripheral without opening a second physical connection.
- Connect-time heartbeat policy uses the canonical LED-on/status command without changing manual tare behavior.

## Verification

### Local gates (run before pushing)

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 2511 passed
- [x] `(cd packages/dye2-plugin && npm run build)` — N/A, no plugin files changed

### Manual verification (if applicable)

- OS / platform tested: macOS host test runner; physical iOS device
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): Yes — maintainer verified normal BLE connection on iOS
- What you personally verified and how: maintainer verified that iOS still connects normally; focused Decent Scale and BLE transport tests passed 44/44; full Flutter suite passed 2511/2511.
- Edge cases checked: first initialization write succeeds then native disconnect occurs during the second; system-connected attachment precedes service discovery; remote/watchdog teardown remains non-destructive; short status frames are ignored; watchdog retry errors are handled.
- What you did **not** verify: real macOS/Android hardware lifecycle behavior.

### Evidence

- [x] Test output (failing before + passing after) — focused 44/44 and full 2511/2511 passing; regression test exercises the previously uncovered second-write drop
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Additional checks:

- `git diff --check` — clean
- `universal_ble` remains pinned to 2.2.3 (`6ced44211ae8e284b0c095c1a3079a27706e76f7`)
- 2.2.3 also includes Android reconnect/lifecycle fixes: delayed reconnect after GATT disconnect, delayed-connect failure reporting, reconnect cooldown/cancellation, adapter-off disconnect deduplication, and connect timestamp normalization.

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Yes
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If any `No` or `Yes`, explain exact steps: no migration or operator action is required; the dependency remains pinned to the tested 2.2.3 commit.

## Risks & Mitigations

- Risk: calling `connect()` for an Apple system-connected peripheral could regress native lifecycle handling if the dependency stops treating it as idempotent.
  - Mitigation: pin `universal_ble` 2.2.3 and test that attachment occurs before service discovery without a second physical connect.
- Risk: stricter initialization may reject a scale after a transient link loss instead of publishing a false connected state.
  - Mitigation: fail closed and let the existing ConnectionManager reconnect policy retry with a fresh transport.

