### PR TITLE
fix(scale): accept protocol-correct Acaia weight frames

### DIFF
--- a/doc/plans/archive/acaia-declared-length-parsing/design.md
+++ b/doc/plans/archive/acaia-declared-length-parsing/design.md
@@ -1,0 +1,22 @@
+# Acaia Declared-Length Parsing
+
+## Goal
+
+Accept protocol-correct Lunar and Pyxis weight notifications without weakening frame isolation or readiness checks.
+
+## Approach
+
+1. Keep byte 3 as the declared span from the length byte through the semantic event records, with the two checksum bytes outside that span.
+2. Isolate a complete frame before semantic parsing.
+3. Validate direct weight bodies and tagged records within the isolated event payload.
+4. Validate heartbeat wrappers and inner records without treating timer, button, unknown, or incomplete records as weight.
+5. Preserve liveness updates only for structurally accepted frames and retain bounded resynchronization for impossible or malformed candidates.
+6. Replace old synthetic fixtures with protocol-correct frames and cover real, split, concatenated, truncated, embedded-header, and initialization paths.
+
+## Scope Decision
+
+The notification-request timer interval is independent of the reported weight initialization failure. Compare it with the reference implementations and keep any correction clearly separate in the pull request with a focused test.
+
+## Verification
+
+Run formatting, the Acaia unit test, affected BLE tests, `flutter analyze`, and the full Flutter test suite where the repository environment permits.

--- a/lib/src/models/device/impl/acaia/acaia_scale.dart
+++ b/lib/src/models/device/impl/acaia/acaia_scale.dart
@@ -14,6 +14,8 @@ import 'package:rxdart/subjects.dart';
 
 enum AcaiaProtocol { ips, pyxis }
 
