### PR TITLE
refactor(shot): use native scale control

### DIFF
--- a/doc/AI_DEBUG_NOTES.md
+++ b/doc/AI_DEBUG_NOTES.md
@@ -132,6 +132,8 @@ An Acaia shot that stops at a weight far above the scale display can be a timer-
 
 An Acaia scale that is linked but publishes no weight must not be reported connected. Identification and configuration writes, settings frames, timer frames, and information frames do not establish readiness. Initialization must observe a valid weight frame or tear down and leave retry ownership with ConnectionManager.
 
+A shot can otherwise reuse the last scale value forever after notifications stall. Shot-scale freshness is supervised by accepted native callback arrival, not device timestamps. Once a shot marks the scale stale, scale actuation stays disabled, later scale frames cannot re-arm it, and machine-cadence snapshots stop repeating the stale weight.
+
 ## Keeping Notes Fresh
 
 Add debugging patterns with: symptom, root cause, fix pattern, prevention. Prune when fixes ship and patterns are no longer current.

--- a/doc/plans/archive/shot-native-scale-control/design.md
+++ b/doc/plans/archive/shot-native-scale-control/design.md
@@ -1,0 +1,33 @@
+# Native-Rate Shot Scale Control
+
+## Evidence
+
+- `ShotSequencer` currently uses `withLatestFrom`, so machine lifecycle waits for a scale sample and scale decisions only run at machine cadence.
+- Scale commands are launched independently from machine transitions; reset, tare, start, and stop can overlap or be dropped by device-level in-flight guards.
+- Issue #423 records concurrent machine-stop and scale-maintenance BLE writes, followed by a scale write timeout. PR #512 already prevents the transport-loss path from powering off the physical scale.
+- Bengle exposes its integrated scale through `BengleVirtualScale`, while firmware owns final stop-at-weight and the app retains per-step weight exits.
+
+## Invariants
+
+- Machine samples alone drive lifecycle, volume integration, raw snapshots, persistence, and natural completion.
+- Distinct native scale callbacks alone drive tare confirmation, freshness, target crossings, per-step exits, and final-yield refinement.
+- Scale availability is explicit and can only degrade during a shot; disconnect, tare failure, tare timeout, and staleness cannot re-arm.
+- Pour-time scale control arms only after the tare command succeeds and a distinct post-start sample is within 3 g of zero.
+- Final and per-step crossings require two consecutive distinct native samples at or above the projected threshold.
+- Shot scale commands run FIFO, once per transition, with local error ownership and generation guards.
+- A stop request is latched once; `stopping` begins only after a later machine snapshot confirms the pour ended.
+
+## Compatibility Decisions
+
+- Preserve the public scale API, shot states, decision vocabulary, machine-cadence persistence, preparing-for-shot tare, volume fallback, and Bengle final-SAW bypass.
+- Default tare-confirmation and freshness timeouts are two seconds and are injectable only through constructor durations.
+- Use raw weight plus `controlWeightFlow` projection for actuation and keep display smoothing out of control decisions.
+- Do not retry DE1 stop or skip requests automatically.
+
+## Rejected Alternatives
+
+- `combineLatest`, `merge`, or another combined stream could let scale events repeat machine lifecycle and volume integration.
+- A universal weight or grams-per-second clamp would reject legitimate catch-up after transport pauses.
+- Treating GATT write completion as physical tare completion can arm against cup weight.
+- Reconnection inside the sequencer would conflict with ConnectionManager ownership and could silently re-arm mid-shot.
+- Persisting at scale cadence would change the storage and public snapshot contract.

--- a/doc/plans/archive/shot-native-scale-control/design.md
+++ b/doc/plans/archive/shot-native-scale-control/design.md
@@ -11,7 +11,7 @@
 
 - Machine samples alone drive lifecycle, volume integration, raw snapshots, persistence, and natural completion.
 - Distinct native scale callbacks alone drive tare confirmation, freshness, target crossings, per-step exits, and final-yield refinement.
-- Scale availability is explicit and can only degrade during a shot; disconnect, tare failure, tare timeout, and staleness cannot re-arm.
+- Scale availability is explicit and can only degrade during a shot; connection-generation changes, disconnect, tare failure, tare timeout, and staleness cannot re-arm.
 - Pour-time scale control arms only after the tare command succeeds and a distinct post-start sample is within 3 g of zero.
 - Final and per-step crossings require two consecutive distinct native samples at or above the projected threshold.
 - Shot scale commands run FIFO, once per transition, with local error ownership and generation guards.
@@ -30,4 +30,5 @@
 - A universal weight or grams-per-second clamp would reject legitimate catch-up after transport pauses.
 - Treating GATT write completion as physical tare completion can arm against cup weight.
 - Reconnection inside the sequencer would conflict with ConnectionManager ownership and could silently re-arm mid-shot.
