### PR TITLE
fix(websocket): wait for machine connection

### DIFF
--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -23,12 +23,15 @@ channels:
   MachineSnapshot:
     address: ws/v1/machine/snapshot
     description: >
+      The socket may be opened before any machine is connected. It remains open
+      and silent while no machine is attached, then automatically attaches when
+      the first machine appears. Every frame remains a MachineSnapshot; no
+      error or status frame is emitted on this typed telemetry channel.
       Real-time snapshot data from the espresso machine. The socket re-binds
       across a machine instance swap: when the machine reconnects (for example
       after a power-cycle) the server re-attaches this socket to the new machine
-      and frames simply resume. Clients do not need to reconnect. No status
-      frame is emitted — every frame on this channel is a MachineSnapshot.
-      Link state is published on ws/v1/devices.
+      and frames simply resume. Clients do not need to reconnect.
+      Connection state remains available from /ws/v1/devices.
     messages:
       machineSnapshotMessage:
         $ref: '#/components/messages/MachineSnapshot'
@@ -64,6 +67,10 @@ channels:
         $ref: '#/components/messages/ScaleStatus'
   MachineRaw:
     description: >
+      Opening the socket before a machine connects does not close it. It remains
+      open and waits for attachment. A detached inbound command receives exactly
+      `{"error": "No machine connected"}`; it is not queued, and the socket
+      remains open after the error and attaches normally when a machine appears.
       Bidirectional channel for raw BLE characteristic data (read/write/notify).
       The server streams outbound data (notifications and read responses) and
       accepts inbound commands (read/write requests). Re-binds across a machine

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -27,7 +27,7 @@ channels:
       and silent while no machine is attached, then automatically attaches when
       the first machine appears. Every frame remains a MachineSnapshot; no
       error or status frame is emitted on this typed telemetry channel.
-      Real-time snapshot data from the espresso machine. The socket re-binds
+      The socket re-binds
       across a machine instance swap: when the machine reconnects (for example
       after a power-cycle) the server re-attaches this socket to the new machine
       and frames simply resume. Clients do not need to reconnect.
@@ -76,9 +76,7 @@ channels:
       accepts inbound commands (read/write requests). Re-binds across a machine
       instance swap — see MachineSnapshot. Commands are delivered to the machine
       the socket is currently bound to, not the one present when the socket was
-      opened. If a command is sent while no machine is connected the server
-      replies with an error frame (`{"error": "No machine connected"}`). The
-      socket stays open across the disconnected gap.
+      opened.
     address: ws/v1/machine/raw
     messages:
       machineRawMessage:

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -99,7 +99,7 @@ A machine power-cycle drops the De1 object and builds a new one under the same d
 
 - **No `{"status": ...}` frames.** Unlike the scale socket, the machine sockets carry a single typed payload per frame and existing clients parse every frame as that type; injecting a status frame would be a breaking change to the wire contract. Link state is already published, instance-independently, on `/ws/v1/devices`.
 
-- **Initial attachment is deterministic.** The initial machine is read from `connectedDe1OrNull` and subscribed immediately, before subscribing to the controller stream. This eliminates the window where a command could arrive while `attached` is still null waiting for the BehaviorSubject replay.
+- **Initial attachment is deterministic.** When `connectedDe1OrNull` returns a machine, it is subscribed immediately before subscribing to the controller stream. When no machine exists, the socket starts detached and waits for the first non-null `De1Controller.de1` event. Telemetry sockets emit nothing until attachment, while raw commands still return the documented detached-command error.
 
 - **Commands during disconnect produce an error frame.** `/ws/v1/machine/raw` commands sent while no machine is attached get a `{"error": "No machine connected"}` response rather than being silently dropped. The socket stays open. Raw commands are never queued for later delivery — a delayed raw read/write could be stale or unsafe.
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -388,8 +388,9 @@ For clients this means:
   `{"error": "No machine connected"}` rather than silently dropping it. The socket stays open and
   resumes normal operation when a machine reconnects. Raw commands are not queued for later delivery.
 