+enum _AcaiaFrameResult { accepted, ignored, malformed }
+
 class AcaiaScale implements Scale {
   static final _ipsService = BleServiceIdentifier.short('1820');
   static final _ipsCharacteristic = BleServiceIdentifier.short('2a80');
@@ -37,7 +39,10 @@ class AcaiaScale implements Scale {
   static const _header1 = 0xEF;
   static const _header2 = 0xDD;
   static const _metadataLength = 5;
+  static const _checksumLength = 2;
+  static const _weightBodyLength = 6;
   static const _maxPayloadLength = 64;
+  static const _recordBodyLengths = <int, int>{5: 6, 6: 1, 7: 3, 8: 1, 11: 2};
   static const _identPayload = [
     0x30,
     0x31,
@@ -62,7 +67,7 @@ class AcaiaScale implements Scale {
     0x01,
     0x02,
     0x02,
-    0x01,
+    0x05,
     0x03,
     0x04,
   ];
@@ -363,15 +368,9 @@ class AcaiaScale implements Scale {
   Future<void> resetTimer() async {}
 
   void _parseNotification(List<int> data) {
-    _buffer.addAll(data);
+    _buffer = [..._buffer, ...data];
     while (true) {
-      var headerIndex = -1;
-      for (var i = 0; i + 1 < _buffer.length; i++) {
-        if (_buffer[i] == _header1 && _buffer[i + 1] == _header2) {
-          headerIndex = i;
-          break;
-        }
-      }
+      final headerIndex = _findHeader(_buffer);
 
       if (headerIndex < 0) {
         _buffer = _buffer.isNotEmpty && _buffer.last == _header1
@@ -382,21 +381,36 @@ class AcaiaScale implements Scale {
       if (headerIndex > 0) _buffer = _buffer.sublist(headerIndex);
       if (_buffer.length < _metadataLength) return;
 
-      final payloadLength = _buffer[3];
-      if (payloadLength > _maxPayloadLength) {
-        _buffer = _buffer.sublist(2);
-        continue;
-      }
-      if (!_hasValidKnownLength(_buffer[2], payloadLength, _buffer[4])) {
+      final messageType = _buffer[2];
+      final declaredLength = _buffer[3];
+      final eventType = _buffer[4];
+      final lengthReason = _knownLengthError(
+        messageType,
+        declaredLength,
+        eventType,
+      );
+      if (declaredLength > _maxPayloadLength || lengthReason != null) {
+        _logRejectedFrame(
+          command: messageType,
+          declaredLength: declaredLength,
+          eventType: eventType,
+          reason: lengthReason ?? 'declared length exceeds maximum',
+        );
         _buffer = _buffer.sublist(2);
         continue;
       }
 
-      final frameLength = _metadataLength + payloadLength;
-      if (_buffer.length < frameLength) return;
+      final frameLength = _metadataLength + declaredLength;
+      if (_buffer.length < frameLength) {
+        if (_resyncPartialWeightFrame(messageType, eventType)) continue;
+        return;
+      }
       final frame = List<int>.unmodifiable(_buffer.sublist(0, frameLength));
       _buffer = _buffer.sublist(frameLength);
-      if (_processFrame(frame)) {
+      final result = _processFrame(frame);
+      if (result == _AcaiaFrameResult.malformed) {
+        _resyncMalformedFrame(frame);
+      } else if (result == _AcaiaFrameResult.accepted) {
         _lastValidFrame = DateTime.now();
         if (_protocol == AcaiaProtocol.pyxis &&
             _connectionStateController.value == ConnectionState.connected) {
@@ -406,17 +420,102 @@ class AcaiaScale implements Scale {
     }
   }
 
-  bool _hasValidKnownLength(int messageType, int payloadLength, int eventType) {
-    if (messageType == 0x08) return payloadLength == 3;
-    if (messageType != 0x0C) return true;
-    return switch (eventType) {
-      5 => payloadLength == 6,
-      11 => payloadLength == 9,
-      _ => true,
-    };
+  int _findHeader(List<int> data, {int start = 0}) {
+    for (var i = start; i + 1 < data.length; i++) {
+      if (data[i] == _header1 && data[i + 1] == _header2) return i;
+    }
+    return -1;
   }
 
-  bool _processFrame(List<int> frame) {
+  String? _knownLengthError(
+    int messageType,
+    int declaredLength,
+    int eventType,
+  ) {
+    if (messageType == 0x08) {
+      return declaredLength == 3
+          ? null
+          : 'settings frame requires declared length 3';
+    }
+    if (messageType != 0x0C) return null;
+    final minimumLength = switch (eventType) {
+      5 => 2 + _weightBodyLength,
+      11 => 8,
+      _ => 2,
+    };
+    return declaredLength >= minimumLength
+        ? null
+        : 'declared length is below the minimum for event type $eventType';
+  }
+
+  bool _resyncPartialWeightFrame(int messageType, int eventType) {
+    if (messageType != 0x0C) return false;
+    final weightOffset = switch (eventType) {
+      5 => _metadataLength,
+      11
+          when _buffer.length > _metadataLength + 2 &&
+              _buffer[_metadataLength + 2] == 5 =>
+        _metadataLength + 3,
+      _ => -1,
+    };
+    if (weightOffset < 0 || !_hasValidWeightBody(_buffer, weightOffset)) {
+      final bodyEnd = weightOffset + _weightBodyLength;
+      if (weightOffset >= 0 && _buffer.length >= bodyEnd) {
+        final nextHeader = _findHeader(_buffer, start: 2);
+        if (nextHeader >= 0 && nextHeader < bodyEnd) {
+          _logRejectedFrame(
+            command: messageType,
+            declaredLength: _buffer[3],
+            eventType: eventType,
+            innerTag: eventType == 11 ? _buffer[7] : null,
+            reason: 'invalid weight body before the next frame',
+          );
+          _buffer = _buffer.sublist(nextHeader);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  void _resyncMalformedFrame(List<int> frame) {
+    final nextHeader = _findHeader(frame, start: 2);
+    if (nextHeader >= 0) {
+      _buffer = [...frame.sublist(nextHeader), ..._buffer];
+    }
+  }
+
+  void _logRejectedFrame({
+    required int command,
+    required int declaredLength,
+    int? eventType,
+    int? innerTag,
+    required String reason,
+  }) {
+    final event = eventType == null ? '' : ' eventType=$eventType';
+    final inner = innerTag == null ? '' : ' innerTag=$innerTag';
+    _log.fine(
+      'Rejected Acaia frame command=$command declaredLength=$declaredLength'
+      '$event$inner: $reason',
+    );
+  }
+
+  _AcaiaFrameResult _rejectFrame(
+    List<int> frame,
+    String reason, {
+    int? innerTag,
+  }) {
+    _logRejectedFrame(
+      command: frame[2],
+      declaredLength: frame[3],
+      eventType: frame[4],
+      innerTag: innerTag,
+      reason: reason,
+    );
+    return _AcaiaFrameResult.malformed;
+  }
+
+  _AcaiaFrameResult _processFrame(List<int> frame) {
     final messageType = frame[2];
     final eventType = frame[4];
 
@@ -428,27 +527,94 @@ class AcaiaScale implements Scale {
         _badBatteryLogged = true;
         _log.warning('Ignoring out-of-range Acaia battery value $battery');
       }
-      return true;
+      return _AcaiaFrameResult.accepted;
     }
-    if (messageType != 0x0C) return false;
+    if (messageType != 0x0C) return _AcaiaFrameResult.ignored;
 
+    final payload = frame.sublist(
+      _metadataLength,
+      frame.length - _checksumLength,
+    );
     if (eventType == 5) {
-      _decodeWeight(frame, _metadataLength);
-      return true;
+      if (payload.length < _weightBodyLength) {
+        return _rejectFrame(frame, 'incomplete direct weight body');
+      }
+      if (!_hasValidWeightBody(payload, 0)) {
+        return _rejectFrame(frame, 'invalid direct weight body');
+      }
+      if (!_hasCompleteRecordChain(payload, _weightBodyLength)) {
+        return _rejectFrame(frame, 'incomplete or unknown trailing record');
+      }
+      _decodeWeight(payload.sublist(0, _weightBodyLength));
+      return _AcaiaFrameResult.accepted;
     }
-    if (eventType != 11) return false;
-    if (frame[7] == 7) return true;
-    if (frame[7] != 5) return false;
-    _decodeWeight(frame, _metadataLength + 3);
+    if (eventType != 11) return _AcaiaFrameResult.ignored;
+    if (payload.length < 3) {
+      return _rejectFrame(frame, 'incomplete heartbeat wrapper');
+    }
+
+    final innerTag = payload[2];
+    final innerBodyLength = _recordBodyLengths[innerTag];
+    if (innerBodyLength == null) {
+      return _rejectFrame(
+        frame,
+        'unknown heartbeat inner tag',
+        innerTag: innerTag,
+      );
+    }
+    final innerBodyStart = 3;
+    if (payload.length < innerBodyStart + innerBodyLength) {
+      return _rejectFrame(
+        frame,
+        'incomplete heartbeat inner record',
+        innerTag: innerTag,
+      );
+    }
+    if (!_hasCompleteRecordChain(payload, innerBodyStart + innerBodyLength)) {
+      return _rejectFrame(
+        frame,
+        'incomplete or unknown heartbeat trailing record',
+        innerTag: innerTag,
+      );
+    }
+    if (innerTag == 5) {
+      if (!_hasValidWeightBody(payload, innerBodyStart)) {
+        return _rejectFrame(
+          frame,
+          'invalid heartbeat weight body',
+          innerTag: innerTag,
+        );
+      }
+      _decodeWeight(
+        payload.sublist(innerBodyStart, innerBodyStart + _weightBodyLength),
+      );
+    }
+    return _AcaiaFrameResult.accepted;
+  }
+
+  bool _hasValidWeightBody(List<int> payload, int offset) {
+    if (offset + _weightBodyLength > payload.length) return false;
+    final unit = payload[offset + 4];
+    final flags = payload[offset + 5];
+    return unit >= 1 && unit <= 4 && flags <= 2;
+  }
+
+  bool _hasCompleteRecordChain(List<int> payload, int offset) {
+    while (offset < payload.length) {
+      final bodyLength = _recordBodyLengths[payload[offset]];
+      if (bodyLength == null || offset + 1 + bodyLength > payload.length) {
+        return false;
+      }
+      offset += 1 + bodyLength;
+    }
     return true;
   }
 
-  void _decodeWeight(List<int> frame, int offset) {
-    final magnitude =
-        (frame[offset + 2] << 16) | (frame[offset + 1] << 8) | frame[offset];
-    final exponent = frame[offset + 4];
+  void _decodeWeight(List<int> body) {
+    final magnitude = (body[2] << 16) | (body[1] << 8) | body[0];
+    final exponent = body[4];
     var weight = magnitude / pow(10, exponent);
-    if (frame[offset + 5] > 1) weight *= -1;
+    if (body[5] > 1) weight *= -1;
     _hasValidWeight = true;
     _streamController.add(
       ScaleSnapshot(

--- a/lib/src/models/device/impl/acaia/acaia_scale.dart
+++ b/lib/src/models/device/impl/acaia/acaia_scale.dart
@@ -370,6 +370,7 @@ class AcaiaScale implements Scale {
   Future<void> resetTimer() async {}
 
   void _parseNotification(List<int> data) {
+    final continuationBoundary = _partialFramePending ? _buffer.length : null;
     _buffer = [..._buffer, ...data];
     while (true) {
       final headerIndex = _findHeader(_buffer);
@@ -412,10 +413,18 @@ class AcaiaScale implements Scale {
         return;
       }
       final frame = List<int>.unmodifiable(_buffer.sublist(0, frameLength));
+      final partialWeightHeader = _partialFramePending
+          ? _partialWeightHeader(
+              _buffer,
+              messageType,
+              eventType,
+              continuationBoundary,
+            )
+          : null;
       _buffer = _buffer.sublist(frameLength);
-      if (_partialFramePending && _hasPartialWeightHeader(frame, eventType)) {
+      if (partialWeightHeader != null) {
         _partialFramePending = false;
-        _buffer = [...frame.sublist(_findHeader(frame, start: 2)), ..._buffer];
+        _buffer = [...frame.sublist(partialWeightHeader), ..._buffer];
         continue;
       }
       _partialFramePending = false;
@@ -460,14 +469,7 @@ class AcaiaScale implements Scale {
 
   bool _resyncPartialWeightFrame(int messageType, int eventType) {
     if (messageType != 0x0C) return false;
-    final weightOffset = switch (eventType) {
-      5 => _metadataLength,
-      11
-          when _buffer.length > _metadataLength + 2 &&
-              _buffer[_metadataLength + 2] == 5 =>
-        _metadataLength + 3,
-      _ => -1,
-    };
+    final weightOffset = _weightBodyOffset(_buffer, eventType);
     if (weightOffset < 0 || !_hasValidWeightBody(_buffer, weightOffset)) {
       final bodyEnd = weightOffset + _weightBodyLength;
       if (weightOffset >= 0 && _buffer.length >= bodyEnd) {
@@ -488,8 +490,8 @@ class AcaiaScale implements Scale {
     return false;
   }
 
-  bool _hasPartialWeightHeader(List<int> frame, int eventType) {
-    final weightOffset = switch (eventType) {
+  int _weightBodyOffset(List<int> frame, int eventType) {
+    return switch (eventType) {
       5 => _metadataLength,
       11
           when frame.length > _metadataLength + 2 &&
@@ -497,9 +499,38 @@ class AcaiaScale implements Scale {
         _metadataLength + 3,
       _ => -1,
     };
-    if (weightOffset < 0) return false;
-    final nextHeader = _findHeader(frame, start: 2);
-    return nextHeader == weightOffset + _weightBodyLength - 1;
+  }
+
+  int? _partialWeightHeader(
+    List<int> frame,
+    int messageType,
+    int eventType,
+    int? continuationBoundary,
+  ) {
+    if (messageType != 0x0C || continuationBoundary == null) return null;
+    final weightOffset = _weightBodyOffset(frame, eventType);
+    if (weightOffset < 0) return null;
+    final bodyEnd = weightOffset + _weightBodyLength;
+    if (continuationBoundary == bodyEnd - 1) {
+      return frame[continuationBoundary] == _header1 &&
+              continuationBoundary + 1 < frame.length &&
+              frame[continuationBoundary + 1] == _header2
+          ? continuationBoundary
+          : null;
+    }
+    if (continuationBoundary < bodyEnd) return null;
+    for (final headerIndex in [
+      continuationBoundary,
+      continuationBoundary - 1,
+    ]) {
+      if (headerIndex >= 2 &&
+          headerIndex + 1 < frame.length &&
+          frame[headerIndex] == _header1 &&
+          frame[headerIndex + 1] == _header2) {
+        return headerIndex;
+      }
+    }
+    return null;
   }
 
   void _resyncMalformedFrame(List<int> frame) {

--- a/lib/src/models/device/impl/acaia/acaia_scale.dart
+++ b/lib/src/models/device/impl/acaia/acaia_scale.dart
@@ -86,6 +86,7 @@ class AcaiaScale implements Scale {
   Timer? _maintenanceTimer;
   Timer? _watchdogTimer;
   List<int> _buffer = [];
+  bool _partialFramePending = false;
   DateTime _lastValidFrame = DateTime.now();
   int _batteryLevel = 0;
   int _generation = 0;
@@ -190,6 +191,7 @@ class AcaiaScale implements Scale {
     _hasValidWeight = false;
     _badBatteryLogged = false;
     _buffer = [];
+    _partialFramePending = false;
     await _transport.subscribe(
       _serviceUuid,
       _notifyCharacteristic,
@@ -402,11 +404,21 @@ class AcaiaScale implements Scale {
 
       final frameLength = _metadataLength + declaredLength;
       if (_buffer.length < frameLength) {
-        if (_resyncPartialWeightFrame(messageType, eventType)) continue;
+        if (_resyncPartialWeightFrame(messageType, eventType)) {
+          _partialFramePending = false;
+          continue;
+        }
+        _partialFramePending = true;
         return;
       }
       final frame = List<int>.unmodifiable(_buffer.sublist(0, frameLength));
       _buffer = _buffer.sublist(frameLength);
+      if (_partialFramePending && _hasPartialWeightHeader(frame, eventType)) {
+        _partialFramePending = false;
+        _buffer = [...frame.sublist(_findHeader(frame, start: 2)), ..._buffer];
+        continue;
+      }
+      _partialFramePending = false;
       final result = _processFrame(frame);
       if (result == _AcaiaFrameResult.malformed) {
         _resyncMalformedFrame(frame);
@@ -433,14 +445,12 @@ class AcaiaScale implements Scale {
     int eventType,
   ) {
     if (messageType == 0x08) {
-      return declaredLength == 3
-          ? null
-          : 'settings frame requires declared length 3';
+      return declaredLength >= 3 ? null : 'settings frame is too short';
     }
     if (messageType != 0x0C) return null;
     final minimumLength = switch (eventType) {
       5 => 2 + _weightBodyLength,
-      11 => 8,
+      11 => 5,
       _ => 2,
     };
     return declaredLength >= minimumLength
@@ -476,6 +486,20 @@ class AcaiaScale implements Scale {
       }
     }
     return false;
+  }
+
+  bool _hasPartialWeightHeader(List<int> frame, int eventType) {
+    final weightOffset = switch (eventType) {
+      5 => _metadataLength,
+      11
+          when frame.length > _metadataLength + 2 &&
+              frame[_metadataLength + 2] == 5 =>
+        _metadataLength + 3,
+      _ => -1,
+    };
+    if (weightOffset < 0) return false;
+    final nextHeader = _findHeader(frame, start: 2);
+    return nextHeader == weightOffset + _weightBodyLength - 1;
   }
 
   void _resyncMalformedFrame(List<int> frame) {
@@ -542,9 +566,6 @@ class AcaiaScale implements Scale {
       if (!_hasValidWeightBody(payload, 0)) {
         return _rejectFrame(frame, 'invalid direct weight body');
       }
-      if (!_hasCompleteRecordChain(payload, _weightBodyLength)) {
-        return _rejectFrame(frame, 'incomplete or unknown trailing record');
-      }
       _decodeWeight(payload.sublist(0, _weightBodyLength));
       return _AcaiaFrameResult.accepted;
     }
@@ -570,13 +591,6 @@ class AcaiaScale implements Scale {
         innerTag: innerTag,
       );
     }
-    if (!_hasCompleteRecordChain(payload, innerBodyStart + innerBodyLength)) {
-      return _rejectFrame(
-        frame,
-        'incomplete or unknown heartbeat trailing record',
-        innerTag: innerTag,
-      );
-    }
     if (innerTag == 5) {
       if (!_hasValidWeightBody(payload, innerBodyStart)) {
         return _rejectFrame(
@@ -588,6 +602,14 @@ class AcaiaScale implements Scale {
       _decodeWeight(
         payload.sublist(innerBodyStart, innerBodyStart + _weightBodyLength),
       );
+      return _AcaiaFrameResult.accepted;
+    }
+    if (!_hasCompleteRecordChain(payload, innerBodyStart + innerBodyLength)) {
+      return _rejectFrame(
+        frame,
+        'incomplete or unknown heartbeat trailing record',
+        innerTag: innerTag,
+      );
     }
     return _AcaiaFrameResult.accepted;
   }
@@ -595,8 +617,7 @@ class AcaiaScale implements Scale {
   bool _hasValidWeightBody(List<int> payload, int offset) {
     if (offset + _weightBodyLength > payload.length) return false;
     final unit = payload[offset + 4];
-    final flags = payload[offset + 5];
-    return unit >= 1 && unit <= 4 && flags <= 2;
+    return unit >= 1 && unit <= 4;
   }
 
   bool _hasCompleteRecordChain(List<int> payload, int offset) {
@@ -614,7 +635,7 @@ class AcaiaScale implements Scale {
     final magnitude = (body[2] << 16) | (body[1] << 8) | body[0];
     final exponent = body[4];
     var weight = magnitude / pow(10, exponent);
-    if (body[5] > 1) weight *= -1;
+    if ((body[5] & 0x02) != 0) weight *= -1;
     _hasValidWeight = true;
     _streamController.add(
       ScaleSnapshot(

--- a/test/unit/models/acaia_scale_test.dart
+++ b/test/unit/models/acaia_scale_test.dart
@@ -10,25 +10,65 @@ import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
 
-const _weightFrame = <int>[
+const _weightBody = <int>[0xDF, 0x06, 0x00, 0x00, 0x01, 0x00];
+const _realWeightFrame = <int>[
   0xEF,
   0xDD,
   0x0C,
-  0x06,
+  0x0C,
   0x05,
-  0xE8,
-  0x03,
+  0xDF,
+  0x06,
   0x00,
   0x00,
   0x01,
   0x00,
+  0x07,
+  0x00,
+  0x00,
+  0x02,
+  0xF3,
+  0x0D,
 ];
 
+List<int> _frame(int command, List<int> payload) {
+  final body = [payload.length + 1, ...payload];
+  var even = 0;
+  var odd = 0;
+  for (var i = 0; i < body.length; i++) {
+    if (i.isEven) {
+      even = (even + body[i]) & 0xFF;
+    } else {
+      odd = (odd + body[i]) & 0xFF;
+    }
+  }
+  return [0xEF, 0xDD, command, ...body, even, odd];
+}
+
+List<int> _eventFrame(int eventType, List<int> payload) =>
+    _frame(0x0C, [eventType, ...payload]);
+
+List<int> _minimalWeightFrame() => _eventFrame(5, _weightBody);
+
+List<int> _heartbeatWeightFrame() => _eventFrame(11, [0, 0, 5, ..._weightBody]);
+
+List<int> _heartbeatTimerFrame() =>
+    _eventFrame(11, [0, 0, 7, 0x01, 0x1E, 0x05]);
+
+List<int> _heartbeatButtonFrame() => _eventFrame(11, [0, 0, 8, 0]);
+
+List<int> _settingsFrame(int battery) => _frame(0x08, [battery, 0]);
+
 class _AcaiaTransport extends BLETransport {
-  _AcaiaTransport({required this.services, this.emitWeightDuringInit = true});
+  _AcaiaTransport({
+    required this.services,
+    this.emitWeightDuringInit = true,
+    this.initializationFrame = _realWeightFrame,
+  });
 
   final List<String> services;
   final bool emitWeightDuringInit;
+  final List<int> initializationFrame;
   final BehaviorSubject<ConnectionState> states = BehaviorSubject.seeded(
     ConnectionState.discovered,
   );
@@ -92,7 +132,7 @@ class _AcaiaTransport extends BLETransport {
     writes.add(data.toList());
     if (emitWeightDuringInit && !_initWeightSent && data[2] == 0x0C) {
       _initWeightSent = true;
-      scheduleMicrotask(() => emit(_weightFrame));
+      scheduleMicrotask(() => emit(initializationFrame));
     }
     await writeBehavior?.call(data);
   }
@@ -106,9 +146,13 @@ class _AcaiaTransport extends BLETransport {
   Future<void> dispose() async => states.close();
 }
 
-_AcaiaTransport _ips({bool emitWeightDuringInit = true}) => _AcaiaTransport(
+_AcaiaTransport _ips({
+  bool emitWeightDuringInit = true,
+  List<int> initializationFrame = _realWeightFrame,
+}) => _AcaiaTransport(
   services: const ['00001820-0000-1000-8000-00805f9b34fb'],
   emitWeightDuringInit: emitWeightDuringInit,
+  initializationFrame: initializationFrame,
 );
 
 Future<(AcaiaScale, _AcaiaTransport)> _connected() async {
@@ -144,47 +188,194 @@ void main() {
   });
 
   test(
-    'timer event 11 emits no weight and weight selector emits 100g',
+    'timer event 11 emits no weight and weight selector emits 175.9g',
     () async {
       final (scale, transport) = await _connected();
       final snapshots = <ScaleSnapshot>[];
       final subscription = scale.currentSnapshot.listen(snapshots.add);
 
-      transport.emit(const [
-        0xEF,
-        0xDD,
-        0x0C,
-        0x09,
-        0x0B,
-        0x00,
-        0x00,
-        0x07,
-        0x12,
-        0x34,
-        0x56,
-        0x78,
-        0x9A,
-        0xBC,
-      ]);
-      transport.emit(const [
-        0xEF,
-        0xDD,
-        0x0C,
-        0x09,
-        0x0B,
-        0x00,
-        0x00,
-        0x05,
-        0xE8,
-        0x03,
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-      ]);
+      transport.emit(_heartbeatTimerFrame());
+      transport.emit(_heartbeatWeightFrame());
       await Future<void>.delayed(Duration.zero);
 
-      expect(snapshots.map((snapshot) => snapshot.weight), [100.0]);
+      expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+      await subscription.cancel();
+      await scale.disconnect();
+      await transport.dispose();
+    },
+  );
+
+  test(
+    'real multi-record direct frame completes initialization once',
+    () async {
+      final transport = _ips(initializationFrame: _realWeightFrame);
+      final scale = AcaiaScale(transport: transport);
+      final snapshots = <ScaleSnapshot>[];
+      final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+      await scale.onConnect();
+
+      expect(await scale.connectionState.first, ConnectionState.connected);
+      expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+      expect(_realWeightFrame[3], 0x0C);
+
+      await subscription.cancel();
+      await scale.disconnect();
+      await transport.dispose();
+    },
+  );
+
+  test(
+    'initialization requests the reference timer notification interval',
+    () async {
+      final (scale, transport) = await _connected();
+      final request = transport.writes.firstWhere((write) => write[2] == 0x0C);
+
+      expect(request.sublist(3, 12), [9, 0, 1, 1, 2, 2, 5, 3, 4]);
+
+      await scale.disconnect();
+      await transport.dispose();
+    },
+  );
+
+  test('minimal direct weight uses the declared protocol length', () async {
+    final frame = _minimalWeightFrame();
+    final transport = _ips(initializationFrame: frame);
+    final scale = AcaiaScale(transport: transport);
+    final snapshots = <ScaleSnapshot>[];
+    final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+    await scale.onConnect();
+
+    expect(frame[3], 8);
+    expect(await scale.connectionState.first, ConnectionState.connected);
+    expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+
+    await subscription.cancel();
+    await scale.disconnect();
+    await transport.dispose();
+  });
+
+  test('heartbeat-wrapped weight completes initialization', () async {
+    final frame = _heartbeatWeightFrame();
+    final transport = _ips(initializationFrame: frame);
+    final scale = AcaiaScale(transport: transport);
+    final snapshots = <ScaleSnapshot>[];
+    final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+    await scale.onConnect();
+
+    expect(frame[3], 11);
+    expect(await scale.connectionState.first, ConnectionState.connected);
+    expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+
+    await subscription.cancel();
+    await scale.disconnect();
+    await transport.dispose();
+  });
+
+  test('heartbeat timer and button records never publish weight', () async {
+    final (scale, transport) = await _connected();
+    final snapshots = <ScaleSnapshot>[];
+    final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+    transport.emit(_heartbeatTimerFrame());
+    transport.emit(_heartbeatButtonFrame());
+    await Future<void>.delayed(Duration.zero);
+
+    expect(snapshots, isEmpty);
+    await subscription.cancel();
+    await scale.disconnect();
+    await transport.dispose();
+  });
+
+  test('unknown and incomplete heartbeat records are rejected', () async {
+    for (final frame in [
+      _eventFrame(11, [0, 0, 9, 0]),
+      _eventFrame(11, [0, 0, 5, ..._weightBody.sublist(0, 5)]),
+    ]) {
+      final (scale, transport) = await _connected();
+      final snapshots = <ScaleSnapshot>[];
+      final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+      transport.emit([...frame, ..._minimalWeightFrame()]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+      await subscription.cancel();
+      await scale.disconnect();
+      await transport.dispose();
+    }
+  });
+
+  test('direct weight accepts complete trailing records', () async {
+    final frame = _eventFrame(5, [..._weightBody, 7, 0x01, 0x1E, 0x05]);
+    final (scale, transport) = await _connected();
+    final snapshots = <ScaleSnapshot>[];
+    final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+    transport.emit(frame);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+    await subscription.cancel();
+    await scale.disconnect();
+    await transport.dispose();
+  });
+
+  test(
+    'truncated direct and heartbeat weights recover before a valid frame',
+    () async {
+      for (final frame in [_minimalWeightFrame(), _heartbeatWeightFrame()]) {
+        final (scale, transport) = await _connected();
+        final snapshots = <ScaleSnapshot>[];
+        final subscription = scale.currentSnapshot.listen(snapshots.add);
+        final weightOffset = frame[4] == 5 ? 5 : 8;
+
+        transport.emit(frame.sublist(0, weightOffset + 5));
+        await Future<void>.delayed(Duration.zero);
+        expect(snapshots, isEmpty);
+
+        transport.emit(_minimalWeightFrame());
+        await Future<void>.delayed(Duration.zero);
+        expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+
+        await subscription.cancel();
+        await scale.disconnect();
+        await transport.dispose();
+      }
+    },
+  );
+
+  test(
+    'two complete weight frames in one notification are both consumed',
+    () async {
+      final (scale, transport) = await _connected();
+      final snapshots = <ScaleSnapshot>[];
+      final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+      transport.emit([..._minimalWeightFrame(), ..._heartbeatWeightFrame()]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(snapshots.map((snapshot) => snapshot.weight), [175.9, 175.9]);
+      await subscription.cancel();
+      await scale.disconnect();
+      await transport.dispose();
+    },
+  );
+
+  test(
+    'embedded header bytes remain inside a complete weight payload',
+    () async {
+      final frame = _eventFrame(5, [0xEF, 0xDD, 0x00, 0x00, 0x01, 0x00]);
+      final (scale, transport) = await _connected();
+      final snapshots = <ScaleSnapshot>[];
+      final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+      transport.emit(frame);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(snapshots.map((snapshot) => snapshot.weight), [5681.5]);
       await subscription.cancel();
       await scale.disconnect();
       await transport.dispose();
@@ -196,17 +387,17 @@ void main() {
     () async {
       for (final prefix in [
         [0xEF, 0xDD, 0x0C, 0x02, 0x05, 0xAA, 0xBB],
-        [0xEF, 0xDD, 0x0C, 0x0C, 0x05, 0xAA, 0xBB],
+        [0xEF, 0xDD, 0x0C, 0x0C, 0x05, ..._weightBody.sublist(0, 2)],
         [0xEF, 0xDD, 0x0C, 0xFF, 0x05, 0x00],
       ]) {
         final (scale, transport) = await _connected();
         final snapshots = <ScaleSnapshot>[];
         final subscription = scale.currentSnapshot.listen(snapshots.add);
 
-        transport.emit([...prefix, ..._weightFrame]);
+        transport.emit([...prefix, ..._realWeightFrame]);
         await Future<void>.delayed(Duration.zero);
 
-        expect(snapshots.map((snapshot) => snapshot.weight), [100.0]);
+        expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
         await subscription.cancel();
         await scale.disconnect();
         await transport.dispose();
@@ -220,17 +411,12 @@ void main() {
     final subscription = scale.currentSnapshot.listen(snapshots.add);
 
     transport.emit([
-      0xEF,
-      0xDD,
-      0x0B,
-      0x0B,
-      0x01,
-      ..._weightFrame,
-      ..._weightFrame,
+      ..._frame(0x0B, [0x01, ..._minimalWeightFrame()]),
+      ..._minimalWeightFrame(),
     ]);
     await Future<void>.delayed(Duration.zero);
 
-    expect(snapshots.map((snapshot) => snapshot.weight), [100.0]);
+    expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
     await subscription.cancel();
     await scale.disconnect();
     await transport.dispose();
@@ -238,14 +424,14 @@ void main() {
 
   test('concatenated settings and weight frames are both processed', () async {
     for (final frames in [
-      [0xEF, 0xDD, 0x08, 0x03, 72, 0, 0, 0, ..._weightFrame],
-      [..._weightFrame, 0xEF, 0xDD, 0x08, 0x03, 72, 0, 0, 0],
+      [..._settingsFrame(72), ..._minimalWeightFrame()],
+      [..._minimalWeightFrame(), ..._settingsFrame(72)],
     ]) {
       final (scale, transport) = await _connected();
       final snapshots = <ScaleSnapshot>[];
       final subscription = scale.currentSnapshot.listen(snapshots.add);
       transport.emit(frames);
-      transport.emit(_weightFrame);
+      transport.emit(_minimalWeightFrame());
       await Future<void>.delayed(Duration.zero);
       expect(snapshots.last.batteryLevel, 72);
       await subscription.cancel();
@@ -255,16 +441,16 @@ void main() {
   });
 
   test('split frames and split headers are retained', () async {
-    for (final split in [1, 7]) {
+    for (final split in [1, 3, 4, 8, 12, 16]) {
       final (scale, transport) = await _connected();
       final snapshots = <ScaleSnapshot>[];
       final subscription = scale.currentSnapshot.listen(snapshots.add);
-      transport.emit([0x99, ..._weightFrame.sublist(0, split)]);
+      transport.emit([0x99, ..._realWeightFrame.sublist(0, split)]);
       await Future<void>.delayed(Duration.zero);
       expect(snapshots, isEmpty);
-      transport.emit(_weightFrame.sublist(split));
+      transport.emit(_realWeightFrame.sublist(split));
       await Future<void>.delayed(Duration.zero);
-      expect(snapshots.map((snapshot) => snapshot.weight), [100.0]);
+      expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
       await subscription.cancel();
       await scale.disconnect();
       await transport.dispose();
@@ -274,13 +460,13 @@ void main() {
   test('battery high bit is masked and invalid battery is retained', () async {
     final (scale, transport) = await _connected();
     var snapshot = scale.currentSnapshot.first;
-    transport.emit(const [0xEF, 0xDD, 0x08, 0x03, 0xC8, 0, 0, 0]);
-    transport.emit(_weightFrame);
+    transport.emit(_settingsFrame(0xC8));
+    transport.emit(_minimalWeightFrame());
     expect((await snapshot).batteryLevel, 72);
 
     snapshot = scale.currentSnapshot.first;
-    transport.emit(const [0xEF, 0xDD, 0x08, 0x03, 0xE5, 0, 0, 0]);
-    transport.emit(_weightFrame);
+    transport.emit(_settingsFrame(0xE5));
+    transport.emit(_minimalWeightFrame());
     expect((await snapshot).batteryLevel, 72);
     await scale.disconnect();
     await transport.dispose();
@@ -304,11 +490,29 @@ void main() {
     });
   });
 
+  test('heartbeat timer initialization does not establish readiness', () {
+    fakeAsync((async) {
+      final transport = _ips(initializationFrame: _heartbeatTimerFrame());
+      final scale = AcaiaScale(transport: transport);
+      final snapshots = <ScaleSnapshot>[];
+      final states = <ConnectionState>[];
+      scale.currentSnapshot.listen(snapshots.add);
+      scale.connectionState.listen(states.add);
+
+      scale.onConnect();
+      async.elapse(const Duration(seconds: 9));
+      async.flushMicrotasks();
+
+      expect(snapshots, isEmpty);
+      expect(states, isNot(contains(ConnectionState.connected)));
+      expect(states.last, ConnectionState.disconnected);
+      expect(transport.disconnectCalls, 1);
+      transport.dispose();
+    });
+  });
+
   test('event 5 and event 11 weight complete initialization', () {
-    for (final frame in [
-      _weightFrame,
-      const [0xEF, 0xDD, 0x0C, 0x09, 0x0B, 0, 0, 0x05, 0xE8, 0x03, 0, 0, 1, 0],
-    ]) {
+    for (final frame in [_minimalWeightFrame(), _heartbeatWeightFrame()]) {
       fakeAsync((async) {
         final transport = _ips(emitWeightDuringInit: false);
         transport.writeBehavior = (data) async {
@@ -331,7 +535,7 @@ void main() {
       final transport = _ips(emitWeightDuringInit: false);
       transport.writeBehavior = (data) async {
         if (data[2] != 0x0C) return;
-        scheduleMicrotask(() => transport.emit(_weightFrame));
+        scheduleMicrotask(() => transport.emit(_minimalWeightFrame()));
         Timer(
           const Duration(milliseconds: 100),
           () => transport.states.add(ConnectionState.disconnected),

--- a/test/unit/models/acaia_scale_test.dart
+++ b/test/unit/models/acaia_scale_test.dart
@@ -30,6 +30,7 @@ const _realWeightFrame = <int>[
   0xF3,
   0x0D,
 ];
+const _secondWeightBody = <int>[0xA4, 0x01, 0x00, 0x00, 0x01, 0x00];
 const _realSettingsFrame = <int>[
   0xEF,
   0xDD,
@@ -430,6 +431,26 @@ void main() {
       }
     },
   );
+
+  test('truncated real records preserve the following weight frame', () async {
+    for (var cut = 11; cut < _realWeightFrame.length; cut++) {
+      final (scale, transport) = await _connected();
+      final snapshots = <ScaleSnapshot>[];
+      final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+      transport.emit(_realWeightFrame.sublist(0, cut));
+      await Future<void>.delayed(Duration.zero);
+      expect(snapshots, isEmpty);
+
+      transport.emit(_eventFrame(5, _secondWeightBody));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(snapshots.map((snapshot) => snapshot.weight), [42.0]);
+      await subscription.cancel();
+      await scale.disconnect();
+      await transport.dispose();
+    }
+  });
 
   test(
     'two complete weight frames in one notification are both consumed',

--- a/test/unit/models/acaia_scale_test.dart
+++ b/test/unit/models/acaia_scale_test.dart
@@ -30,6 +30,22 @@ const _realWeightFrame = <int>[
   0xF3,
   0x0D,
 ];
+const _realSettingsFrame = <int>[
+  0xEF,
+  0xDD,
+  0x08,
+  0x09,
+  0x5D,
+  0x02,
+  0x02,
+  0x01,
+  0x00,
+  0x01,
+  0x01,
+  0x00,
+  0x0D,
+  0x60,
+];
 
 List<int> _frame(int command, List<int> payload) {
   final body = [payload.length + 1, ...payload];
@@ -289,6 +305,36 @@ void main() {
     await transport.dispose();
   });
 
+  test('short heartbeat button frames refresh Pyxis liveness', () {
+    fakeAsync((async) {
+      final transport = _AcaiaTransport(
+        services: const ['49535343-fe7d-4ae5-8fa9-9fafd205e455'],
+      );
+      final scale = AcaiaScale(transport: transport);
+      final snapshots = <ScaleSnapshot>[];
+      final states = <ConnectionState>[];
+      scale.currentSnapshot.listen(snapshots.add);
+      scale.connectionState.listen(states.add);
+
+      scale.onConnect();
+      async.elapse(const Duration(seconds: 2));
+      async.flushMicrotasks();
+      expect(states.last, ConnectionState.connected);
+
+      snapshots.clear();
+      transport.emit(_heartbeatButtonFrame());
+      async.flushMicrotasks();
+      async.elapse(const Duration(milliseconds: 4500));
+      async.flushMicrotasks();
+
+      expect(states.last, ConnectionState.connected);
+      expect(snapshots, isEmpty);
+      scale.disconnect();
+      async.flushMicrotasks();
+      transport.dispose();
+    });
+  });
+
   test('unknown and incomplete heartbeat records are rejected', () async {
     for (final frame in [
       _eventFrame(11, [0, 0, 9, 0]),
@@ -318,6 +364,44 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+    await subscription.cancel();
+    await scale.disconnect();
+    await transport.dispose();
+  });
+
+  test(
+    'complete weights ignore unknown or incomplete trailing records',
+    () async {
+      for (final frame in [
+        _eventFrame(5, [..._weightBody, 0x09]),
+        _eventFrame(5, [..._weightBody, 0x07, 0x01]),
+        _eventFrame(11, [0, 0, 5, ..._weightBody, 0x09]),
+        _eventFrame(11, [0, 0, 5, ..._weightBody, 0x07, 0x01]),
+      ]) {
+        final (scale, transport) = await _connected();
+        final snapshots = <ScaleSnapshot>[];
+        final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+        transport.emit(frame);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(snapshots.map((snapshot) => snapshot.weight), [175.9]);
+        await subscription.cancel();
+        await scale.disconnect();
+        await transport.dispose();
+      }
+    },
+  );
+
+  test('weight flags use bit 0x02 for the negative sign', () async {
+    final (scale, transport) = await _connected();
+    final snapshots = <ScaleSnapshot>[];
+    final subscription = scale.currentSnapshot.listen(snapshots.add);
+
+    transport.emit(_eventFrame(5, [..._weightBody.sublist(0, 5), 0x03]));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(snapshots.map((snapshot) => snapshot.weight), [-175.9]);
     await subscription.cancel();
     await scale.disconnect();
     await transport.dispose();
@@ -438,6 +522,19 @@ void main() {
       await scale.disconnect();
       await transport.dispose();
     }
+  });
+
+  test('real declared-length settings frame updates the battery', () async {
+    final (scale, transport) = await _connected();
+    final snapshot = scale.currentSnapshot.first;
+
+    transport.emit(_realSettingsFrame);
+    transport.emit(_minimalWeightFrame());
+
+    expect(_realSettingsFrame[3], 9);
+    expect((await snapshot).batteryLevel, 93);
+    await scale.disconnect();
+    await transport.dispose();
   });
 
   test('split frames and split headers are retained', () async {


### PR DESCRIPTION
## Summary

- Problem: protocol-correct Acaia Lunar/Pyxis frames were rejected because declared lengths and record tails were validated too narrowly.
- Why it matters: initialization could miss valid weight/settings notifications and repeatedly disconnect.
- What changed: accept real settings frames, short heartbeat buttons, bit-field weight flags, and complete weights with unknown/incomplete trailing records while preserving frame isolation.
- What did NOT change: readiness still requires a decoded valid weight; strict checksum rejection was not added; physical hardware validation remains outstanding.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope

- [x] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [ ] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Independent Protocol Alignment

- The timer notification registration argument changed from `0x01` to `0x05`. It controls the requested number of heartbeats between timer notifications.
- Both maintained/reference implementations use `0x05`: [`encode_notification_request()` in aioacaia](https://github.com/zweckj/aioacaia/blob/main/aioacaia/encoder.py) and [`encodeNotificationRequest()` in pyacaia](https://github.com/lucapinello/pyacaia/blob/master/pyacaia/__init__.py).
- Focused unit coverage asserts the registration payload. Physical Lunar/Pyxis beta validation remains outstanding.
- This alignment is independent of and not required for the declared-length parser correction.

## Linked Issues

- Related #509
- Regression from #528

## Root Cause

- Root cause: Acaia byte 3 declares the span beginning at the length byte, including event and semantic records but excluding checksum bytes. The parser compared it to inner body sizes and required every trailing record to be recognized.
- Missing detection or guardrail: settings required exactly 3; all heartbeat events required 8; weight flags were treated as a scalar; partial-frame recovery could consume the next frame header as a flag byte.
- Contributing context (if known): real aioacaia captures use declared-length-9 settings frames, declared-length-6 button heartbeats, combined flag bits, and optional/unknown trailing records.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (simulate=1 + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/unit/models/acaia_scale_test.dart`
- Scenario the test should lock in: real settings battery 93, short heartbeat button liveness, flags 0x03 negative weight, direct and heartbeat weights with unknown/incomplete tails, and recovery after truncated frames.
- If no new test added, why not: New tests were added.

## Documentation Obligations

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed)
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A - no docs affected

## Security Impact

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? Yes - notification parsing is more compatible, but remains bounded by declared length and known body validation.
- File system access changed? No
- Plugin sandbox boundary changed? No
- If any Yes, explain risk and mitigation: The parser processes only declared frame payloads; boundary-adjacent headers are used only for bounded resynchronization, incomplete weight bodies are rejected, and strict structural validation remains for non-weight heartbeat records.

## User-Visible Changes

Acaia Lunar/Pyxis scales can remain initialized when they send protocol-correct settings, button, or weight frame variants that were previously rejected.

## Verification

### Local gates

- [x] Direct Dart formatter on both changed files - no remaining formatting changes
- [x] `flutter analyze --no-pub` - no issues found
- [x] `flutter test test/unit/models/acaia_scale_test.dart` - all 34 tests passed
- [ ] `flutter test --no-pub` - 2,581 passed; 14 unrelated environment/asset failures remain: QuickJS DLL loading, onboarding cascade, and missing bundled-skins manifest
- [ ] `(cd packages/dye2-plugin && npm run build)` - not run; no plugin files changed

### Manual verification

- OS / platform tested: Windows
- Simulated devices? (simulate=1): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: Protocol fixtures and mock BLE transport tests.
- Edge cases checked: split and concatenated frames, truncated weight recovery, real-record truncation at cuts 11-16 preserving the following frame, embedded headers, unknown records, settings length 9, button length 6, and combined flags.
- What you did not verify: physical LUNAR-E01ED7 or Pyxis hardware.

### Evidence

- [x] Test output (focused tests and analyzer)
- [x] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- If any No or Yes, explain exact steps: None.

## Risks & Mitigations

- Risk: Acaia firmware variants may still use unobserved record layouts.
  - Mitigation: frame-bounded parsing, strict non-weight record validation, and physical validation before merge.