+- Accepting replacement-scale samples from the controller's shared stream can actuate against an untared reference.
 - Persisting at scale cadence would change the storage and public snapshot contract.

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -11,6 +11,9 @@ import 'package:rxdart/rxdart.dart';
 
 class ScaleController {
   Scale? _scale;
+  int _connectionGeneration = 0;
+
+  int get connectionGeneration => _connectionGeneration;
 
   StreamSubscription<ConnectionState>? _scaleConnection;
   StreamSubscription<ScaleSnapshot>? _scaleSnapshot;
@@ -137,6 +140,7 @@ class ScaleController {
   }
 
   void _onDisconnect() {
+    _connectionGeneration++;
     _scaleSnapshot?.cancel();
     _scaleConnection?.cancel();
     _scale = null;

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -14,6 +14,12 @@ class ScaleController {
   int _connectionGeneration = 0;
 
   int get connectionGeneration => _connectionGeneration;
+  ({Scale scale, int generation})? get currentScaleLease {
+    final scale = _scale;
+    return scale == null
+        ? null
+        : (scale: scale, generation: _connectionGeneration);
+  }
 
   StreamSubscription<ConnectionState>? _scaleConnection;
   StreamSubscription<ScaleSnapshot>? _scaleSnapshot;
@@ -205,8 +211,13 @@ class ScaleController {
   /// visualizer right after each tare. Throws [DeviceNotConnectedException] if
   /// no scale is connected.
   Future<void> tare() async {
-    final scale = connectedScale();
-    await scale.tare();
+    final lease = currentScaleLease;
+    if (lease == null) throw const DeviceNotConnectedException.scale();
+    await lease.scale.tare();
+    if (_connectionGeneration != lease.generation ||
+        !identical(_scale, lease.scale)) {
+      return;
+    }
     _kalmanEstimator?.reset(0.0);
     _resetDisplayEstimator();
     _flowSettleUntil = _lastSnapshotTime?.add(_smoothingWindow);

--- a/lib/src/controllers/shot_scale_command_queue.dart
+++ b/lib/src/controllers/shot_scale_command_queue.dart
@@ -13,13 +13,18 @@ enum ShotScaleCommand {
 
 class ShotScaleCommandQueue {
   final Scale _scale;
+  final bool Function() _isCurrent;
   final Logger _log;
   final Set<ShotScaleCommand> _requested = {};
   Future<void> _tail = Future.value();
   int _generation = 0;
 
-  ShotScaleCommandQueue(this._scale, {Logger? logger})
-    : _log = logger ?? Logger('ShotScaleCommandQueue');
+  ShotScaleCommandQueue(
+    this._scale, {
+    required bool Function() isCurrent,
+    Logger? logger,
+  }) : _isCurrent = isCurrent,
+       _log = logger ?? Logger('ShotScaleCommandQueue');
 
   Future<void> get settled => _tail;
 
@@ -33,7 +38,7 @@ class ShotScaleCommandQueue {
     if (!_requested.add(command)) return;
     final generation = _generation;
     _tail = _tail.then((_) async {
-      if (generation != _generation) return;
+      if (generation != _generation || !_isCurrent()) return;
       try {
         onStart?.call();
         await operation(_scale);

--- a/lib/src/controllers/shot_scale_command_queue.dart
+++ b/lib/src/controllers/shot_scale_command_queue.dart
@@ -42,10 +42,10 @@ class ShotScaleCommandQueue {
       try {
         onStart?.call();
         await operation(_scale);
-        if (generation == _generation) onSuccess?.call();
+        if (generation == _generation && _isCurrent()) onSuccess?.call();
       } catch (error, stackTrace) {
         _log.warning('${command.name} failed', error, stackTrace);
-        if (generation != _generation) return;
+        if (generation != _generation || !_isCurrent()) return;
         try {
           onFailure?.call(error);
         } catch (callbackError, callbackStackTrace) {

--- a/lib/src/controllers/shot_scale_command_queue.dart
+++ b/lib/src/controllers/shot_scale_command_queue.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+
+enum ShotScaleCommand {
+  preparingTare,
+  timerReset,
+  pourTare,
+  timerStart,
+  timerStop,
+}
+
+class ShotScaleCommandQueue {
+  final Scale _scale;
+  final Logger _log;
+  final Set<ShotScaleCommand> _requested = {};
+  Future<void> _tail = Future.value();
+  int _generation = 0;
+
+  ShotScaleCommandQueue(this._scale, {Logger? logger})
+    : _log = logger ?? Logger('ShotScaleCommandQueue');
+
+  Future<void> get settled => _tail;
+
+  void enqueue(
+    ShotScaleCommand command,
+    Future<void> Function(Scale scale) operation, {
+    void Function()? onStart,
+    void Function()? onSuccess,
+    void Function(Object error)? onFailure,
+  }) {
+    if (!_requested.add(command)) return;
+    final generation = _generation;
+    _tail = _tail.then((_) async {
+      if (generation != _generation) return;
+      try {
+        onStart?.call();
+        await operation(_scale);
+        if (generation == _generation) onSuccess?.call();
+      } catch (error, stackTrace) {
+        _log.warning('${command.name} failed', error, stackTrace);
+        if (generation != _generation) return;
+        try {
+          onFailure?.call(error);
+        } catch (callbackError, callbackStackTrace) {
+          _log.warning(
+            '${command.name} failure callback failed',
+            callbackError,
+            callbackStackTrace,
+          );
+        }
+      }
+    });
+  }
+
+  void dispose() {
+    _generation++;
+  }
+}

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -99,11 +99,9 @@ class ShotSequencer {
       "Initializing ShotSequencer (weightFlowMultiplier: $_weightFlowMultiplier, volumeFlowMultiplier: $_volumeFlowMultiplier, machineHasAutonomousSAW: $_machineHasAutonomousSAW, stepExitArbiterEnabled: $_stepExitArbiterEnabled)",
     );
 
-    final scaleConnected =
-        scaleController.currentConnectionState ==
-        device.ConnectionState.connected;
+    final scaleLease = scaleController.currentScaleLease;
 
-    if (_blockOnNoScale && !scaleConnected) {
+    if (_blockOnNoScale && scaleLease == null) {
       _emitDecision(
         ShotDecisionKind.abort,
         ShotDecisionReason.noScale,
@@ -119,10 +117,10 @@ class ShotSequencer {
       return;
     }
 
-    if (scaleConnected) {
-      _scaleGeneration = scaleController.connectionGeneration;
+    if (scaleLease != null) {
+      _scaleGeneration = scaleLease.generation;
       _commandQueue = ShotScaleCommandQueue(
-        scaleController.connectedScale(),
+        scaleLease.scale,
         isCurrent: () =>
             scaleController.connectionGeneration == _scaleGeneration,
         logger: _log,
@@ -305,9 +303,8 @@ class ShotSequencer {
       return;
     }
     _latestScale = scale;
-    if (_pourTareStarted ||
-        _state == ShotState.pouring ||
-        _state == ShotState.stopping) {
+    if (_scaleAvailability == _ScaleAvailability.ready &&
+        (_state == ShotState.pouring || _state == ShotState.stopping)) {
       _resetFreshnessTimer();
     }
     if (_scaleAvailability == _ScaleAvailability.awaitingPourTare) {
@@ -329,10 +326,7 @@ class ShotSequencer {
     _freshnessTimer?.cancel();
     _freshnessTimer = Timer(_scaleFreshnessTimeout, () {
       if (_state != ShotState.pouring && _state != ShotState.stopping) return;
-      if (_scaleAvailability != _ScaleAvailability.awaitingPourTare &&
-          _scaleAvailability != _ScaleAvailability.ready) {
-        return;
-      }
+      if (_scaleAvailability != _ScaleAvailability.ready) return;
       _disableScale(_ScaleAvailability.stale, 'Scale feed became stale');
     });
   }
@@ -344,6 +338,7 @@ class ShotSequencer {
     }
     _scaleAvailability = availability;
     _scaleLost = true;
+    _commandQueue?.dispose();
     _latestScale = null;
     _tareConfirmationTimer?.cancel();
     _freshnessTimer?.cancel();
@@ -360,8 +355,17 @@ class ShotSequencer {
   }
 
   void _enqueuePourCommands() {
-    if (_scaleAvailability == _ScaleAvailability.awaitingPourTare ||
-        _scaleAvailability == _ScaleAvailability.ready) {
+    if (_scaleAvailability == _ScaleAvailability.awaitingPourTare) {
+      _tareConfirmationTimer?.cancel();
+      _tareConfirmationTimer = Timer(_tareConfirmationTimeout, () {
+        if (_scaleAvailability == _ScaleAvailability.awaitingPourTare) {
+          _disableScale(
+            _ScaleAvailability.unavailable,
+            'Pour tare confirmation timed out',
+          );
+        }
+      });
+    } else if (_scaleAvailability == _ScaleAvailability.ready) {
       _resetFreshnessTimer();
     }
     final queue = _commandQueue;
@@ -401,15 +405,6 @@ class ShotSequencer {
     _pourTareZeroObserved = false;
     _finalCrossing.reset();
     _stepCrossing.reset();
-    _tareConfirmationTimer?.cancel();
-    _tareConfirmationTimer = Timer(_tareConfirmationTimeout, () {
-      if (_scaleAvailability == _ScaleAvailability.awaitingPourTare) {
-        _disableScale(
-          _ScaleAvailability.unavailable,
-          'Pour tare confirmation timed out',
-        );
-      }
-    });
   }
 
   void _completePourTare() {
@@ -422,6 +417,7 @@ class ShotSequencer {
     if (!_pourTareSucceeded || !_pourTareZeroObserved) return;
     _tareConfirmationTimer?.cancel();
     _scaleAvailability = _ScaleAvailability.ready;
+    _resetFreshnessTimer();
   }
 
   void _evaluateScaleControl(WeightSnapshot scale) {

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -360,14 +360,12 @@ class ShotSequencer {
   }
 
   void _enqueuePourCommands() {
-    final queue = _commandQueue;
-    if (queue == null || _bypassSAW) {
-      if (_scaleAvailability == _ScaleAvailability.ready &&
-          _latestScale != null) {
-        _resetFreshnessTimer();
-      }
-      return;
+    if (_scaleAvailability == _ScaleAvailability.awaitingPourTare ||
+        _scaleAvailability == _ScaleAvailability.ready) {
+      _resetFreshnessTimer();
     }
+    final queue = _commandQueue;
+    if (queue == null || _bypassSAW) return;
     queue.enqueue(
       ShotScaleCommand.pourTare,
       _tareCapturedScale,
@@ -424,7 +422,6 @@ class ShotSequencer {
     if (!_pourTareSucceeded || !_pourTareZeroObserved) return;
     _tareConfirmationTimer?.cancel();
     _scaleAvailability = _ScaleAvailability.ready;
-    _resetFreshnessTimer();
   }
 
   void _evaluateScaleControl(WeightSnapshot scale) {
@@ -643,7 +640,10 @@ class ShotSequencer {
   void _trackFrameAdvance(int profileFrame) {
     if (profileFrame != _lastProfileFrame) {
       _stepExitArbiter.onFrameAdvanced(profileFrame);
-      _stepCrossing.reset();
+      if (_lastProfileFrame >= 0) {
+        _finalCrossing.reset();
+        _stepCrossing.reset();
+      }
       _lastProfileFrame = profileFrame;
     }
     if (_maxFrameSeen < 0) {

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -303,7 +303,8 @@ class ShotSequencer {
       return;
     }
     _latestScale = scale;
-    if (_scaleAvailability == _ScaleAvailability.ready &&
+    if ((_scaleAvailability == _ScaleAvailability.awaitingPourTare ||
+            _scaleAvailability == _ScaleAvailability.ready) &&
         (_state == ShotState.pouring || _state == ShotState.stopping)) {
       _resetFreshnessTimer();
     }
@@ -326,7 +327,10 @@ class ShotSequencer {
     _freshnessTimer?.cancel();
     _freshnessTimer = Timer(_scaleFreshnessTimeout, () {
       if (_state != ShotState.pouring && _state != ShotState.stopping) return;
-      if (_scaleAvailability != _ScaleAvailability.ready) return;
+      if (_scaleAvailability != _ScaleAvailability.awaitingPourTare &&
+          _scaleAvailability != _ScaleAvailability.ready) {
+        return;
+      }
       _disableScale(_ScaleAvailability.stale, 'Scale feed became stale');
     });
   }
@@ -417,7 +421,6 @@ class ShotSequencer {
     if (!_pourTareSucceeded || !_pourTareZeroObserved) return;
     _tareConfirmationTimer?.cancel();
     _scaleAvailability = _ScaleAvailability.ready;
-    _resetFreshnessTimer();
   }
 
   void _evaluateScaleControl(WeightSnapshot scale) {

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -4,19 +4,32 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/shot_scale_command_queue.dart';
 import 'package:reaprime/src/controllers/step_exit_arbiter.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_snapshot.dart';
 import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:rxdart/rxdart.dart';
 
-// The shot-state vocabulary lived here before it gained wire serialization;
-// re-export so existing importers keep working.
 export 'package:reaprime/src/models/data/shot_state_event.dart'
     show ShotState, ShotDecision, ShotDecisionKind, ShotDecisionReason;
+
+enum _ScaleAvailability { unavailable, awaitingPourTare, ready, stale }
+
+class _CrossingGate {
+  int _samples = 0;
+
+  bool add(bool crossed) {
+    _samples = crossed ? _samples + 1 : 0;
+    return _samples >= 2;
+  }
+
+  void reset() => _samples = 0;
+}
 
 class ShotSequencer {
   final De1Controller de1controller;
@@ -31,54 +44,25 @@ class ShotSequencer {
   final double _weightFlowMultiplier;
   final double _volumeFlowMultiplier;
   final bool _stepExitArbiterEnabled;
+  final Duration _tareConfirmationTimeout;
+  final Duration _scaleFreshnessTimeout;
 
-  /// `true` when the connected machine runs its own autonomous SAW
-  /// (currently only Bengle). The app's SAW loop must defer to FW to
-  /// avoid double-stop.
-  ///
-  /// Captured once at construction. A sequencer's lifetime is bound
-  /// to a single shot (owned + recreated per shot by [De1StateManager])
-  /// and machines can't be swapped mid-shot — if the connection dies
-  /// the shot is already over and a stale flag is the least of our
-  /// problems. Don't try to make this reactive.
-  ///
-  /// Only the FINAL target-yield stop is bypassed for autonomous-SAW
-  /// machines. Per-step weight exits (`ProfileStep.weight`) still run
-  /// app-side: FW only exposes one SAW target, not per-frame weight
-  /// transitions. Wiring per-step skips into FW would need a new
-  /// `ProfileStepFrame` data object and likely a separate endpoint —
-  /// out of scope until that exists.
   final bool _machineHasAutonomousSAW;
 
-  // Skip step on weight specific
-  List<int> skippedSteps = [];
+  Set<int> skippedSteps = const {};
   final StepExitArbiter _stepExitArbiter = StepExitArbiter();
   int _lastProfileFrame = -1;
 
-  /// Highest profile frame reported so far this shot, for one-shot
-  /// `profileAdvance` emission that survives BLE frame reordering. See
-  /// [_trackFrameAdvance].
   int _maxFrameSeen = -1;
 
-  // Volume counting state
   double _accumulatedVolume = 0.0;
   DateTime? _lastVolumeUpdateTime;
   bool _volumeCountingActive = false;
 
-  // Final beverage weight on weighed shots. After the machine-reported stop the
-  // pump is off, so flow onto the scale can only decay — the post-stop window
-  // keeps taking the rising weight (turbo catch-up included, with no flow or
-  // gram cap) and locks the yield on the first of three events: the scale
-  // settles, the cup is removed (a sharp drop), or a touch spikes the flow back
-  // up against the decay. The saved trace stops at the stop boundary, so only
-  // this value follows the tail, not the graph. Null when no scale weighs the
-  // shot.
-  static const double _settleFlowThreshold = 0.4; // g/s; |flow| below = still
-  static const int _settleSampleCount =
-      10; // consecutive still samples = settled (was 3; raised for Kalman smoothness — 3 samples at ~10 Hz ≈ 0.3s misses trailing drips)
-  static const double _removalFlowThreshold =
-      3.0; // g/s; flow < -this = removal
-  static const double _spikeFlowJump = 3.0; // g/s; flow rising vs prev = spike
+  static const double _settleFlowThreshold = 0.4;
+  static const int _settleSampleCount = 10;
+  static const double _removalFlowThreshold = 3.0;
+  static const double _spikeFlowJump = 3.0;
   static const Duration _stoppingBackstop = Duration(seconds: 4);
   double? _trustedFinalYield;
   bool _stoppingYieldLocked = false;
@@ -100,29 +84,26 @@ class ShotSequencer {
     required double weightFlowMultiplier,
     required double volumeFlowMultiplier,
     required bool stepExitArbiterEnabled,
+    Duration tareConfirmationTimeout = const Duration(seconds: 2),
+    Duration scaleFreshnessTimeout = const Duration(seconds: 2),
   }) : _bypassSAW = bypassSAW,
        _blockOnNoScale = blockOnNoScale,
        _weightFlowMultiplier = weightFlowMultiplier,
        _volumeFlowMultiplier = volumeFlowMultiplier,
        _stepExitArbiterEnabled = stepExitArbiterEnabled,
+       _tareConfirmationTimeout = tareConfirmationTimeout,
+       _scaleFreshnessTimeout = scaleFreshnessTimeout,
        _machineHasAutonomousSAW =
            de1controller.connectedDe1() is BengleInterface {
     _log.info(
       "Initializing ShotSequencer (weightFlowMultiplier: $_weightFlowMultiplier, volumeFlowMultiplier: $_volumeFlowMultiplier, machineHasAutonomousSAW: $_machineHasAutonomousSAW, stepExitArbiterEnabled: $_stepExitArbiterEnabled)",
     );
 
-    // When the app won't tare (SAW bypass), trust the scale's readings as-is —
-    // there's no app-side tare to gate on.
-    _scaleTared = _bypassSAW;
-
     final scaleConnected =
         scaleController.currentConnectionState ==
         device.ConnectionState.connected;
 
     if (_blockOnNoScale && !scaleConnected) {
-      // The sequencer is created reactively, after the machine has already
-      // entered espresso (incl. GHC / physical starts), so "block" means abort
-      // the shot in progress and publish the reason rather than prevent it.
       _emitDecision(
         ShotDecisionKind.abort,
         ShotDecisionReason.noScale,
@@ -138,60 +119,52 @@ class ShotSequencer {
       return;
     }
 
-    if (!scaleConnected) {
-      _log.info("Continuing without scale");
-      _snapshotSubscription = de1controller
-          .connectedDe1()
-          .currentSnapshot
-          .map((snapshot) => ShotSnapshot(machine: snapshot))
-          .listen(
-            _processSnapshot,
-            onError: (error) =>
-                _log.warning("Error processing DE1 snapshot: $error"),
-          );
-    } else {
-      _log.info("Scale connected, combining streams");
-      final combinedStream = de1controller
-          .connectedDe1()
-          .currentSnapshot
-          .withLatestFrom(
-            scaleController.weightSnapshot,
-            (machine, weight) => ShotSnapshot(machine: machine, scale: weight),
-          );
-
-      _snapshotSubscription = combinedStream.listen(
-        _processSnapshot,
-        onError: (error) =>
-            _log.warning("Error processing combined snapshot: $error"),
+    if (scaleConnected) {
+      _commandQueue = ShotScaleCommandQueue(
+        scaleController.connectedScale(),
+        logger: _log,
       );
-
-      // Monitor scale connection during shot
-      _scaleConnectionSubscription = scaleController.connectionState.listen((
-        state,
-      ) {
-        if (state == device.ConnectionState.disconnected && !_scaleLost) {
-          if (_state != ShotState.idle && _state != ShotState.finished) {
-            _scaleLost = true;
-            _log.warning(
-              'Scale disconnected during shot (state: ${_state.name}). '
-              'Stop-at-weight disabled for remainder of this shot.',
-            );
-          }
-        }
-      });
+      _scaleAvailability = _bypassSAW
+          ? _ScaleAvailability.ready
+          : _ScaleAvailability.awaitingPourTare;
     }
+
+    _machineSubscription = de1controller.connectedDe1().currentSnapshot.listen(
+      _processMachineSnapshot,
+      onError: (error, stackTrace) =>
+          _log.warning('Error processing machine snapshot', error, stackTrace),
+    );
+    _scaleSubscription = scaleController.weightSnapshot.listen(
+      _processScaleSnapshot,
+      onError: (error, stackTrace) =>
+          _log.warning('Error processing scale snapshot', error, stackTrace),
+    );
+    _scaleConnectionSubscription = scaleController.connectionState.listen(
+      _processScaleConnection,
+      onError: (error, stackTrace) =>
+          _log.warning('Error processing scale connection', error, stackTrace),
+    );
   }
 
   void dispose() {
     _log.fine("dispose");
-    _snapshotSubscription?.cancel();
+    _disposed = true;
+    _tareConfirmationTimer?.cancel();
+    _freshnessTimer?.cancel();
+    _stoppingTimer?.cancel();
+    _commandQueue?.dispose();
+    _machineSubscription?.cancel();
+    _scaleSubscription?.cancel();
     _scaleConnectionSubscription?.cancel();
     _rawShotDataStream.close();
     _shotDataStream.close();
     _decisionStream.close();
+    _resetCommand.close();
+    _stateStream.close();
   }
 
-  StreamSubscription<ShotSnapshot>? _snapshotSubscription;
+  StreamSubscription<MachineSnapshot>? _machineSubscription;
+  StreamSubscription<WeightSnapshot>? _scaleSubscription;
 
   final StreamController<ShotSnapshot> _rawShotDataStream =
       StreamController.broadcast();
@@ -210,36 +183,19 @@ class ShotSequencer {
   );
   Stream<ShotState> get state => _stateStream.stream;
 
-  /// Sequencer decisions (e.g. why a shot was stopped). Groundwork for a
-  /// future `/ws/v1/shotState` topic. BehaviorSubject so consumers that
-  /// subscribe after construction still receive a decision emitted in the
-  /// constructor (e.g. the blockOnNoScale abort).
   final BehaviorSubject<ShotDecision> _decisionStream = BehaviorSubject();
   Stream<ShotDecision> get decisions => _decisionStream.stream;
 
-  /// Dedicated logger for the decision trail: one consistent, greppable line
-  /// per decision, regardless of who owns this sequencer (De1StateManager or
-  /// a route-constructed instance). The per-site `_log.info` lines this
-  /// replaces were deleted — do not re-add them, or every decision double-logs.
   static final Logger _decisionLog = Logger('ShotState');
 
-  /// The reason the shot stopped, retained for persistence onto the
-  /// ShotRecord. Set by the stop/abort/terminal decision sites; `finalize`
-  /// decisions (e.g. the stopping backstop) never overwrite it — they close
-  /// the settling window, they are not why the shot stopped.
   ShotDecisionReason? _finalStopReason;
   ShotDecisionReason? get finalStopReason => _finalStopReason;
 
-  /// Current shot phase — lets the owner distinguish a natural finish from a
-  /// mid-shot teardown (disconnect) without subscribing to [state].
   ShotState get currentState => _state;
 
   bool get scaleLost => _scaleLost;
   bool get machineHasAutonomousSAW => _machineHasAutonomousSAW;
 
-  /// Emits a decision on [decisions] and writes the single consolidated log
-  /// line. Abort/terminal log at WARNING (abnormal endings, telemetry-worthy
-  /// and rare); finalize at FINE (window bookkeeping); the rest at INFO.
   void _emitDecision(
     ShotDecisionKind kind,
     ShotDecisionReason reason, {
@@ -273,46 +229,225 @@ class ShotSequencer {
   ShotState _state = ShotState.idle;
   bool _scaleLost = false;
 
-  /// Whether this shot's scale has been tared for the pour yet. Flips `true`
-  /// when the app issues the pour-time tare (the preheating→pouring
-  /// transition). Until then the scale's absolute reading is whatever sits on
-  /// the platter (cup, portafilter, residual drips) and the derived flow is
-  /// noise — so we report 0 for both rather than feed pre-tare garbage into the
-  /// recorded trace and the visualizer upload. Gating through the whole
-  /// preheat (rather than flipping at the earlier preparing-for-shot tare)
-  /// also sidesteps the in-flight-tare race: by the pour the scale has
-  /// physically settled to zero. Seeded `true` when the app won't tare (SAW
-  /// bypass, e.g. Bengle's autonomous SAW) — there's no app-side tare to wait
-  /// for, so the scale's own readings are trusted as-is.
-  bool _scaleTared = false;
+  bool _disposed = false;
+  bool _pourTareStarted = false;
+  bool _pourTareSucceeded = false;
+  bool _pourTareZeroObserved = false;
+  bool _stopRequested = false;
+  _ScaleAvailability _scaleAvailability = _ScaleAvailability.unavailable;
+  MachineSnapshot? _latestMachine;
+  WeightSnapshot? _latestScale;
+  ShotScaleCommandQueue? _commandQueue;
+  Timer? _tareConfirmationTimer;
+  Timer? _freshnessTimer;
+  Timer? _stoppingTimer;
+  final _finalCrossing = _CrossingGate();
+  final _stepCrossing = _CrossingGate();
   StreamSubscription<device.ConnectionState>? _scaleConnectionSubscription;
 
-  void _processSnapshot(ShotSnapshot snapshot) {
-    _log.finest("Processing snapshot");
-
-    // Until the scale is tared for this shot, suppress its weight and flow:
-    // the pre-tare reading reflects whatever is resting on the scale, not the
-    // beverage, and the flow derived from it is noise.
-    if (!_scaleTared && snapshot.scale != null) {
-      final raw = snapshot.scale!;
-      snapshot = snapshot.copyWith(
-        scale: WeightSnapshot(
-          timestamp: raw.timestamp,
-          weight: 0,
-          weightFlow: 0,
-          battery: raw.battery,
-          timerValue: raw.timerValue,
-        ),
-      );
-    }
-
-    // Update volume calculation
-    final snapshotWithVolume = _updateVolume(snapshot);
+  void _processMachineSnapshot(MachineSnapshot machine) {
+    if (_disposed) return;
+    _latestMachine = machine;
+    final snapshotWithVolume = _updateVolume(
+      ShotSnapshot(machine: machine, scale: _visibleScale()),
+    );
 
     _rawShotDataStream.add(snapshotWithVolume);
-    _handleStateTransition(snapshotWithVolume);
+    _handleMachineState(snapshotWithVolume);
     if (dataCollectionEnabled) {
       _shotDataStream.add(snapshotWithVolume);
+    }
+  }
+
+  WeightSnapshot? _visibleScale() {
+    final scale = _latestScale;
+    if (scale == null ||
+        _scaleAvailability == _ScaleAvailability.unavailable ||
+        _scaleAvailability == _ScaleAvailability.stale) {
+      return null;
+    }
+    if (_scaleAvailability == _ScaleAvailability.ready) return scale;
+    return WeightSnapshot(
+      timestamp: scale.timestamp,
+      weight: 0,
+      weightFlow: 0,
+      controlWeightFlow: 0,
+      battery: scale.battery,
+      timerValue: scale.timerValue,
+    );
+  }
+
+  void _processScaleConnection(device.ConnectionState state) {
+    if (_disposed || state != device.ConnectionState.disconnected) return;
+    if (_commandQueue == null) return;
+    _commandQueue?.dispose();
+    _disableScale(_ScaleAvailability.unavailable, 'Scale disconnected');
+  }
+
+  void _processScaleSnapshot(WeightSnapshot scale) {
+    if (_disposed ||
+        _scaleAvailability == _ScaleAvailability.unavailable ||
+        _scaleAvailability == _ScaleAvailability.stale) {
+      return;
+    }
+    _latestScale = scale;
+    if (_pourTareStarted ||
+        _state == ShotState.pouring ||
+        _state == ShotState.stopping) {
+      _resetFreshnessTimer();
+    }
+    if (_scaleAvailability == _ScaleAvailability.awaitingPourTare) {
+      if (_pourTareStarted && scale.weight.abs() <= 3) {
+        _pourTareZeroObserved = true;
+        _tryArmScaleControl();
+      }
+      return;
+    }
+    if (_state == ShotState.pouring) {
+      _evaluateScaleControl(scale);
+    } else if (_state == ShotState.stopping) {
+      _refineStoppingYield(scale);
+      if (_stoppingYieldLocked) _finishStopping();
+    }
+  }
+
+  void _resetFreshnessTimer() {
+    _freshnessTimer?.cancel();
+    _freshnessTimer = Timer(_scaleFreshnessTimeout, () {
+      if (_state != ShotState.pouring && _state != ShotState.stopping) return;
+      if (_scaleAvailability != _ScaleAvailability.awaitingPourTare &&
+          _scaleAvailability != _ScaleAvailability.ready) {
+        return;
+      }
+      _disableScale(_ScaleAvailability.stale, 'Scale feed became stale');
+    });
+  }
+
+  void _disableScale(_ScaleAvailability availability, String reason) {
+    if (_scaleAvailability == _ScaleAvailability.unavailable ||
+        _scaleAvailability == _ScaleAvailability.stale) {
+      return;
+    }
+    _scaleAvailability = availability;
+    _scaleLost = true;
+    _latestScale = null;
+    _tareConfirmationTimer?.cancel();
+    _freshnessTimer?.cancel();
+    _finalCrossing.reset();
+    _stepCrossing.reset();
+    _log.warning('$reason; scale control disabled for this shot');
+  }
+
+  void _enqueuePreparingCommands() {
+    final queue = _commandQueue;
+    if (queue == null || _bypassSAW) return;
+    queue.enqueue(ShotScaleCommand.preparingTare, _tareCapturedScale);
+    queue.enqueue(ShotScaleCommand.timerReset, (scale) => scale.resetTimer());
+  }
+
+  void _enqueuePourCommands() {
+    final queue = _commandQueue;
+    if (queue == null || _bypassSAW) {
+      if (_scaleAvailability == _ScaleAvailability.ready &&
+          _latestScale != null) {
+        _resetFreshnessTimer();
+      }
+      return;
+    }
+    queue.enqueue(
+      ShotScaleCommand.pourTare,
+      _tareCapturedScale,
+      onStart: _beginPourTare,
+      onSuccess: _completePourTare,
+      onFailure: (_) =>
+          _disableScale(_ScaleAvailability.unavailable, 'Pour tare failed'),
+    );
+    queue.enqueue(ShotScaleCommand.timerStart, (scale) => scale.startTimer());
+  }
+
+  Future<void> _tareCapturedScale(Scale scale) async {
+    if (!identical(scaleController.connectedScale(), scale)) {
+      throw StateError('Shot scale changed');
+    }
+    await scaleController.tare();
+  }
+
+  void _enqueueTimerStop() {
+    _commandQueue?.enqueue(
+      ShotScaleCommand.timerStop,
+      (scale) => scale.stopTimer(),
+    );
+  }
+
+  void _beginPourTare() {
+    if (_state != ShotState.pouring ||
+        _scaleAvailability != _ScaleAvailability.awaitingPourTare) {
+      return;
+    }
+    _pourTareStarted = true;
+    _pourTareSucceeded = false;
+    _pourTareZeroObserved = false;
+    _finalCrossing.reset();
+    _stepCrossing.reset();
+    _tareConfirmationTimer?.cancel();
+    _tareConfirmationTimer = Timer(_tareConfirmationTimeout, () {
+      if (_scaleAvailability == _ScaleAvailability.awaitingPourTare) {
+        _disableScale(
+          _ScaleAvailability.unavailable,
+          'Pour tare confirmation timed out',
+        );
+      }
+    });
+  }
+
+  void _completePourTare() {
+    if (_scaleAvailability != _ScaleAvailability.awaitingPourTare) return;
+    _pourTareSucceeded = true;
+    _tryArmScaleControl();
+  }
+
+  void _tryArmScaleControl() {
+    if (!_pourTareSucceeded || !_pourTareZeroObserved) return;
+    _tareConfirmationTimer?.cancel();
+    _scaleAvailability = _ScaleAvailability.ready;
+    _resetFreshnessTimer();
+  }
+
+  void _evaluateScaleControl(WeightSnapshot scale) {
+    final machine = _latestMachine;
+    if (machine == null || _stopRequested || _bypassSAW) return;
+    final projected =
+        scale.weight + scale.controlWeightFlow * _weightFlowMultiplier;
+    _handleStepWeightExit(machine.profileFrame, projected, machine);
+    if (_machineHasAutonomousSAW || targetYield <= 0) return;
+    if (!_finalCrossing.add(projected >= targetYield)) return;
+    _requestStop(
+      ShotDecisionReason.targetWeight,
+      'Target weight ${targetYield}g reached (projected: $projected).',
+      {'targetYield': targetYield, 'projectedWeight': projected},
+    );
+  }
+
+  void _requestStop(
+    ShotDecisionReason reason,
+    String details,
+    Map<String, dynamic> data,
+  ) {
+    if (_stopRequested) return;
+    _stopRequested = true;
+    _finalStopReason = reason;
+    _emitDecision(ShotDecisionKind.stop, reason, details: details, data: data);
+    unawaited(_requestMachineState(MachineState.idle, 'stop shot'));
+  }
+
+  Future<void> _requestMachineState(
+    MachineState state,
+    String operation,
+  ) async {
+    try {
+      await de1controller.connectedDe1().requestState(state);
+    } catch (error, stackTrace) {
+      _log.warning('Failed to $operation', error, stackTrace);
     }
   }
 
@@ -320,18 +455,14 @@ class ShotSequencer {
     final MachineSnapshot machine = snapshot.machine;
     final int currentFrame = machine.profileFrame;
 
-    // Check if we should be counting volume
     if (_volumeCountingActive &&
         currentFrame >= targetProfile.targetVolumeCountStart) {
       final now = snapshot.machine.timestamp;
 
       if (_lastVolumeUpdateTime != null) {
-        // Calculate time delta in seconds
         final timeDelta =
             now.difference(_lastVolumeUpdateTime!).inMilliseconds / 1000.0;
 
-        // Integrate flow over time to get volume
-        // Flow is in ml/s, timeDelta is in seconds
         final volumeDelta = machine.flow * timeDelta;
         _accumulatedVolume += volumeDelta;
 
@@ -344,16 +475,13 @@ class ShotSequencer {
       _lastVolumeUpdateTime = now;
     }
 
-    // Return snapshot with volume data
     return snapshot.copyWith(volume: _accumulatedVolume);
   }
 
   bool dataCollectionEnabled = false;
-  Future<void>? _stoppingStateFuture;
 
-  void _handleStateTransition(ShotSnapshot snapshot) {
+  void _handleMachineState(ShotSnapshot snapshot) {
     final MachineSnapshot machine = snapshot.machine;
-    final WeightSnapshot? scale = snapshot.scale;
 
     _log.finest(
       "recv: ${machine.state.substate.name}, ${machine.state.state.name}",
@@ -361,10 +489,6 @@ class ShotSequencer {
 
     _log.finest("State in: ${_state.name}");
 
-    // Terminal arm: a machine fault ends the shot from any active phase.
-    // Without this the sequencer would sit in `pouring` forever — the DE1
-    // reports MachineState.error, not espresso/pouringDone, so the regular
-    // stop detection below never fires.
     if (machine.state.state == MachineState.error &&
         _state != ShotState.idle &&
         _state != ShotState.finished) {
@@ -389,7 +513,6 @@ class ShotSequencer {
           _resetCommand.add(true);
           _shotStartTime = DateTime.now();
 
-          // Reset volume counting for new shot
           _accumulatedVolume = 0.0;
           _lastVolumeUpdateTime = null;
           _volumeCountingActive = false;
@@ -397,21 +520,19 @@ class ShotSequencer {
           _stoppingYieldLocked = false;
           _settleSamples = 0;
           _prevStoppingFlow = null;
-          skippedSteps.clear();
+          skippedSteps = const {};
           _stepExitArbiter.reset();
           _lastProfileFrame = -1;
           _maxFrameSeen = -1;
           _finalStopReason = null;
+          _stopRequested = false;
+          _pourTareStarted = false;
+          _pourTareSucceeded = false;
+          _pourTareZeroObserved = false;
+          _finalCrossing.reset();
+          _stepCrossing.reset();
 
-          if (_bypassSAW == false && scale != null && !_scaleLost) {
-            _log.info(
-              "Machine getting ready. Taring scale and resetting timer...",
-            );
-            scaleController.tare().catchError(
-              (e) => _log.warning("Failed to tare scale at shot start", e),
-            );
-            scaleController.connectedScale().resetTimer();
-          }
+          _enqueuePreparingCommands();
           _state = ShotState.preheating;
           _stateStream.add(_state);
           dataCollectionEnabled = true;
@@ -419,18 +540,8 @@ class ShotSequencer {
         break;
 
       case ShotState.preheating:
-        // Abort arm: the machine left espresso before the pour began (GHC /
-        // app / REST stop during preheat, or a mode change). End the shot as
-        // an abort so De1StateManager tears the sequencer down — otherwise it
-        // sits in `preheating` forever, hangs the shotState feed on a stale
-        // frame, and gets recycled into the next espresso/steam/hot-water
-        // session. A steam session (De1SubState.steaming also maps to the
-        // `pouring` substate) is caught here by the state check, not the
-        // substate check below.
         if (machine.state.state != MachineState.espresso) {
           final intent = de1controller.consumeStopIntent();
-          // No _finalStopReason: an aborted shot is never persisted — the
-          // abort decision itself carries the reason to the feed.
           _emitDecision(
             ShotDecisionKind.abort,
             intent ?? ShotDecisionReason.machineEnded,
@@ -440,149 +551,74 @@ class ShotSequencer {
         }
         if (machine.state.substate == MachineSubstate.preinfusion ||
             machine.state.substate == MachineSubstate.pouring) {
-          if (_bypassSAW == false && scale != null && !_scaleLost) {
-            _log.info("Taring scale again and starting timer.");
-            scaleController.tare().catchError(
-              (e) => _log.warning("Failed to tare scale for pour", e),
-            );
-            scaleController.connectedScale().startTimer();
-            _scaleTared = true;
-          }
-
-          // Start volume counting when shot begins
           _volumeCountingActive = true;
           _log.info(
             "Volume counting activated. Will start from frame ${targetProfile.targetVolumeCountStart}",
           );
 
-          // TODO: Settings control, whether reset should happen here or not
-          //_resetCommand.add(true);
           _state = ShotState.pouring;
           _stateStream.add(_state);
+          _enqueuePourCommands();
         }
         break;
 
       case ShotState.pouring:
         _trackFrameAdvance(machine.profileFrame);
-        if (_bypassSAW == false && scale != null && !_scaleLost) {
-          double currentWeight = scale.weight;
-          double weightFlow = scale.controlWeightFlow;
-          double projectedWeight =
-              currentWeight + (weightFlow * _weightFlowMultiplier);
-
-          _handleStepWeightExit(machine.profileFrame, projectedWeight, machine);
-          if (!_machineHasAutonomousSAW &&
-              targetYield > 0 &&
-              projectedWeight >= targetYield) {
-            _finalStopReason = ShotDecisionReason.targetWeight;
+        if (machine.state.substate == MachineSubstate.pouringDone ||
+            machine.state.substate == MachineSubstate.idle) {
+          if (!_stopRequested) {
+            final intent = de1controller.consumeStopIntent();
+            final reason = intent ?? ShotDecisionReason.machineEnded;
+            _finalStopReason ??= reason;
             _emitDecision(
               ShotDecisionKind.stop,
-              ShotDecisionReason.targetWeight,
-              details:
-                  'Target weight ${targetYield}g reached '
-                  '(projected: $projectedWeight). Stopping shot.',
-              data: {
-                'targetYield': targetYield,
-                'projectedWeight': projectedWeight,
+              reason,
+              details: switch (reason) {
+                ShotDecisionReason.apiStop =>
+                  'Shot stopped via REST API request',
+                ShotDecisionReason.appStop => 'Shot stopped from the app UI',
+                _ =>
+                  'Machine reported shot end '
+                      '(${machine.state.substate.name})',
               },
             );
-            de1controller.connectedDe1().requestState(
-              MachineState.idle,
-            ); // Send stop command to machine
-            _enterStopping(scale);
-            break;
           }
+          _enterStopping(
+            _scaleAvailability == _ScaleAvailability.ready
+                ? _latestScale
+                : null,
+          );
+          break;
         }
-        if (!_bypassSAW &&
+        if (!_stopRequested &&
+            !_bypassSAW &&
             !_machineHasAutonomousSAW &&
-            (scale == null || _scaleLost) &&
+            (_scaleAvailability == _ScaleAvailability.unavailable ||
+                _scaleAvailability == _ScaleAvailability.stale) &&
             (targetProfile.targetVolume ?? 0) > 0) {
-          // Use volumeFlowMultiplier to project future volume and stop at the right time
           final projectedVolume =
               _accumulatedVolume + (machine.flow * _volumeFlowMultiplier);
           if (projectedVolume > targetProfile.targetVolume!) {
-            _finalStopReason = ShotDecisionReason.targetVolume;
-            _emitDecision(
-              ShotDecisionKind.stop,
+            _requestStop(
               ShotDecisionReason.targetVolume,
-              details:
-                  'Target volume ${targetProfile.targetVolume}ml reached '
-                  '(projected: $projectedVolume). Stopping shot.',
-              data: {
+              'Target volume ${targetProfile.targetVolume}ml reached '
+              '(projected: $projectedVolume).',
+              {
                 'targetVolume': targetProfile.targetVolume,
                 'projectedVolume': projectedVolume,
               },
             );
-            de1controller.connectedDe1().requestState(
-              MachineState.idle,
-            ); // Send stop command to machine
-            _enterStopping(scale);
-            break;
           }
-        }
-        if (machine.state.substate == MachineSubstate.pouringDone ||
-            machine.state.substate == MachineSubstate.idle) {
-          // The machine reported the end without an app-side target firing.
-          // If a stop command recently passed through this app (REST client
-          // or the in-app Stop button), attribute it to that source; the
-          // unmarked remainder is the GHC or natural profile completion,
-          // indistinguishable from the substate stream alone.
-          final intent = de1controller.consumeStopIntent();
-          final reason = intent ?? ShotDecisionReason.machineEnded;
-          _finalStopReason ??= reason;
-          _emitDecision(
-            ShotDecisionKind.stop,
-            reason,
-            details: switch (reason) {
-              ShotDecisionReason.apiStop => 'Shot stopped via REST API request',
-              ShotDecisionReason.appStop => 'Shot stopped from the app UI',
-              _ =>
-                'Machine reported shot end '
-                    '(${machine.state.substate.name})',
-            },
-          );
-          _enterStopping(scale);
         }
         break;
 
       case ShotState.stopping:
-        // Stop volume counting and scale timer
-        _volumeCountingActive = false;
-        if (_bypassSAW == false && scale != null && !_scaleLost) {
-          scaleController.connectedScale().stopTimer();
-        }
-
-        _refineStoppingYield(scale);
-        if (_stoppingYieldLocked) {
-          _log.info(
-            "Final yield ${trustedFinalYield}g locked. "
-            "Final volume: ${_accumulatedVolume}ml",
-          );
-          _finishStopping();
-          break;
-        }
-
-        // Safety backstop: a noisy scale might never produce a settle / removal
-        // / spike event. Guarantee the shot still finalizes.
-        _stoppingStateFuture ??= Future.delayed(_stoppingBackstop, () {
-          if (_state == ShotState.stopping) {
-            _emitDecision(
-              ShotDecisionKind.finalize,
-              ShotDecisionReason.stoppingBackstop,
-              details:
-                  'Stopping backstop fired. '
-                  'Final volume: ${_accumulatedVolume}ml',
-              data: {'finalVolume': _accumulatedVolume},
-            );
-            _finishStopping();
-          }
-        });
         break;
 
       case ShotState.finished:
-        // Reset or prepare for next shot
         dataCollectionEnabled = false;
-        _stoppingStateFuture = null;
+        _stoppingTimer?.cancel();
+        _stoppingTimer = null;
         _state = ShotState.idle;
         _stateStream.add(_state);
         break;
@@ -590,20 +626,10 @@ class ShotSequencer {
     _log.finest("State out: ${_state.name}");
   }
 
-  /// Tracks profile-frame changes during pouring and reports firmware-natural
-  /// advances (frames the app did NOT skip) as `profileAdvance` decisions.
-  ///
-  /// `skippedSteps` records the *vacated* frame at the moment the app
-  /// requests a skip, so an increment whose previous frame is in that set is
-  /// the firmware acknowledging our skip — already reported as `profileSkip`.
-  /// The frame index is a raw byte off the BLE shot sample with no
-  /// monotonicity guarantee, so advances are emitted against a high-water
-  /// mark ([_maxFrameSeen]): a jump >1 reports each vacated frame once, and a
-  /// regression followed by recovery does not re-report frames already
-  /// emitted. The arbiter still tracks the true current frame separately.
   void _trackFrameAdvance(int profileFrame) {
     if (profileFrame != _lastProfileFrame) {
       _stepExitArbiter.onFrameAdvanced(profileFrame);
+      _stepCrossing.reset();
       _lastProfileFrame = profileFrame;
     }
     if (_maxFrameSeen < 0) {
@@ -639,18 +665,19 @@ class ShotSequencer {
     final step = targetProfile.steps[profileFrame];
     final stepExitWeight = step.weight;
     if (stepExitWeight == null || stepExitWeight <= 0) {
+      _stepCrossing.reset();
       return;
     }
 
     if (skippedSteps.contains(profileFrame)) {
+      _stepCrossing.reset();
       return;
     }
 
-    if (projectedWeight < stepExitWeight) {
+    if (!_stepCrossing.add(projectedWeight >= stepExitWeight)) {
       return;
     }
 
-    // Mixed step: consult the arbiter to avoid racing firmware.
     if (_stepExitArbiterEnabled && step.exit != null) {
       final verdict = _stepExitArbiter.evaluate(
         profileFrame: profileFrame,
@@ -675,22 +702,32 @@ class ShotSequencer {
         'projectedWeight': projectedWeight,
       },
     );
-    skippedSteps.add(profileFrame);
-    de1controller.connectedDe1().requestState(MachineState.skipStep);
+    skippedSteps = {...skippedSteps, profileFrame};
+    unawaited(_requestMachineState(MachineState.skipStep, 'skip profile step'));
   }
 
   void _enterStopping(WeightSnapshot? scale) {
     _latchTrustedFinalYield(scale);
-    // Recording stops at the machine-reported shot end.
+    _prevStoppingFlow = scale?.controlWeightFlow;
+    _volumeCountingActive = false;
     dataCollectionEnabled = false;
-    // The post-stop window exists solely to catch the final drips on the scale
-    // and fold them into the yield (see _refineStoppingYield). With a scale,
-    // hold in `stopping` until the yield locks; without one there is nothing to
-    // catch, so end the shot immediately — no settling window, no waiting.
+    if (!_bypassSAW) _enqueueTimerStop();
     _state = _trustedFinalYield != null
         ? ShotState.stopping
         : ShotState.finished;
     _stateStream.add(_state);
+    if (_state != ShotState.stopping) return;
+    _stoppingTimer?.cancel();
+    _stoppingTimer = Timer(_stoppingBackstop, () {
+      if (_state != ShotState.stopping) return;
+      _emitDecision(
+        ShotDecisionKind.finalize,
+        ShotDecisionReason.stoppingBackstop,
+        details: 'Stopping backstop fired. Final volume: $_accumulatedVolume',
+        data: {'finalVolume': _accumulatedVolume},
+      );
+      _finishStopping();
+    });
   }
 
   void _latchTrustedFinalYield(WeightSnapshot? scale) {
@@ -699,20 +736,6 @@ class ShotSequencer {
     _trustedFinalYield = weight;
   }
 
-  /// Refines the final yield during the post-stop window.
-  ///
-  /// The pump is off, so flow onto the scale can only decay. We keep taking the
-  /// rising weight — turbo catch-up included, with no flow or gram cap — and
-  /// lock the yield on the first of:
-  ///   * removal: a sharp drop (flow below -[_removalFlowThreshold]) — keep the
-  ///     peak from before it;
-  ///   * spike: flow jumping up vs the previous sample (a touch/bump rising
-  ///     against the decay) — keep the prior value;
-  ///   * settle: [_settleSampleCount] consecutive near-still samples — trust the
-  ///     settled reading itself.
-  ///
-  /// Magnitude is never gated, so a high-flow turbo tail is not mistaken for a
-  /// spike; only flow rising *against* the decay is.
   void _refineStoppingYield(WeightSnapshot? scale) {
     if (_stoppingYieldLocked) return;
     final weight = scale?.weight;
@@ -723,25 +746,19 @@ class ShotSequencer {
     final prevFlow = _prevStoppingFlow;
     _prevStoppingFlow = flow;
 
-    // Cup removal — a sharp drop. Keep the peak from before it.
     if (flow < -_removalFlowThreshold) {
       _stoppingYieldLocked = true;
       return;
     }
-    // Touch/bump — flow jumps up against the post-stop decay. Keep the prior
-    // value. Skipped on the first sample, which has no decay baseline yet.
     if (prevFlow != null && flow > prevFlow + _spikeFlowJump) {
       _stoppingYieldLocked = true;
       return;
     }
 
-    // Still filling — take the rising weight.
     if (_trustedFinalYield == null || weight > _trustedFinalYield!) {
       _trustedFinalYield = weight;
     }
 
-    // Settled — trust the settled reading (authoritative over any earlier
-    // transient peak) and lock.
     if (flow.abs() < _settleFlowThreshold) {
       if (++_settleSamples >= _settleSampleCount) {
         _trustedFinalYield = weight;
@@ -753,11 +770,9 @@ class ShotSequencer {
   }
 
   void _finishStopping() {
+    _freshnessTimer?.cancel();
+    _stoppingTimer?.cancel();
     _state = ShotState.finished;
     _stateStream.add(_state);
   }
 }
-
-// ShotState, ShotDecision, ShotDecisionKind and ShotDecisionReason moved to
-// lib/src/models/data/shot_state_event.dart (re-exported above) when the
-// decision stream gained wire serialization for /ws/v1/machine/shotState.

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -120,6 +120,7 @@ class ShotSequencer {
     }
 
     if (scaleConnected) {
+      _scaleGeneration = scaleController.connectionGeneration;
       _commandQueue = ShotScaleCommandQueue(
         scaleController.connectedScale(),
         logger: _log,
@@ -238,6 +239,7 @@ class ShotSequencer {
   MachineSnapshot? _latestMachine;
   WeightSnapshot? _latestScale;
   ShotScaleCommandQueue? _commandQueue;
+  int? _scaleGeneration;
   Timer? _tareConfirmationTimer;
   Timer? _freshnessTimer;
   Timer? _stoppingTimer;
@@ -278,8 +280,13 @@ class ShotSequencer {
   }
 
   void _processScaleConnection(device.ConnectionState state) {
-    if (_disposed || state != device.ConnectionState.disconnected) return;
-    if (_commandQueue == null) return;
+    if (_disposed || _commandQueue == null) return;
+    if (scaleController.connectionGeneration != _scaleGeneration) {
+      _commandQueue?.dispose();
+      _disableScale(_ScaleAvailability.unavailable, 'Active scale changed');
+      return;
+    }
+    if (state != device.ConnectionState.disconnected) return;
     _commandQueue?.dispose();
     _disableScale(_ScaleAvailability.unavailable, 'Scale disconnected');
   }
@@ -288,6 +295,11 @@ class ShotSequencer {
     if (_disposed ||
         _scaleAvailability == _ScaleAvailability.unavailable ||
         _scaleAvailability == _ScaleAvailability.stale) {
+      return;
+    }
+    if (scaleController.connectionGeneration != _scaleGeneration) {
+      _commandQueue?.dispose();
+      _disableScale(_ScaleAvailability.unavailable, 'Active scale changed');
       return;
     }
     _latestScale = scale;

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -567,6 +567,7 @@ class ShotSequencer {
             "Volume counting activated. Will start from frame ${targetProfile.targetVolumeCountStart}",
           );
 
+          _trackFrameAdvance(machine.profileFrame);
           _state = ShotState.pouring;
           _stateStream.add(_state);
           _enqueuePourCommands();

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -123,6 +123,8 @@ class ShotSequencer {
       _scaleGeneration = scaleController.connectionGeneration;
       _commandQueue = ShotScaleCommandQueue(
         scaleController.connectedScale(),
+        isCurrent: () =>
+            scaleController.connectionGeneration == _scaleGeneration,
         logger: _log,
       );
       _scaleAvailability = _bypassSAW

--- a/test/controllers/shot_scale_command_queue_test.dart
+++ b/test/controllers/shot_scale_command_queue_test.dart
@@ -65,8 +65,13 @@ void main() {
 
   test('connection generation change prevents queued commands', () async {
     final blocked = Completer<void>();
+    var completed = false;
 
-    queue.enqueue(ShotScaleCommand.preparingTare, (_) => blocked.future);
+    queue.enqueue(
+      ShotScaleCommand.preparingTare,
+      (_) => blocked.future,
+      onSuccess: () => completed = true,
+    );
     queue.enqueue(ShotScaleCommand.timerReset, (scale) => scale.resetTimer());
     queue.enqueue(ShotScaleCommand.timerStart, (scale) => scale.startTimer());
     await Future<void>.delayed(Duration.zero);
@@ -75,5 +80,6 @@ void main() {
     await queue.settled;
 
     expect(scale.commandCalls, isEmpty);
+    expect(completed, isFalse);
   });
 }

--- a/test/controllers/shot_scale_command_queue_test.dart
+++ b/test/controllers/shot_scale_command_queue_test.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/shot_scale_command_queue.dart';
+
+import '../helpers/test_scale.dart';
+
+void main() {
+  late TestScale scale;
+  late ShotScaleCommandQueue queue;
+
+  setUp(() {
+    scale = TestScale();
+    queue = ShotScaleCommandQueue(scale);
+  });
+
+  tearDown(() {
+    queue.dispose();
+    scale.dispose();
+  });
+
+  test('runs commands once in FIFO order', () async {
+    final blocked = Completer<void>();
+    scale.resetTimerHandler = () => blocked.future;
+
+    queue.enqueue(ShotScaleCommand.timerReset, (scale) => scale.resetTimer());
+    queue.enqueue(ShotScaleCommand.timerStart, (scale) => scale.startTimer());
+    queue.enqueue(ShotScaleCommand.timerStart, (scale) => scale.startTimer());
+    await Future<void>.delayed(Duration.zero);
+
+    expect(scale.commandCalls, ['reset']);
+    blocked.complete();
+    await queue.settled;
+    expect(scale.commandCalls, ['reset', 'start']);
+  });
+
+  test('a failed command does not poison later work', () async {
+    scale.resetTimerHandler = () => Future.error(StateError('failed'));
+
+    queue.enqueue(ShotScaleCommand.timerReset, (scale) => scale.resetTimer());
+    queue.enqueue(ShotScaleCommand.timerStart, (scale) => scale.startTimer());
+    await queue.settled;
+
+    expect(scale.commandCalls, ['reset', 'start']);
+  });
+
+  test('dispose prevents queued commands from starting', () async {
+    final blocked = Completer<void>();
+    scale.resetTimerHandler = () => blocked.future;
+
+    queue.enqueue(ShotScaleCommand.timerReset, (scale) => scale.resetTimer());
+    queue.enqueue(ShotScaleCommand.timerStart, (scale) => scale.startTimer());
+    await Future<void>.delayed(Duration.zero);
+    queue.dispose();
+    blocked.complete();
+    await queue.settled;
+
+    expect(scale.commandCalls, ['reset']);
+  });
+}

--- a/test/controllers/shot_scale_command_queue_test.dart
+++ b/test/controllers/shot_scale_command_queue_test.dart
@@ -8,10 +8,15 @@ import '../helpers/test_scale.dart';
 void main() {
   late TestScale scale;
   late ShotScaleCommandQueue queue;
+  late int connectionGeneration;
 
   setUp(() {
     scale = TestScale();
-    queue = ShotScaleCommandQueue(scale);
+    connectionGeneration = 0;
+    queue = ShotScaleCommandQueue(
+      scale,
+      isCurrent: () => connectionGeneration == 0,
+    );
   });
 
   tearDown(() {
@@ -56,5 +61,19 @@ void main() {
     await queue.settled;
 
     expect(scale.commandCalls, ['reset']);
+  });
+
+  test('connection generation change prevents queued commands', () async {
+    final blocked = Completer<void>();
+
+    queue.enqueue(ShotScaleCommand.preparingTare, (_) => blocked.future);
+    queue.enqueue(ShotScaleCommand.timerReset, (scale) => scale.resetTimer());
+    queue.enqueue(ShotScaleCommand.timerStart, (scale) => scale.startTimer());
+    await Future<void>.delayed(Duration.zero);
+    connectionGeneration++;
+    blocked.complete();
+    await queue.settled;
+
+    expect(scale.commandCalls, isEmpty);
   });
 }

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -17,12 +17,12 @@ import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/impl/bengle/bengle_virtual_scale.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../helpers/test_de1.dart';
-import '../helpers/test_scale.dart';
 
 /// Bengle-flavoured TestDe1: reuses every DE1-side behavior but also
 /// implements [BengleInterface] so `machine is BengleInterface` returns
@@ -30,6 +30,8 @@ import '../helpers/test_scale.dart';
 /// because TestDe1 already covers the full De1Interface surface.
 class _TestBengle extends TestDe1 implements BengleInterface {
   final List<double> sawWrites = [];
+  final BehaviorSubject<ScaleSnapshot> _weight = BehaviorSubject(sync: true);
+  int tareCalls = 0;
 
   @override
   Future<void> setStopAtWeightTarget(double grams) async {
@@ -47,9 +49,13 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   @override
   Future<double> getCupWarmerTemperature() async => 0.0;
   @override
-  Stream<ScaleSnapshot> get weightSnapshot => const Stream.empty();
+  Stream<ScaleSnapshot> get weightSnapshot => _weight.stream;
   @override
-  Future<void> tareIntegratedScale() async {}
+  Future<void> tareIntegratedScale() async {
+    tareCalls++;
+    if (tareCalls == 2) _emitWeight(0);
+  }
+
   @override
   Stream<LedStripState> get ledStripState => const Stream.empty();
   @override
@@ -71,6 +77,30 @@ class _TestBengle extends TestDe1 implements BengleInterface {
   Stream<bool> get probeAttached => const Stream.empty();
   @override
   Stream<double> get probeTemperature => const Stream.empty();
+
+  void emitIntegratedSample(double weight) {
+    emitStateAndSubstate(
+      snapshotSubject.value.state.state,
+      snapshotSubject.value.state.substate,
+    );
+    _emitWeight(weight);
+  }
+
+  void _emitWeight(double weight) {
+    _weight.add(
+      ScaleSnapshot(
+        timestamp: DateTime(2026, 1, 15, 8, 0),
+        weight: weight,
+        batteryLevel: 100,
+      ),
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _weight.close();
+    await super.dispose();
+  }
 }
 
 class _FakeDiscoveryService extends DeviceDiscoveryService {
@@ -95,45 +125,30 @@ class _BengleDe1Controller extends De1Controller {
   Stream<De1Interface?> get de1 => BehaviorSubject.seeded(bengle).stream;
 }
 
-class _TestScaleController extends ScaleController {
-  final TestScale testScale;
-  final BehaviorSubject<ConnectionState> _connectionState;
-  final BehaviorSubject<WeightSnapshot> _weight = BehaviorSubject();
+class _BengleScaleController extends ScaleController {
+  final BengleVirtualScale scale;
 
-  _TestScaleController(this.testScale)
-    : _connectionState = BehaviorSubject.seeded(ConnectionState.connected);
+  _BengleScaleController(this.scale);
 
   @override
-  Stream<ConnectionState> get connectionState => _connectionState.stream;
-  @override
-  ConnectionState get currentConnectionState => _connectionState.value;
-  @override
-  Stream<WeightSnapshot> get weightSnapshot => _weight.stream;
+  Stream<ConnectionState> get connectionState => scale.connectionState;
 
   @override
-  Scale connectedScale() {
-    if (_connectionState.value != ConnectionState.connected) {
-      throw 'No scale connected';
-    }
-    return testScale;
-  }
-
-  void emitWeight(double weight, {double weightFlow = 0.0}) {
-    _weight.add(
-      WeightSnapshot(
-        timestamp: DateTime(2026, 1, 15, 8, 0),
-        weight: weight,
-        weightFlow: weightFlow,
-      ),
-    );
-  }
+  ConnectionState get currentConnectionState => ConnectionState.connected;
 
   @override
-  void dispose() {
-    _connectionState.close();
-    _weight.close();
-    super.dispose();
-  }
+  Stream<WeightSnapshot> get weightSnapshot => scale.currentSnapshot.map(
+    (snapshot) => WeightSnapshot(
+      timestamp: snapshot.timestamp,
+      weight: snapshot.weight,
+      weightFlow: 0,
+      battery: snapshot.batteryLevel,
+      timerValue: snapshot.timerValue,
+    ),
+  );
+
+  @override
+  Scale connectedScale() => scale;
 }
 
 class _NullStorageService implements StorageService {
@@ -230,29 +245,23 @@ void main() {
     () {
       late _TestBengle bengle;
       late _BengleDe1Controller de1Controller;
-      late TestScale testScale;
-      late _TestScaleController scaleController;
+      late ScaleController scaleController;
       late PersistenceController persistence;
       late Profile profile;
 
       setUp(() {
         bengle = _TestBengle();
         de1Controller = _BengleDe1Controller(bengle);
-        testScale = TestScale();
-        scaleController = _TestScaleController(testScale);
-        testScale.tareHandler = () async {
-          if (testScale.tareCallCount == 2) scaleController.emitWeight(0);
-        };
+        scaleController = _BengleScaleController(BengleVirtualScale(bengle));
         persistence = PersistenceController(
           storageService: _NullStorageService(),
         );
         profile = _simpleProfile();
       });
 
-      tearDown(() {
-        bengle.dispose();
-        testScale.dispose();
+      tearDown(() async {
         scaleController.dispose();
+        await bengle.dispose();
         persistence.dispose();
       });
 
@@ -260,8 +269,6 @@ void main() {
         'does not request idle even when projected weight exceeds target',
         () {
           fakeAsync((async) {
-            scaleController.emitWeight(0.0);
-
             final shot = ShotSequencer(
               scaleController: scaleController,
               de1controller: de1Controller,
@@ -290,11 +297,7 @@ void main() {
             async.elapse(const Duration(milliseconds: 10));
 
             // Weight blows past the target. App SAW would normally fire.
-            scaleController.emitWeight(40.0);
-            bengle.emitStateAndSubstate(
-              MachineState.espresso,
-              MachineSubstate.pouring,
-            );
+            bengle.emitIntegratedSample(40.0);
             async.elapse(const Duration(milliseconds: 10));
 
             expect(
@@ -312,6 +315,10 @@ void main() {
 
       test('keeps machine cadence and app-side step exits', () {
         fakeAsync((async) {
+          final nativeWeights = <WeightSnapshot>[];
+          final weightSubscription = scaleController.weightSnapshot.listen(
+            nativeWeights.add,
+          );
           final shot = ShotSequencer(
             scaleController: scaleController,
             de1controller: de1Controller,
@@ -343,26 +350,23 @@ void main() {
           final rawBefore = raw.length;
           final persistedBefore = persisted.length;
 
-          scaleController.emitWeight(12);
-          scaleController.emitWeight(12);
+          bengle.emitIntegratedSample(12);
+          bengle.emitIntegratedSample(12);
           async.flushMicrotasks();
+          expect(bengle.tareCalls, 2);
+          expect(nativeWeights.map((sample) => sample.weight), [0, 12, 12]);
+          expect(shot.scaleLost, isFalse);
           expect(bengle.requestedStates, [MachineState.skipStep]);
-          expect(raw, hasLength(rawBefore));
-          expect(persisted, hasLength(persistedBefore));
+          expect(raw, hasLength(rawBefore + 2));
+          expect(persisted, hasLength(persistedBefore + 2));
           expect(
             states.where((state) => state == ShotState.pouring),
             hasLength(1),
           );
 
-          bengle.emitStateAndSubstate(
-            MachineState.espresso,
-            MachineSubstate.pouring,
-          );
-          async.flushMicrotasks();
-          expect(raw, hasLength(rawBefore + 1));
-          expect(persisted, hasLength(persistedBefore + 1));
           expect(bengle.requestedStates, isNot(contains(MachineState.idle)));
           shot.dispose();
+          weightSubscription.cancel();
         });
       });
     },

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -137,6 +137,10 @@ class _BengleScaleController extends ScaleController {
   ConnectionState get currentConnectionState => ConnectionState.connected;
 
   @override
+  ({Scale scale, int generation})? get currentScaleLease =>
+      (scale: scale, generation: connectionGeneration);
+
+  @override
   Stream<WeightSnapshot> get weightSnapshot => scale.currentSnapshot.map(
     (snapshot) => WeightSnapshot(
       timestamp: snapshot.timestamp,

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -201,7 +201,7 @@ class _NullStorageService implements StorageService {
   Future<SteamRecord?> getLatestSteamMeta() async => null;
 }
 
-Profile _simpleProfile() => Profile(
+Profile _simpleProfile({double? stepWeight}) => Profile(
   version: '2',
   title: 'T',
   notes: '',
@@ -216,6 +216,7 @@ Profile _simpleProfile() => Profile(
       transition: TransitionType.fast,
       volume: 0,
       seconds: 30,
+      weight: stepWeight,
       temperature: 93,
       sensor: TemperatureSensor.coffee,
       pressure: 9,
@@ -239,6 +240,9 @@ void main() {
         de1Controller = _BengleDe1Controller(bengle);
         testScale = TestScale();
         scaleController = _TestScaleController(testScale);
+        testScale.tareHandler = () async {
+          if (testScale.tareCallCount == 2) scaleController.emitWeight(0);
+        };
         persistence = PersistenceController(
           storageService: _NullStorageService(),
         );
@@ -305,6 +309,62 @@ void main() {
           });
         },
       );
+
+      test('keeps machine cadence and app-side step exits', () {
+        fakeAsync((async) {
+          final shot = ShotSequencer(
+            scaleController: scaleController,
+            de1controller: de1Controller,
+            persistenceController: persistence,
+            targetProfile: _simpleProfile(stepWeight: 10),
+            targetYield: 30,
+            bypassSAW: false,
+            blockOnNoScale: false,
+            weightFlowMultiplier: 0,
+            volumeFlowMultiplier: 0,
+            stepExitArbiterEnabled: true,
+          );
+          final states = <ShotState>[];
+          final raw = <Object>[];
+          final persisted = <Object>[];
+          shot.state.listen(states.add);
+          shot.rawData.listen(raw.add);
+          shot.shotData.listen(persisted.add);
+
+          bengle.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.preparingForShot,
+          );
+          bengle.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.pouring,
+          );
+          async.flushMicrotasks();
+          final rawBefore = raw.length;
+          final persistedBefore = persisted.length;
+
+          scaleController.emitWeight(12);
+          scaleController.emitWeight(12);
+          async.flushMicrotasks();
+          expect(bengle.requestedStates, [MachineState.skipStep]);
+          expect(raw, hasLength(rawBefore));
+          expect(persisted, hasLength(persistedBefore));
+          expect(
+            states.where((state) => state == ShotState.pouring),
+            hasLength(1),
+          );
+
+          bengle.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.pouring,
+          );
+          async.flushMicrotasks();
+          expect(raw, hasLength(rawBefore + 1));
+          expect(persisted, hasLength(persistedBefore + 1));
+          expect(bengle.requestedStates, isNot(contains(MachineState.idle)));
+          shot.dispose();
+        });
+      });
     },
   );
 }

--- a/test/controllers/shot_sequencer_native_scale_test.dart
+++ b/test/controllers/shot_sequencer_native_scale_test.dart
@@ -47,7 +47,11 @@ class _UnusedStorage implements StorageService {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-Profile _profile({double? targetVolume, double? stepWeight}) => Profile(
+Profile _profile({
+  double? targetVolume,
+  double? stepWeight,
+  double? secondStepWeight,
+}) => Profile(
   version: '2',
   title: 'native scale',
   notes: '',
@@ -68,6 +72,17 @@ Profile _profile({double? targetVolume, double? stepWeight}) => Profile(
       sensor: TemperatureSensor.coffee,
       pressure: 9,
     ),
+    if (secondStepWeight != null)
+      ProfileStepPressure(
+        name: 'second pour',
+        transition: TransitionType.fast,
+        volume: 0,
+        seconds: 30,
+        weight: secondStepWeight,
+        temperature: 93,
+        sensor: TemperatureSensor.coffee,
+        pressure: 9,
+      ),
   ],
 );
 
@@ -98,11 +113,16 @@ void main() {
     double targetYield = 36,
     double? targetVolume,
     double? stepWeight,
+    double? secondStepWeight,
   }) => ShotSequencer(
     scaleController: scaleController,
     de1controller: de1Controller,
     persistenceController: persistence,
-    targetProfile: _profile(targetVolume: targetVolume, stepWeight: stepWeight),
+    targetProfile: _profile(
+      targetVolume: targetVolume,
+      stepWeight: stepWeight,
+      secondStepWeight: secondStepWeight,
+    ),
     targetYield: targetYield,
     bypassSAW: false,
     blockOnNoScale: false,
@@ -389,10 +409,6 @@ void main() {
       final shot = makeShot();
       driveToPouring(async);
 
-      machine.emitStateAndSubstate(
-        MachineState.espresso,
-        MachineSubstate.pouring,
-      );
       scaleController.emitWeight(40);
       machine.emitSnapshot(
         machine.snapshotSubject.value.copyWith(profileFrame: 1),
@@ -404,6 +420,31 @@ void main() {
       scaleController.emitWeight(40);
       async.flushMicrotasks();
       expect(machine.requestedStates, [MachineState.idle]);
+      shot.dispose();
+    });
+  });
+
+  test('first profile frame change resets step crossing candidate', () {
+    fakeAsync((async) {
+      enableAutomaticZero();
+      final shot = makeShot(
+        targetYield: 0,
+        stepWeight: 10,
+        secondStepWeight: 10,
+      );
+      driveToPouring(async);
+
+      scaleController.emitWeight(12);
+      machine.emitSnapshot(
+        machine.snapshotSubject.value.copyWith(profileFrame: 1),
+      );
+      scaleController.emitWeight(12);
+      async.flushMicrotasks();
+      expect(machine.requestedStates, isEmpty);
+
+      scaleController.emitWeight(12);
+      async.flushMicrotasks();
+      expect(machine.requestedStates, [MachineState.skipStep]);
       shot.dispose();
     });
   });

--- a/test/controllers/shot_sequencer_native_scale_test.dart
+++ b/test/controllers/shot_sequencer_native_scale_test.dart
@@ -298,6 +298,24 @@ void main() {
     });
   });
 
+  test('replacement scale samples cannot stop or skip the shot', () {
+    fakeAsync((async) {
+      enableAutomaticZero();
+      final shot = makeShot(stepWeight: 10);
+      driveToPouring(async);
+
+      scaleController.simulateScaleSwitch();
+      async.flushMicrotasks();
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      async.flushMicrotasks();
+
+      expect(machine.requestedStates, isEmpty);
+      expect(shot.scaleLost, isTrue);
+      shot.dispose();
+    });
+  });
+
   test('stale feed cannot re-arm scale control', () {
     fakeAsync((async) {
       enableAutomaticZero();

--- a/test/controllers/shot_sequencer_native_scale_test.dart
+++ b/test/controllers/shot_sequencer_native_scale_test.dart
@@ -1,0 +1,362 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/shot_sequencer.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/services/storage/storage_service.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../helpers/test_de1.dart';
+import '../helpers/test_scale.dart';
+import '../helpers/test_scale_controller.dart';
+
+class _Discovery extends DeviceDiscoveryService {
+  @override
+  Stream<List<Device>> get devices => const Stream.empty();
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+}
+
+class _De1Controller extends De1Controller {
+  final TestDe1 machine;
+
+  _De1Controller(this.machine)
+    : super(controller: DeviceController([_Discovery()]));
+
+  @override
+  De1Interface connectedDe1() => machine;
+
+  @override
+  Stream<De1Interface?> get de1 => BehaviorSubject.seeded(machine).stream;
+}
+
+class _UnusedStorage implements StorageService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Profile _profile({double? targetVolume, double? stepWeight}) => Profile(
+  version: '2',
+  title: 'native scale',
+  notes: '',
+  author: 'test',
+  beverageType: BeverageType.espresso,
+  targetVolumeCountStart: 0,
+  targetVolume: targetVolume,
+  targetWeight: 36,
+  tankTemperature: 0,
+  steps: [
+    ProfileStepPressure(
+      name: 'pour',
+      transition: TransitionType.fast,
+      volume: 0,
+      seconds: 30,
+      weight: stepWeight,
+      temperature: 93,
+      sensor: TemperatureSensor.coffee,
+      pressure: 9,
+    ),
+  ],
+);
+
+void main() {
+  late TestDe1 machine;
+  late TestScale scale;
+  late TestScaleController scaleController;
+  late _De1Controller de1Controller;
+  late PersistenceController persistence;
+
+  setUp(() {
+    machine = TestDe1();
+    scale = TestScale();
+    scaleController = TestScaleController(scale);
+    de1Controller = _De1Controller(machine);
+    persistence = PersistenceController(storageService: _UnusedStorage());
+  });
+
+  tearDown(() {
+    machine.dispose();
+    scale.dispose();
+    scaleController.dispose();
+    persistence.dispose();
+  });
+
+  ShotSequencer makeShot({
+    Duration timeout = const Duration(milliseconds: 100),
+    double targetYield = 36,
+    double? targetVolume,
+    double? stepWeight,
+  }) => ShotSequencer(
+    scaleController: scaleController,
+    de1controller: de1Controller,
+    persistenceController: persistence,
+    targetProfile: _profile(targetVolume: targetVolume, stepWeight: stepWeight),
+    targetYield: targetYield,
+    bypassSAW: false,
+    blockOnNoScale: false,
+    weightFlowMultiplier: 0,
+    volumeFlowMultiplier: 0,
+    stepExitArbiterEnabled: true,
+    tareConfirmationTimeout: timeout,
+    scaleFreshnessTimeout: timeout,
+  );
+
+  void driveToPouring(FakeAsync async) {
+    machine.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.preparingForShot,
+    );
+    machine.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.pouring,
+    );
+    async.flushMicrotasks();
+  }
+
+  void enableAutomaticZero() {
+    scale.tareHandler = () async {
+      if (scale.tareCallCount == 2) scaleController.emitWeight(0);
+    };
+  }
+
+  test(
+    'machine cadence stays independent and crossings use native samples',
+    () {
+      fakeAsync((async) {
+        final shot = makeShot();
+        final states = <ShotState>[];
+        final raw = <Object>[];
+        final persisted = <Object>[];
+        shot.state.listen(states.add);
+        shot.rawData.listen(raw.add);
+        shot.shotData.listen(persisted.add);
+
+        machine.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.preparingForShot,
+        );
+        machine.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouring,
+        );
+        async.flushMicrotasks();
+        expect(shot.currentState, ShotState.pouring);
+        scaleController.emitWeight(0);
+        async.flushMicrotasks();
+
+        final rawBefore = raw.length;
+        final persistedBefore = persisted.length;
+        scaleController.emitWeight(40);
+        for (var i = 0; i < 10; i++) {
+          machine.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.pouring,
+          );
+        }
+        async.flushMicrotasks();
+        expect(machine.requestedStates, isNot(contains(MachineState.idle)));
+        expect(raw, hasLength(rawBefore + 10));
+        expect(persisted, hasLength(persistedBefore + 10));
+
+        scaleController.emitWeight(20);
+        scaleController.emitWeight(40);
+        expect(machine.requestedStates, isNot(contains(MachineState.idle)));
+        scaleController.emitWeight(40);
+        async.flushMicrotasks();
+        expect(
+          machine.requestedStates.where((state) => state == MachineState.idle),
+          hasLength(1),
+        );
+        expect(states.last, ShotState.pouring);
+        expect(raw, hasLength(rawBefore + 10));
+
+        machine.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouringDone,
+        );
+        async.flushMicrotasks();
+        expect(states, contains(ShotState.stopping));
+        expect(
+          scale.commandCalls.where((call) => call == 'stop'),
+          hasLength(1),
+        );
+        shot.dispose();
+      });
+    },
+  );
+
+  test('tare success without a zero sample never arms scale control', () {
+    fakeAsync((async) {
+      final shot = makeShot();
+      driveToPouring(async);
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      expect(machine.requestedStates, isEmpty);
+      async.elapse(const Duration(milliseconds: 101));
+      scaleController.emitWeight(0);
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      expect(machine.requestedStates, isEmpty);
+      expect(shot.scaleLost, isTrue);
+      shot.dispose();
+    });
+  });
+
+  test('zero before tare completion arms only after completion', () {
+    fakeAsync((async) {
+      final pourTare = Completer<void>();
+      scale.tareHandler = () {
+        if (scale.tareCallCount != 2) return Future.value();
+        scaleController.emitWeight(0);
+        return pourTare.future;
+      };
+      final shot = makeShot();
+      driveToPouring(async);
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      expect(machine.requestedStates, isEmpty);
+      pourTare.complete();
+      async.flushMicrotasks();
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      async.flushMicrotasks();
+      expect(machine.requestedStates, [MachineState.idle]);
+      shot.dispose();
+    });
+  });
+
+  test('tare completion before zero arms only after the zero sample', () {
+    fakeAsync((async) {
+      final shot = makeShot();
+      driveToPouring(async);
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      expect(machine.requestedStates, isEmpty);
+      scaleController.emitWeight(0);
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      async.flushMicrotasks();
+      expect(machine.requestedStates, [MachineState.idle]);
+      shot.dispose();
+    });
+  });
+
+  test('tare failure permanently enables volume fallback', () {
+    fakeAsync((async) {
+      scale.tareHandler = () => scale.tareCallCount == 2
+          ? Future.error(StateError('tare failed'))
+          : Future.value();
+      final shot = makeShot(targetVolume: 1);
+      driveToPouring(async);
+
+      var snapshot = machine.snapshotSubject.value;
+      machine.emitSnapshot(
+        snapshot.copyWith(
+          timestamp: snapshot.timestamp.add(const Duration(seconds: 1)),
+          flow: 2,
+        ),
+      );
+      snapshot = machine.snapshotSubject.value;
+      machine.emitSnapshot(
+        snapshot.copyWith(
+          timestamp: snapshot.timestamp.add(const Duration(seconds: 1)),
+          flow: 2,
+        ),
+      );
+      async.flushMicrotasks();
+      expect(machine.requestedStates, [MachineState.idle]);
+      expect(shot.scaleLost, isTrue);
+      shot.dispose();
+    });
+  });
+
+  test('disconnect cannot re-arm scale control', () {
+    fakeAsync((async) {
+      enableAutomaticZero();
+      final disconnected = makeShot();
+      driveToPouring(async);
+      scaleController.emitWeight(40);
+      scaleController.simulateDisconnect();
+      async.flushMicrotasks();
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      expect(machine.requestedStates, isEmpty);
+      expect(disconnected.scaleLost, isTrue);
+      disconnected.dispose();
+    });
+  });
+
+  test('stale feed cannot re-arm scale control', () {
+    fakeAsync((async) {
+      enableAutomaticZero();
+      final stale = makeShot();
+      driveToPouring(async);
+      async.elapse(const Duration(milliseconds: 101));
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      expect(machine.requestedStates, isEmpty);
+      expect(stale.scaleLost, isTrue);
+      stale.dispose();
+    });
+  });
+
+  test('failed machine stop is owned until machine confirmation', () {
+    fakeAsync((async) {
+      enableAutomaticZero();
+      machine.requestStateHandler = (_) => Future.error(StateError('write'));
+      final shot = makeShot();
+      final states = <ShotState>[];
+      shot.state.listen(states.add);
+      driveToPouring(async);
+      scaleController.emitWeight(40);
+      scaleController.emitWeight(40);
+      async.flushMicrotasks();
+      expect(machine.requestedStates, [MachineState.idle]);
+      expect(states.last, ShotState.pouring);
+
+      machine.requestStateHandler = null;
+      machine.emitStateAndSubstate(
+        MachineState.espresso,
+        MachineSubstate.pouringDone,
+      );
+      async.flushMicrotasks();
+      expect(states, contains(ShotState.stopping));
+      expect(scale.commandCalls.where((call) => call == 'stop'), hasLength(1));
+      shot.dispose();
+    });
+  });
+
+  test('blocked reset preserves command order and timer start', () {
+    fakeAsync((async) {
+      final reset = Completer<void>();
+      enableAutomaticZero();
+      scale.resetTimerHandler = () => reset.future;
+      final shot = makeShot(targetYield: 0);
+      driveToPouring(async);
+      expect(scale.commandCalls, ['tare', 'reset']);
+
+      reset.complete();
+      async.flushMicrotasks();
+      expect(scale.commandCalls, ['tare', 'reset', 'tare', 'start']);
+      machine.emitStateAndSubstate(
+        MachineState.espresso,
+        MachineSubstate.pouringDone,
+      );
+      async.flushMicrotasks();
+      expect(scale.commandCalls, ['tare', 'reset', 'tare', 'start', 'stop']);
+      shot.dispose();
+    });
+  });
+}

--- a/test/controllers/shot_sequencer_native_scale_test.dart
+++ b/test/controllers/shot_sequencer_native_scale_test.dart
@@ -330,6 +330,84 @@ void main() {
     });
   });
 
+  test('pour freshness expires while preparing command is blocked', () {
+    fakeAsync((async) {
+      final preparingTare = Completer<void>();
+      scale.tareHandler = () => preparingTare.future;
+      final shot = makeShot(targetYield: 0, targetVolume: 1);
+      driveToPouring(async);
+
+      async.elapse(const Duration(milliseconds: 101));
+      var snapshot = machine.snapshotSubject.value;
+      machine.emitSnapshot(
+        snapshot.copyWith(
+          timestamp: snapshot.timestamp.add(const Duration(seconds: 1)),
+          flow: 2,
+        ),
+      );
+      snapshot = machine.snapshotSubject.value;
+      machine.emitSnapshot(
+        snapshot.copyWith(
+          timestamp: snapshot.timestamp.add(const Duration(seconds: 1)),
+          flow: 2,
+        ),
+      );
+      async.flushMicrotasks();
+
+      expect(machine.requestedStates, [MachineState.idle]);
+      expect(shot.scaleLost, isTrue);
+      preparingTare.complete();
+      async.flushMicrotasks();
+      shot.dispose();
+    });
+  });
+
+  test('tare completion does not renew callback freshness', () {
+    fakeAsync((async) {
+      final pourTare = Completer<void>();
+      scale.tareHandler = () {
+        if (scale.tareCallCount != 2) return Future.value();
+        scaleController.emitWeight(0);
+        return pourTare.future;
+      };
+      final shot = makeShot(targetYield: 0);
+      driveToPouring(async);
+
+      async.elapse(const Duration(milliseconds: 90));
+      pourTare.complete();
+      async.flushMicrotasks();
+      async.elapse(const Duration(milliseconds: 11));
+
+      expect(shot.scaleLost, isTrue);
+      shot.dispose();
+    });
+  });
+
+  test('profile frame change resets final crossing candidate', () {
+    fakeAsync((async) {
+      enableAutomaticZero();
+      final shot = makeShot();
+      driveToPouring(async);
+
+      machine.emitStateAndSubstate(
+        MachineState.espresso,
+        MachineSubstate.pouring,
+      );
+      scaleController.emitWeight(40);
+      machine.emitSnapshot(
+        machine.snapshotSubject.value.copyWith(profileFrame: 1),
+      );
+      scaleController.emitWeight(40);
+      async.flushMicrotasks();
+      expect(machine.requestedStates, isEmpty);
+
+      scaleController.emitWeight(40);
+      async.flushMicrotasks();
+      expect(machine.requestedStates, [MachineState.idle]);
+      shot.dispose();
+    });
+  });
+
   test('failed machine stop is owned until machine confirmation', () {
     fakeAsync((async) {
       enableAutomaticZero();

--- a/test/controllers/shot_sequencer_native_scale_test.dart
+++ b/test/controllers/shot_sequencer_native_scale_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/controllers/shot_sequencer.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
@@ -150,6 +151,42 @@ void main() {
       if (scale.tareCallCount == 2) scaleController.emitWeight(0);
     };
   }
+
+  test('scale handoff is treated as no scale without throwing', () async {
+    final controller = ScaleController();
+    final first = TestScale(deviceId: 'first');
+    final second = TestScale(deviceId: 'second');
+    final connecting = Completer<void>();
+    second.onConnectHandler = () => connecting.future;
+    await controller.connectToScale(first);
+
+    final switching = controller.connectToScale(second);
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.currentScaleLease, isNull);
+
+    final shot = ShotSequencer(
+      scaleController: controller,
+      de1controller: de1Controller,
+      persistenceController: persistence,
+      targetProfile: _profile(),
+      targetYield: 36,
+      bypassSAW: false,
+      blockOnNoScale: true,
+      weightFlowMultiplier: 0,
+      volumeFlowMultiplier: 0,
+      stepExitArbiterEnabled: true,
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(machine.requestedStates, [MachineState.idle]);
+
+    connecting.complete();
+    await switching;
+    shot.dispose();
+    controller.dispose();
+    first.dispose();
+    second.dispose();
+  });
 
   test(
     'machine cadence stays independent and crossings use native samples',
@@ -350,14 +387,17 @@ void main() {
     });
   });
 
-  test('pour freshness expires while preparing command is blocked', () {
+  test('pour readiness expires while samples continue during blocked tare', () {
     fakeAsync((async) {
       final preparingTare = Completer<void>();
       scale.tareHandler = () => preparingTare.future;
       final shot = makeShot(targetYield: 0, targetVolume: 1);
       driveToPouring(async);
 
-      async.elapse(const Duration(milliseconds: 101));
+      for (var i = 0; i < 11; i++) {
+        scaleController.emitWeight(i.toDouble());
+        async.elapse(const Duration(milliseconds: 10));
+      }
       var snapshot = machine.snapshotSubject.value;
       machine.emitSnapshot(
         snapshot.copyWith(
@@ -378,11 +418,31 @@ void main() {
       expect(shot.scaleLost, isTrue);
       preparingTare.complete();
       async.flushMicrotasks();
+      expect(scale.commandCalls, ['tare']);
       shot.dispose();
     });
   });
 
-  test('tare completion does not renew callback freshness', () {
+  test('timed-out pour tare cannot start the scale timer', () {
+    fakeAsync((async) {
+      final pourTare = Completer<void>();
+      scale.tareHandler = () =>
+          scale.tareCallCount == 2 ? pourTare.future : Future.value();
+      final shot = makeShot(targetYield: 0);
+      driveToPouring(async);
+
+      expect(scale.commandCalls, ['tare', 'reset', 'tare']);
+      async.elapse(const Duration(milliseconds: 101));
+      expect(shot.scaleLost, isTrue);
+
+      pourTare.complete();
+      async.flushMicrotasks();
+      expect(scale.commandCalls, ['tare', 'reset', 'tare']);
+      shot.dispose();
+    });
+  });
+
+  test('scale freshness starts when tare control arms', () {
     fakeAsync((async) {
       final pourTare = Completer<void>();
       scale.tareHandler = () {
@@ -398,6 +458,8 @@ void main() {
       async.flushMicrotasks();
       async.elapse(const Duration(milliseconds: 11));
 
+      expect(shot.scaleLost, isFalse);
+      async.elapse(const Duration(milliseconds: 90));
       expect(shot.scaleLost, isTrue);
       shot.dispose();
     });

--- a/test/controllers/shot_sequencer_native_scale_test.dart
+++ b/test/controllers/shot_sequencer_native_scale_test.dart
@@ -442,24 +442,23 @@ void main() {
     });
   });
 
-  test('scale freshness starts when tare control arms', () {
+  test('tare completion preserves native callback freshness', () {
     fakeAsync((async) {
       final pourTare = Completer<void>();
-      scale.tareHandler = () {
-        if (scale.tareCallCount != 2) return Future.value();
-        scaleController.emitWeight(0);
-        return pourTare.future;
-      };
+      scale.tareHandler = () =>
+          scale.tareCallCount == 2 ? pourTare.future : Future.value();
       final shot = makeShot(targetYield: 0);
       driveToPouring(async);
 
-      async.elapse(const Duration(milliseconds: 90));
+      async.elapse(const Duration(milliseconds: 20));
+      scaleController.emitWeight(0);
+      async.elapse(const Duration(milliseconds: 70));
       pourTare.complete();
       async.flushMicrotasks();
-      async.elapse(const Duration(milliseconds: 11));
+      async.elapse(const Duration(milliseconds: 29));
 
       expect(shot.scaleLost, isFalse);
-      async.elapse(const Duration(milliseconds: 90));
+      async.elapse(const Duration(milliseconds: 2));
       expect(shot.scaleLost, isTrue);
       shot.dispose();
     });

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -73,6 +73,12 @@ class _TestScaleController extends ScaleController {
   Stream<WeightSnapshot> get weightSnapshot => _weight.stream;
 
   @override
+  ({Scale scale, int generation})? get currentScaleLease =>
+      _connectionState.value == ConnectionState.connected
+      ? (scale: testScale, generation: connectionGeneration)
+      : null;
+
+  @override
   Scale connectedScale() {
     if (_connectionState.value != ConnectionState.connected) {
       throw 'No scale connected';

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -263,6 +263,9 @@ void main() {
       testScale = TestScale();
       de1Controller = _TestDe1Controller(testDe1);
       scaleController = _TestScaleController(testScale);
+      testScale.tareHandler = () async {
+        if (testScale.tareCallCount == 2) scaleController.emitWeight(0);
+      };
       persistenceController = PersistenceController(
         storageService: _NullStorageService(),
       );
@@ -406,6 +409,12 @@ void main() {
 
         async.elapse(Duration(milliseconds: 10));
         driveToPouring(shotSequencer);
+        async.elapse(Duration(milliseconds: 10));
+        scaleController.emitWeight(
+          35.0,
+          weightFlow: 0.0,
+          controlWeightFlow: 2.0,
+        );
         scaleController.emitWeight(
           35.0,
           weightFlow: 0.0,
@@ -503,6 +512,7 @@ void main() {
 
         // Scale stays connected; emit weight above target
         scaleController.emitWeight(40.0);
+        scaleController.emitWeight(40.0);
 
         // Emit a machine snapshot to trigger combined stream processing
         testDe1.emitStateAndSubstate(
@@ -557,8 +567,9 @@ void main() {
         driveToPouring(shotSequencer);
         async.elapse(Duration(milliseconds: 10));
 
-        scaleController.emitWeight(12.0);
         emitPouringFrame(0);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -608,8 +619,9 @@ void main() {
         async.elapse(Duration(milliseconds: 10));
 
         // Emit weight above step threshold with pressure near firmware exit.
-        scaleController.emitWeight(12.0);
         emitPouringFrameWithPressure(0, 4.0);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -621,12 +633,13 @@ void main() {
         );
 
         // After max deferral frames (3), fires regardless.
-        scaleController.emitWeight(12.0);
         emitPouringFrameWithPressure(0, 4.2);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
-        scaleController.emitWeight(12.0);
         emitPouringFrameWithPressure(0, 4.4);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -673,8 +686,9 @@ void main() {
         driveToPouring(shotSequencer);
         async.elapse(Duration(milliseconds: 10));
 
-        scaleController.emitWeight(12.0);
         emitPouringFrame(0);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -711,8 +725,9 @@ void main() {
         driveToPouring(shotSequencer);
         async.elapse(Duration(milliseconds: 10));
 
-        scaleController.emitWeight(12.0);
         emitPouringFrame(0);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(testDe1.requestedStates, contains(MachineState.skipStep));
@@ -757,15 +772,17 @@ void main() {
         async.elapse(Duration(milliseconds: 10));
 
         // Frame 0: near firmware exit → defers
-        scaleController.emitWeight(12.0);
         emitPouringFrameWithPressure(0, 4.0);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(testDe1.requestedStates, isNot(contains(MachineState.skipStep)));
 
         // Frame 1: pure weight step → fires
-        scaleController.emitWeight(22.0);
         emitPouringFrame(1);
+        scaleController.emitWeight(22.0);
+        scaleController.emitWeight(22.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(testDe1.requestedStates, contains(MachineState.skipStep));
@@ -809,8 +826,9 @@ void main() {
         async.elapse(Duration(milliseconds: 10));
 
         // Frame 0: weight reached, near firmware exit → defers
-        scaleController.emitWeight(12.0);
         emitPouringFrameWithPressure(0, 4.0);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -821,8 +839,8 @@ void main() {
 
         // Firmware advances to frame 1 (firmware handled the exit itself).
         // Weight 12.0 is below frame 1's weight threshold (50), so no skip.
-        scaleController.emitWeight(12.0);
         emitPouringFrame(1);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -872,8 +890,9 @@ void main() {
         async.elapse(Duration(milliseconds: 10));
 
         // Weight above threshold, flow near firmware exit.
-        scaleController.emitWeight(12.0);
         emitPouringFrameWithFlow(0, 2.5);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -883,12 +902,13 @@ void main() {
         );
 
         // After max deferral frames (3), fires regardless.
-        scaleController.emitWeight(12.0);
         emitPouringFrameWithFlow(0, 2.3);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
-        scaleController.emitWeight(12.0);
         emitPouringFrameWithFlow(0, 2.1);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         expect(
@@ -1334,6 +1354,9 @@ void main() {
       testScale = TestScale();
       de1Controller = _TestDe1Controller(testDe1);
       scaleController = _TestScaleController(testScale);
+      testScale.tareHandler = () async {
+        if (testScale.tareCallCount == 2) scaleController.emitWeight(0);
+      };
       persistenceController = PersistenceController(
         storageService: _NullStorageService(),
       );
@@ -1446,6 +1469,9 @@ void main() {
       testScale = TestScale();
       de1Controller = _TestDe1Controller(testDe1);
       scaleController = _TestScaleController(testScale);
+      testScale.tareHandler = () async {
+        if (testScale.tareCallCount == 2) scaleController.emitWeight(0);
+      };
       persistenceController = PersistenceController(
         storageService: _NullStorageService(),
       );
@@ -1521,9 +1547,10 @@ void main() {
         async.elapse(Duration(milliseconds: 10));
 
         // Weight exceeds step threshold (12 > 10)
-        scaleController.emitWeight(12.0);
         // Pressure near threshold (4.0, exit at 5.0)
         emitPouringFrameWithPressure(0, 4.0);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         // With arbiter disabled, skipStep fires immediately despite
@@ -1553,6 +1580,9 @@ void main() {
       testScale = TestScale();
       de1Controller = _TestDe1Controller(testDe1);
       scaleController = _TestScaleController(testScale);
+      testScale.tareHandler = () async {
+        if (testScale.tareCallCount == 2) scaleController.emitWeight(0);
+      };
       persistenceController = PersistenceController(
         storageService: _NullStorageService(),
       );
@@ -1621,6 +1651,7 @@ void main() {
         driveToPouring();
         async.elapse(Duration(milliseconds: 10));
 
+        scaleController.emitWeight(40.0);
         scaleController.emitWeight(40.0);
         testDe1.emitStateAndSubstate(
           MachineState.espresso,
@@ -1824,8 +1855,9 @@ void main() {
         driveToPouring();
         async.elapse(Duration(milliseconds: 10));
 
-        scaleController.emitWeight(12.0);
         emitPouringFrame(0);
+        scaleController.emitWeight(12.0);
+        scaleController.emitWeight(12.0);
         async.elapse(Duration(milliseconds: 10));
 
         final skip = decisions.singleWhere(

--- a/test/helpers/test_de1.dart
+++ b/test/helpers/test_de1.dart
@@ -83,6 +83,7 @@ class TestDe1 implements De1Interface {
 
   /// Records every [MachineState] passed to [requestState].
   final List<MachineState> requestedStates = [];
+  Future<void> Function(MachineState state)? requestStateHandler;
 
   /// Emit an arbitrary [MachineSnapshot].
   void emitSnapshot(MachineSnapshot snapshot) {
@@ -133,6 +134,7 @@ class TestDe1 implements De1Interface {
   @override
   Future<void> requestState(MachineState newState) async {
     requestedStates.add(newState);
+    await requestStateHandler?.call(newState);
   }
 
   @override

--- a/test/helpers/test_scale.dart
+++ b/test/helpers/test_scale.dart
@@ -63,13 +63,16 @@ class TestScale implements Scale {
   Stream<ScaleSnapshot> get currentSnapshot => _snapshotSubject.stream;
 
   @override
-  Future<void> onConnect() async {}
+  Future<void> onConnect() async {
+    await onConnectHandler?.call();
+  }
 
   @override
   Future<void> disconnect() async {}
 
   int tareCallCount = 0;
   final List<String> commandCalls = [];
+  Future<void> Function()? onConnectHandler;
   Future<void> Function()? tareHandler;
   Future<void> Function()? resetTimerHandler;
   Future<void> Function()? startTimerHandler;

--- a/test/helpers/test_scale.dart
+++ b/test/helpers/test_scale.dart
@@ -69,10 +69,17 @@ class TestScale implements Scale {
   Future<void> disconnect() async {}
 
   int tareCallCount = 0;
+  final List<String> commandCalls = [];
+  Future<void> Function()? tareHandler;
+  Future<void> Function()? resetTimerHandler;
+  Future<void> Function()? startTimerHandler;
+  Future<void> Function()? stopTimerHandler;
 
   @override
   Future<void> tare() async {
     tareCallCount++;
+    commandCalls.add('tare');
+    await tareHandler?.call();
   }
 
   @override
@@ -82,11 +89,20 @@ class TestScale implements Scale {
   Future<void> wakeDisplay() async {}
 
   @override
-  Future<void> startTimer() async {}
+  Future<void> startTimer() async {
+    commandCalls.add('start');
+    await startTimerHandler?.call();
+  }
 
   @override
-  Future<void> stopTimer() async {}
+  Future<void> stopTimer() async {
+    commandCalls.add('stop');
+    await stopTimerHandler?.call();
+  }
 
   @override
-  Future<void> resetTimer() async {}
+  Future<void> resetTimer() async {
+    commandCalls.add('reset');
+    await resetTimerHandler?.call();
+  }
 }

--- a/test/helpers/test_scale_controller.dart
+++ b/test/helpers/test_scale_controller.dart
@@ -34,18 +34,27 @@ class TestScaleController extends ScaleController {
     return testScale;
   }
 
-  void emitWeight(double weight, {double weightFlow = 0.0}) {
+  void emitWeight(
+    double weight, {
+    double weightFlow = 0.0,
+    double? controlWeightFlow,
+  }) {
     _weight.add(
       WeightSnapshot(
         timestamp: DateTime(2026, 1, 15, 8, 0),
         weight: weight,
         weightFlow: weightFlow,
+        controlWeightFlow: controlWeightFlow,
       ),
     );
   }
 
   void simulateDisconnect() {
     _connectionState.add(device.ConnectionState.disconnected);
+  }
+
+  void simulateConnect() {
+    _connectionState.add(device.ConnectionState.connected);
   }
 
   @override

--- a/test/helpers/test_scale_controller.dart
+++ b/test/helpers/test_scale_controller.dart
@@ -28,6 +28,12 @@ class TestScaleController extends ScaleController {
   int get connectionGeneration => _generation;
 
   @override
+  ({Scale scale, int generation})? get currentScaleLease =>
+      _connectionState.value == device.ConnectionState.connected
+      ? (scale: testScale, generation: _generation)
+      : null;
+
+  @override
   Stream<WeightSnapshot> get weightSnapshot => _weight.stream;
 
   @override

--- a/test/helpers/test_scale_controller.dart
+++ b/test/helpers/test_scale_controller.dart
@@ -11,6 +11,7 @@ class TestScaleController extends ScaleController {
   final TestScale testScale;
   final BehaviorSubject<device.ConnectionState> _connectionState;
   final BehaviorSubject<WeightSnapshot> _weight = BehaviorSubject();
+  int _generation = 0;
 
   TestScaleController(this.testScale)
     : _connectionState = BehaviorSubject.seeded(
@@ -22,6 +23,9 @@ class TestScaleController extends ScaleController {
 
   @override
   device.ConnectionState get currentConnectionState => _connectionState.value;
+
+  @override
+  int get connectionGeneration => _generation;
 
   @override
   Stream<WeightSnapshot> get weightSnapshot => _weight.stream;
@@ -54,6 +58,11 @@ class TestScaleController extends ScaleController {
   }
 
   void simulateConnect() {
+    _connectionState.add(device.ConnectionState.connected);
+  }
+
+  void simulateScaleSwitch() {
+    _generation++;
     _connectionState.add(device.ConnectionState.connected);
   }
 

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -21,6 +21,7 @@ class _TrackingScale implements Scale {
   );
   final _snap = BehaviorSubject<ScaleSnapshot>();
   bool disconnected = false;
+  Future<void> Function()? tareHandler;
 
   @override
   String get name => deviceId;
@@ -46,7 +47,9 @@ class _TrackingScale implements Scale {
   }
 
   @override
-  Future<void> tare() async {}
+  Future<void> tare() async {
+    await tareHandler?.call();
+  }
 
   @override
   Future<void> sleepDisplay() async {}
@@ -321,6 +324,38 @@ void main() {
     expect(historical.controlWeightFlow, 4.5);
     expect(live.controlWeightFlow, 4.5);
     expect(live.toJson(), isNot(contains('controlWeightFlow')));
+  });
+
+  test('old tare completion does not reset replacement scale flow', () async {
+    final controller = ScaleController();
+    final first = _TrackingScale('A');
+    final second = _TrackingScale('B');
+    final tare = Completer<void>();
+    first.tareHandler = () => tare.future;
+    await controller.connectToScale(first);
+
+    final staleTare = controller.tare();
+    await Future<void>.delayed(Duration.zero);
+    await controller.connectToScale(second);
+
+    final frames = <WeightSnapshot>[];
+    final sub = controller.weightSnapshot.listen(frames.add);
+    final t0 = DateTime.utc(2026, 7, 22);
+    second.emitAt(t0, 0);
+    second.emitAt(t0.add(const Duration(milliseconds: 100)), 1);
+    second.emitAt(t0.add(const Duration(milliseconds: 200)), 2);
+    await Future<void>.delayed(Duration.zero);
+    expect(frames.last.controlWeightFlow, greaterThan(0));
+
+    tare.complete();
+    await staleTare;
+    second.emitAt(t0.add(const Duration(milliseconds: 300)), 3);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(frames.last.controlWeightFlow, greaterThan(0));
+
+    await sub.cancel();
+    controller.dispose();
   });
 
   test('tare suppresses the flow transient for one smoothing window without '

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -197,10 +197,12 @@ void main() {
       final b = _TrackingScale('B');
 
       await controller.connectToScale(a);
+      final firstGeneration = controller.connectionGeneration;
       expect(controller.connectedScale().deviceId, 'A');
       expect(a.disconnected, isFalse);
 
       await controller.connectToScale(b);
+      expect(controller.connectionGeneration, firstGeneration + 1);
       expect(controller.connectedScale().deviceId, 'B');
       expect(
         a.disconnected,
@@ -218,7 +220,9 @@ void main() {
     final a = _TrackingScale('A');
 
     await controller.connectToScale(a);
+    final firstGeneration = controller.connectionGeneration;
     await controller.connectToScale(a); // same device id
+    expect(controller.connectionGeneration, firstGeneration + 1);
     expect(
       a.disconnected,
       isFalse,


### PR DESCRIPTION
## Summary

> **Naming:** The display name is **Decent.app**. The repo, package, and bundle ID use legacy `reaprime` / `streamline-bridge` — see the naming table in [`CLAUDE.md`](CLAUDE.md).

- Problem: shot scale decisions ran at machine cadence and scale commands could overlap or outlive the scale connection that queued them.
- Why it matters: stale weights, delayed stop-at-weight decisions, or timer/tare work during disconnect can produce incorrect shot control.
- What changed: native scale callbacks drive tare/freshness/crossing decisions; machine snapshots retain lifecycle/persistence ownership; scale commands are FIFO and generation-guarded.
- What did NOT change: public scale APIs, shot-state vocabulary, machine-cadence persistence, volume fallback, or Bengle firmware ownership of final stop-at-weight.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [x] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Related #423
- Depends on #528

## Root Cause (if bug fix)

- Root cause: one combined machine/scale stream tied actuation to machine cadence, while fire-and-forget scale commands lacked one serialized connection-generation owner.
- Missing detection or guardrail: stale callbacks, blocked tare freshness, first profile-frame transitions, scale replacement, and queued timer commands were not covered as one lifecycle.
- Contributing context: Bengle final stop-at-weight is firmware-owned and must retain machine-cadence per-step behavior rather than use the external-scale path.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `shot_sequencer_native_scale_test.dart`, `shot_scale_command_queue_test.dart`, Bengle bypass tests, and scale-controller tests.
- Scenario the test should lock in: stale/replacement-scale activity cannot arm or actuate; crossings require two native samples in one profile frame; queued timer/tare work cannot execute after generation change.
- If no new test added, why not: N/A — regressions were added.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml`
- [ ] API docs updated: `doc/Api.md`
- [ ] Plugin docs updated: `doc/Plugins.md`
- [ ] Skin docs updated: `doc/Skins.md`
- [ ] Profile docs updated: `doc/Profiles.md`
- [ ] Device docs updated: `doc/DeviceManagement.md`
- [x] N/A — no listed user-facing/API docs are affected; internal debug notes and the archived design were updated.

Planning rationale: [`doc/plans/archive/shot-native-scale-control/design.md`](doc/plans/archive/shot-native-scale-control/design.md).

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? Yes
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any Yes, explain risk and mitigation: the bytes and transport APIs are unchanged, but ordering and timing of existing scale tare/timer commands change. A FIFO queue plus controller-generation checks prevents commands from crossing a disconnect or scale replacement.

## User-Visible Changes

Stop-at-weight and per-step exits react to native scale cadence, with safer tare/timer behavior during reconnects. No settings, API, or migration changes.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean
- [ ] `flutter test` — full Windows suite is blocked by pre-existing plugin-loader temp-directory failures; 66 shot/control-focused tests pass
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A, plugin code unchanged

### Manual verification (if applicable)

- OS / platform tested: Windows
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: focused sequencer, command queue, Bengle, and scale-controller tests; analyzer and raw diff checks.
- Edge cases checked: blocked/failed tare, freshness expiry, stale callbacks, disconnect/replacement generations, first and later profile-frame crossings, final crossing confirmation, failed stop ownership, and Bengle cadence.
- What you did **not** verify: real DE1, Bengle, or external scale timing. Human hardware-risk acceptance remains required before approval/merge.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording
- [ ] curl / websocat output

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- If any No or Yes, explain exact steps: no migration; public contracts and persisted machine-cadence snapshots remain unchanged.

## Risks & Mitigations

- Risk: native callback timing differs across physical scales and mobile BLE stacks.
  - Mitigation: freshness, tare confirmation, generation guards, and consecutive-sample gates fail closed; perform normal human hardware-risk acceptance before merge.
- Risk: Bengle integrated-scale behavior could diverge from external-scale behavior.
  - Mitigation: Bengle final stop remains firmware-owned and shared-source machine-cadence regressions preserve per-step behavior.
- Risk: command serialization changes timer/tare timing on slow scales.
  - Mitigation: commands remain ordered once per transition, failures are locally owned, and stale generations are dropped.