### PR TITLE
Fix Decent Scale FFF4 readiness detection

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -172,6 +172,8 @@ A queue can produce only one wrapper timeout per faulted generation; followers a
 
 ## Comms-Layer Patterns
 
+An awake Decent Scale connection requires a valid FFF4 status or weight notification after subscription and a status request. Two seconds of silence triggers one immediate re-subscribe and status request; a second silent window tears down the transport without sending the physical power-off command so ConnectionManager owns the next reconnect. A deliberately sleeping reconnect only restores the subscription while remaining dark and defers the same readiness probe until wake.
+
 Three reusable idioms from the comms-harden effort:
 
 1. **Tracked-latest over `Rx.combineLatest`** — for single-writer derived state, capture each stream's latest value into a field and route everything through one `_computeStatus()` method. Avoids hidden reentrancy.

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -172,7 +172,7 @@ A queue can produce only one wrapper timeout per faulted generation; followers a
 
 ## Comms-Layer Patterns
 
-An awake Decent Scale connection requires a valid FFF4 status or weight notification after subscription and a status request. Two seconds of silence triggers one immediate re-subscribe and status request; a second silent window tears down the transport without sending the physical power-off command so ConnectionManager owns the next reconnect. A deliberately sleeping reconnect only restores the subscription while remaining dark and defers the same readiness probe until wake.
+An awake Decent Scale connection requires a recognised FFF4 status or weight frame after subscription and a status request. Two seconds of silence triggers one immediate re-subscribe and status request; a second silent window tears down the transport without sending the physical power-off command so ConnectionManager owns the next reconnect. A deliberately sleeping reconnect only restores the subscription while remaining dark and defers the same readiness probe until wake.
 
 Three reusable idioms from the comms-harden effort:
 

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -585,6 +585,8 @@ Future<void> connectToDe1(De1Interface de1Interface) async {
 
 **Note:** ScaleController does **not** auto-connect. Connection decisions are made by `ConnectionManager`. ScaleController only handles the mechanics of connecting to a specific scale.
 
+Device implementations define their own readiness gate before `ScaleController` adopts them. Acaia requires its first structurally valid weight frame. An awake Decent Scale connection requires a valid FFF4 status or weight notification, retrying the subscription and status probe once after two seconds. A deliberately sleeping reconnect restores the subscription while remaining dark and defers readiness verification until wake. Successful GATT setup or arbitrary notifications alone are not connected readiness. A mute transport is torn down without powering off the scale, and normal ConnectionManager recovery remains responsible for retrying.
+
 **Connection Flow:**
 ```dart
 Future<void> connectToScale(Scale scale) async {

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -585,7 +585,7 @@ Future<void> connectToDe1(De1Interface de1Interface) async {
 
 **Note:** ScaleController does **not** auto-connect. Connection decisions are made by `ConnectionManager`. ScaleController only handles the mechanics of connecting to a specific scale.
 
-Device implementations define their own readiness gate before `ScaleController` adopts them. Acaia requires its first structurally valid weight frame. An awake Decent Scale connection requires a valid FFF4 status or weight notification, retrying the subscription and status probe once after two seconds. A deliberately sleeping reconnect restores the subscription while remaining dark and defers readiness verification until wake. Successful GATT setup or arbitrary notifications alone are not connected readiness. A mute transport is torn down without powering off the scale, and normal ConnectionManager recovery remains responsible for retrying.
+Device implementations define their own readiness gate before `ScaleController` adopts them. Acaia requires its first structurally valid weight frame. An awake Decent Scale connection requires a recognised FFF4 status or weight frame, retrying the subscription and status probe once after two seconds. A deliberately sleeping reconnect restores the subscription while remaining dark and defers readiness verification until wake. Successful GATT setup or arbitrary notifications alone are not connected readiness. A mute transport is torn down without powering off the scale, and normal ConnectionManager recovery remains responsible for retrying.
 
 **Connection Flow:**
 ```dart

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -249,7 +249,15 @@ class DecentScale implements Scale, TransportHandoffScale {
     _initializationNotification = firstNotification;
     try {
       for (var attempt = 0; attempt < 2; attempt++) {
-        await _registerNotifications();
+        if (attempt == 0) {
+          await _registerNotifications();
+        } else {
+          await _device.resetSubscription(
+            serviceIdentifier.long,
+            dataCharacteristic.long,
+            _parseNotification,
+          );
+        }
         if (!current()) return false;
         final requestSent = await _sendOledOn(isCurrent: current);
         if (!current()) return false;
@@ -261,7 +269,10 @@ class DecentScale implements Scale, TransportHandoffScale {
           return current();
         } on TimeoutException {
           if (!current()) return false;
-          if (attempt == 1) rethrow;
+          if (attempt == 1) {
+            await _readSilentDataChannelDiagnostic();
+            rethrow;
+          }
         }
       }
       return false;
@@ -269,6 +280,22 @@ class DecentScale implements Scale, TransportHandoffScale {
       if (identical(_initializationNotification, firstNotification)) {
         _initializationNotification = null;
       }
+    }
+  }
+
+  Future<void> _readSilentDataChannelDiagnostic() async {
+    try {
+      final data = await _device.read(
+        serviceIdentifier.long,
+        dataCharacteristic.long,
+        timeout: const Duration(seconds: 1),
+      );
+      _log.warning(
+        'Silent FFF4 diagnostic read returned ${data.length} bytes '
+        '(${_dataFrameType(data) ?? 'invalid'})',
+      );
+    } catch (error, stackTrace) {
+      _log.warning('Silent FFF4 diagnostic read failed', error, stackTrace);
     }
   }
 
@@ -508,16 +535,9 @@ class DecentScale implements Scale, TransportHandoffScale {
   }
 
   void _parseNotification(List<int> data) {
-    if (data.length >= 2 && data[0] == 0x03) {
-      final command = data[1];
-      final weightFrame =
-          (command == 0xCE || command == 0xCA) &&
-          _weightFrameLengths.contains(data.length);
-      final statusFrame = command == 0x0A && data.length == 7;
-      if ((weightFrame || statusFrame) &&
-          !(_initializationNotification?.isCompleted ?? true)) {
-        _initializationNotification!.complete();
-      }
+    if (_dataFrameType(data) != null &&
+        !(_initializationNotification?.isCompleted ?? true)) {
+      _initializationNotification!.complete();
     }
     _ticksSinceLastNotification = 0;
     _watchdogRetryAttempted = false;
@@ -536,6 +556,17 @@ class DecentScale implements Scale, TransportHandoffScale {
           _parseStatusResponse(data);
         }
     }
+  }
+
+  static String? _dataFrameType(List<int> data) {
+    if (data.length < 2 || data[0] != 0x03) return null;
+    final command = data[1];
+    if ((command == 0xCE || command == 0xCA) &&
+        _weightFrameLengths.contains(data.length)) {
+      return 'weight';
+    }
+    if (command == 0x0A && data.length == 7) return 'status';
+    return null;
   }
 
   void _parseWeight(List<int> data) {

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -153,7 +153,18 @@ class DecentScale implements Scale, TransportHandoffScale {
           .where((state) => state == ConnectionState.disconnected)
           .listen((_) {
             _log.info("Transport disconnected");
-            unawaited(_disconnect(powerOff: false));
+            unawaited(
+              _disconnect(powerOff: false).catchError((
+                Object error,
+                StackTrace stackTrace,
+              ) {
+                _log.severe(
+                  'Failed to tear down disconnected scale transport',
+                  error,
+                  stackTrace,
+                );
+              }),
+            );
           });
 
       final services = await _device.discoverServices();
@@ -229,17 +240,25 @@ class DecentScale implements Scale, TransportHandoffScale {
         throw const DeviceNotConnectedException.scale();
       }
       _connectionStateController.add(ConnectionState.connected);
-    } catch (e) {
+    } catch (e, stackTrace) {
       _log.warning('Failed to initialize scale: $e');
-      subscription?.cancel();
+      await subscription?.cancel();
+      subscription = null;
       _heartbeatTimer?.cancel();
       _heartbeatTimer = null;
       _notificationWatchdog?.cancel();
-      _connectionStateController.add(ConnectionState.disconnected);
       try {
         await _device.disconnect();
-      } catch (_) {}
-      rethrow;
+      } catch (disconnectError, disconnectStackTrace) {
+        _log.severe(
+          'Failed to tear down scale transport',
+          disconnectError,
+          disconnectStackTrace,
+        );
+        Error.throwWithStackTrace(disconnectError, disconnectStackTrace);
+      }
+      _connectionStateController.add(ConnectionState.disconnected);
+      Error.throwWithStackTrace(e, stackTrace);
     }
   }
 
@@ -344,8 +363,8 @@ class DecentScale implements Scale, TransportHandoffScale {
     // so no extra try/catch needed here.
     try {
       await _device.disconnect();
-    } finally {
       _connectionStateController.add(ConnectionState.disconnected);
+    } finally {
       _isDisconnecting = false;
     }
   }

--- a/lib/src/models/device/impl/decent_scale/scale.dart
+++ b/lib/src/models/device/impl/decent_scale/scale.dart
@@ -22,6 +22,8 @@ class DecentScale implements Scale, TransportHandoffScale {
       BleServiceIdentifier.short('36f5');
 
   static final bool isUsingHeartBeat = false;
+  static const _initializationProbeTimeout = Duration(seconds: 2);
+  static const _weightFrameLengths = {7, 10};
 
   final String _deviceId;
 
@@ -49,7 +51,11 @@ class DecentScale implements Scale, TransportHandoffScale {
   // dropping (GATT busy-window, Android radio starvation, etc).
   // Resets on every notification (_parseNotification).
   Timer? _notificationWatchdog;
+  Future<void>? _displayOperation;
+  Completer<void>? _initializationNotification;
   static const Duration _notificationWatchdogTimeout = Duration(seconds: 5);
+  int _displayGeneration = 0;
+  bool _desiredDisplaySleeping = false;
 
   DecentScale({required BLETransport transport})
     : _deviceId = transport.id,
@@ -157,7 +163,11 @@ class DecentScale implements Scale, TransportHandoffScale {
           'Discovered services: $services',
         );
       }
-      await _registerNotifications();
+      if (_isSleeping) {
+        await _registerNotifications();
+      } else {
+        await _confirmDataChannel();
+      }
       _heartbeatTimer?.cancel();
       _notificationWatchdog?.cancel();
       _ticksSinceLastNotification = 0;
@@ -215,9 +225,6 @@ class DecentScale implements Scale, TransportHandoffScale {
       if (isUsingHeartBeat && !await _sendHeartBeat()) {
         throw const DeviceNotConnectedException.scale();
       }
-      if (!_isSleeping && !await _sendOledOn()) {
-        throw const DeviceNotConnectedException.scale();
-      }
       if (await _device.getConnectionState() != ConnectionState.connected) {
         throw const DeviceNotConnectedException.scale();
       }
@@ -233,6 +240,35 @@ class DecentScale implements Scale, TransportHandoffScale {
         await _device.disconnect();
       } catch (_) {}
       rethrow;
+    }
+  }
+
+  Future<bool> _confirmDataChannel({bool Function()? isCurrent}) async {
+    bool current() => isCurrent?.call() ?? true;
+    final firstNotification = Completer<void>();
+    _initializationNotification = firstNotification;
+    try {
+      for (var attempt = 0; attempt < 2; attempt++) {
+        await _registerNotifications();
+        if (!current()) return false;
+        final requestSent = await _sendOledOn(isCurrent: current);
+        if (!current()) return false;
+        if (!requestSent) {
+          throw const DeviceNotConnectedException.scale();
+        }
+        try {
+          await firstNotification.future.timeout(_initializationProbeTimeout);
+          return current();
+        } on TimeoutException {
+          if (!current()) return false;
+          if (attempt == 1) rethrow;
+        }
+      }
+      return false;
+    } finally {
+      if (identical(_initializationNotification, firstNotification)) {
+        _initializationNotification = null;
+      }
     }
   }
 
@@ -258,7 +294,9 @@ class DecentScale implements Scale, TransportHandoffScale {
       "disconnecting (notifications=$_totalNotifications, "
       "uptime=${uptimeSec}s, powerOff=$powerOff)",
     );
-    subscription?.cancel();
+    final activeSubscription = subscription;
+    subscription = null;
+    activeSubscription?.cancel();
     _heartbeatTimer?.cancel();
     _heartbeatTimer = null;
     _notificationWatchdog?.cancel();
@@ -325,12 +363,14 @@ class DecentScale implements Scale, TransportHandoffScale {
     return _writeCommand([0x0A, 0x01, 0x01, 0x00, heartbeatByte]);
   }
 
-  Future<bool> _sendOledOn() async {
+  Future<bool> _sendOledOn({bool Function()? isCurrent}) async {
+    if (isCurrent?.call() == false) return false;
     final heartbeatByte = isUsingHeartBeat ? 0x01 : 0x00;
     if (!await _requestBatteryData()) {
       return false;
     }
     await Future.delayed(Duration(milliseconds: 100));
+    if (isCurrent?.call() == false) return false;
     return _writeCommand([0x0A, 0x04, 0x00, 0x00, heartbeatByte]);
   }
 
@@ -341,10 +381,11 @@ class DecentScale implements Scale, TransportHandoffScale {
   }
 
   bool _isSleeping = false;
-  bool _wakeInFlight = false;
 
   @override
   Future<void> sleepDisplay() async {
+    _desiredDisplaySleeping = true;
+    _displayGeneration++;
     _isSleeping = true;
     _notificationWatchdog?.cancel();
     _log.info('Putting Decent Scale display to sleep');
@@ -363,18 +404,37 @@ class DecentScale implements Scale, TransportHandoffScale {
   }
 
   @override
-  Future<void> wakeDisplay() async {
-    _isSleeping = false;
-    _ticksSinceLastNotification = 0;
-    _watchdogRetryAttempted = false;
-    _notificationWatchdog?.cancel();
-    if (_wakeInFlight) return;
-    _wakeInFlight = true;
-    _log.info('Waking Decent Scale display');
+  Future<void> wakeDisplay() {
+    _desiredDisplaySleeping = false;
+    _displayGeneration++;
+    return _displayOperation ??= _runWakeDisplay();
+  }
+
+  Future<void> _runWakeDisplay() async {
     try {
-      await _sendOledOn();
+      while (!_desiredDisplaySleeping) {
+        final generation = _displayGeneration;
+        _isSleeping = false;
+        _notificationWatchdog?.cancel();
+        try {
+          final confirmed = await _confirmDataChannel(
+            isCurrent: () =>
+                generation == _displayGeneration && !_desiredDisplaySleeping,
+          );
+          if (!confirmed) continue;
+          _ticksSinceLastNotification = 0;
+          _watchdogRetryAttempted = false;
+          _resetNotificationWatchdog();
+          return;
+        } catch (_) {
+          if (generation == _displayGeneration && !_desiredDisplaySleeping) {
+            await _disconnect(powerOff: false);
+            rethrow;
+          }
+        }
+      }
     } finally {
-      _wakeInFlight = false;
+      _displayOperation = null;
     }
   }
 
@@ -448,6 +508,17 @@ class DecentScale implements Scale, TransportHandoffScale {
   }
 
   void _parseNotification(List<int> data) {
+    if (data.length >= 2 && data[0] == 0x03) {
+      final command = data[1];
+      final weightFrame =
+          (command == 0xCE || command == 0xCA) &&
+          _weightFrameLengths.contains(data.length);
+      final statusFrame = command == 0x0A && data.length == 7;
+      if ((weightFrame || statusFrame) &&
+          !(_initializationNotification?.isCompleted ?? true)) {
+        _initializationNotification!.complete();
+      }
+    }
     _ticksSinceLastNotification = 0;
     _watchdogRetryAttempted = false;
     _totalNotifications++;

--- a/lib/src/models/device/transport/ble_transport.dart
+++ b/lib/src/models/device/transport/ble_transport.dart
@@ -21,6 +21,12 @@ abstract class BLETransport extends DataTransport {
     void Function(Uint8List) callback,
   );
 
+  Future<void> resetSubscription(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) => subscribe(serviceUUID, characteristicUUID, callback);
+
   Future<Uint8List> read(
     String serviceUUID,
     String characteristicUUID, {

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -36,6 +36,7 @@ class UniversalBleTransport extends BLETransport {
   bool _linkDeadDeclared = false;
   int _connectionGeneration = 0;
   int? _recoveringQueueGeneration;
+  Future<void>? _nativeDisconnectOperation;
   DateTime? _lastAdvertProbe;
   StreamSubscription<BleDevice>? _advertSub;
 
@@ -110,8 +111,13 @@ class UniversalBleTransport extends BLETransport {
 
   @override
   Future<void> connect() async {
+    if (UniversalBle.getQueueDiagnostics(_device.deviceId).state ==
+        QueueDiagnosticsState.faulted) {
+      throw StateError(
+        'BLE queue recovery is still pending for ${_device.deviceId}',
+      );
+    }
     _connectionGeneration++;
-    _recoveringQueueGeneration = null;
     _linkDeadDeclared = false;
     _lastAdvertProbe = null;
     // Use connectionUpdateStream (from our universal_ble fork) to get
@@ -123,6 +129,7 @@ class UniversalBleTransport extends BLETransport {
           if (update.isConnected) {
             _connectionStateSubject.add(device.ConnectionState.connected);
           } else {
+            _recoveringQueueGeneration = null;
             final reason = update.error ?? 'unknown';
             _log.warning('Transport disconnected: $reason');
             _connectionStateSubject.add(device.ConnectionState.disconnected);
@@ -311,7 +318,6 @@ class UniversalBleTransport extends BLETransport {
   @override
   Future<void> disconnect() async {
     _connectionGeneration++;
-    _recoveringQueueGeneration = null;
     await _advertSub?.cancel();
     _advertSub = null;
 
@@ -331,17 +337,35 @@ class UniversalBleTransport extends BLETransport {
 
     try {
       _log.fine("disconnect");
-      await UniversalBle.disconnect(
-        _device.deviceId,
-        timeout: const Duration(seconds: 5),
-      );
+      await _disconnectNative();
     } catch (error, stackTrace) {
       _log.warning("failed to disconnect", error, stackTrace);
+      if (UniversalBle.getQueueDiagnostics(_device.deviceId).state ==
+          QueueDiagnosticsState.faulted) {
+        rethrow;
+      }
       _connectionStateSubject.add(device.ConnectionState.disconnected);
     } finally {
       await _connectionStateSubscription?.cancel();
       _connectionStateSubscription = null;
     }
+  }
+
+  Future<void> _disconnectNative() {
+    final active = _nativeDisconnectOperation;
+    if (active != null) return active;
+    late final Future<void> operation;
+    operation =
+        UniversalBle.disconnect(
+          _device.deviceId,
+          timeout: _faultRecoveryDisconnectTimeout,
+        ).whenComplete(() {
+          if (identical(_nativeDisconnectOperation, operation)) {
+            _nativeDisconnectOperation = null;
+          }
+        });
+    _nativeDisconnectOperation = operation;
+    return operation;
   }
 
   @override
@@ -441,24 +465,24 @@ class UniversalBleTransport extends BLETransport {
 
   Future<void> _recoverFaultedQueue(int generation, String context) async {
     final deadline = DateTime.now().add(_faultRecoveryGrace);
+    var disconnectAttempted = false;
     try {
-      while (generation == _connectionGeneration && !_linkDeadDeclared) {
+      while (true) {
+        if (_recoveringQueueGeneration != generation) return;
         final diagnostics = UniversalBle.getQueueDiagnostics(_device.deviceId);
         if (diagnostics.state != QueueDiagnosticsState.faulted) return;
         if (diagnostics.activeOperations == 0) {
           _clearQueue(UniversalBleErrorCode.operationCancelled);
           return;
         }
-        if (!DateTime.now().isBefore(deadline)) {
+        if (!disconnectAttempted && !DateTime.now().isBefore(deadline)) {
+          disconnectAttempted = true;
           _log.warning(
             '$context native operation remained unresolved for '
             '${_faultRecoveryGrace.inMilliseconds}ms — disconnecting',
           );
           try {
-            await UniversalBle.disconnect(
-              _device.deviceId,
-              timeout: _faultRecoveryDisconnectTimeout,
-            );
+            await _disconnectNative();
           } catch (error, stackTrace) {
             _log.warning(
               'Failed to disconnect unresolved BLE link',
@@ -466,7 +490,6 @@ class UniversalBleTransport extends BLETransport {
               stackTrace,
             );
           }
-          return;
         }
         await Future<void>.delayed(_faultRecoveryPollInterval);
       }
@@ -548,6 +571,7 @@ class UniversalBleTransport extends BLETransport {
   void _declareLinkDead(String reason) {
     if (_linkDeadDeclared) return;
     _linkDeadDeclared = true;
+    _recoveringQueueGeneration = null;
     _log.warning('Declaring BLE link dead: $reason');
     _advertSub?.cancel();
     _advertSub = null;
@@ -616,6 +640,12 @@ class UniversalBleTransport extends BLETransport {
         characteristicUUID,
         timeout: const Duration(seconds: 2),
       );
+    } on TimeoutException {
+      _onOperationTimeout(
+        'reset subscription',
+        '$serviceUUID/$characteristicUUID',
+      );
+      rethrow;
     } on UniversalBleException catch (e) {
       _handleGattError(
         e,
@@ -678,7 +708,6 @@ class UniversalBleTransport extends BLETransport {
   @override
   Future<void> dispose() async {
     _connectionGeneration++;
-    _recoveringQueueGeneration = null;
     _advertSub?.cancel();
     _advertSub = null;
     _connectionStateSubscription?.cancel();

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -11,7 +11,7 @@ import 'package:reaprime/src/services/ble/ble_exception_mapper.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:universal_ble/universal_ble.dart';
 
-class UniversalBleTransport implements BLETransport {
+class UniversalBleTransport extends BLETransport {
   final BleDevice _device;
 
   late Logger _log;
@@ -41,6 +41,7 @@ class UniversalBleTransport implements BLETransport {
 
   static const Duration _linkProbeTimeout = Duration(seconds: 2);
   static const Duration _faultRecoveryPollInterval = Duration(milliseconds: 50);
+  static const Duration _notificationResetSettle = Duration(milliseconds: 100);
 
   /// Minimum spacing between advert-triggered OS probes. A disconnected
   /// peripheral advertises ~1/s during a scan; one probe per window is
@@ -441,10 +442,18 @@ class UniversalBleTransport implements BLETransport {
             '$context native operation remained unresolved for '
             '${_faultRecoveryGrace.inMilliseconds}ms — disconnecting',
           );
-          await UniversalBle.disconnect(
-            _device.deviceId,
-            timeout: _faultRecoveryDisconnectTimeout,
-          );
+          try {
+            await UniversalBle.disconnect(
+              _device.deviceId,
+              timeout: _faultRecoveryDisconnectTimeout,
+            );
+          } catch (error, stackTrace) {
+            _log.warning(
+              'Failed to disconnect unresolved BLE link',
+              error,
+              stackTrace,
+            );
+          }
           return;
         }
         await Future<void>.delayed(_faultRecoveryPollInterval);
@@ -565,6 +574,42 @@ class UniversalBleTransport implements BLETransport {
       );
     } on UniversalBleException catch (e) {
       _handleGattError(e, 'subscribe', '$serviceUUID/$characteristicUUID');
+    }
+  }
+
+  @override
+  Future<void> resetSubscription(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {
+    final key = "$serviceUUID--$characteristicUUID";
+    if (!_subscriptions.containsKey(key)) {
+      _subscriptions[key] = UniversalBle.characteristicValueStream(
+        _device.deviceId,
+        characteristicUUID,
+      ).listen(callback);
+    }
+    try {
+      await UniversalBle.unsubscribe(
+        _device.deviceId,
+        serviceUUID,
+        characteristicUUID,
+        timeout: const Duration(seconds: 2),
+      );
+      await Future<void>.delayed(_notificationResetSettle);
+      await UniversalBle.subscribeNotifications(
+        _device.deviceId,
+        serviceUUID,
+        characteristicUUID,
+        timeout: const Duration(seconds: 2),
+      );
+    } on UniversalBleException catch (e) {
+      _handleGattError(
+        e,
+        'reset subscription',
+        '$serviceUUID/$characteristicUUID',
+      );
     }
   }
 

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -312,24 +312,36 @@ class UniversalBleTransport extends BLETransport {
   Future<void> disconnect() async {
     _connectionGeneration++;
     _recoveringQueueGeneration = null;
-    _advertSub?.cancel();
+    await _advertSub?.cancel();
     _advertSub = null;
+
+    final listeners = _subscriptions.values.toList(growable: false);
+    _subscriptions.clear();
+    for (final listener in listeners) {
+      try {
+        await listener.cancel();
+      } catch (error, stackTrace) {
+        _log.warning(
+          'Failed to cancel BLE notification listener',
+          error,
+          stackTrace,
+        );
+      }
+    }
+
     try {
       _log.fine("disconnect");
-      for (var sub in _subscriptions.keys) {
-        final split = sub.split('--');
-        UniversalBle.unsubscribe(_device.deviceId, split[0], split[1]);
-        _subscriptions[sub]?.cancel();
-      }
       await UniversalBle.disconnect(
         _device.deviceId,
-        timeout: Duration(seconds: 5),
+        timeout: const Duration(seconds: 5),
       );
-    } catch (e) {
-      _log.warning("failed to disconnect", e);
+    } catch (error, stackTrace) {
+      _log.warning("failed to disconnect", error, stackTrace);
       _connectionStateSubject.add(device.ConnectionState.disconnected);
+    } finally {
+      await _connectionStateSubscription?.cancel();
+      _connectionStateSubscription = null;
     }
-    _connectionStateSubscription?.cancel();
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1706,11 +1706,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2.2.3"
-      resolved-ref: "6ced44211ae8e284b0c095c1a3079a27706e76f7"
+      ref: "2.2.4"
+      resolved-ref: "68dc6ea1c26df08e47c35aa142ffc0db646657ef"
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
-    version: "2.2.3"
+    version: "2.2.4"
   universal_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   universal_ble:
     git:
       url: https://github.com/tadelv/universal_ble.git
-      ref: 2.2.3
+      ref: 2.2.4
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/test/difluid_r2_sensor_test.dart
+++ b/test/difluid_r2_sensor_test.dart
@@ -17,7 +17,7 @@ typedef _WriteRecord = ({
   bool withResponse,
 });
 
-class _FakeR2Transport implements BLETransport {
+class _FakeR2Transport extends BLETransport {
   final BehaviorSubject<ConnectionState> _states = BehaviorSubject.seeded(
     ConnectionState.discovered,
   );

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -129,11 +129,14 @@ class _RecordingBleTransport extends BLETransport {
   int nativeConnectCalls = 0;
   int disconnectCalls = 0;
   int subscribeCalls = 0;
+  int resetSubscriptionCalls = 0;
+  int readCalls = 0;
   int respondedSubscribeCall = 0;
   bool failWrites = false;
   int? disconnectOnWrite;
   bool failSubscriptions = false;
   final List<int> responseSubscribeCalls;
+  Uint8List diagnosticRead = Uint8List(0);
 
   @override
   String get id => 'recording-decent-scale';
@@ -174,7 +177,10 @@ class _RecordingBleTransport extends BLETransport {
     String serviceUUID,
     String characteristicUUID, {
     Duration? timeout,
-  }) async => Uint8List(0);
+  }) async {
+    readCalls++;
+    return diagnosticRead;
+  }
 
   @override
   Future<void> subscribe(
@@ -187,6 +193,16 @@ class _RecordingBleTransport extends BLETransport {
       throw StateError('subscription failed');
     }
     notificationCallback = callback;
+  }
+
+  @override
+  Future<void> resetSubscription(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {
+    resetSubscriptionCalls++;
+    await subscribe(serviceUUID, characteristicUUID, callback);
   }
 
   @override
@@ -300,6 +316,7 @@ void main() {
       _elapse(async, const Duration(milliseconds: 100));
 
       expect(transport.subscribeCalls, 2);
+      expect(transport.resetSubscriptionCalls, 1);
       expect(completed, isTrue);
       expect(states.last, ConnectionState.connected);
       scale.disconnectForHandoff();
@@ -311,9 +328,8 @@ void main() {
   test(
     'silent FFF4 initialization fails without publishing connected',
     () async {
-      final transport = _RecordingBleTransport(
-        responseSubscribeCalls: const [],
-      );
+      final transport = _RecordingBleTransport(responseSubscribeCalls: const [])
+        ..diagnosticRead = Uint8List.fromList([0x03, 0x0A, 0, 0, 100, 0, 0]);
       final scale = DecentScale(transport: transport);
       final states = <ConnectionState>[];
       scale.connectionState.listen(states.add);
@@ -324,6 +340,8 @@ void main() {
       await expectLater(connection, throwsA(isA<TimeoutException>()));
 
       expect(transport.subscribeCalls, 2);
+      expect(transport.resetSubscriptionCalls, 1);
+      expect(transport.readCalls, 1);
       expect(states, isNot(contains(ConnectionState.connected)));
       expect(states.last, ConnectionState.disconnected);
       expect(_hasCommand(transport, 0x0A, 0x02), isFalse);

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -133,6 +133,7 @@ class _RecordingBleTransport extends BLETransport {
   int readCalls = 0;
   int respondedSubscribeCall = 0;
   bool failWrites = false;
+  bool failDisconnect = false;
   int? disconnectOnWrite;
   bool failSubscriptions = false;
   final List<int> responseSubscribeCalls;
@@ -163,6 +164,7 @@ class _RecordingBleTransport extends BLETransport {
   @override
   Future<void> disconnect() async {
     disconnectCalls++;
+    if (failDisconnect) throw StateError('unsafe teardown');
     _nativeState = ConnectionState.disconnected;
     _connectionState.add(ConnectionState.disconnected);
   }
@@ -338,6 +340,7 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 150));
       transport.emitNotification([0x03, 0x0A, 0, 0, 100, 0]);
       await expectLater(connection, throwsA(isA<TimeoutException>()));
+      await Future<void>.delayed(Duration.zero);
 
       expect(transport.subscribeCalls, 2);
       expect(transport.resetSubscriptionCalls, 1);
@@ -477,6 +480,26 @@ void main() {
     await subscription.cancel();
     await transport.dispose();
   });
+
+  test(
+    'failed initialization teardown does not publish disconnected',
+    () async {
+      final transport = _RecordingBleTransport()
+        ..failWrites = true
+        ..failDisconnect = true;
+      final scale = DecentScale(transport: transport);
+      final states = <ConnectionState>[];
+      final subscription = scale.connectionState.listen(states.add);
+
+      await expectLater(scale.onConnect(), throwsA(isA<StateError>()));
+
+      expect(states, isNot(contains(ConnectionState.connected)));
+      expect(states, isNot(contains(ConnectionState.disconnected)));
+
+      await subscription.cancel();
+      await transport.dispose();
+    },
+  );
 
   test(
     'native drop on the second initialization write never publishes connected',

--- a/test/unit/models/decent_scale_disconnect_test.dart
+++ b/test/unit/models/decent_scale_disconnect_test.dart
@@ -117,6 +117,7 @@ class _HangingBleTransport extends _DisconnectedBleTransport {
 class _RecordingBleTransport extends BLETransport {
   _RecordingBleTransport({
     ConnectionState nativeState = ConnectionState.disconnected,
+    this.responseSubscribeCalls = const [1],
   }) : _nativeState = nativeState;
 
   final BehaviorSubject<ConnectionState> _connectionState =
@@ -128,9 +129,11 @@ class _RecordingBleTransport extends BLETransport {
   int nativeConnectCalls = 0;
   int disconnectCalls = 0;
   int subscribeCalls = 0;
+  int respondedSubscribeCall = 0;
   bool failWrites = false;
   int? disconnectOnWrite;
   bool failSubscriptions = false;
+  final List<int> responseSubscribeCalls;
 
   @override
   String get id => 'recording-decent-scale';
@@ -203,6 +206,14 @@ class _RecordingBleTransport extends BLETransport {
       _connectionState.add(ConnectionState.disconnected);
       throw const DeviceNotConnectedException.scale();
     }
+    if (data.length == 7 &&
+        data[1] == 0x0A &&
+        data[2] == 0x01 &&
+        responseSubscribeCalls.contains(subscribeCalls) &&
+        respondedSubscribeCall < subscribeCalls) {
+      respondedSubscribeCall = subscribeCalls;
+      scheduleMicrotask(() => emitNotification([0x03, 0x0A, 0, 0, 100, 0, 0]));
+    }
   }
 
   void emitDisconnected() {
@@ -231,7 +242,205 @@ bool _hasCommand(
       (subcommand == null || data[2] == subcommand),
 );
 
+void _elapse(FakeAsync async, Duration duration) {
+  async.elapse(duration);
+  async.flushMicrotasks();
+}
+
+({DecentScale scale, _RecordingBleTransport transport}) _sleepingReconnect(
+  FakeAsync async, {
+  required List<int> responseSubscribeCalls,
+}) {
+  final transport = _RecordingBleTransport(
+    responseSubscribeCalls: responseSubscribeCalls,
+  );
+  final scale = DecentScale(transport: transport);
+  var connected = false;
+  scale.onConnect().then((_) => connected = true);
+  async.flushMicrotasks();
+  _elapse(async, const Duration(milliseconds: 100));
+  expect(connected, isTrue);
+  var slept = false;
+  scale.sleepDisplay().then((_) => slept = true);
+  async.flushMicrotasks();
+  _elapse(async, const Duration(milliseconds: 100));
+  expect(slept, isTrue);
+  var disconnected = false;
+  scale.disconnectForHandoff().then((_) => disconnected = true);
+  async.flushMicrotasks();
+  expect(disconnected, isTrue);
+  transport.writes.clear();
+  var reconnected = false;
+  scale.onConnect().then((_) => reconnected = true);
+  async.flushMicrotasks();
+  expect(reconnected, isTrue);
+  expect(transport.writes, isEmpty);
+  transport.disconnectCalls = 0;
+  return (scale: scale, transport: transport);
+}
+
 void main() {
+  test('initialization retries FFF4 once before publishing connected', () {
+    fakeAsync((async) {
+      final transport = _RecordingBleTransport(
+        responseSubscribeCalls: const [2],
+      );
+      final scale = DecentScale(transport: transport);
+      final states = <ConnectionState>[];
+      scale.connectionState.listen(states.add);
+      var completed = false;
+      scale.onConnect().then((_) => completed = true);
+
+      async.flushMicrotasks();
+      _elapse(async, const Duration(milliseconds: 100));
+      expect(transport.subscribeCalls, 1);
+      expect(states, isNot(contains(ConnectionState.connected)));
+
+      _elapse(async, const Duration(seconds: 2));
+      _elapse(async, const Duration(milliseconds: 100));
+
+      expect(transport.subscribeCalls, 2);
+      expect(completed, isTrue);
+      expect(states.last, ConnectionState.connected);
+      scale.disconnectForHandoff();
+      async.flushMicrotasks();
+      transport.dispose();
+    });
+  });
+
+  test(
+    'silent FFF4 initialization fails without publishing connected',
+    () async {
+      final transport = _RecordingBleTransport(
+        responseSubscribeCalls: const [],
+      );
+      final scale = DecentScale(transport: transport);
+      final states = <ConnectionState>[];
+      scale.connectionState.listen(states.add);
+
+      final connection = scale.onConnect();
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      transport.emitNotification([0x03, 0x0A, 0, 0, 100, 0]);
+      await expectLater(connection, throwsA(isA<TimeoutException>()));
+
+      expect(transport.subscribeCalls, 2);
+      expect(states, isNot(contains(ConnectionState.connected)));
+      expect(states.last, ConnectionState.disconnected);
+      expect(_hasCommand(transport, 0x0A, 0x02), isFalse);
+      await transport.dispose();
+    },
+    timeout: const Timeout(Duration(seconds: 10)),
+  );
+
+  test('sleeping reconnect stays dark and verifies FFF4 on wake', () {
+    fakeAsync((async) {
+      final (:scale, :transport) = _sleepingReconnect(
+        async,
+        responseSubscribeCalls: const [1, 4],
+      );
+      expect(transport.subscribeCalls, 2);
+
+      var woke = false;
+      scale.wakeDisplay().then((_) => woke = true);
+      async.flushMicrotasks();
+      _elapse(async, const Duration(milliseconds: 100));
+      expect(woke, isFalse);
+      expect(transport.subscribeCalls, 3);
+
+      _elapse(async, const Duration(seconds: 2));
+      _elapse(async, const Duration(milliseconds: 100));
+
+      expect(woke, isTrue);
+      expect(transport.subscribeCalls, 4);
+      expect(_hasCommand(transport, 0x0A, 0x01), isTrue);
+      expect(_hasCommand(transport, 0x0A, 0x04), isTrue);
+      scale.disconnectForHandoff();
+      async.flushMicrotasks();
+      transport.dispose();
+    });
+  });
+
+  test('sleep supersedes a silent wake before its retry', () {
+    fakeAsync((async) {
+      final (:scale, :transport) = _sleepingReconnect(
+        async,
+        responseSubscribeCalls: const [1],
+      );
+      var woke = false;
+      scale.wakeDisplay().then((_) => woke = true);
+      async.flushMicrotasks();
+      _elapse(async, const Duration(milliseconds: 100));
+
+      scale.sleepDisplay();
+      async.flushMicrotasks();
+      _elapse(async, const Duration(milliseconds: 100));
+      final writesAfterSleep = List<Uint8List>.of(transport.writes);
+
+      _elapse(async, const Duration(seconds: 3));
+
+      expect(woke, isTrue);
+      expect(transport.subscribeCalls, 3);
+      expect(transport.writes, orderedEquals(writesAfterSleep));
+      scale.disconnectForHandoff();
+      async.flushMicrotasks();
+      transport.dispose();
+    });
+  });
+
+  test('latest wake runs after a superseded wake probe', () {
+    fakeAsync((async) {
+      final (:scale, :transport) = _sleepingReconnect(
+        async,
+        responseSubscribeCalls: const [1, 4],
+      );
+      var firstWoke = false;
+      var secondWoke = false;
+      scale.wakeDisplay().then((_) => firstWoke = true);
+      async.flushMicrotasks();
+      _elapse(async, const Duration(milliseconds: 100));
+
+      scale.sleepDisplay();
+      async.flushMicrotasks();
+      scale.wakeDisplay().then((_) => secondWoke = true);
+      async.flushMicrotasks();
+      expect(secondWoke, isFalse);
+      _elapse(async, const Duration(seconds: 2));
+      expect(transport.subscribeCalls, 4);
+      _elapse(async, const Duration(milliseconds: 100));
+
+      expect(firstWoke, isTrue);
+      expect(secondWoke, isTrue);
+      expect(transport.writes.last[2], 0x04);
+      expect(transport.writes.last[3], 0);
+      scale.disconnectForHandoff();
+      async.flushMicrotasks();
+      transport.dispose();
+    });
+  });
+
+  test('silent wake disconnects once without powering off', () async {
+    final transport = _RecordingBleTransport(responseSubscribeCalls: const [1]);
+    final scale = DecentScale(transport: transport);
+    await scale.onConnect();
+    await scale.sleepDisplay();
+    await scale.disconnectForHandoff();
+    transport.writes.clear();
+    transport.disconnectCalls = 0;
+    await scale.onConnect();
+
+    await expectLater(scale.wakeDisplay(), throwsA(isA<TimeoutException>()));
+
+    expect(transport.disconnectCalls, 1);
+    expect(_hasCommand(transport, 0x0A, 0x02), isFalse);
+    final subscriptions = transport.subscribeCalls;
+    final secondWake = scale.wakeDisplay();
+    await Future<void>.delayed(Duration.zero);
+    expect(transport.subscribeCalls, subscriptions + 1);
+    await scale.sleepDisplay();
+    await secondWake;
+    await transport.dispose();
+  });
+
   test('disconnected initialization write never publishes connected', () async {
     final transport = _RecordingBleTransport()..failWrites = true;
     final scale = DecentScale(transport: transport);
@@ -303,7 +512,9 @@ void main() {
   test(
     'connection and rediscovery use heartbeat-off LED-on without tare',
     () async {
-      final transport = _RecordingBleTransport();
+      final transport = _RecordingBleTransport(
+        responseSubscribeCalls: const [1, 2],
+      );
       final scale = DecentScale(transport: transport);
 
       await scale.onConnect();

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -21,7 +21,9 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   bool emitDisconnectEvent = true;
   bool hangWrites = false;
   Completer<void>? writeBlocker;
+  Completer<void>? notifiableBlocker;
   UniversalBleException? writeError;
+  int connectCalls = 0;
   int writeCalls = 0;
   int getConnectionStateCalls = 0;
   final List<String> disconnectCalls = [];
@@ -62,6 +64,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     bool autoConnect = false,
     ConnectionPlatformConfig? platformConfig,
   }) async {
+    connectCalls++;
     updateConnection(deviceId, true);
   }
 
@@ -88,6 +91,10 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     final key = '$deviceId/$characteristic';
     final count = (_setNotifiableCounts[key] ?? 0) + 1;
     _setNotifiableCounts[key] = count;
+    final blocker = notifiableBlocker;
+    if (count == 2 && blocker != null) {
+      await blocker.future;
+    }
     if (throwOnSecondSetNotifiable && count == 2) {
       throw UniversalBleException(
         code: UniversalBleErrorCode.failed,
@@ -678,6 +685,54 @@ void main() {
           BleInputProperty.notification,
         ]);
       },
+    );
+
+    test(
+      'timed-out reset blocks replacement work until native completion',
+      () async {
+        await transport.subscribe(service, chars[0], (_) {});
+        platform.notifiableBlocker = Completer<void>();
+        platform.emitDisconnectEvent = false;
+
+        await expectLater(
+          transport.resetSubscription(service, chars[0], (_) {}),
+          throwsA(isA<TimeoutException>()),
+        );
+        await expectLater(transport.disconnect(), throwsA(anything));
+
+        expect(
+          UniversalBle.getQueueDiagnostics(deviceId).state,
+          QueueDiagnosticsState.faulted,
+        );
+        expect(
+          observedStates,
+          isNot(contains(device.ConnectionState.disconnected)),
+        );
+        await expectLater(transport.connect(), throwsA(isA<StateError>()));
+        await expectLater(
+          transport.write(
+            service,
+            chars[0],
+            Uint8List.fromList([1]),
+            timeout: _writeTimeout,
+          ),
+          throwsA(isA<UniversalBleException>()),
+        );
+        expect(platform.connectCalls, 1);
+        expect(platform.writeCalls, 0);
+
+        platform.notifiableBlocker!.complete();
+        await pump(100);
+
+        await transport.write(
+          service,
+          chars[0],
+          Uint8List.fromList([2]),
+          timeout: _writeTimeout,
+        );
+        expect(platform.writeCalls, 1);
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
     );
 
     test('disconnect cancels listeners without writing CCCDs', () async {

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -679,5 +679,22 @@ void main() {
         ]);
       },
     );
+
+    test('disconnect cancels listeners without writing CCCDs', () async {
+      final received = <int>[];
+      await transport.subscribe(
+        service,
+        chars[0],
+        (data) => received.add(data[0]),
+      );
+
+      await transport.disconnect();
+      push(chars[0], 1);
+      await pump();
+
+      expect(received, isEmpty);
+      expect(platform.notificationProperties, [BleInputProperty.notification]);
+      expect(platform.disconnectCalls, [deviceId]);
+    });
   });
 }

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -25,6 +25,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   int writeCalls = 0;
   int getConnectionStateCalls = 0;
   final List<String> disconnectCalls = [];
+  final List<BleInputProperty> notificationProperties = [];
 
   /// When true, the second `setNotifiable` call (per device+characteristic)
   /// throws a [UniversalBleException] — used to prove `subscribe()`
@@ -83,6 +84,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     String characteristic,
     BleInputProperty bleInputProperty,
   ) async {
+    notificationProperties.add(bleInputProperty);
     final key = '$deviceId/$characteristic';
     final count = (_setNotifiableCounts[key] ?? 0) + 1;
     _setNotifiableCounts[key] = count;
@@ -652,6 +654,29 @@ void main() {
           transport.subscribe(service, chars[0], (_) {}),
           throwsA(isA<UniversalBleException>()),
         );
+      },
+    );
+
+    test(
+      'reset disables and re-enables CCCD without dropping listener',
+      () async {
+        final received = <int>[];
+        await transport.subscribe(service, chars[0], (data) {
+          received.add(data[0]);
+        });
+
+        final reset = transport.resetSubscription(service, chars[0], (_) {});
+        await pump(20);
+        push(chars[0], 1);
+        await pump(20);
+        await reset;
+
+        expect(received, [1]);
+        expect(platform.notificationProperties, [
+          BleInputProperty.notification,
+          BleInputProperty.disabled,
+          BleInputProperty.notification,
+        ]);
       },
     );
   });


### PR DESCRIPTION
## Summary

- Problem: GATT setup could succeed while the Decent Scale FFF4 data channel remained silent, and a timed-out CCCD reset could leave UniversalBle's per-device queue faulted during teardown.
- Why it matters: Decent.app could publish a connection that could not deliver weight data, or allow a reconnect to overlap unresolved native GATT work.
- What changed: Require a recognised FFF4 status or weight frame before publishing an awake connection; retry one subscription reset; preserve queue recovery through teardown; block replacement BLE work until native completion or confirmed disconnect; update the UniversalBle fork to 2.2.4.
- What did NOT change: No REST, WebSocket, storage, plugin, UI, or scale protocol changes. FFF4 recognition remains type-based and does not add a checksum requirement.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes: N/A
- Related #512

## Root Cause (if bug fix)

- Root cause: Decent Scale initialization treated subscription setup as readiness without requiring a recognised FFF4 data frame. CCCD timeout recovery also stopped when teardown incremented the transport connection generation.
- Missing detection or guardrail: Tests did not model a silent FFF4 channel, an unresolved native `setNotifiable`, and a disconnect that emitted no event in the same lifecycle.
- Contributing context (if known): UniversalBle serializes GATT operations per device. A wrapper timeout faults that queue while the native operation may still be running.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/models/decent_scale_disconnect_test.dart` and `test/universal_ble_transport_recovery_test.dart`
- Scenario the test should lock in: A silent FFF4 subscription retries once; an unresolved CCCD write times out; a missing disconnect event does not publish a retryable disconnected state; replacement BLE work remains blocked; native completion clears recovery and permits the next operation.
- If no new test added, why not: N/A, regression tests added.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [x] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

Maintainer planning waiver: This targeted follow-up extends the existing Decent Scale readiness and BLE queue-recovery design documented in `doc/AI_BLE_NOTES.md` and `doc/DeviceManagement.md`. No separate archived design document is required.

## Security Impact (required)

- New or changed REST endpoints? (`Yes/No`) No
- New or changed WebSocket topics? (`Yes/No`) No
- New or changed network calls? (`Yes/No`) No
- BLE/USB surface changed? (`Yes/No`) Yes, BLE subscription reset, timeout recovery, and disconnect coordination changed.
- File system access changed? (`Yes/No`) No
- Plugin sandbox boundary changed? (`Yes/No`) No
- If any `Yes`, explain risk and mitigation: An unresolved native CCCD operation could overlap a replacement connection. The transport now keeps the queue faulted, rejects replacement BLE work, and clears recovery only after native completion or confirmed disconnect.

## User-Visible Changes

An awake Decent Scale is not reported connected until it sends a recognised FFF4 status or weight frame. A silent channel gets one subscription reset before normal reconnect recovery takes over.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` - 646 files checked, 0 changed
- [x] `flutter analyze` - clean (no new warnings)
- [ ] `flutter test` - full suite not run; focused tests passed
- [ ] `(cd packages/dye2-plugin && npm run build)` - plugin not changed

### Manual verification (if applicable)

- OS / platform tested: Windows host with mocked UniversalBle platform
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: Automated tests reproduced the silent FFF4 and unresolved native CCCD paths, then passed with the fix.
- Edge cases checked: Subscription silence, CCCD timeout, no native disconnect event, failed teardown, blocked replacement operation, native completion, and successful later dispatch.
- What you did **not** verify: Real Decent Scale hardware or Android, iOS, macOS, and Linux BLE stacks. Approval remains subject to normal maintainer hardware-risk acceptance.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Focused verification: 41 tests passed across `test/unit/models/decent_scale_disconnect_test.dart`, `test/universal_ble_transport_recovery_test.dart`, and `test/difluid_r2_sensor_test.dart`. `flutter analyze` and `git diff --check` passed.

## Compatibility & Migration

- Backward compatible? (`Yes/No`) Yes
- Config / env changes needed? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If any `No` or `Yes`, explain exact steps: No migration or operator action is required. BLE connection publication is stricter for silent Decent Scale sessions.

## Risks & Mitigations

- Risk: Slow or unusual hardware may exceed the two-second readiness windows.
  - Mitigation: The scale gets one subscription reset and status retry before normal ConnectionManager recovery. Real-hardware acceptance remains pending.
- Risk: A native CCCD call can remain unresolved after teardown fails.
  - Mitigation: The queue remains faulted and replacement operations are rejected until native completion or confirmed disconnect makes retirement safe.