-The one unchanged case: opening a machine socket while **no** machine is connected still returns an
-error frame and closes, so reconnect-until-present loops keep working.
+Machine sockets opened before the first machine connection behave like any later disconnected gap:
+the socket stays open and remains silent until a machine attaches. No error or status frame is emitted
+on the typed telemetry sockets.
 
 ### `shotState` events
 

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -299,11 +299,6 @@ class De1Handler {
     void Function(De1Interface de1, dynamic message)? onMessage,
   }) {
     final initial = _controller.connectedDe1OrNull;
-    if (initial == null) {
-      socket.sink.add(jsonEncode({'error': 'No machine connected'}));
-      socket.sink.close();
-      return;
-    }
 
     De1Interface? attached;
     StreamSubscription<dynamic>? payloadSub;
@@ -320,8 +315,10 @@ class De1Handler {
     // controller stream. This eliminates the window where a command could
     // arrive while attached is still null, waiting for the BehaviorSubject
     // replay.
-    attached = initial;
-    payloadSub = attach(initial);
+    if (initial != null) {
+      attached = initial;
+      payloadSub = attach(initial);
+    }
 
     de1Sub = _controller.de1.listen(
       (de1) {

--- a/test/webserver/de1handler_machine_swap_ws_test.dart
+++ b/test/webserver/de1handler_machine_swap_ws_test.dart
@@ -214,19 +214,26 @@ void main() {
     );
 
     test(
-      'with no machine connected the socket still errors and closes',
+      'with no machine connected the socket waits for the first machine',
       () async {
         final (channel, messages) = connectWs('/ws/v1/machine/snapshot');
+        final received = <Map<String, dynamic>>[];
+        var closed = false;
+        messages.listen(received.add, onDone: () => closed = true);
 
-        final first = await messages.first.timeout(const Duration(seconds: 2));
-        expect(first['error'], 'No machine connected');
+        await settle();
+        expect(received, isEmpty);
+        expect(closed, isFalse);
 
-        // Contract relied on by every ReconnectingWebSocket client: the socket
-        // is CLOSED, so the client retries until a machine appears.
-        await expectLater(
-          messages.drain<void>().timeout(const Duration(seconds: 2)),
-          completes,
-        );
+        final machine = TestDe1(deviceId: 'usb-2e8a-a-8549628789ABCDEF');
+        await de1Controller.connectToDe1(machine);
+        await settle();
+
+        received.clear();
+        machine.emitSnapshot(snapshotAt(83.09));
+        await settle();
+
+        expect(received.map((f) => f['groupTemperature']), contains(83.09));
         await channel.sink.close();
       },
     );
@@ -531,6 +538,45 @@ void main() {
 
       await channel.sink.close();
     });
+
+    test(
+      'a socket opened before the first machine waits and then attaches',
+      () async {
+        final (channel, messages) = connectWs('/ws/v1/machine/raw');
+        final received = <Map<String, dynamic>>[];
+        var closed = false;
+        messages.listen(received.add, onDone: () => closed = true);
+
+        await settle();
+        expect(received, isEmpty);
+        expect(closed, isFalse);
+
+        channel.sink.add(jsonEncode(rawCommand()));
+        await settle();
+
+        expect(received, hasLength(1));
+        expect(received.single, {'error': 'No machine connected'});
+        expect(closed, isFalse);
+
+        final machine = TestDe1(deviceId: 'usb-2e8a-a-8549628789ABCDEF');
+        await de1Controller.connectToDe1(machine);
+        await settle();
+
+        received.clear();
+        machine.emitRawMessage(
+          rawCommand(
+            type: De1RawMessageType.response,
+            operation: De1RawOperationType.notify,
+            characteristicUUID: '0x05',
+            payload: 'ee',
+          ),
+        );
+        await settle();
+
+        expect(received.map((f) => f['characteristicUUID']), contains('0x05'));
+        await channel.sink.close();
+      },
+    );
 
     test(
       'a command during the disconnected gap returns an error frame',


### PR DESCRIPTION
## Summary

- Problem: Machine WebSockets opened before a machine connection returned an error and closed.
- Why it matters: Dashboards had to implement reconnect loops, and typed telemetry channels could receive an error object.
- What changed: Machine sockets now remain detached and silent until the first machine appears, then attach and reattach normally. Detached raw commands return the existing structured error without being queued or closing the socket. The AsyncAPI specification documents both lifecycle paths.
- What did NOT change (scope boundary): No new topics, status frames, command queues, reconnect timers, schemas, message definitions, REST behavior, or client changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] REST API / handlers
- [x] WebSocket API
- [ ] BLE transport / device comms
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #
- Related #

## Root Cause (if bug fix)

- Root cause: `De1Handler._withDe1Ws` immediately sent `{"error":"No machine connected"}` and closed when `connectedDe1OrNull` was null, so it never subscribed to the controller stream.
- Missing detection or guardrail: The existing machine-swap coverage started with an attached machine and did not cover the initial detached startup race.
- Contributing context: `De1Controller.de1` is a replaying stream, so the shared helper can wait for the first non-null machine without a new abstraction.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/webserver/de1handler_machine_swap_ws_test.dart`
- Scenario the test should lock in: A detached snapshot socket emits nothing and stays open until a machine connects, then receives a snapshot. A detached raw socket returns exactly `{"error":"No machine connected"}`, stays open, and receives later machine frames.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/websocket_v1.yml`
- [x] API docs updated: `doc/Api.md`
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [ ] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No new topics; existing lifecycle behavior only
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any Yes, explain risk and mitigation: No new trust boundary. Detached raw commands are rejected rather than queued, and typed telemetry channels emit no error or status frames.

## User-Visible Changes

Machine telemetry and raw WebSockets opened before connection now remain usable through discovery and attach automatically when a machine appears. Raw commands sent during the gap receive the existing error and are not delivered later.

## Verification

### Local gates (run before pushing)

- [x] Focused Dart formatting on changed Dart files
- [x] `flutter analyze` - no issues found
- [x] `flutter test test/webserver/de1handler_machine_swap_ws_test.dart` - 16 tests passed
- [ ] `flutter test` - not run; the focused test passed and the task limited verification to the affected suite
- [ ] `(cd packages/dye2-plugin && npm run build)` - not applicable

### Manual verification (if applicable)

- OS / platform tested: Windows
- Simulated devices? (`simulate=1`): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: Focused WebSocket server tests, analyzer, and `git diff --check`.
- Edge cases checked: Initial detached attachment, detached raw command errors, socket persistence, machine swap reattachment, duplicate subscription prevention, cleanup, and typed telemetry frames.
- What you did NOT verify: Full Flutter suite and real hardware behavior.

### Evidence

- [x] Test output
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- If any No or Yes, explain exact steps: No migration or configuration changes.

## Risks & Mitigations

None.