### PR TITLE
fix(api): prevent profile export route shadowing

### DIFF
--- a/lib/src/services/webserver/profile_handler.dart
+++ b/lib/src/services/webserver/profile_handler.dart
@@ -11,9 +11,9 @@ class ProfileHandler {
     // Get all profiles
     app.get('/api/v1/profiles', _handleGetAll);
 
-    // List bundled default profiles — must be registered before the /<id> route
-    // so 'defaults' isn't matched as an id.
+    // Literal one-segment GET routes must be registered before the /<id> route.
     app.get('/api/v1/profiles/defaults', _handleListDefaults);
+    app.get('/api/v1/profiles/export', _handleExport);
 
     // Get single profile by ID
     app.get('/api/v1/profiles/<id>', _handleGetById);
@@ -35,9 +35,6 @@ class ProfileHandler {
 
     // Import profiles
     app.post('/api/v1/profiles/import', _handleImport);
-
-    // Export profiles
-    app.get('/api/v1/profiles/export', _handleExport);
 
     // Restore default profile
     app.post('/api/v1/profiles/restore/<filename>', _handleRestoreDefault);

--- a/test/services/webserver/profile_handler_export_test.dart
+++ b/test/services/webserver/profile_handler_export_test.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/profile_controller.dart';
+import 'package:reaprime/src/models/data/profile_record.dart';
+import 'package:reaprime/src/services/storage/profile_storage_service.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class _StubStorage implements ProfileStorageService {
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> store(ProfileRecord record) async {}
+
+  @override
+  Future<ProfileRecord?> get(String id) async => null;
+
+  @override
+  Future<List<ProfileRecord>> getAll({Visibility? visibility}) async =>
+      const [];
+
+  @override
+  Future<void> update(ProfileRecord record) async {}
+
+  @override
+  Future<void> delete(String id) async {}
+
+  @override
+  Future<bool> exists(String id) async => false;
+
+  @override
+  Future<List<String>> getAllIds() async => const [];
+
+  @override
+  Future<List<ProfileRecord>> getByParentId(String parentId) async => const [];
+
+  @override
+  Future<void> storeAll(List<ProfileRecord> records) async {}
+
+  @override
+  Future<void> clear() async {}
+
+  @override
+  Future<int> count({Visibility? visibility}) async => 0;
+}
+
+class _ExportStub extends ProfileController {
+  _ExportStub({required this.fixture}) : super(storage: _StubStorage());
+
+  final List<Map<String, dynamic>> fixture;
+  final List<String> getCalls = [];
+  int exportCalls = 0;
+  bool? includeHidden;
+  bool? includeDeleted;
+
+  @override
+  Future<ProfileRecord?> get(String id) async {
+    getCalls.add(id);
+    return null;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> exportProfiles({
+    bool includeHidden = false,
+    bool includeDeleted = false,
+  }) async {
+    exportCalls++;
+    this.includeHidden = includeHidden;
+    this.includeDeleted = includeDeleted;
+    return fixture;
+  }
+}
+
+void main() {
+  late _ExportStub controller;
+  late Handler handler;
+
+  Future<Response> sendGet(String path) async {
+    return handler(Request('GET', Uri.parse('http://localhost$path')));
+  }
+
+  setUp(() {
+    controller = _ExportStub(
+      fixture: [
+        {'id': 'profile-1', 'title': 'Morning espresso'},
+      ],
+    );
+    final profileHandler = ProfileHandler(controller: controller);
+    final app = Router().plus;
+    profileHandler.addRoutes(app);
+    handler = app.call;
+  });
+
+  test('dispatches export before the profile ID route', () async {
+    final response = await sendGet('/api/v1/profiles/export');
+
+    expect(response.statusCode, 200);
+    expect(response.headers['content-type'], contains('application/json'));
+    expect(
+      response.headers['content-disposition'],
+      contains('filename="profiles_export.json"'),
+    );
+    expect(jsonDecode(await response.readAsString()), controller.fixture);
+    expect(controller.exportCalls, 1);
+    expect(controller.includeHidden, isFalse);
+    expect(controller.includeDeleted, isFalse);
+    expect(controller.getCalls, isEmpty);
+  });
+
+  test('passes export query flags to the controller', () async {
+    final response = await sendGet(
+      '/api/v1/profiles/export?includeHidden=true&includeDeleted=true',
+    );
+
+    expect(response.statusCode, 200);
+    expect(controller.includeHidden, isTrue);
+    expect(controller.includeDeleted, isTrue);
+    expect(controller.getCalls, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- Problem: `GET /api/v1/profiles/export` was shadowed by the earlier `GET /api/v1/profiles/<id>` route and returned 404 with `id == export`.
- Why it matters: The documented JSON profile export endpoint was unreachable.
- What changed: Registered the literal `defaults` and `export` GET routes before the `/<id>` catch-all and added router-level regression coverage.
- What did NOT change: Export remains a JSON attachment named `profiles_export.json`; no payload semantics, controller behavior, package name, or API schema changed.

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [x] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

- Issue: N/A; no linked issue.
- Related: N/A.

## Root Cause
- Root cause: `/api/v1/profiles/<id>` was registered before the literal `/api/v1/profiles/export` route, so shelf-router dispatched `export` to `_handleGetById`.
- Missing detection or guardrail: Existing route-order coverage protected `/profiles/defaults`, but no equivalent regression test covered `/profiles/export`.
- Contributing context: The export route was registered later alongside import and restore routes instead of with the other literal single-segment GET routes.

## Test Coverage
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/services/webserver/profile_handler_export_test.dart`
- Scenario the test locks in: A real `Router().plus` dispatches `/api/v1/profiles/export` to `exportProfiles`, returns the JSON fixture with the documented attachment headers, passes both query flags, and never calls `get('export')`.
- The test was added before the production reorder. Before the fix both test cases failed with `Expected: <200> Actual: <404>`, demonstrating the route-shadowing failure.
- After the fix: `2` focused tests passed.

## Documentation And Specs
- [ ] API spec updated: `assets/api/rest_v1.yml`
- [ ] API docs updated: `doc/Api.md`
- [ ] Profile docs updated: `doc/Profiles.md`
- [x] N/A — no docs affected.

The existing REST spec, API docs, and profile docs already describe this endpoint as a JSON export with `includeHidden` and `includeDeleted` parameters. This fix only makes runtime routing conform to that existing contract.

## Surface And Security
- New or changed REST endpoints? No — this is an existing endpoint becoming reachable; its contract is unchanged.
- New or changed WebSocket topics? No.
- New or changed network calls? No.
- BLE/USB surface changed? No.
- File system access changed? No.
- Plugin sandbox boundary changed? No.
- Security impact: No new endpoint or network surface. Only route dispatch for the existing export endpoint is corrected.

User-visible change: `GET /api/v1/profiles/export` now returns the documented JSON attachment instead of 404. No other profile ID routes were changed.

## Verification
- [x] `dart format lib test` — formatted 653 files; only the handler and new test changed.
- [ ] `flutter analyze` — blocked by two pre-existing missing asset directories: `assets/plugins/dye2.reaplugin/` and `assets/bundled_skins/`.
- [ ] `flutter test` — 2567 tests reached; 14 unrelated failures remain, including tests requiring missing bundled-skin assets and other pre-existing environment-dependent failures. The new export test passed in the focused run.
- [x] `(cd packages/dye2-plugin && npm run build)` — passed on Windows as `npm.cmd run build` after `npm.cmd ci` installed the locked dependencies.
- OS / platform tested: Windows.
- Simulated devices? (`simulate=1`): No.
- Real hardware? (DE1/Bengle/scale): No.
- What was personally verified: Router-level export dispatch, status code, JSON content type, `profiles_export.json` content disposition, exact fixture body, controller invocation, default flags, query flags, and absence of `get('export')`.
- Edge cases checked: `/api/v1/profiles/export?includeHidden=true&includeDeleted=true`; `/api/v1/profiles/defaults` route remains before the catch-all.
- What was not verified: Running `sb-dev.sh` plus curl against a live app. Git Bash reached the script but `jq` is unavailable; the WSL bash shim has no `/bin/bash`.

Commands and outcomes:
- `git remote -v` — canonical fetch and push URL: `https://github.com/decentespresso/decaid`.
- Base synchronization — `origin/main` at `ec2481f300734c32ba943c9c822cc3cec30d70f1`.
- Pre-fix focused test — failed both export cases with 404 as expected.
- Post-fix focused test — passed 2 tests.
- `git diff --check` — passed.
- `npm.cmd run build` — passed.
- `git fetch origin main` before push — `origin/main` had not advanced; no rebase was needed.
- `git push -u origin HEAD:fix/profile-export-route-order` — passed.

## Compatibility And Risk
- Backward compatible? Yes.
- Config / env changes needed? No.
- Database migration needed? No.
- Risk: Low. `export` is now correctly reserved as the documented literal endpoint; profile IDs other than reserved literal paths retain existing behavior.
  - Mitigation: The router-level regression test asserts the export handler is called and the ID handler is not.

## Attachment
- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API smoke test unavailable in this environment)