### PR TITLE
fix(ble): recover Linux BlueZ runtime and stale GATT

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ Build both architectures:
 make dual-build
 ```
 
+For a systemd installation, order ReaPrime after BlueZ:
+
+```ini
+[Unit]
+Wants=bluetooth.service
+After=bluetooth.service
+```
+
+This reduces startup races but does not replace the application's Bluetooth recovery.
+
 ## System Requirements
 
 ### Minimum Requirements

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -50,7 +50,12 @@ enum ConnectionPhase {
 
 enum AmbiguityReason { machinePicker, scalePicker }
 
-enum ConnectionIntent { automatic, explicitDiscovery, scaleRecovery }
+enum ConnectionIntent {
+  automatic,
+  explicitDiscovery,
+  adapterRecovery,
+  scaleRecovery,
+}
 
 class TransportCondition {
   final TransportType transportType;
@@ -159,7 +164,9 @@ class ConnectionManager {
   /// wedging `_isConnecting` (comms-harden #31). Real-hardware
   /// connect currently observes 3–10s on tablet; 30s leaves ~3x
   /// headroom for slow adapters without feeling sluggish.
-  static const _connectTimeout = Duration(seconds: 30);
+  Duration get _connectTimeout => Platform.isLinux
+      ? const Duration(seconds: 60)
+      : const Duration(seconds: 30);
 
   // Device-connection state + unexpected-disconnect emission live on
   // DisconnectSupervisor — it owns the two stream subscribers and
@@ -191,6 +198,14 @@ class ConnectionManager {
   /// [_queuedScaleOnly] so explicit user-requested discovery is not
   /// delayed behind background scale reacquisition.
   Completer<void>? _queuedExplicitScan;
+  bool _adapterRecoveryQueued = false;
+  bool _adapterRecoveryNeeded = false;
+  int _adapterRecoveryEpoch = 0;
+  AdapterState? _lastAdapterState;
+  Timer? _adapterRecoveryTimer;
+
+  @visibleForTesting
+  Duration adapterRecoveryDebounce = const Duration(seconds: 1);
 
   /// Deferred scale-only rescan armed when the preferred machine
   /// connects but no preferred scale is configured. The initial scan
@@ -370,6 +385,30 @@ class ConnectionManager {
 
   void _listenForAdapter() {
     _adapterSub = deviceScanner.adapterStateStream.listen((state) {
+      if (state == _lastAdapterState) return;
+      final previous = _lastAdapterState;
+      _lastAdapterState = state;
+      if (state == AdapterState.poweredOn) {
+        if (_adapterRecoveryNeeded) {
+          final epoch = _adapterRecoveryEpoch;
+          _adapterRecoveryTimer?.cancel();
+          _adapterRecoveryTimer = Timer(adapterRecoveryDebounce, () {
+            if (epoch != _adapterRecoveryEpoch ||
+                !_adapterRecoveryNeeded ||
+                _lastAdapterState != AdapterState.poweredOn) {
+              return;
+            }
+            _adapterRecoveryNeeded = false;
+            _queueAdapterRecovery();
+          });
+        }
+      } else if (previous == AdapterState.poweredOn) {
+        _adapterRecoveryEpoch++;
+        _adapterRecoveryNeeded = true;
+        _adapterRecoveryTimer?.cancel();
+        _adapterRecoveryTimer = null;
+        deviceScanner.stopScan();
+      }
       if (state == AdapterState.poweredOff) {
         final error = ConnectionError(
           kind: ConnectionErrorKind.adapterOff,
@@ -606,8 +645,10 @@ class ConnectionManager {
   Future<void> _runConnect({
     required bool scaleOnly,
     required ConnectionAttemptPolicy policy,
+    bool adapterRecovery = false,
   }) async {
     if (_isConnecting) {
+      if (adapterRecovery) return;
       if (scaleOnly) {
         final completer = _queuedScaleOnly ??= Completer<void>();
         return completer.future;
@@ -616,12 +657,19 @@ class ConnectionManager {
     }
 
     try {
-      await _executeConnect(scaleOnly, policy: policy);
+      if (adapterRecovery) {
+        _adapterRecoveryQueued = false;
+        await _executeAdapterRecovery();
+      } else {
+        await _executeConnect(scaleOnly, policy: policy);
+      }
     } finally {
       // Single priority-aware drain loop: explicit always evaluated
       // first at each scheduling boundary. An explicit request arriving
       // during a queued scale-only drain is picked up immediately.
-      while (_queuedExplicitScan != null || _queuedScaleOnly != null) {
+      while (_queuedExplicitScan != null ||
+          _adapterRecoveryQueued ||
+          _queuedScaleOnly != null) {
         if (_queuedExplicitScan != null) {
           final drain = _queuedExplicitScan!;
           _queuedExplicitScan = null;
@@ -634,6 +682,12 @@ class ConnectionManager {
           } catch (e, st) {
             drain.completeError(e, st);
           }
+          continue;
+        }
+
+        if (_adapterRecoveryQueued) {
+          _adapterRecoveryQueued = false;
+          await _executeAdapterRecovery();
           continue;
         }
 
@@ -655,15 +709,18 @@ class ConnectionManager {
   Future<void> _executeConnect(
     bool scaleOnly, {
     required ConnectionAttemptPolicy policy,
+    ConnectionIntent? intent,
   }) async {
     _isConnecting = true;
     _publishStatus(
       currentStatus.copyWith(
-        intent: identical(policy, ConnectionAttemptPolicy.explicitScan)
-            ? ConnectionIntent.explicitDiscovery
-            : identical(policy, ConnectionAttemptPolicy.scaleRecovery)
-            ? ConnectionIntent.scaleRecovery
-            : ConnectionIntent.automatic,
+        intent:
+            intent ??
+            (identical(policy, ConnectionAttemptPolicy.explicitScan)
+                ? ConnectionIntent.explicitDiscovery
+                : identical(policy, ConnectionAttemptPolicy.scaleRecovery)
+                ? ConnectionIntent.scaleRecovery
+                : ConnectionIntent.automatic),
         activeTargetTransport: () => null,
       ),
     );
@@ -677,6 +734,44 @@ class ConnectionManager {
         _activeScaleOnlyScan = false;
       }
       _isConnecting = false;
+    }
+  }
+
+  void _queueAdapterRecovery() {
+    if (_adapterRecoveryQueued) return;
+    _adapterRecoveryQueued = true;
+    if (_isConnecting) return;
+    unawaited(
+      _runConnect(
+        scaleOnly: false,
+        policy: ConnectionAttemptPolicy.automatic,
+        adapterRecovery: true,
+      ),
+    );
+  }
+
+  Future<void> _executeAdapterRecovery() async {
+    final preferredMachine = settingsController.preferredMachineId;
+    final preferredScale = settingsController.preferredScaleId;
+    if (preferredMachine != null &&
+        preferredMachine.isNotEmpty &&
+        !_machineConnected) {
+      await _executeConnect(
+        false,
+        policy: ConnectionAttemptPolicy.automatic,
+        intent: ConnectionIntent.adapterRecovery,
+      );
+      return;
+    }
+    if (_machineConnected &&
+        preferredScale != null &&
+        preferredScale.isNotEmpty &&
+        !_scaleConnected) {
+      await _executeConnect(
+        true,
+        policy: ConnectionAttemptPolicy.scaleRecovery,
+        intent: ConnectionIntent.adapterRecovery,
+      );
     }
   }
 
@@ -1852,6 +1947,9 @@ class ConnectionManager {
     _cancelSelectionSession(emitReport: false);
     _stopMachineRecovery();
     _deferredScaleScan?.cancel();
+    _adapterRecoveryTimer?.cancel();
+    _adapterRecoveryTimer = null;
+    _adapterRecoveryQueued = false;
     _cancelPreferredScaleReconnect();
     await _attachReconnectCoordinator?.dispose();
     _queuedExplicitScan?.complete();

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -402,12 +402,14 @@ class ConnectionManager {
             _queueAdapterRecovery();
           });
         }
-      } else if (previous == AdapterState.poweredOn) {
+      } else {
         _adapterRecoveryEpoch++;
         _adapterRecoveryNeeded = true;
         _adapterRecoveryTimer?.cancel();
         _adapterRecoveryTimer = null;
-        deviceScanner.stopScan();
+        if (previous == AdapterState.poweredOn) {
+          deviceScanner.stopScan();
+        }
       }
       if (state == AdapterState.poweredOff) {
         final error = ConnectionError(

--- a/lib/src/services/ble/ble_lifecycle_gate.dart
+++ b/lib/src/services/ble/ble_lifecycle_gate.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+String normalizeBleDeviceId(String deviceId) => deviceId.toLowerCase();
+
+class BleLifecycleGate {
+  final Map<String, Future<void>> _pending = {};
+
+  Future<T> run<T>(String deviceId, Future<T> Function() operation) async {
+    final key = normalizeBleDeviceId(deviceId);
+    final previous = _pending[key] ?? Future<void>.value();
+    final done = Completer<void>();
+    _pending[key] = done.future;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      done.complete();
+      if (identical(_pending[key], done.future)) _pending.remove(key);
+    }
+  }
+}

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -267,6 +267,7 @@ class UniversalBleTransport extends BLETransport {
   /// Brief scan to repopulate BlueZ's device cache (the device can drop out of
   /// the adapter's object tree after a disconnect), then settle before retry.
   Future<void> _refreshDeviceCache([int? maintenanceGeneration]) async {
+    var ownsScan = false;
     try {
       await UniversalBle.stopScan();
       if (maintenanceGeneration != null) {
@@ -277,6 +278,7 @@ class UniversalBleTransport extends BLETransport {
         _checkMaintenanceGeneration(maintenanceGeneration);
       }
       await UniversalBle.startScan(scanFilter: ScanFilter(withServices: []));
+      ownsScan = true;
       if (maintenanceGeneration != null) {
         _checkMaintenanceGeneration(maintenanceGeneration);
       }
@@ -284,21 +286,26 @@ class UniversalBleTransport extends BLETransport {
       if (maintenanceGeneration != null) {
         _checkMaintenanceGeneration(maintenanceGeneration);
       }
-      await UniversalBle.stopScan();
-      if (maintenanceGeneration != null) {
-        _checkMaintenanceGeneration(maintenanceGeneration);
-      }
-      await Future.delayed(_bluezScanSettleDelay);
-      if (maintenanceGeneration != null) {
-        _checkMaintenanceGeneration(maintenanceGeneration);
-      }
     } on _MaintenanceCancelled {
       rethrow;
     } catch (e) {
       _log.warning("BlueZ cache-refresh scan failed: $e");
-      try {
-        await UniversalBle.stopScan();
-      } catch (_) {}
+      return;
+    } finally {
+      if (ownsScan) {
+        try {
+          await UniversalBle.stopScan();
+        } catch (e) {
+          _log.warning("Failed to stop BlueZ cache-refresh scan: $e");
+        }
+      }
+    }
+    if (maintenanceGeneration != null) {
+      _checkMaintenanceGeneration(maintenanceGeneration);
+    }
+    await Future.delayed(_bluezScanSettleDelay);
+    if (maintenanceGeneration != null) {
+      _checkMaintenanceGeneration(maintenanceGeneration);
     }
   }
 
@@ -444,11 +451,18 @@ class UniversalBleTransport extends BLETransport {
       return services.map((s) => s.uuid).toList();
     }
 
+    final generation = _connectionGeneration;
     try {
       return await _discoverServicesBlueZ();
     } on UniversalBleException catch (error) {
       if (error.code != UniversalBleErrorCode.servicesNotResolved) rethrow;
-      return _recoverBlueZServices(_connectionGeneration);
+      if (_connectionGeneration != generation || _disposed) {
+        throw UniversalBleException(
+          code: UniversalBleErrorCode.operationCancelled,
+          message: 'BLE service discovery was cancelled',
+        );
+      }
+      return _recoverBlueZServices(generation);
     }
   }
 
@@ -464,6 +478,9 @@ class UniversalBleTransport extends BLETransport {
   Future<List<String>> _recoverBlueZServices(int generation) async {
     _maintenanceGeneration = generation;
     try {
+      await _advertSub?.cancel();
+      _advertSub = null;
+      _checkMaintenanceGeneration(generation);
       await _stopScanAndSettle(generation);
       await _disconnectNative();
       _checkMaintenanceGeneration(generation);
@@ -480,6 +497,7 @@ class UniversalBleTransport extends BLETransport {
       _checkMaintenanceGeneration(generation);
       final services = await _discoverServicesBlueZ();
       _checkMaintenanceGeneration(generation);
+      _startAdvertWatch();
       _maintenanceGeneration = null;
       return services;
     } on _MaintenanceCancelled {
@@ -627,6 +645,7 @@ class UniversalBleTransport extends BLETransport {
   }
 
   void _onOwnAdvertisement(BleDevice _) {
+    if (_maintenanceGeneration == _connectionGeneration) return;
     if (_connectionStateSubject.valueOrNull !=
         device.ConnectionState.connected) {
       return;
@@ -657,11 +676,15 @@ class UniversalBleTransport extends BLETransport {
         timeout: _linkProbeTimeout,
       );
     } catch (e) {
-      if (generation != _connectionGeneration) return;
+      if (generation != _connectionGeneration ||
+          _maintenanceGeneration == generation) {
+        return;
+      }
       _log.fine('Link probe inconclusive ($context): $e');
       return;
     }
     if (generation != _connectionGeneration ||
+        _maintenanceGeneration == generation ||
         state == BleConnectionState.connected ||
         state == BleConnectionState.connecting) {
       return;

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -8,6 +8,7 @@ import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart'
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/services/ble/ble_exception_mapper.dart';
+import 'package:reaprime/src/services/ble/ble_lifecycle_gate.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:universal_ble/universal_ble.dart';
 
@@ -35,6 +36,8 @@ class UniversalBleTransport extends BLETransport {
   //     while connected (this transport is shared by scales and sensors).
   bool _linkDeadDeclared = false;
   int _connectionGeneration = 0;
+  int? _maintenanceGeneration;
+  bool _disposed = false;
   int? _recoveringQueueGeneration;
   Future<void>? _nativeDisconnectOperation;
   DateTime? _lastAdvertProbe;
@@ -55,11 +58,6 @@ class UniversalBleTransport extends BLETransport {
   // triggers `le-connection-abort-by-local`, so we stop scanning and let the
   // adapter settle before connecting; GATT service resolution also needs
   // retries because BlueZ resolves services asynchronously after connect.
-  static const Duration _bluezPostConnectDelay = Duration(milliseconds: 500);
-  static const Duration _bluezScanSettleDelay = Duration(seconds: 2);
-  static const Duration _bluezCacheRefreshScan = Duration(seconds: 4);
-  static const int _bluezDiscoveryRetries = 3;
-  static const Duration _bluezDiscoveryRetryDelay = Duration(seconds: 1);
 
   bool get _isAndroid => _isAndroidOverride ?? Platform.isAndroid;
   bool get _isLinux => _isLinuxOverride ?? Platform.isLinux;
@@ -72,13 +70,21 @@ class UniversalBleTransport extends BLETransport {
     bool? isLinuxOverride,
     Duration faultRecoveryGrace = const Duration(seconds: 2),
     Duration faultRecoveryDisconnectTimeout = const Duration(seconds: 5),
+    BleLifecycleGate? lifecycleGate,
+    Duration bluezPostConnectDelay = const Duration(milliseconds: 500),
+    Duration bluezScanSettleDelay = const Duration(seconds: 2),
+    Duration bluezCacheRefreshScan = const Duration(seconds: 4),
   }) : _device = device,
        _stopScan = stopScan,
        _requestLargeMtuNonAndroid = requestLargeMtuNonAndroid,
        _isAndroidOverride = isAndroidOverride,
        _isLinuxOverride = isLinuxOverride,
        _faultRecoveryGrace = faultRecoveryGrace,
-       _faultRecoveryDisconnectTimeout = faultRecoveryDisconnectTimeout {
+       _faultRecoveryDisconnectTimeout = faultRecoveryDisconnectTimeout,
+       _lifecycleGate = lifecycleGate ?? BleLifecycleGate(),
+       _bluezPostConnectDelay = bluezPostConnectDelay,
+       _bluezScanSettleDelay = bluezScanSettleDelay,
+       _bluezCacheRefreshScan = bluezCacheRefreshScan {
     _log = Logger("BLETransport-${device.deviceId}");
   }
 
@@ -94,6 +100,10 @@ class UniversalBleTransport extends BLETransport {
   final bool? _isLinuxOverride;
   final Duration _faultRecoveryGrace;
   final Duration _faultRecoveryDisconnectTimeout;
+  final BleLifecycleGate _lifecycleGate;
+  final Duration _bluezPostConnectDelay;
+  final Duration _bluezScanSettleDelay;
+  final Duration _bluezCacheRefreshScan;
 
   Future<void> _stopScanViaOwner() =>
       _stopScan?.call() ?? UniversalBle.stopScan();
@@ -110,7 +120,11 @@ class UniversalBleTransport extends BLETransport {
   );
 
   @override
-  Future<void> connect() async {
+  Future<void> connect() =>
+      _lifecycleGate.run(_device.deviceId, _connectNative);
+
+  Future<void> _connectNative() async {
+    if (_disposed) throw StateError('BLE transport is disposed');
     if (UniversalBle.getQueueDiagnostics(_device.deviceId).state ==
         QueueDiagnosticsState.faulted) {
       throw StateError(
@@ -118,23 +132,13 @@ class UniversalBleTransport extends BLETransport {
       );
     }
     _connectionGeneration++;
+    final generation = _connectionGeneration;
     _linkDeadDeclared = false;
     _lastAdvertProbe = null;
     // Use connectionUpdateStream (from our universal_ble fork) to get
     // native disconnect reason codes (GATT error, HCI status) — the
     // standard connectionStream only emits bool.
-    _connectionStateSubscription?.cancel();
-    _connectionStateSubscription =
-        UniversalBle.connectionUpdateStream(_device.deviceId).listen((update) {
-          if (update.isConnected) {
-            _connectionStateSubject.add(device.ConnectionState.connected);
-          } else {
-            _recoveringQueueGeneration = null;
-            final reason = update.error ?? 'unknown';
-            _log.warning('Transport disconnected: $reason');
-            _connectionStateSubject.add(device.ConnectionState.disconnected);
-          }
-        });
+    await _listenForConnectionUpdates(generation);
     if (_isLinux) {
       await _connectBlueZ();
       _startAdvertWatch();
@@ -205,41 +209,91 @@ class UniversalBleTransport extends BLETransport {
     }
   }
 
-  Future<void> _doConnectBlueZ() async {
+  Future<void> _listenForConnectionUpdates(int generation) async {
+    await _connectionStateSubscription?.cancel();
+    if (_connectionGeneration != generation || _disposed) return;
+    _connectionStateSubscription =
+        UniversalBle.connectionUpdateStream(_device.deviceId).listen((update) {
+          if (_connectionGeneration != generation) return;
+          if (update.isConnected) {
+            _connectionStateSubject.add(device.ConnectionState.connected);
+          } else {
+            if (_maintenanceGeneration == generation) return;
+            _recoveringQueueGeneration = null;
+            final reason = update.error ?? 'unknown';
+            _log.warning('Transport disconnected: $reason');
+            _publishDisconnected();
+          }
+        });
+  }
+
+  Future<void> _doConnectBlueZ([int? maintenanceGeneration]) async {
     // Stop scanning and let the adapter settle — connecting while a scan is
     // active (or immediately after) causes le-connection-abort-by-local.
-    await _stopScanAndSettle();
+    await _stopScanAndSettle(maintenanceGeneration);
     await UniversalBle.connect(
       _device.deviceId,
       timeout: Duration(seconds: 15),
     );
+    if (maintenanceGeneration != null) {
+      _checkMaintenanceGeneration(maintenanceGeneration);
+    }
     // BlueZ finalizes GATT client setup slightly after connect reports success.
     await Future.delayed(_bluezPostConnectDelay);
+    if (maintenanceGeneration != null) {
+      _checkMaintenanceGeneration(maintenanceGeneration);
+    }
   }
 
-  Future<void> _stopScanAndSettle() async {
+  Future<void> _stopScanAndSettle([int? maintenanceGeneration]) async {
     try {
       await _stopScanViaOwner();
     } catch (e) {
       _log.fine("stopScan before BlueZ connect failed (ignored): $e");
+    }
+    if (maintenanceGeneration != null) {
+      _checkMaintenanceGeneration(maintenanceGeneration);
     }
     _log.fine(
       "Waiting ${_bluezScanSettleDelay.inSeconds}s for BlueZ to settle "
       "before connect",
     );
     await Future.delayed(_bluezScanSettleDelay);
+    if (maintenanceGeneration != null) {
+      _checkMaintenanceGeneration(maintenanceGeneration);
+    }
   }
 
   /// Brief scan to repopulate BlueZ's device cache (the device can drop out of
   /// the adapter's object tree after a disconnect), then settle before retry.
-  Future<void> _refreshDeviceCache() async {
+  Future<void> _refreshDeviceCache([int? maintenanceGeneration]) async {
     try {
       await UniversalBle.stopScan();
+      if (maintenanceGeneration != null) {
+        _checkMaintenanceGeneration(maintenanceGeneration);
+      }
       await Future.delayed(const Duration(milliseconds: 500));
+      if (maintenanceGeneration != null) {
+        _checkMaintenanceGeneration(maintenanceGeneration);
+      }
       await UniversalBle.startScan(scanFilter: ScanFilter(withServices: []));
+      if (maintenanceGeneration != null) {
+        _checkMaintenanceGeneration(maintenanceGeneration);
+      }
       await Future.delayed(_bluezCacheRefreshScan);
+      if (maintenanceGeneration != null) {
+        _checkMaintenanceGeneration(maintenanceGeneration);
+      }
       await UniversalBle.stopScan();
+      if (maintenanceGeneration != null) {
+        _checkMaintenanceGeneration(maintenanceGeneration);
+      }
       await Future.delayed(_bluezScanSettleDelay);
+      if (maintenanceGeneration != null) {
+        _checkMaintenanceGeneration(maintenanceGeneration);
+      }
+    } on _MaintenanceCancelled {
+      rethrow;
     } catch (e) {
       _log.warning("BlueZ cache-refresh scan failed: $e");
       try {
@@ -316,8 +370,13 @@ class UniversalBleTransport extends BLETransport {
       _connectionStateSubject.asBroadcastStream();
 
   @override
-  Future<void> disconnect() async {
+  Future<void> disconnect() {
     _connectionGeneration++;
+    return _lifecycleGate.run(_device.deviceId, _disconnectLocked);
+  }
+
+  Future<void> _disconnectLocked() async {
+    _maintenanceGeneration = null;
     await _advertSub?.cancel();
     _advertSub = null;
 
@@ -338,13 +397,14 @@ class UniversalBleTransport extends BLETransport {
     try {
       _log.fine("disconnect");
       await _disconnectNative();
+      _publishDisconnected();
     } catch (error, stackTrace) {
       _log.warning("failed to disconnect", error, stackTrace);
       if (UniversalBle.getQueueDiagnostics(_device.deviceId).state ==
           QueueDiagnosticsState.faulted) {
         rethrow;
       }
-      _connectionStateSubject.add(device.ConnectionState.disconnected);
+      _publishDisconnected();
     } finally {
       await _connectionStateSubscription?.cancel();
       _connectionStateSubscription = null;
@@ -369,7 +429,10 @@ class UniversalBleTransport extends BLETransport {
   }
 
   @override
-  Future<List<String>> discoverServices() async {
+  Future<List<String>> discoverServices() =>
+      _lifecycleGate.run(_device.deviceId, _discoverServicesLocked);
+
+  Future<List<String>> _discoverServicesLocked() async {
     if (!_isLinux) {
       final services = await UniversalBle.discoverServices(
         _device.deviceId,
@@ -381,38 +444,79 @@ class UniversalBleTransport extends BLETransport {
       return services.map((s) => s.uuid).toList();
     }
 
-    // BlueZ resolves GATT services asynchronously after connect; a query too
-    // soon can throw "Failed to resolve services" or return empty. Retry a
-    // few times (ported from LinuxBluePlusTransport).
-    for (int attempt = 1; attempt <= _bluezDiscoveryRetries; attempt++) {
-      try {
-        final services = await UniversalBle.discoverServices(
-          _device.deviceId,
-          timeout: Duration(seconds: 15),
-        );
-        if (services.isEmpty && attempt < _bluezDiscoveryRetries) {
-          _log.warning(
-            "discoverServices returned empty "
-            "(attempt $attempt/$_bluezDiscoveryRetries), retrying",
-          );
-          await Future.delayed(_bluezDiscoveryRetryDelay);
-          continue;
-        }
-        _log.fine("discovered ${services.length} services");
-        return services.map((s) => s.uuid).toList();
-      } on UniversalBleException catch (e) {
-        _log.warning(
-          "discoverServices attempt $attempt/$_bluezDiscoveryRetries "
-          "failed: $e",
-        );
-        if (attempt < _bluezDiscoveryRetries) {
-          await Future.delayed(_bluezDiscoveryRetryDelay);
-        } else {
-          rethrow;
-        }
-      }
+    try {
+      return await _discoverServicesBlueZ();
+    } on UniversalBleException catch (error) {
+      if (error.code != UniversalBleErrorCode.servicesNotResolved) rethrow;
+      return _recoverBlueZServices(_connectionGeneration);
     }
-    return [];
+  }
+
+  Future<List<String>> _discoverServicesBlueZ() async {
+    final services = await UniversalBle.discoverServices(
+      _device.deviceId,
+      timeout: const Duration(seconds: 15),
+    );
+    _log.fine('discovered ${services.length} services');
+    return services.map((service) => service.uuid).toList();
+  }
+
+  Future<List<String>> _recoverBlueZServices(int generation) async {
+    _maintenanceGeneration = generation;
+    try {
+      await _stopScanAndSettle(generation);
+      await _disconnectNative();
+      _checkMaintenanceGeneration(generation);
+      await _waitForNativeDisconnect(generation);
+      _checkMaintenanceGeneration(generation);
+      await _connectionStateSubscription?.cancel();
+      _connectionStateSubscription = null;
+      _checkMaintenanceGeneration(generation);
+      await UniversalBle.clearGattCache(_device.deviceId);
+      _checkMaintenanceGeneration(generation);
+      await _refreshDeviceCache(generation);
+      await _doConnectBlueZ(generation);
+      await _listenForConnectionUpdates(generation);
+      _checkMaintenanceGeneration(generation);
+      final services = await _discoverServicesBlueZ();
+      _checkMaintenanceGeneration(generation);
+      _maintenanceGeneration = null;
+      return services;
+    } on _MaintenanceCancelled {
+      _maintenanceGeneration = null;
+      throw UniversalBleException(
+        code: UniversalBleErrorCode.operationCancelled,
+        message: 'BLE maintenance recovery was cancelled',
+      );
+    } catch (_) {
+      _maintenanceGeneration = null;
+      try {
+        await _disconnectNative();
+      } catch (_) {}
+      _publishDisconnected();
+      rethrow;
+    }
+  }
+
+  Future<void> _waitForNativeDisconnect(int generation) async {
+    final deadline = DateTime.now().add(_faultRecoveryDisconnectTimeout);
+    while (DateTime.now().isBefore(deadline)) {
+      _checkMaintenanceGeneration(generation);
+      final state = await UniversalBle.getConnectionState(
+        _device.deviceId,
+        timeout: const Duration(seconds: 2),
+      );
+      _checkMaintenanceGeneration(generation);
+      if (state == BleConnectionState.disconnected) return;
+      await Future<void>.delayed(_faultRecoveryPollInterval);
+    }
+    throw TimeoutException('Timed out waiting for native BLE disconnect');
+  }
+
+  void _checkMaintenanceGeneration(int generation) {
+    if (_connectionGeneration != generation || _disposed) {
+      throw const _MaintenanceCancelled();
+    }
   }
 
   @override
@@ -578,6 +682,14 @@ class UniversalBleTransport extends BLETransport {
     _clearQueue(UniversalBleErrorCode.deviceDisconnected);
     if (_connectionStateSubject.valueOrNull !=
         device.ConnectionState.disconnected) {
+      _publishDisconnected();
+    }
+  }
+
+  void _publishDisconnected() {
+    if (!_connectionStateSubject.isClosed &&
+        _connectionStateSubject.valueOrNull !=
+            device.ConnectionState.disconnected) {
       _connectionStateSubject.add(device.ConnectionState.disconnected);
     }
   }
@@ -706,8 +818,14 @@ class UniversalBleTransport extends BLETransport {
   }
 
   @override
-  Future<void> dispose() async {
+  Future<void> dispose() {
     _connectionGeneration++;
+    _disposed = true;
+    return _lifecycleGate.run(_device.deviceId, _disposeLocked);
+  }
+
+  Future<void> _disposeLocked() async {
+    _maintenanceGeneration = null;
     _advertSub?.cancel();
     _advertSub = null;
     _connectionStateSubscription?.cancel();
@@ -720,4 +838,8 @@ class UniversalBleTransport extends BLETransport {
       _connectionStateSubject.close();
     }
   }
+}
+
+class _MaintenanceCancelled implements Exception {
+  const _MaintenanceCancelled();
 }

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -7,6 +7,7 @@ import 'package:reaprime/src/models/device/transport/ble_connect_exception.dart'
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart' as domain;
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
+import 'package:reaprime/src/services/ble/ble_lifecycle_gate.dart';
 import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
 import 'package:reaprime/src/services/device_factory.dart';
 import 'package:reaprime/src/services/device_matcher.dart';
@@ -25,6 +26,7 @@ typedef BleTransportFactory =
       required BleDevice device,
       required Future<void> Function() stopScan,
       required bool requestLargeMtuNonAndroid,
+      required BleLifecycleGate lifecycleGate,
     });
 
 class UniversalBleDiscoveryService extends BleDiscoveryService
@@ -41,16 +43,19 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     required BleDevice device,
     required Future<void> Function() stopScan,
     required bool requestLargeMtuNonAndroid,
+    required BleLifecycleGate lifecycleGate,
   }) {
     return UniversalBleTransport(
       device: device,
       stopScan: stopScan,
       requestLargeMtuNonAndroid: requestLargeMtuNonAndroid,
+      lifecycleGate: lifecycleGate,
     );
   }
 
   final bool Function() _watchSupportGate;
   final BleTransportFactory _transportFactory;
+  final BleLifecycleGate _lifecycleGate = BleLifecycleGate();
 
   bool Function() requestLargeMtuNonAndroid;
 
@@ -59,6 +64,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       device: device,
       stopScan: _stopScanForConnect,
       requestLargeMtuNonAndroid: requestLargeMtuNonAndroid(),
+      lifecycleGate: _lifecycleGate,
     );
   }
 
@@ -221,7 +227,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     final adapterGen = _watchAdapterGeneration;
 
     _watchScanSub = UniversalBle.scanStream.listen((result) async {
-      if (_currentlyScanning.contains(result.deviceId)) {
+      if (_currentlyScanning.contains(normalizeBleDeviceId(result.deviceId))) {
         return;
       }
       await _deviceScanned(result);
@@ -349,7 +355,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     if (state == _lastWatchAdapterState) return;
     _lastWatchAdapterState = state;
     _watchAdapterGeneration++;
-    if (state == AdapterState.poweredOff) {
+    if (state != AdapterState.poweredOn) {
       if (!_watchScanActive) return;
       unawaited(
         _deactivateWatchScan(stopOsScan: false, context: 'adapter-off'),
@@ -363,6 +369,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   }
 
   final Map<String, Device> _devices = {};
+  final Map<String, Future<Device?>> _candidateInFlight = {};
 
   final log = logging.Logger("UniversalBleDeviceService");
 
@@ -371,7 +378,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
 
   final Map<String, StreamSubscription<ConnectionState>> _connections = {};
 
-  final List<String> _currentlyScanning = [];
+  final Set<String> _currentlyScanning = {};
+  StreamSubscription<AvailabilityState>? _availabilitySubscription;
+  bool _disposed = false;
 
   bool _isScanning = false;
 
@@ -393,6 +402,8 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
 
   @override
   Future<void> initialize() async {
+    if (_availabilitySubscription != null) return;
+    _disposed = false;
     // perDevice: each BLE peripheral gets its own command queue, so
     // DE1 GATT operations never block scale heartbeat writes and vice
     // versa. Mirrors flutter_blue_plus' per-connection serialization.
@@ -418,7 +429,8 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     // initial replay of this same state doesn't count as a transition.
     _lastWatchAdapterState = mappedInitialState;
 
-    UniversalBle.availabilityStream.listen((state) {
+    _availabilitySubscription = UniversalBle.availabilityStream.listen((state) {
+      if (_disposed) return;
       log.info("BLE Adapter state: ${state.name}");
       final mapped = _mapAvailabilityState(state);
       _adapterStateSubject.add(mapped);
@@ -526,7 +538,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
         log.finest(
           "Found: ${result.deviceId}: ${result.name}, adv: ${result.services}",
         );
-        if (_currentlyScanning.contains(result.deviceId)) {
+        if (_currentlyScanning.contains(
+          normalizeBleDeviceId(result.deviceId),
+        )) {
           return;
         }
         await _deviceScanned(result);
@@ -587,36 +601,59 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   }
 
   Future<void> _deviceScanned(BleDevice device) async {
-    _currentlyScanning.add(device.deviceId);
+    final deviceId = normalizeBleDeviceId(device.deviceId);
+    if (_currentlyScanning.contains(deviceId)) return;
+    _currentlyScanning.add(deviceId);
 
     try {
       final name = device.name ?? '';
       if (name.isEmpty) return;
 
-      if (_devices.containsKey(device.deviceId.toString())) return;
+      if (_devices.containsKey(deviceId)) return;
 
-      final matchedDevice = await DeviceMatcher.match(
-        transport: _createTransport(device),
-        advertisedName: name,
+      final matchedDevice = await _candidate(
+        deviceId,
+        () => DeviceMatcher.match(
+          transport: _createTransport(device),
+          advertisedName: name,
+        ),
       );
 
       if (matchedDevice != null) {
-        _devices[device.deviceId.toString()] = matchedDevice;
+        _devices[deviceId] = matchedDevice;
         _deviceStreamController.add(_devices.values.toList());
         log.fine("found new device: ${device.name}");
 
-        _connections[device.deviceId
-            .toString()] = _devices[device.deviceId.toString()]!.connectionState
-            .listen((connectionState) {
-              if (connectionState == ConnectionState.disconnected) {
-                _devices.remove(device.deviceId.toString());
-                _deviceStreamController.add(_devices.values.toList());
-              }
-            });
+        await _connections.remove(deviceId)?.cancel();
+        _connections[deviceId] = matchedDevice.connectionState.listen((
+          connectionState,
+        ) {
+          if (connectionState == ConnectionState.disconnected) {
+            _devices.remove(deviceId);
+            _deviceStreamController.add(_devices.values.toList());
+          }
+        });
       }
     } finally {
-      _currentlyScanning.remove(device.deviceId);
+      _currentlyScanning.remove(deviceId);
     }
+  }
+
+  Future<Device?> _candidate(
+    String deviceId,
+    Future<Device?> Function() create,
+  ) {
+    final key = normalizeBleDeviceId(deviceId);
+    final existing = _candidateInFlight[key];
+    if (existing != null) return existing;
+    late final Future<Device?> candidate;
+    candidate = create().whenComplete(() {
+      if (identical(_candidateInFlight[key], candidate)) {
+        _candidateInFlight.remove(key);
+      }
+    });
+    _candidateInFlight[key] = candidate;
+    return candidate;
   }
 
   @override
@@ -627,7 +664,18 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       return null;
     }
 
+    return _candidate(
+      remembered.id,
+      () => _tryQuickConnectCandidate(remembered, impl),
+    );
+  }
+
+  Future<Device?> _tryQuickConnectCandidate(
+    RememberedDevice remembered,
+    DeviceImplementation impl,
+  ) async {
     final deviceId = remembered.id;
+    final key = normalizeBleDeviceId(deviceId);
 
     BleDevice? bleDevice;
     if (Platform.isIOS || Platform.isMacOS) {
@@ -669,11 +717,12 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
           }
         }
       }
-      _devices[deviceId] = device;
+      _devices[key] = device;
       _deviceStreamController.add(_devices.values.toList());
-      _connections[deviceId] = device.connectionState.listen((state) {
+      await _connections.remove(key)?.cancel();
+      _connections[key] = device.connectionState.listen((state) {
         if (state == ConnectionState.disconnected) {
-          _devices.remove(deviceId);
+          _devices.remove(key);
           _deviceStreamController.add(_devices.values.toList());
         }
       });
@@ -697,7 +746,10 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
         withServices: [],
       );
       for (final d in systemDevices) {
-        if (d.deviceId == deviceId) return d;
+        if (normalizeBleDeviceId(d.deviceId) ==
+            normalizeBleDeviceId(deviceId)) {
+          return d;
+        }
       }
     } catch (e, st) {
       log.fine('getSystemDevices failed during quick-connect', e, st);
@@ -706,7 +758,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   }
 
   Future<void> _connectWithRetry(Device device) async {
-    const timeout = Duration(seconds: 10);
+    final timeout = Platform.isLinux
+        ? const Duration(seconds: 60)
+        : const Duration(seconds: 10);
     try {
       await device.onConnect().timeout(timeout);
     } on BleConnectException catch (e) {
@@ -716,6 +770,26 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
         await device.disconnect();
       } catch (_) {}
       await device.onConnect().timeout(timeout);
+    }
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _availabilitySubscription?.cancel();
+    _availabilitySubscription = null;
+    _cancelScanDurationWait();
+    await stopDeviceWatch();
+    for (final subscription in _connections.values) {
+      await subscription.cancel();
+    }
+    _connections.clear();
+    if (!_deviceStreamController.isClosed) {
+      await _deviceStreamController.close();
+    }
+    if (!_adapterStateSubject.isClosed) await _adapterStateSubject.close();
+    if (!_watchFailureController.isClosed) {
+      await _watchFailureController.close();
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1706,11 +1706,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2.2.4"
-      resolved-ref: "68dc6ea1c26df08e47c35aa142ffc0db646657ef"
+      ref: "2.2.5"
+      resolved-ref: a2639e32eb873a3b0d313a755ef3f43ca381fba9
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
-    version: "2.2.4"
+    version: "2.2.5"
   universal_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   universal_ble:
     git:
       url: https://github.com/tadelv/universal_ble.git
-      ref: 2.2.4
+      ref: 2.2.5
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -206,6 +206,28 @@ void main() {
       expect(connectionManager.currentStatus.error, isNull);
     });
 
+    test('adapter restoration queues one current-state recovery', () async {
+      await settingsController.setPreferredMachineId('pref-de1');
+      connectionManager.adapterRecoveryDebounce = Duration.zero;
+
+      mockScanner.mockAdapterState(AdapterState.poweredOn);
+      await Future<void>.delayed(Duration.zero);
+      expect(mockScanner.scanCallCount, 0);
+
+      mockScanner.mockAdapterState(AdapterState.poweredOff);
+      mockScanner.mockAdapterState(AdapterState.unknown);
+      mockScanner.mockAdapterState(AdapterState.poweredOn);
+      mockScanner.mockAdapterState(AdapterState.poweredOn);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(mockScanner.stopScanCallCount, 1);
+      expect(mockScanner.scanCallCount, 1);
+      expect(
+        connectionManager.currentStatus.intent,
+        ConnectionIntent.adapterRecovery,
+      );
+    });
+
     group('connect', () {
       test('emits scanning phase during scan', () async {
         final phases = <ConnectionPhase>[];

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -207,26 +207,46 @@ void main() {
       expect(connectionManager.currentStatus.error, isNull);
     });
 
-    test('adapter restoration queues one current-state recovery', () async {
+    test('initial powered off then on recovers preferred machine', () async {
       await settingsController.setPreferredMachineId('pref-de1');
       connectionManager.adapterRecoveryDebounce = Duration.zero;
 
-      mockScanner.mockAdapterState(AdapterState.poweredOn);
-      await Future<void>.delayed(Duration.zero);
-      expect(mockScanner.scanCallCount, 0);
-
       mockScanner.mockAdapterState(AdapterState.poweredOff);
-      mockScanner.mockAdapterState(AdapterState.unknown);
-      mockScanner.mockAdapterState(AdapterState.poweredOn);
       mockScanner.mockAdapterState(AdapterState.poweredOn);
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
-      expect(mockScanner.stopScanCallCount, 1);
       expect(mockScanner.scanCallCount, 1);
       expect(
         connectionManager.currentStatus.intent,
         ConnectionIntent.adapterRecovery,
       );
+    });
+
+    test('initial unknown then on recovers preferred machine', () async {
+      await settingsController.setPreferredMachineId('pref-de1');
+      connectionManager.adapterRecoveryDebounce = Duration.zero;
+
+      mockScanner.mockAdapterState(AdapterState.unknown);
+      mockScanner.mockAdapterState(AdapterState.poweredOn);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(mockScanner.scanCallCount, 1);
+      expect(
+        connectionManager.currentStatus.intent,
+        ConnectionIntent.adapterRecovery,
+      );
+    });
+
+    test('duplicate powered on emissions coalesce recovery', () async {
+      await settingsController.setPreferredMachineId('pref-de1');
+      connectionManager.adapterRecoveryDebounce = Duration.zero;
+
+      mockScanner.mockAdapterState(AdapterState.poweredOff);
+      mockScanner.mockAdapterState(AdapterState.poweredOn);
+      mockScanner.mockAdapterState(AdapterState.poweredOn);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(mockScanner.scanCallCount, 1);
     });
 
     group('connect', () {

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1416,9 +1417,10 @@ void main() {
         expect(settingsController.preferredMachineId, isNull);
       });
 
-      test('connect timeout: machine that never responds fails after 30s '
+      test('connect timeout: machine that never responds uses platform budget '
           '(comms-harden #31)', () {
         fakeAsync((async) {
+          final timeoutSeconds = Platform.isLinux ? 60 : 30;
           final completer = Completer<void>();
           final slowDe1Controller = _SlowMockDe1Controller(
             controller: DeviceController([dummyDiscoveryService]),
@@ -1436,9 +1438,7 @@ void main() {
           Object? caughtError;
           manager.connectMachine(fakeDe1).catchError((e) => caughtError = e);
 
-          // Advance past the 30s connect budget; the TimeoutException
-          // in connectMachine should cause rethrow + machineConnectFailed.
-          async.elapse(const Duration(seconds: 35));
+          async.elapse(Duration(seconds: timeoutSeconds + 5));
           async.flushMicrotasks();
 
           expect(
@@ -1451,7 +1451,7 @@ void main() {
           expect(status.error?.kind, ConnectionErrorKind.machineConnectFailed);
           expect(
             status.error?.message,
-            contains('did not respond within 30s'),
+            contains('did not respond within ${timeoutSeconds}s'),
             reason: 'timeout-specific error message should surface',
           );
 

--- a/test/services/ble/ble_lifecycle_gate_test.dart
+++ b/test/services/ble/ble_lifecycle_gate_test.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/ble/ble_lifecycle_gate.dart';
+
+void main() {
+  test('serializes normalized device ids', () async {
+    final gate = BleLifecycleGate();
+    final firstStarted = Completer<void>();
+    final releaseFirst = Completer<void>();
+    var active = 0;
+    var peak = 0;
+
+    Future<void> operation(Completer<void>? blocker) async {
+      active++;
+      peak = active > peak ? active : peak;
+      if (!firstStarted.isCompleted) firstStarted.complete();
+      if (blocker != null) await blocker.future;
+      active--;
+    }
+
+    final first = gate.run('AA:BB', () => operation(releaseFirst));
+    await firstStarted.future;
+    final second = gate.run('aa:bb', () => operation(null));
+    await Future<void>.delayed(Duration.zero);
+    expect(active, 1);
+    releaseFirst.complete();
+    await Future.wait([first, second]);
+    expect(peak, 1);
+  });
+
+  test('allows different device ids concurrently', () async {
+    final gate = BleLifecycleGate();
+    final release = Completer<void>();
+    var active = 0;
+
+    Future<void> operation() async {
+      active++;
+      await release.future;
+      active--;
+    }
+
+    final first = gate.run('a', operation);
+    final second = gate.run('b', operation);
+    await Future<void>.delayed(Duration.zero);
+    expect(active, 2);
+    release.complete();
+    await Future.wait([first, second]);
+  });
+}

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -201,9 +201,7 @@ void main() {
   });
 
   tearDown(() async {
-    // Stop any active watch so its refresh/liveness timers cannot fire
-    // in a later test against that test's replaced UniversalBle fake.
-    await service.stopDeviceWatch();
+    await service.dispose();
   });
 
   ({ScanFilter? filter, PlatformConfig? config}) lastStart() =>
@@ -247,6 +245,36 @@ void main() {
         contains('AA:BB:CC:DD:EE:FF'),
       );
       await sub.cancel();
+    });
+
+    test('normalized duplicate results create one candidate', () async {
+      var transports = 0;
+      final sut = UniversalBleDiscoveryService(
+        watchSupportGate: () => true,
+        transportFactory:
+            ({
+              required device,
+              required stopScan,
+              required requestLargeMtuNonAndroid,
+              required lifecycleGate,
+            }) {
+              transports++;
+              return FakeBleTransport();
+            },
+      );
+      addTearDown(sut.dispose);
+      await sut.initialize();
+      await sut.startDeviceWatch(_watchFilter);
+
+      platform.updateScanResult(
+        BleDevice(deviceId: 'AA:BB:CC:DD:EE:FF', name: 'Decent Scale'),
+      );
+      platform.updateScanResult(
+        BleDevice(deviceId: 'aa:bb:cc:dd:ee:ff', name: 'Decent Scale'),
+      );
+      await pump();
+
+      expect(transports, 1);
     });
   });
 
@@ -689,6 +717,7 @@ void main() {
                 required device,
                 required stopScan,
                 required requestLargeMtuNonAndroid,
+                required lifecycleGate,
               }) {
                 return transport;
               },
@@ -743,6 +772,7 @@ void main() {
                 required device,
                 required stopScan,
                 required requestLargeMtuNonAndroid,
+                required lifecycleGate,
               }) {
                 return transport;
               },
@@ -799,6 +829,7 @@ void main() {
                 required device,
                 required stopScan,
                 required requestLargeMtuNonAndroid,
+                required lifecycleGate,
               }) {
                 capturedValues.add(requestLargeMtuNonAndroid);
 

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -27,8 +27,13 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   int writeCalls = 0;
   int getConnectionStateCalls = 0;
   int clearGattCacheCalls = 0;
+  int discoverServicesCalls = 0;
+  int stopScanCalls = 0;
+  bool scanning = false;
   bool updateConnectionStateOnLifecycle = false;
   Completer<void>? clearGattCacheBlocker;
+  Completer<void>? serviceDiscoveryBlocker;
+  BleDevice? scanResult;
   final List<Object> serviceDiscoveryResults = [];
   final List<String> disconnectCalls = [];
   final List<BleInputProperty> notificationProperties = [];
@@ -53,13 +58,20 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   Future<void> startScan({
     ScanFilter? scanFilter,
     PlatformConfig? platformConfig,
-  }) async {}
+  }) async {
+    scanning = true;
+    final result = scanResult;
+    if (result != null) updateScanResult(result);
+  }
 
   @override
-  Future<void> stopScan() async {}
+  Future<void> stopScan() async {
+    stopScanCalls++;
+    scanning = false;
+  }
 
   @override
-  Future<bool> isScanning() async => false;
+  Future<bool> isScanning() async => scanning;
 
   @override
   Future<void> connect(
@@ -89,6 +101,8 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     String deviceId,
     bool withDescriptors,
   ) async {
+    discoverServicesCalls++;
+    await serviceDiscoveryBlocker?.future;
     if (serviceDiscoveryResults.isEmpty) return [];
     final result = serviceDiscoveryResults.removeAt(0);
     if (result is Error || result is Exception) throw result;
@@ -782,13 +796,15 @@ void main() {
         StreamSubscription<device.ConnectionState>,
       )
     >
-    createLinuxTransport() async {
+    createLinuxTransport({
+      Duration cacheRefreshScan = Duration.zero,
+    }) async {
       final linux = UniversalBleTransport(
         device: bleDevice('$deviceId-linux'),
         isLinuxOverride: true,
         bluezPostConnectDelay: Duration.zero,
         bluezScanSettleDelay: Duration.zero,
-        bluezCacheRefreshScan: Duration.zero,
+        bluezCacheRefreshScan: cacheRefreshScan,
         faultRecoveryDisconnectTimeout: const Duration(milliseconds: 100),
       );
       final states = <device.ConnectionState>[];
@@ -818,6 +834,33 @@ void main() {
       expect(services, [_serviceUuid]);
       expect(platform.clearGattCacheCalls, 1);
       expect(states, isNot(contains(device.ConnectionState.disconnected)));
+    });
+
+    test('cache refresh advert does not cancel recovery', () async {
+      final (linux, states, subscription) = await createLinuxTransport();
+      addTearDown(subscription.cancel);
+      addTearDown(linux.dispose);
+      platform.scanResult = bleDevice(linux.id);
+      platform.serviceDiscoveryResults.addAll([
+        unresolved(),
+        <BleService>[BleService(_serviceUuid, [])],
+      ]);
+      var teardownCalls = 0;
+      final teardownSubscription = linux.connectionState
+          .where((state) => state == device.ConnectionState.disconnected)
+          .listen((_) {
+            teardownCalls++;
+            unawaited(linux.disconnect());
+          });
+      addTearDown(teardownSubscription.cancel);
+
+      final services = await linux.discoverServices();
+
+      expect(services, [_serviceUuid]);
+      expect(states, isNot(contains(device.ConnectionState.disconnected)));
+      expect(teardownCalls, 0);
+      expect(platform.disconnectCalls, [linux.id]);
+      expect(platform.connectCalls, 2);
     });
 
     test('second unresolved result disconnects exactly once', () async {
@@ -868,7 +911,66 @@ void main() {
         ),
       );
       await disconnect;
-      expect(platform.connectCalls, 2);
+      expect(platform.connectCalls, 1);
+    });
+
+    test('disconnect during initial discovery prevents reconnect', () async {
+      final (linux, _, subscription) = await createLinuxTransport();
+      addTearDown(subscription.cancel);
+      addTearDown(linux.dispose);
+      platform.serviceDiscoveryBlocker = Completer<void>();
+      platform.serviceDiscoveryResults.add(unresolved());
+
+      final discovery = linux.discoverServices();
+      while (platform.discoverServicesCalls == 0) {
+        await pump(1);
+      }
+      final disconnect = linux.disconnect();
+      platform.serviceDiscoveryBlocker!.complete();
+
+      await expectLater(
+        discovery,
+        throwsA(
+          isA<UniversalBleException>().having(
+            (error) => error.code,
+            'code',
+            UniversalBleErrorCode.operationCancelled,
+          ),
+        ),
+      );
+      await disconnect;
+      expect(platform.connectCalls, 1);
+      expect(platform.clearGattCacheCalls, 0);
+    });
+
+    test('disconnect during refresh scan stops the scan', () async {
+      final (linux, _, subscription) = await createLinuxTransport(
+        cacheRefreshScan: const Duration(milliseconds: 50),
+      );
+      addTearDown(subscription.cancel);
+      addTearDown(linux.dispose);
+      platform.serviceDiscoveryResults.add(unresolved());
+
+      final discovery = linux.discoverServices();
+      while (!platform.scanning) {
+        await pump(1);
+      }
+      final stopCallsBeforeCancellation = platform.stopScanCalls;
+      final disconnect = linux.disconnect();
+
+      await expectLater(
+        discovery,
+        throwsA(
+          isA<UniversalBleException>().having(
+            (error) => error.code,
+            'code',
+            UniversalBleErrorCode.operationCancelled,
+          ),
+        ),
+      );
+      await disconnect;
+      expect(platform.stopScanCalls, greaterThan(stopCallsBeforeCancellation));
+      expect(platform.scanning, isFalse);
     });
   });
 }

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -843,6 +843,7 @@ void main() {
         unresolved(),
         <BleService>[BleService(_serviceUuid, [])],
       ]);
+      final connectCallsBeforeRecovery = platform.connectCalls;
       var teardownCalls = 0;
       final teardownSubscription = linux.connectionState
           .where((state) => state == device.ConnectionState.disconnected)
@@ -858,7 +859,7 @@ void main() {
       expect(states, isNot(contains(device.ConnectionState.disconnected)));
       expect(teardownCalls, 0);
       expect(platform.disconnectCalls, [linux.id]);
-      expect(platform.connectCalls, 2);
+      expect(platform.connectCalls, connectCallsBeforeRecovery + 1);
     });
 
     test('second unresolved result disconnects exactly once', () async {
@@ -890,6 +891,7 @@ void main() {
       addTearDown(linux.dispose);
       platform.clearGattCacheBlocker = Completer<void>();
       platform.serviceDiscoveryResults.add(unresolved());
+      final connectCallsBeforeDiscovery = platform.connectCalls;
 
       final discovery = linux.discoverServices();
       while (platform.clearGattCacheCalls == 0) {
@@ -909,7 +911,7 @@ void main() {
         ),
       );
       await disconnect;
-      expect(platform.connectCalls, 1);
+      expect(platform.connectCalls, connectCallsBeforeDiscovery);
     });
 
     test('disconnect during initial discovery prevents reconnect', () async {
@@ -918,6 +920,7 @@ void main() {
       addTearDown(linux.dispose);
       platform.serviceDiscoveryBlocker = Completer<void>();
       platform.serviceDiscoveryResults.add(unresolved());
+      final connectCallsBeforeDiscovery = platform.connectCalls;
 
       final discovery = linux.discoverServices();
       while (platform.discoverServicesCalls == 0) {
@@ -937,7 +940,7 @@ void main() {
         ),
       );
       await disconnect;
-      expect(platform.connectCalls, 1);
+      expect(platform.connectCalls, connectCallsBeforeDiscovery);
       expect(platform.clearGattCacheCalls, 0);
     });
 

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -796,9 +796,7 @@ void main() {
         StreamSubscription<device.ConnectionState>,
       )
     >
-    createLinuxTransport({
-      Duration cacheRefreshScan = Duration.zero,
-    }) async {
+    createLinuxTransport({Duration cacheRefreshScan = Duration.zero}) async {
       final linux = UniversalBleTransport(
         device: bleDevice('$deviceId-linux'),
         isLinuxOverride: true,

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -26,6 +26,10 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   int connectCalls = 0;
   int writeCalls = 0;
   int getConnectionStateCalls = 0;
+  int clearGattCacheCalls = 0;
+  bool updateConnectionStateOnLifecycle = false;
+  Completer<void>? clearGattCacheBlocker;
+  final List<Object> serviceDiscoveryResults = [];
   final List<String> disconnectCalls = [];
   final List<BleInputProperty> notificationProperties = [];
 
@@ -65,12 +69,18 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     ConnectionPlatformConfig? platformConfig,
   }) async {
     connectCalls++;
+    if (updateConnectionStateOnLifecycle) {
+      connectionStateResult = BleConnectionState.connected;
+    }
     updateConnection(deviceId, true);
   }
 
   @override
   Future<void> disconnect(String deviceId) async {
     disconnectCalls.add(deviceId);
+    if (updateConnectionStateOnLifecycle) {
+      connectionStateResult = BleConnectionState.disconnected;
+    }
     if (emitDisconnectEvent) updateConnection(deviceId, false);
   }
 
@@ -78,7 +88,18 @@ class _FakeBlePlatform extends UniversalBlePlatform {
   Future<List<BleService>> discoverServices(
     String deviceId,
     bool withDescriptors,
-  ) async => [];
+  ) async {
+    if (serviceDiscoveryResults.isEmpty) return [];
+    final result = serviceDiscoveryResults.removeAt(0);
+    if (result is Error || result is Exception) throw result;
+    return result as List<BleService>;
+  }
+
+  @override
+  Future<void> clearGattCache(String deviceId) async {
+    clearGattCacheCalls++;
+    await clearGattCacheBlocker?.future;
+  }
 
   @override
   Future<void> setNotifiable(
@@ -750,6 +771,104 @@ void main() {
       expect(received, isEmpty);
       expect(platform.notificationProperties, [BleInputProperty.notification]);
       expect(platform.disconnectCalls, [deviceId]);
+    });
+  });
+
+  group('Linux stale service recovery', () {
+    Future<
+      (
+        UniversalBleTransport,
+        List<device.ConnectionState>,
+        StreamSubscription<device.ConnectionState>,
+      )
+    >
+    createLinuxTransport() async {
+      final linux = UniversalBleTransport(
+        device: bleDevice('$deviceId-linux'),
+        isLinuxOverride: true,
+        bluezPostConnectDelay: Duration.zero,
+        bluezScanSettleDelay: Duration.zero,
+        bluezCacheRefreshScan: Duration.zero,
+        faultRecoveryDisconnectTimeout: const Duration(milliseconds: 100),
+      );
+      final states = <device.ConnectionState>[];
+      final subscription = linux.connectionState.listen(states.add);
+      platform.updateConnectionStateOnLifecycle = true;
+      await linux.connect();
+      await pump(10);
+      return (linux, states, subscription);
+    }
+
+    UniversalBleException unresolved() => UniversalBleException(
+      code: UniversalBleErrorCode.servicesNotResolved,
+      message: 'stale',
+    );
+
+    test('successful recovery hides the maintenance disconnect', () async {
+      final (linux, states, subscription) = await createLinuxTransport();
+      addTearDown(subscription.cancel);
+      addTearDown(linux.dispose);
+      platform.serviceDiscoveryResults.addAll([
+        unresolved(),
+        <BleService>[BleService(_serviceUuid, [])],
+      ]);
+
+      final services = await linux.discoverServices();
+
+      expect(services, [_serviceUuid]);
+      expect(platform.clearGattCacheCalls, 1);
+      expect(states, isNot(contains(device.ConnectionState.disconnected)));
+    });
+
+    test('second unresolved result disconnects exactly once', () async {
+      final (linux, states, subscription) = await createLinuxTransport();
+      addTearDown(subscription.cancel);
+      addTearDown(linux.dispose);
+      platform.serviceDiscoveryResults.addAll([unresolved(), unresolved()]);
+
+      await expectLater(
+        linux.discoverServices(),
+        throwsA(
+          isA<UniversalBleException>().having(
+            (error) => error.code,
+            'code',
+            UniversalBleErrorCode.servicesNotResolved,
+          ),
+        ),
+      );
+
+      expect(
+        states.where((state) => state == device.ConnectionState.disconnected),
+        hasLength(1),
+      );
+    });
+
+    test('explicit disconnect cancels maintenance before reconnect', () async {
+      final (linux, _, subscription) = await createLinuxTransport();
+      addTearDown(subscription.cancel);
+      addTearDown(linux.dispose);
+      platform.clearGattCacheBlocker = Completer<void>();
+      platform.serviceDiscoveryResults.add(unresolved());
+
+      final discovery = linux.discoverServices();
+      while (platform.clearGattCacheCalls == 0) {
+        await pump(1);
+      }
+      final disconnect = linux.disconnect();
+      platform.clearGattCacheBlocker!.complete();
+
+      await expectLater(
+        discovery,
+        throwsA(
+          isA<UniversalBleException>().having(
+            (error) => error.code,
+            'code',
+            UniversalBleErrorCode.operationCancelled,
+          ),
+        ),
+      );
+      await disconnect;
+      expect(platform.connectCalls, 2);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Problem: Linux BlueZ owner restarts and stale GATT state could strand machine or scale connections.
- Why it matters: Decaid could retain stale public connection state, overlap lifecycle operations, or fail to recover after Bluetooth service restoration.
- What changed: bump `universal_ble` to `2.2.5`, serialize BLE lifecycle work per normalized device ID, add one bounded stale-service maintenance recovery, and queue adapter restoration through the existing connection drain.
- What did NOT change: no generic operation replay framework, no automatic GATT read/write replay, and no global runtime reset for device-scoped scale recovery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #520

## Root Cause (if bug fix)

- Root cause: BlueZ runtime replacement invalidated cached GATT objects while ReaPrime treated BLE discovery, connection, and recovery as independent operations.
- Missing detection or guardrail: adapter restoration was not queued after disconnect propagation, device IDs were not normalized across every lifecycle map, and native lifecycle operations were not serialized per device.
- Contributing context: Linux service discovery could outlive a replaced BlueZ runtime and surface stale-service failures after the normal command timeout.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `connection_manager_test.dart`, `ble_lifecycle_gate_test.dart`, `universal_ble_discovery_service_test.dart`, and `universal_ble_transport_recovery_test.dart`.
- Scenario the test should lock in: one adapter recovery, normalized candidate deduplication, per-device lifecycle serialization, hidden maintenance disconnects, terminal second failure, and explicit-disconnect cancellation.
- If no new test added, why not: N/A.

## Documentation Obligations (required)

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no API, plugin, skin, profile, or device-management contract changed; systemd ordering guidance was added to `README.md`.

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `Yes`
- File system access changed? `No`
- Plugin sandbox boundary changed? `No`
- If any `Yes`, explain risk and mitigation: BLE recovery is bounded, device-scoped, generation-checked, and does not replay reads or writes.

## User-Visible Changes

On Linux, Decaid recovers after BlueZ restarts and performs one hidden stale-GATT maintenance reconnect when service discovery reports `servicesNotResolved`.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — 650 files checked, 0 changed
- [x] `flutter analyze` — clean
- [ ] `flutter test` — focused recovery set passed 187/187; the full Windows suite has 13 unrelated plugin failures because `quickjs_c_bridge.dll` is absent
- [ ] `(cd packages/dye2-plugin && npm run build)` — plugin code unchanged

### Manual verification (if applicable)

- OS / platform tested: Windows host with mocked BLE platform
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: dependency resolution to tag `2.2.5`, formatter, analyzer, and focused mock transport tests.
- Edge cases checked: adapter loss/restoration, duplicate normalized IDs, concurrent lifecycle calls, maintenance success/failure, and explicit cancellation.
- What you did **not** verify: physical Linux BlueZ restart with real DE1 or scale hardware.

### Evidence

- [x] Test output (failing before + passing after)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? `Yes`
- Config / env changes needed? `No`
- Database migration needed? `No`
- If any `No` or `Yes`, explain exact steps: no migration or configuration changes are required.

## Risks & Mitigations

- Risk: maintenance recovery could race an explicit disconnect.
  - Mitigation: the per-device lifecycle gate and connection generation cancel stale maintenance before reconnect.
- Risk: temporary BlueZ disconnect events could tear down higher-level device state.
  - Mitigation: disconnects from the captured maintenance generation are suppressed; terminal failure publishes one disconnect.
