### PR TITLE
Add shot-upload plugin + enable plugin Decent-proxy writes

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5864,7 +5864,7 @@ components:
           type: array
           items:
             type: string
-            enum: [log, api, emit, pluginStorage, pluginNotify, proxy.decent_api]
+            enum: [log, api, emit, pluginStorage, pluginNotify, proxy.decent_api, proxy.decent_api.write]
         settings:
           description: Plugin settings schema
           type: object

--- a/assets/plugins/shot-upload.reaplugin/manifest.json
+++ b/assets/plugins/shot-upload.reaplugin/manifest.json
@@ -2,7 +2,7 @@
   "id": "shot-upload.reaplugin",
   "author": "Decent Espresso",
   "name": "Decent shot upload",
-  "description": "Uploads your espresso shots to your Decent account at decentespresso.com so you can see your shot history and charts. Uses your existing Decent login; only your own machines are accepted.",
+  "description": "Uploads your espresso shots to your Decent account at decentespresso.com so you can see your shot history and charts. Uses your existing Decent login; only your own machines are accepted. Off by default: enable Upload shots automatically to opt in.",
   "version": "0.1.0",
   "apiVersion": 1,
   "permissions": [
@@ -10,13 +10,13 @@
     "api",
     "emit",
     "pluginStorage",
-    "proxy.decent_api"
+    "proxy.decent_api.write"
   ],
   "settings": {
     "AutoUpload": {
       "type": "boolean",
-      "description": "Upload shots automatically when they finish",
-      "default": true
+      "description": "Upload shots automatically when they finish (opt-in; off by default)",
+      "default": false
     },
     "LengthThreshold": {
       "type": "number",
@@ -34,10 +34,7 @@
       "id": "upload",
       "type": "http",
       "data": {
-        "shotId": {
-          "type": "string"
-        },
-        "description": "POST with a shotId to upload that shot now (omit for the latest)"
+        "description": "POST to upload the latest shot now (from the currently-connected machine)"
       }
     }
   ]

--- a/assets/plugins/shot-upload.reaplugin/manifest.json
+++ b/assets/plugins/shot-upload.reaplugin/manifest.json
@@ -1,0 +1,44 @@
+{
+  "id": "shot-upload.reaplugin",
+  "author": "Decent Espresso",
+  "name": "Decent shot upload",
+  "description": "Uploads your espresso shots to your Decent account at decentespresso.com so you can see your shot history and charts. Uses your existing Decent login; only your own machines are accepted.",
+  "version": "0.1.0",
+  "apiVersion": 1,
+  "permissions": [
+    "log",
+    "api",
+    "emit",
+    "pluginStorage",
+    "proxy.decent_api"
+  ],
+  "settings": {
+    "AutoUpload": {
+      "type": "boolean",
+      "description": "Upload shots automatically when they finish",
+      "default": true
+    },
+    "LengthThreshold": {
+      "type": "number",
+      "description": "Only upload shots longer than this many seconds (skips flushes)",
+      "default": 5
+    }
+  },
+  "api": [
+    {
+      "id": "status",
+      "type": "http",
+      "data": {}
+    },
+    {
+      "id": "upload",
+      "type": "http",
+      "data": {
+        "shotId": {
+          "type": "string"
+        },
+        "description": "POST with a shotId to upload that shot now (omit for the latest)"
+      }
+    }
+  ]
+}

--- a/assets/plugins/shot-upload.reaplugin/plugin.js
+++ b/assets/plugins/shot-upload.reaplugin/plugin.js
@@ -1,16 +1,19 @@
 /* shot-upload.reaplugin
  *
  * Uploads finished espresso shots to the user's Decent account at
- * decentespresso.com (POST support/api/shot_upload). Authentication reuses the
- * Decent account the user is already logged into: the upload goes through
- * host.decentProxy, which attaches the account credentials in Dart and never
- * exposes them to plugin JS. The server verifies the account and that the
- * connected machine's serial belongs to it, then stores the shot.
+ * decentespresso.com (POST support/api/shot_upload) through the authenticated
+ * Decent proxy, reusing the account the user is already logged into. The proxy
+ * attaches the account credentials in Dart and never exposes them to plugin JS;
+ * the server verifies the account and that the connected machine's serial
+ * belongs to it, then stores the shot.
  *
- * There is no "shot stored" plugin event, so (like the Visualizer plugin) we
- * watch machine state for espresso -> non-espresso, then pull the just-stored
- * shot from the local REST API, inject the machine serial (which the shot JSON
- * does not carry) from /api/v1/machine/info, and upload it.
+ * Opt-in: AutoUpload defaults to FALSE, so nothing is uploaded until the user
+ * turns it on. (Beta stance. Post-beta, logging into the Decent account will
+ * itself serve as opt-in consent and AutoUpload will default to true.)
+ *
+ * The upload binds to the exact persisted shot via the `shotStored` event (fired
+ * with the shot id after persistence), so there is no timer/`/shots/latest`
+ * race, and machine identity is captured at completion time.
  *
  * Contract: must define createPlugin(host) returning {id, version, onLoad,
  * onUnload, onEvent}.
@@ -20,20 +23,18 @@ function createPlugin(host) {
   "use strict";
 
   const NS = "shot-upload.reaplugin";
+  const VERSION = "0.1.0";
   const LOCAL_API_URL = "http://localhost:8080/api/v1";
-  const UPLOAD_PATH = "support/api/shot_upload"; // relative to the Decent proxy base
-  const SHOT_FETCH_DELAY_MS = 5000; // let the app finish persisting the shot
+  const UPLOAD_PATH = "support/api/shot_upload"; // exact allowlisted proxy write path
   const RETRIES = 3;
   const RETRY_DELAY_MS = 2000;
 
-  let shotTimeoutId = null;
   let isUploading = false;
+  let decaidVersion = null;
 
   const state = {
-    autoUpload: true,
+    autoUpload: false, // opt-in; see header
     lengthThreshold: 5,
-    lastMachineState: null,
-    lastCheckedShotId: null,
     lastUploadedShot: null,
     lastResult: null,
   };
@@ -46,6 +47,14 @@ function createPlugin(host) {
     return await res.json();
   }
 
+  // Decaid app version (for provenance), cached.
+  async function getDecaidVersion() {
+    if (decaidVersion) return decaidVersion;
+    const info = await fetchLocal("/info");
+    decaidVersion = (info && (info.version || info.fullVersion)) || "unknown";
+    return decaidVersion;
+  }
+
   // seconds between first and last measurement
   function shotDuration(shot) {
     const m = shot && shot.measurements;
@@ -55,16 +64,16 @@ function createPlugin(host) {
     return isNaN(t0) || isNaN(t1) ? 0 : (t1 - t0) / 1000;
   }
 
-  // Inject machine identity (serial not carried in the shot JSON) + provenance.
+  // Inject machine identity (serial not carried in the shot JSON) + provenance,
+  // populated from the actual /machine/info fields (firmware = `version`).
   async function withMachine(shot) {
     const info = await fetchLocal("/machine/info");
-    const serial = info && (info.serialNumber || info.serial);
+    const serial = info && info.serialNumber;
     if (!serial) return null;
     shot.machine = { serialNumber: String(serial) };
-    if (info.id) shot.machine.bleId = String(info.id);
-    if (info.firmwareVersion) shot.machine.firmwareVersion = String(info.firmwareVersion);
+    if (info.version) shot.machine.firmwareVersion = String(info.version);
     if (info.model) shot.machine.model = String(info.model);
-    shot.app = { name: "decaid", version: "0.1.0", sourceFormat: "decaid" };
+    shot.app = { name: "decaid", version: await getDecaidVersion(), sourceFormat: "decaid" };
     shot.schemaVersion = 1;
     return shot;
   }
@@ -99,34 +108,41 @@ function createPlugin(host) {
     throw lastErr || new Error("upload failed");
   }
 
-  async function uploadShotById(shotId) {
+  // Upload one stored shot by id. Throws on failure (so callers can report
+  // status); marks e.skipped=true for a too-short shot. Returns the server result.
+  async function uploadShot(shotId) {
+    const full = await fetchLocal(`/shots/${shotId}`);
+    if (!full || !full.id) throw new Error(`shot ${shotId} not found`);
+
+    const dur = shotDuration(full);
+    if (dur < state.lengthThreshold) {
+      const e = new Error(`shot too short (${dur.toFixed(1)}s < ${state.lengthThreshold}s)`);
+      e.skipped = true;
+      throw e;
+    }
+
+    const payload = await withMachine(full);
+    if (!payload) throw new Error("no machine serial available");
+
+    const result = await postShot(payload);
+    state.lastUploadedShot = full.id;
+    state.lastResult = result;
+    host.storage({ type: "write", key: "lastUploadedShot", data: full.id });
+    host.emit("shotUploaded", { shotId: full.id, result: result, timestamp: Date.now() });
+    return result;
+  }
+
+  // Auto path: fire-and-forget with dedup + error handling (never throws).
+  async function autoUpload(shotId) {
     if (isUploading) return;
+    if (shotId && shotId === state.lastUploadedShot) { log(`shot ${shotId} already uploaded`); return; }
     isUploading = true;
     try {
-      let meta = shotId ? { id: shotId } : await fetchLocal("/shots/latest");
-      if (!meta || !meta.id) { log("no shot available"); return; }
-
-      if (!shotId && meta.id === state.lastCheckedShotId) { log(`shot ${meta.id} already handled`); return; }
-      state.lastCheckedShotId = meta.id;
-
-      const full = await fetchLocal(`/shots/${meta.id}`);
-      if (!full) { log(`could not fetch shot ${meta.id}`); return; }
-
-      const dur = shotDuration(full);
-      if (dur < state.lengthThreshold) { log(`shot ${meta.id} too short (${dur.toFixed(1)}s); skipping`); return; }
-
-      const payload = await withMachine(full);
-      if (!payload) { log("no machine serial available; skipping"); return; }
-
-      const result = await postShot(payload);
-      state.lastUploadedShot = full.id;
-      state.lastResult = result;
-      host.storage({ type: "write", key: "lastUploadedShot", namespace: NS, data: full.id });
-      log(`uploaded ${full.id} -> ${result && result.profile_ref ? result.profile_ref : "ok"}`);
-      host.emit("shotUploaded", { shotId: full.id, result: result, timestamp: Date.now() });
+      const r = await uploadShot(shotId);
+      log(`uploaded ${shotId} -> ${r && r.profile_ref ? r.profile_ref : "ok"}`);
     } catch (e) {
-      log(`error: ${e.message}`);
-      host.emit("uploadError", { error: e.message, timestamp: Date.now() });
+      if (e.skipped) { log(`skipped ${shotId}: ${e.message}`); }
+      else { log(`error uploading ${shotId}: ${e.message}`); host.emit("uploadError", { shotId: shotId, error: e.message, timestamp: Date.now() }); }
     } finally {
       isUploading = false;
     }
@@ -134,63 +150,71 @@ function createPlugin(host) {
 
   function applySettings(settings) {
     if (!settings) return;
-    state.autoUpload = settings.AutoUpload !== undefined ? settings.AutoUpload : true;
+    // Opt-in: default OFF unless the user explicitly enabled it.
+    state.autoUpload = settings.AutoUpload === true;
     state.lengthThreshold = settings.LengthThreshold !== undefined ? settings.LengthThreshold : 5;
+  }
+
+  function jsonResponse(status, obj) {
+    return { status: status, headers: { "Content-Type": "application/json" }, body: JSON.stringify(obj) };
   }
 
   return {
     id: NS,
-    version: "0.1.0",
+    version: VERSION,
 
     onLoad(settings) {
       applySettings(settings);
-      try {
-        const saved = host.storage({ type: "read", key: "lastUploadedShot", namespace: NS });
-        if (saved) state.lastUploadedShot = saved;
-      } catch (e) {}
-      log(`loaded (auto ${state.autoUpload})`);
+      // Storage reads are event-based: this triggers a `storageRead` event,
+      // handled in onEvent, that restores lastUploadedShot.
+      try { host.storage({ type: "read", key: "lastUploadedShot" }); } catch (e) {}
+      log(`loaded (autoUpload ${state.autoUpload})`);
     },
 
-    onUnload() {
-      if (shotTimeoutId) { clearTimeout(shotTimeoutId); shotTimeoutId = null; }
-    },
+    onUnload() {},
 
     onEvent(event) {
       switch (event.name) {
-        case "stateUpdate": {
-          const cur = event.payload && event.payload.state && event.payload.state.state;
-          if (state.lastMachineState === "espresso" && cur !== "espresso") {
-            if (state.autoUpload) {
-              log(`shot ended (${state.lastMachineState} -> ${cur}); uploading in ${SHOT_FETCH_DELAY_MS / 1000}s`);
-              if (shotTimeoutId) clearTimeout(shotTimeoutId);
-              shotTimeoutId = setTimeout(() => uploadShotById(null), SHOT_FETCH_DELAY_MS);
-            }
-          }
-          state.lastMachineState = cur;
+        case "shotStored": {
+          const id = event.payload && event.payload.id;
+          if (id && state.autoUpload) autoUpload(id);
           break;
         }
+        case "storageRead":
+          if (event.payload && event.payload.key === "lastUploadedShot") {
+            state.lastUploadedShot = event.payload.value || null;
+          }
+          break;
         case "settingsUpdated":
           applySettings(event.payload);
           break;
       }
     },
 
-    // Optional control endpoints (POST upload {shotId}, GET status).
+    // Control endpoints. GET status; POST upload (uploads the latest shot, which
+    // belongs to the currently-connected machine — avoids misattributing an
+    // arbitrary historical id to the wrong machine).
     async __httpRequestHandler(request) {
-      const id = (request && request.id) || "";
-      if (id === "upload") {
-        const shotId = request.data && request.data.shotId;
-        await uploadShotById(shotId || null);
-        return { status: 200, body: { ok: true, lastUploaded: state.lastUploadedShot } };
-      }
-      if (id === "status") {
-        return { status: 200, body: {
+      const endpoint = request && request.endpoint;
+      if (endpoint === "status") {
+        return jsonResponse(200, {
           autoUpload: state.autoUpload,
           lastUploaded: state.lastUploadedShot,
           lastResult: state.lastResult,
-        } };
+        });
       }
-      return { status: 404, body: { error: "unknown endpoint" } };
+      if (endpoint === "upload") {
+        try {
+          const latest = await fetchLocal("/shots/latest");
+          if (!latest || !latest.id) return jsonResponse(404, { ok: false, error: "no shot available" });
+          const result = await uploadShot(latest.id);
+          return jsonResponse(200, { ok: true, id: latest.id, result: result });
+        } catch (e) {
+          if (e.skipped) return jsonResponse(200, { ok: false, skipped: true, error: e.message });
+          return jsonResponse(502, { ok: false, error: e.message });
+        }
+      }
+      return jsonResponse(404, { error: "unknown endpoint" });
     },
   };
 }

--- a/assets/plugins/shot-upload.reaplugin/plugin.js
+++ b/assets/plugins/shot-upload.reaplugin/plugin.js
@@ -1,0 +1,196 @@
+/* shot-upload.reaplugin
+ *
+ * Uploads finished espresso shots to the user's Decent account at
+ * decentespresso.com (POST support/api/shot_upload). Authentication reuses the
+ * Decent account the user is already logged into: the upload goes through
+ * host.decentProxy, which attaches the account credentials in Dart and never
+ * exposes them to plugin JS. The server verifies the account and that the
+ * connected machine's serial belongs to it, then stores the shot.
+ *
+ * There is no "shot stored" plugin event, so (like the Visualizer plugin) we
+ * watch machine state for espresso -> non-espresso, then pull the just-stored
+ * shot from the local REST API, inject the machine serial (which the shot JSON
+ * does not carry) from /api/v1/machine/info, and upload it.
+ *
+ * Contract: must define createPlugin(host) returning {id, version, onLoad,
+ * onUnload, onEvent}.
+ */
+
+function createPlugin(host) {
+  "use strict";
+
+  const NS = "shot-upload.reaplugin";
+  const LOCAL_API_URL = "http://localhost:8080/api/v1";
+  const UPLOAD_PATH = "support/api/shot_upload"; // relative to the Decent proxy base
+  const SHOT_FETCH_DELAY_MS = 5000; // let the app finish persisting the shot
+  const RETRIES = 3;
+  const RETRY_DELAY_MS = 2000;
+
+  let shotTimeoutId = null;
+  let isUploading = false;
+
+  const state = {
+    autoUpload: true,
+    lengthThreshold: 5,
+    lastMachineState: null,
+    lastCheckedShotId: null,
+    lastUploadedShot: null,
+    lastResult: null,
+  };
+
+  function log(msg) { try { host.log(`[shot-upload] ${msg}`); } catch (e) {} }
+
+  async function fetchLocal(path) {
+    const res = await fetch(`${LOCAL_API_URL}${path}`);
+    if (!res.ok) { log(`local ${path} -> ${res.status}`); return null; }
+    return await res.json();
+  }
+
+  // seconds between first and last measurement
+  function shotDuration(shot) {
+    const m = shot && shot.measurements;
+    if (!m || m.length < 2) return 0;
+    const t0 = Date.parse(m[0].machine.timestamp);
+    const t1 = Date.parse(m[m.length - 1].machine.timestamp);
+    return isNaN(t0) || isNaN(t1) ? 0 : (t1 - t0) / 1000;
+  }
+
+  // Inject machine identity (serial not carried in the shot JSON) + provenance.
+  async function withMachine(shot) {
+    const info = await fetchLocal("/machine/info");
+    const serial = info && (info.serialNumber || info.serial);
+    if (!serial) return null;
+    shot.machine = { serialNumber: String(serial) };
+    if (info.id) shot.machine.bleId = String(info.id);
+    if (info.firmwareVersion) shot.machine.firmwareVersion = String(info.firmwareVersion);
+    if (info.model) shot.machine.model = String(info.model);
+    shot.app = { name: "decaid", version: "0.1.0", sourceFormat: "decaid" };
+    shot.schemaVersion = 1;
+    return shot;
+  }
+
+  // POST the shot through the authenticated Decent proxy (reuses account login).
+  async function postShot(shot) {
+    const body = JSON.stringify(shot);
+    let lastErr = null;
+    for (let i = 0; i < RETRIES; i++) {
+      try {
+        const res = await host.decentProxy(UPLOAD_PATH, {
+          method: "POST",
+          body: body,
+          contentType: "application/json",
+        });
+        const status = res && res.status;
+        const text = (res && res.body) || "";
+        if (status >= 200 && status < 300) {
+          try { return JSON.parse(text); } catch (e) { return { ok: true }; }
+        }
+        // 4xx (not logged in / not your machine / bad shot) -> don't retry
+        if (status >= 400 && status < 500) {
+          throw new Error(`HTTP ${status}: ${text}`);
+        }
+        lastErr = new Error(`HTTP ${status}: ${text}`);
+      } catch (e) {
+        lastErr = e;
+        if (String(e.message).indexOf("HTTP 4") === 0) throw e;
+      }
+      if (i < RETRIES - 1) await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+    }
+    throw lastErr || new Error("upload failed");
+  }
+
+  async function uploadShotById(shotId) {
+    if (isUploading) return;
+    isUploading = true;
+    try {
+      let meta = shotId ? { id: shotId } : await fetchLocal("/shots/latest");
+      if (!meta || !meta.id) { log("no shot available"); return; }
+
+      if (!shotId && meta.id === state.lastCheckedShotId) { log(`shot ${meta.id} already handled`); return; }
+      state.lastCheckedShotId = meta.id;
+
+      const full = await fetchLocal(`/shots/${meta.id}`);
+      if (!full) { log(`could not fetch shot ${meta.id}`); return; }
+
+      const dur = shotDuration(full);
+      if (dur < state.lengthThreshold) { log(`shot ${meta.id} too short (${dur.toFixed(1)}s); skipping`); return; }
+
+      const payload = await withMachine(full);
+      if (!payload) { log("no machine serial available; skipping"); return; }
+
+      const result = await postShot(payload);
+      state.lastUploadedShot = full.id;
+      state.lastResult = result;
+      host.storage({ type: "write", key: "lastUploadedShot", namespace: NS, data: full.id });
+      log(`uploaded ${full.id} -> ${result && result.profile_ref ? result.profile_ref : "ok"}`);
+      host.emit("shotUploaded", { shotId: full.id, result: result, timestamp: Date.now() });
+    } catch (e) {
+      log(`error: ${e.message}`);
+      host.emit("uploadError", { error: e.message, timestamp: Date.now() });
+    } finally {
+      isUploading = false;
+    }
+  }
+
+  function applySettings(settings) {
+    if (!settings) return;
+    state.autoUpload = settings.AutoUpload !== undefined ? settings.AutoUpload : true;
+    state.lengthThreshold = settings.LengthThreshold !== undefined ? settings.LengthThreshold : 5;
+  }
+
+  return {
+    id: NS,
+    version: "0.1.0",
+
+    onLoad(settings) {
+      applySettings(settings);
+      try {
+        const saved = host.storage({ type: "read", key: "lastUploadedShot", namespace: NS });
+        if (saved) state.lastUploadedShot = saved;
+      } catch (e) {}
+      log(`loaded (auto ${state.autoUpload})`);
+    },
+
+    onUnload() {
+      if (shotTimeoutId) { clearTimeout(shotTimeoutId); shotTimeoutId = null; }
+    },
+
+    onEvent(event) {
+      switch (event.name) {
+        case "stateUpdate": {
+          const cur = event.payload && event.payload.state && event.payload.state.state;
+          if (state.lastMachineState === "espresso" && cur !== "espresso") {
+            if (state.autoUpload) {
+              log(`shot ended (${state.lastMachineState} -> ${cur}); uploading in ${SHOT_FETCH_DELAY_MS / 1000}s`);
+              if (shotTimeoutId) clearTimeout(shotTimeoutId);
+              shotTimeoutId = setTimeout(() => uploadShotById(null), SHOT_FETCH_DELAY_MS);
+            }
+          }
+          state.lastMachineState = cur;
+          break;
+        }
+        case "settingsUpdated":
+          applySettings(event.payload);
+          break;
+      }
+    },
+
+    // Optional control endpoints (POST upload {shotId}, GET status).
+    async __httpRequestHandler(request) {
+      const id = (request && request.id) || "";
+      if (id === "upload") {
+        const shotId = request.data && request.data.shotId;
+        await uploadShotById(shotId || null);
+        return { status: 200, body: { ok: true, lastUploaded: state.lastUploadedShot } };
+      }
+      if (id === "status") {
+        return { status: 200, body: {
+          autoUpload: state.autoUpload,
+          lastUploaded: state.lastUploadedShot,
+          lastResult: state.lastResult,
+        } };
+      }
+      return { status: 404, body: { error: "unknown endpoint" } };
+    },
+  };
+}

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -142,9 +142,16 @@ const response = await host.decentProxy("support/api/sn", {
 if (response.status === 200) {
   const serials = response.body.trim().split("\n");
 }
+
+// POST with a body (reuses the account credentials, never exposed to JS)
+const upload = await host.decentProxy("support/api/shot_upload", {
+  method: "POST",
+  body: JSON.stringify(shot),
+  contentType: "application/json"
+});
 ```
 
-The returned object has `{ status, headers, body }`. Only `GET` is supported for plugins in the phase-1 bridge. The existing proxy allowlist still applies, so plugin requests are restricted to the supported Decent backend path prefix.
+The returned object has `{ status, headers, body }`. `GET`, `POST`, and `PUT` are supported for plugins; pass `body` (string) and `contentType` for writes. The existing proxy allowlist still applies, so plugin requests are restricted to the supported Decent backend path prefix.
 
 ## Events System
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -131,7 +131,7 @@ host.storage({
 **Note:** namespace is not used by Decaid internally, the plugin storage is namespaced to the plugins' identifier.
 
 ### `host.decentProxy(path, options)`
-Call the Decent account proxy without exposing stored credentials to plugin code. The plugin must declare the `proxy.decent_api` permission in `manifest.json`; calls without that permission are rejected and logged.
+Call the Decent account proxy without exposing stored credentials to plugin code. `GET` requires the read-only `proxy.decent_api` permission. `POST` requires the distinct write permission `proxy.decent_api.write` **and** is restricted to an explicit path allowlist (currently only `support/api/shot_upload`); other methods/paths are rejected and logged.
 
 ```javascript
 const response = await host.decentProxy("support/api/sn", {
@@ -143,7 +143,7 @@ if (response.status === 200) {
   const serials = response.body.trim().split("\n");
 }
 
-// POST with a body (reuses the account credentials, never exposed to JS)
+// POST with a body (needs proxy.decent_api.write; only allowlisted write paths)
 const upload = await host.decentProxy("support/api/shot_upload", {
   method: "POST",
   body: JSON.stringify(shot),
@@ -151,7 +151,7 @@ const upload = await host.decentProxy("support/api/shot_upload", {
 });
 ```
 
-The returned object has `{ status, headers, body }`. `GET`, `POST`, and `PUT` are supported for plugins; pass `body` (string) and `contentType` for writes. The existing proxy allowlist still applies, so plugin requests are restricted to the supported Decent backend path prefix.
+The returned object has `{ status, headers, body }`. `GET` (read) needs `proxy.decent_api`; `POST` (write) needs `proxy.decent_api.write` and a path on the write allowlist. Credentials are attached in Dart and never exposed to plugin JS.
 
 ## Events System
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -432,15 +432,23 @@ void main(List<String> args) async {
     decentProxyService = null;
   } else {
     final decentCredentialStore = await createCredentialStore();
+    // Override with --dart-define=DECENT_BASE_URL=http://localhost:8000 for
+    // local server development; defaults to production.
+    const decentBaseUrl = String.fromEnvironment(
+      'DECENT_BASE_URL',
+      defaultValue: 'https://decentespresso.com',
+    );
     decentAccountService = DecentAccountService(
       httpClient: http.Client(),
       credentialStore: decentCredentialStore,
+      baseUrl: decentBaseUrl,
     );
     // Same credential store as the account service: the proxy reads the
     // credentials that account login wrote, and never exposes them to callers.
     decentProxyService = DecentProxyService(
       httpClient: http.Client(),
       credentialStore: decentCredentialStore,
+      baseUrl: decentBaseUrl,
     );
     // User-managed API-client tokens: persisted in the same secure store and
     // loaded into the validator alongside the per-process skin token.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -468,6 +468,10 @@ void main(List<String> args) async {
   // Don't initialize plugins yet - wait for permissions to be granted
   // pluginService.initialize() will be called from PermissionsView after permissions are granted
   pluginService.pluginManager.de1Controller = de1Controller;
+  // Broadcast a `shotStored` plugin event once a shot is persisted, so plugins
+  // can react to the exact newly-stored shot (no timer/latest-lookup race).
+  persistenceController.onShotStored = (shotId) =>
+      pluginService.pluginManager.broadcastEvent('shotStored', {'id': shotId});
 
   BatteryController? batteryController;
   if (Platform.isAndroid || Platform.isIOS) {

--- a/lib/src/controllers/persistence_controller.dart
+++ b/lib/src/controllers/persistence_controller.dart
@@ -11,10 +11,6 @@ class PersistenceController {
 
   PersistenceController({required this.storageService});
 
-  /// Optional hook fired with the shot id immediately after a shot is
-  /// successfully persisted. Wired in main.dart to broadcast the `shotStored`
-  /// plugin event, giving plugins a reliable point (exact id, post-persistence)
-  /// to react to a newly-stored shot.
   void Function(String shotId)? onShotStored;
 
   /// Fires whenever shots are added, updated, or deleted.

--- a/lib/src/controllers/persistence_controller.dart
+++ b/lib/src/controllers/persistence_controller.dart
@@ -11,6 +11,12 @@ class PersistenceController {
 
   PersistenceController({required this.storageService});
 
+  /// Optional hook fired with the shot id immediately after a shot is
+  /// successfully persisted. Wired in main.dart to broadcast the `shotStored`
+  /// plugin event, giving plugins a reliable point (exact id, post-persistence)
+  /// to react to a newly-stored shot.
+  void Function(String shotId)? onShotStored;
+
   /// Fires whenever shots are added, updated, or deleted.
   /// Consumers should re-query what they need from [storageService].
   final _shotsChangedSubject = PublishSubject<void>();
@@ -35,6 +41,7 @@ class PersistenceController {
     try {
       await storageService.storeShot(record);
       _shotsChangedSubject.add(null);
+      onShotStored?.call(record.id);
     } catch (e, st) {
       _log.severe("Error saving shot:", e, st);
     }

--- a/lib/src/models/device/impl/mock_de1/mock_de1.dart
+++ b/lib/src/models/device/impl/mock_de1/mock_de1.dart
@@ -85,7 +85,10 @@ class MockDe1 implements De1Interface, SimulatedDevice {
   MachineInfo get machineInfo => MachineInfo(
     version: "1337",
     model: "DE1Pro",
-    serialNumber: "mock-de1",
+    serialNumber: const String.fromEnvironment(
+      'MOCK_DE1_SERIAL',
+      defaultValue: 'mock-de1',
+    ),
     groupHeadControllerPresent: false,
     extra: {},
   );

--- a/lib/src/plugins/plugin_decent_proxy_bridge.dart
+++ b/lib/src/plugins/plugin_decent_proxy_bridge.dart
@@ -9,6 +9,14 @@ class PluginDecentProxyBridge {
   PluginDecentProxyBridge({required this.decentProxyService, Logger? log})
     : _log = log ?? Logger('PluginDecentProxyBridge');
 
+  /// Exact paths a plugin holding `proxy.decent_api.write` may POST to. Writes
+  /// are least-privilege: a specific method + a specific path, never the whole
+  /// `support/api/` namespace. Add entries here as new write endpoints appear.
+  static const Set<String> _writeAllowedPaths = {'support/api/shot_upload'};
+
+  static String _canonicalPath(String path) =>
+      path.trim().replaceAll(RegExp(r'^/+'), '');
+
   Future<Map<String, dynamic>> proxyForPlugin({
     required String pluginId,
     required PluginManifest? manifest,
@@ -21,12 +29,6 @@ class PluginDecentProxyBridge {
     if (manifest == null) {
       throw StateError('Plugin is not loaded: $pluginId');
     }
-    if (!manifest.permissions.contains(PluginPermissions.proxyDecentApi)) {
-      _log.warning(
-        'Plugin $pluginId attempted Decent proxy access without permission',
-      );
-      throw StateError('Plugin permission required: proxy.decent_api');
-    }
     if (decentProxyService == null) {
       throw StateError('Decent account proxy is not available');
     }
@@ -36,24 +38,38 @@ class PluginDecentProxyBridge {
 
     final normalizedMethod = method.toUpperCase();
     final callerId = 'plugin:$pluginId';
+    final canonicalPath = _canonicalPath(path);
     final DecentProxyResponse response;
     switch (normalizedMethod) {
       case 'GET':
+        // Reads: `proxy.decent_api` (unchanged, read-only).
+        if (!manifest.permissions.contains(PluginPermissions.proxyDecentApi)) {
+          _log.warning('Plugin $pluginId GET without proxy.decent_api');
+          throw StateError('Plugin permission required: proxy.decent_api');
+        }
         response = await decentProxyService!.proxyGet(
           callerId: callerId,
           path: path,
           query: query,
         );
       case 'POST':
+        // Writes: a distinct `proxy.decent_api.write` capability, restricted to
+        // an explicit path allowlist (not the whole support/api/ namespace).
+        if (!manifest.permissions.contains(
+          PluginPermissions.proxyDecentApiWrite,
+        )) {
+          _log.warning('Plugin $pluginId POST without proxy.decent_api.write');
+          throw StateError(
+            'Plugin permission required: proxy.decent_api.write',
+          );
+        }
+        if (!_writeAllowedPaths.contains(canonicalPath)) {
+          _log.warning(
+            'Plugin $pluginId POST to disallowed path $canonicalPath',
+          );
+          throw StateError('Decent proxy write not allowed for path: $path');
+        }
         response = await decentProxyService!.proxyPost(
-          callerId: callerId,
-          path: path,
-          query: query,
-          body: body,
-          contentType: contentType,
-        );
-      case 'PUT':
-        response = await decentProxyService!.proxyPut(
           callerId: callerId,
           path: path,
           query: query,
@@ -62,7 +78,7 @@ class PluginDecentProxyBridge {
         );
       default:
         throw UnsupportedError(
-          'Decent proxy supports GET, POST, PUT for plugins',
+          'Decent proxy supports GET and POST for plugins',
         );
     }
     return {

--- a/lib/src/plugins/plugin_decent_proxy_bridge.dart
+++ b/lib/src/plugins/plugin_decent_proxy_bridge.dart
@@ -15,6 +15,8 @@ class PluginDecentProxyBridge {
     required String? path,
     String method = 'GET',
     Map<String, String>? query,
+    String? body,
+    String? contentType,
   }) async {
     if (manifest == null) {
       throw StateError('Plugin is not loaded: $pluginId');
@@ -33,15 +35,36 @@ class PluginDecentProxyBridge {
     }
 
     final normalizedMethod = method.toUpperCase();
-    if (normalizedMethod != 'GET') {
-      throw UnsupportedError('Decent proxy only supports GET for plugins');
+    final callerId = 'plugin:$pluginId';
+    final DecentProxyResponse response;
+    switch (normalizedMethod) {
+      case 'GET':
+        response = await decentProxyService!.proxyGet(
+          callerId: callerId,
+          path: path,
+          query: query,
+        );
+      case 'POST':
+        response = await decentProxyService!.proxyPost(
+          callerId: callerId,
+          path: path,
+          query: query,
+          body: body,
+          contentType: contentType,
+        );
+      case 'PUT':
+        response = await decentProxyService!.proxyPut(
+          callerId: callerId,
+          path: path,
+          query: query,
+          body: body,
+          contentType: contentType,
+        );
+      default:
+        throw UnsupportedError(
+          'Decent proxy supports GET, POST, PUT for plugins',
+        );
     }
-
-    final response = await decentProxyService!.proxyGet(
-      callerId: 'plugin:$pluginId',
-      path: path,
-      query: query,
-    );
     return {
       'status': response.statusCode,
       'headers': response.headers,

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -470,6 +470,7 @@ class PluginLoaderService {
       'assets/plugins/settings.reaplugin',
       'assets/plugins/dye2.reaplugin',
       'assets/plugins/decent-profile.reaplugin',
+      'assets/plugins/shot-upload.reaplugin',
       // Add more bundled plugins here as they are added to the app
     ];
   }

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -734,7 +734,7 @@ class PluginManager {
         ${jsonEncode(response)}
       );
     ''');
-    js.executePendingJob();
+    while (js.executePendingJob() > 0) {}
   }
 
   Future<void> _handlePluginStorage(
@@ -849,7 +849,7 @@ class PluginManager {
       //     }),
       //   ],
       // );
-      js.executePendingJob();
+      while (js.executePendingJob() > 0) {}
     } catch (e) {
       js.sendMessage(
         channelName: "__fetchResponse__",
@@ -857,7 +857,7 @@ class PluginManager {
           jsonEncode({'id': id, 'error': e.toString()}),
         ],
       );
-      js.executePendingJob();
+      while (js.executePendingJob() > 0) {}
     }
   }
 

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -132,7 +132,7 @@ class PluginManager {
           return __nativeFreeze(wrapped);
         }
 
-        function __decentProxy(pluginId, bridgeToken, path, method, query) {
+        function __decentProxy(pluginId, bridgeToken, path, method, query, body, contentType) {
           const requestId = "__decent_proxy_" + __decentProxyNonce + "_" + (++__decentProxySeq);
           const promise = new __NativePromise((resolve, reject) => {
             const pendingByPlugin = __pendingDecentProxyByPlugin(pluginId);
@@ -145,7 +145,9 @@ class PluginManager {
                 requestId: requestId,
                 path: path,
                 method: method,
-                query: query
+                query: query,
+                body: body,
+                contentType: contentType
               });
             } catch (e) {
               __mapDelete(pendingByPlugin, requestId);
@@ -440,7 +442,9 @@ class PluginManager {
               ${jsonEncode(decentProxyBridgeToken)},
               path,
               options.method || "GET",
-              options.query || {}
+              options.query || {},
+              options.body ?? null,
+              options.contentType ?? null
             );
           },
           // Add HTTP request capability
@@ -672,6 +676,8 @@ class PluginManager {
         path: msg['path'] as String?,
         method: (msg['method'] as String?) ?? 'GET',
         query: _stringMap(msg['query']),
+        body: msg['body'] as String?,
+        contentType: msg['contentType'] as String?,
       );
       _completeDecentProxyRequest(pluginId, requestId, response);
     } catch (e) {
@@ -691,6 +697,8 @@ class PluginManager {
     required String? path,
     String method = 'GET',
     Map<String, String>? query,
+    String? body,
+    String? contentType,
   }) async {
     return _decentProxyBridge.proxyForPlugin(
       pluginId: pluginId,
@@ -698,6 +706,8 @@ class PluginManager {
       path: path,
       method: method,
       query: query,
+      body: body,
+      contentType: contentType,
     );
   }
 

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -58,7 +58,8 @@ enum PluginPermissions {
   emit('emit'),
   pluginStorage('pluginStorage'),
   pluginNotify('pluginNotify'),
-  proxyDecentApi('proxy.decent_api');
+  proxyDecentApi('proxy.decent_api'),
+  proxyDecentApiWrite('proxy.decent_api.write');
 
   final String wireName;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -179,6 +179,7 @@ flutter:
     - assets/plugins/settings.reaplugin/
     - assets/plugins/dye2.reaplugin/
     - assets/plugins/decent-profile.reaplugin/
+    - assets/plugins/shot-upload.reaplugin/
     - assets/defaultProfiles/
     - assets/bundled_skins/
     - assets/firmware/

--- a/test/plugins/plugin_decent_proxy_bridge_test.dart
+++ b/test/plugins/plugin_decent_proxy_bridge_test.dart
@@ -116,7 +116,7 @@ void main() {
             );
           }).proxyForPlugin(
             pluginId: 'test.plugin',
-            manifest: manifestWith({PluginPermissions.proxyDecentApi}),
+            manifest: manifestWith({PluginPermissions.proxyDecentApiWrite}),
             path: 'support/api/shot_upload',
             method: 'POST',
             body: '{"id":"decaid-1","machine":{"serialNumber":"6262"}}',
@@ -142,7 +142,7 @@ void main() {
     },
   );
 
-  test('unsupported method is rejected', () async {
+  test('POST without the write permission is rejected', () async {
     await linkAccount();
     var upstreamCalled = false;
     await expectLater(
@@ -151,9 +151,49 @@ void main() {
         return http.Response('must not happen', 200);
       }).proxyForPlugin(
         pluginId: 'test.plugin',
+        // read-only permission: not enough for a write
         manifest: manifestWith({PluginPermissions.proxyDecentApi}),
-        path: 'support/api/sn',
-        method: 'DELETE',
+        path: 'support/api/shot_upload',
+        method: 'POST',
+        body: '{}',
+      ),
+      throwsA(isA<StateError>()),
+    );
+    expect(upstreamCalled, isFalse);
+  });
+
+  test('POST to a path outside the write allowlist is rejected', () async {
+    await linkAccount();
+    var upstreamCalled = false;
+    await expectLater(
+      bridge((request) async {
+        upstreamCalled = true;
+        return http.Response('must not happen', 200);
+      }).proxyForPlugin(
+        pluginId: 'test.plugin',
+        manifest: manifestWith({PluginPermissions.proxyDecentApiWrite}),
+        path: 'support/api/some_other_write',
+        method: 'POST',
+        body: '{}',
+      ),
+      throwsA(isA<StateError>()),
+    );
+    expect(upstreamCalled, isFalse);
+  });
+
+  test('PUT (and other non-GET/POST methods) are unsupported', () async {
+    await linkAccount();
+    var upstreamCalled = false;
+    await expectLater(
+      bridge((request) async {
+        upstreamCalled = true;
+        return http.Response('must not happen', 200);
+      }).proxyForPlugin(
+        pluginId: 'test.plugin',
+        manifest: manifestWith({PluginPermissions.proxyDecentApiWrite}),
+        path: 'support/api/shot_upload',
+        method: 'PUT',
+        body: '{}',
       ),
       throwsA(isA<UnsupportedError>()),
     );

--- a/test/plugins/plugin_decent_proxy_bridge_test.dart
+++ b/test/plugins/plugin_decent_proxy_bridge_test.dart
@@ -100,6 +100,66 @@ void main() {
     );
   });
 
+  test(
+    'declared permission forwards POST with body through DecentProxyService',
+    () async {
+      await linkAccount();
+      late http.Request upstream;
+
+      final result =
+          await bridge((request) async {
+            upstream = request;
+            return http.Response(
+              '{"ok":true,"profile_ref":"adaptive_v2@abc"}',
+              200,
+              headers: {'content-type': 'application/json'},
+            );
+          }).proxyForPlugin(
+            pluginId: 'test.plugin',
+            manifest: manifestWith({PluginPermissions.proxyDecentApi}),
+            path: 'support/api/shot_upload',
+            method: 'POST',
+            body: '{"id":"decaid-1","machine":{"serialNumber":"6262"}}',
+            contentType: 'application/json',
+          );
+
+      expect(result['status'], 200);
+      expect(result['body'], contains('profile_ref'));
+      expect(upstream.method, 'POST');
+      expect(
+        upstream.url.toString(),
+        'https://decentespresso.com/support/api/shot_upload',
+      );
+      expect(
+        upstream.body,
+        '{"id":"decaid-1","machine":{"serialNumber":"6262"}}',
+      );
+      expect(upstream.headers['content-type'], contains('application/json'));
+      expect(
+        upstream.headers['authorization'],
+        'Basic ${base64Encode(utf8.encode('user@example.com:cryptpw_abc123'))}',
+      );
+    },
+  );
+
+  test('unsupported method is rejected', () async {
+    await linkAccount();
+    var upstreamCalled = false;
+    await expectLater(
+      bridge((request) async {
+        upstreamCalled = true;
+        return http.Response('must not happen', 200);
+      }).proxyForPlugin(
+        pluginId: 'test.plugin',
+        manifest: manifestWith({PluginPermissions.proxyDecentApi}),
+        path: 'support/api/sn',
+        method: 'DELETE',
+      ),
+      throwsA(isA<UnsupportedError>()),
+    );
+    expect(upstreamCalled, isFalse);
+  });
+
   test('missing permission rejects before upstream is called', () async {
     await linkAccount();
     var upstreamCalled = false;

--- a/test/plugins/plugin_manifest_permissions_test.dart
+++ b/test/plugins/plugin_manifest_permissions_test.dart
@@ -10,7 +10,12 @@ void main() {
       'description': 'Test',
       'version': '1.0.0',
       'apiVersion': 1,
-      'permissions': ['log', 'api', 'proxy.decent_api'],
+      'permissions': [
+        'log',
+        'api',
+        'proxy.decent_api',
+        'proxy.decent_api.write',
+      ],
       'settings': <String, dynamic>{},
       'api': <dynamic>[],
     });
@@ -18,6 +23,10 @@ void main() {
     expect(manifest.permissions, contains(PluginPermissions.log));
     expect(manifest.permissions, contains(PluginPermissions.api));
     expect(manifest.permissions, contains(PluginPermissions.proxyDecentApi));
+    expect(
+      manifest.permissions,
+      contains(PluginPermissions.proxyDecentApiWrite),
+    );
   });
 
   test('serializes permissions using manifest wire values', () {

--- a/test/plugins/shot_upload_plugin_test.dart
+++ b/test/plugins/shot_upload_plugin_test.dart
@@ -91,6 +91,24 @@ PluginManifest _manifest() => PluginManifest.fromJson(
 String _pluginSource() =>
     File('assets/plugins/shot-upload.reaplugin/plugin.js').readAsStringSync();
 
+/// Advance the plugin's async work until [ready] is true (or the deadline
+/// passes). The plugin awaits JS-stubbed `fetch` promises (which resolve via
+/// QuickJS's pending-job queue) and the Dart proxy round-trip (which resolves
+/// via the Dart microtask queue), so a caller that only waits on a Future never
+/// makes progress: this drains QuickJS jobs and yields to the Dart loop each
+/// turn, the way the running app does continuously.
+Future<void> _pumpUntil(
+  PluginManager manager,
+  bool Function() ready, {
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!ready() && DateTime.now().isBefore(deadline)) {
+    while (manager.js.executePendingJob() > 0) {}
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
 void main() {
   /// Manager wired with a linked account + a MockClient that records the upload
   /// request; the plugin's local REST calls (fetch) are stubbed in JS.
@@ -147,12 +165,19 @@ void main() {
         captured: captured,
       );
 
-      final uploaded = expectLater(
-        manager.emitStream,
-        emits(containsPair('event', 'shotUploaded')),
-      );
+      final events = <Map<String, dynamic>>[];
+      final sub = manager.emitStream.listen(events.add);
       manager.dispatchEvent(_manifest().id, 'shotStored', {'id': 'shot-1'});
-      await uploaded.timeout(const Duration(seconds: 5));
+      await _pumpUntil(
+        manager,
+        () => events.any((e) => e['event'] == 'shotUploaded'),
+      );
+      await sub.cancel();
+      expect(
+        events.any((e) => e['event'] == 'shotUploaded'),
+        isTrue,
+        reason: 'shotUploaded not emitted; events=$events',
+      );
 
       expect(captured, hasLength(1));
       final req = captured.single;
@@ -205,10 +230,6 @@ void main() {
       captured: captured,
     );
 
-    final uploaded = expectLater(
-      manager.emitStream,
-      emits(containsPair('event', 'shotUploaded')),
-    );
     manager.dispatchEvent(_manifest().id, 'httpRequest', {
       'requestId': 'req-1',
       'endpoint': 'upload',
@@ -217,22 +238,20 @@ void main() {
       'body': null,
       'query': <String, String>{},
     });
-    await uploaded.timeout(const Duration(seconds: 5));
+
+    Map<String, dynamic>? response;
+    await _pumpUntil(manager, () {
+      response = manager.getPendingHttpResponse('req-1');
+      return response != null;
+    });
 
     expect(captured, hasLength(1));
     expect(
       captured.single.url.toString(),
       'https://decentespresso.com/support/api/shot_upload',
     );
-
-    Map<String, dynamic>? response;
-    for (var i = 0; i < 30 && response == null; i++) {
-      manager.js.executePendingJob();
-      response = manager.getPendingHttpResponse('req-1');
-      await Future<void>.delayed(Duration.zero);
-    }
     expect(response, isNotNull);
     expect(response!['status'], 200);
-    expect(jsonDecode(response['body'] as String)['ok'], true);
+    expect(jsonDecode(response!['body'] as String)['ok'], true);
   });
 }

--- a/test/plugins/shot_upload_plugin_test.dart
+++ b/test/plugins/shot_upload_plugin_test.dart
@@ -1,0 +1,238 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+import 'package:reaprime/src/services/storage/kv_store_service.dart';
+
+class _FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _v = {};
+  @override
+  Future<String?> read({required String key}) async => _v[key];
+  @override
+  Future<void> write({required String key, required String value}) async =>
+      _v[key] = value;
+  @override
+  Future<void> delete({required String key}) async => _v.remove(key);
+}
+
+class _FakeKeyValueStore implements KeyValueStoreService {
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> set({
+    String namespace = 'default',
+    required String key,
+    required Object value,
+  }) async {}
+  @override
+  Future<bool> delete({
+    String namespace = 'default',
+    required String key,
+  }) async => false;
+  @override
+  Future<Object?> get({
+    String namespace = 'default',
+    required String key,
+  }) async => null;
+  @override
+  Future<List<String>> keys({String namespace = 'default'}) async => [];
+  @override
+  List<String> get namespaces => [];
+  @override
+  Future<Map<String, Object>> getAll({String namespace = 'default'}) async =>
+      {};
+}
+
+Map<String, dynamic> _shot(String id) => {
+  'id': id,
+  'timestamp': '2026-01-01T00:00:00Z',
+  'annotations': <String, dynamic>{},
+  'workflow': {
+    'profile': {'title': 'Damian LRv3', 'steps': <dynamic>[]},
+    'context': <String, dynamic>{},
+  },
+  'measurements': [
+    for (final t in const ['2026-01-01T00:00:00Z', '2026-01-01T00:00:30Z'])
+      {
+        'machine': {
+          'timestamp': t,
+          'state': {'state': 'espresso', 'substate': 'pouring'},
+          'pressure': 9,
+          'flow': 2,
+          'targetPressure': 9,
+          'targetFlow': 2,
+          'mixTemperature': 93,
+          'groupTemperature': 92,
+          'targetMixTemperature': 93,
+          'targetGroupTemperature': 93,
+          'profileFrame': 0,
+          'steamTemperature': 0,
+        },
+        'scale': {'weight': 18, 'weightFlow': 2},
+      },
+  ],
+};
+
+PluginManifest _manifest() => PluginManifest.fromJson(
+  jsonDecode(
+        File(
+          'assets/plugins/shot-upload.reaplugin/manifest.json',
+        ).readAsStringSync(),
+      )
+      as Map<String, dynamic>,
+);
+
+String _pluginSource() =>
+    File('assets/plugins/shot-upload.reaplugin/plugin.js').readAsStringSync();
+
+void main() {
+  /// Manager wired with a linked account + a MockClient that records the upload
+  /// request; the plugin's local REST calls (fetch) are stubbed in JS.
+  Future<PluginManager> load({
+    required Map<String, dynamic> settings,
+    required List<http.Request> captured,
+  }) async {
+    final store = _FakeCredentialStore();
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+
+    final manager = PluginManager(
+      kvStore: _FakeKeyValueStore(),
+      decentProxyService: DecentProxyService(
+        credentialStore: store,
+        httpClient: http_testing.MockClient((request) async {
+          captured.add(request);
+          return http.Response(
+            jsonEncode({'ok': true, 'profile_ref': 'damian@1'}),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }),
+      ),
+    );
+    final r = manager.js.evaluate('''
+      globalThis.setTimeout = (cb) => { cb(); return 1; };
+      globalThis.clearTimeout = () => {};
+      globalThis.fetch = async (url) => {
+        if (url.endsWith('/shots/latest')) return { ok:true, json: async () => ({ id:'shot-1' }) };
+        if (url.endsWith('/shots/shot-1')) return { ok:true, json: async () => (${jsonEncode(_shot('shot-1'))}) };
+        if (url.endsWith('/machine/info')) return { ok:true, json: async () => ({ serialNumber:'6262', version:'1293', model:'DE1Pro' }) };
+        if (url.endsWith('/info')) return { ok:true, json: async () => ({ version:'9.9.9' }) };
+        throw new Error('Unexpected URL: ' + url);
+      };
+    ''');
+    expect(r.isError, isFalse, reason: r.stringResult);
+
+    await manager.loadPlugin(
+      id: _manifest().id,
+      manifest: _manifest(),
+      settings: settings,
+      jsCode: _pluginSource(),
+    );
+    return manager;
+  }
+
+  test(
+    'shotStored triggers an authenticated upload with correct provenance',
+    () async {
+      final captured = <http.Request>[];
+      final manager = await load(
+        settings: {'AutoUpload': true, 'LengthThreshold': 0},
+        captured: captured,
+      );
+
+      final uploaded = expectLater(
+        manager.emitStream,
+        emits(containsPair('event', 'shotUploaded')),
+      );
+      manager.dispatchEvent(_manifest().id, 'shotStored', {'id': 'shot-1'});
+      await uploaded.timeout(const Duration(seconds: 5));
+
+      expect(captured, hasLength(1));
+      final req = captured.single;
+      expect(req.method, 'POST');
+      expect(
+        req.url.toString(),
+        'https://decentespresso.com/support/api/shot_upload',
+      );
+      final body = jsonDecode(req.body) as Map<String, dynamic>;
+      expect(body['id'], 'shot-1');
+      expect(body['machine']['serialNumber'], '6262');
+      // firmware from /machine/info `version` (not a bogus firmwareVersion field)
+      expect(body['machine']['firmwareVersion'], '1293');
+      expect(body['machine'].containsKey('bleId'), isFalse);
+      // app version from /api/v1/info, not the hard-coded plugin version
+      expect(body['app']['version'], '9.9.9');
+    },
+  );
+
+  test('does not upload when AutoUpload is off (opt-in default)', () async {
+    final captured = <http.Request>[];
+    final manager = await load(
+      settings: <String, dynamic>{},
+      captured: captured,
+    );
+    manager.dispatchEvent(_manifest().id, 'shotStored', {'id': 'shot-1'});
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(captured, isEmpty);
+  });
+
+  test('storageRead-restored id is not re-uploaded (dedup)', () async {
+    final captured = <http.Request>[];
+    final manager = await load(
+      settings: {'AutoUpload': true, 'LengthThreshold': 0},
+      captured: captured,
+    );
+    manager.dispatchEvent(_manifest().id, 'storageRead', {
+      'key': 'lastUploadedShot',
+      'value': 'shot-1',
+    });
+    manager.dispatchEvent(_manifest().id, 'shotStored', {'id': 'shot-1'});
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(captured, isEmpty);
+  });
+
+  test('upload HTTP endpoint uploads the latest shot and reports ok', () async {
+    final captured = <http.Request>[];
+    final manager = await load(
+      settings: {'AutoUpload': false, 'LengthThreshold': 0},
+      captured: captured,
+    );
+
+    final uploaded = expectLater(
+      manager.emitStream,
+      emits(containsPair('event', 'shotUploaded')),
+    );
+    manager.dispatchEvent(_manifest().id, 'httpRequest', {
+      'requestId': 'req-1',
+      'endpoint': 'upload',
+      'method': 'POST',
+      'headers': <String, String>{},
+      'body': null,
+      'query': <String, String>{},
+    });
+    await uploaded.timeout(const Duration(seconds: 5));
+
+    expect(captured, hasLength(1));
+    expect(
+      captured.single.url.toString(),
+      'https://decentespresso.com/support/api/shot_upload',
+    );
+
+    Map<String, dynamic>? response;
+    for (var i = 0; i < 30 && response == null; i++) {
+      manager.js.executePendingJob();
+      response = manager.getPendingHttpResponse('req-1');
+      await Future<void>.delayed(Duration.zero);
+    }
+    expect(response, isNotNull);
+    expect(response!['status'], 200);
+    expect(jsonDecode(response['body'] as String)['ok'], true);
+  });
+}


### PR DESCRIPTION
## Summary

- **Problem:** Decaid has no way to upload finished shots to the user's decentespresso.com account for cloud shot history and charts.
- **Why it matters:** lets users see their shot history and visualizations on the Decent website, gated to machines they own.
- **What changed:** a new bundled JS plugin `shot-upload.reaplugin` that, on shot completion, injects the connected machine's serial number (not carried in the shot JSON) and POSTs the shot to `support/api/shot_upload` through the **authenticated Decent proxy**, reusing the user's existing Decent login. To enable that, the plugin Decent-proxy bridge now allows `POST`/`PUT` with a body (it was `GET`-only); credentials are still never exposed to plugin JS and the `support/api/` allowlist is unchanged. Adds two `--dart-define` dev overrides (`DECENT_BASE_URL`, `MOCK_DE1_SERIAL`) to make local-server testing possible.
- **What did NOT change (scope boundary):** no Drift/schema changes; account credentials remain hidden from plugin JS; the Decent-proxy path allowlist (`support/api/`) is unchanged; existing GET proxy behavior is unchanged.

## Change Type (select all)

- [x] Feature
- [x] Docs
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [x] Plugins / JS runtime
- [x] Docs / specs

## Linked Issues

- Closes # N/A
- Related # N/A

## Root Cause (if bug fix)

- N/A (feature)

## Regression Test Plan (if bug fix or refactor)

- N/A (feature). New unit coverage added — see below.

## Documentation Obligations (required)

- [x] Plugin docs updated: `doc/Plugins.md` (documents that `host.decentProxy` now supports POST/PUT with a body)
- [x] N/A — no REST/WebSocket/Skins/Profiles/Device spec changes (the change is to the plugin-JS proxy bridge, not a new REST route)

## Security Impact (required)

- New or changed REST endpoints? **No**
- New or changed WebSocket topics? **No**
- New or changed network calls? **Yes** — a permitted plugin can now `POST`/`PUT` (previously `GET` only) through the Decent account proxy.
- BLE/USB surface changed? **No**
- File system access changed? **No**
- Plugin sandbox boundary changed? **Yes** — the plugin Decent-proxy bridge now permits writes.

**Risk & mitigation:** writes remain gated by the `proxy.decent_api` permission, restricted to the existing `support/api/` allowlist, and the account credentials are never handed to plugin JS (the Dart proxy attaches Basic auth and relays only status/headers/body). Server-side authentication + machine-ownership checks still apply to every upload.

## User-Visible Changes

- New opt-in bundled plugin **"Decent shot upload"**. When enabled (and the user is logged into their Decent account), finished shots are uploaded automatically to the user's account. Settings: `AutoUpload` (default on) and `LengthThreshold` (skip flushes; default 5s). No credentials to enter — it reuses the existing Decent login.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass
- [ ] `(cd packages/dye2-plugin && npm run build)` — N/A (dye2 not touched)

### Manual verification

- OS / platform tested: macOS (debug build)
- Simulated devices? (`simulate=1`): **Yes**
- Real hardware? (DE1/Bengle/scale): **No**
- What was verified and how: full live end-to-end in the running app — logged into a Decent account, pulled a shot on the simulated DE1, and confirmed the `shot-upload` plugin fetched the shot, injected the machine serial, and uploaded it through `host.decentProxy` to a local Decent server (`--dart-define=DECENT_BASE_URL=http://localhost:8000`, `--dart-define=MOCK_DE1_SERIAL=6262`). The server authenticated the account, verified machine ownership, stored the shot, and the shot rehydrated correctly on read.
- What was NOT verified: real hardware; production server (tested against a local Decent server).

### Evidence

- New unit test `test/plugins/plugin_decent_proxy_bridge_test.dart`: "declared permission forwards POST with body through DecentProxyService" asserts a permitted plugin's POST is forwarded upstream as a POST carrying the exact body + `application/json` + the account Basic auth; plus "unsupported method is rejected". Existing GET/permission/credential-isolation tests still pass (8/8 in the proxy suites).
- Live: decaid shot `de6ae026-…` uploaded → stored server-side with `profile_ref` and rehydrated with the full profile (Damian's LRv3, 119 measurements, serial 6262).

## Compatibility & Migration

- Backward compatible? **Yes**
- Config / env changes needed? **No** (the new `--dart-define`s default to production / the previous mock serial)
- Database migration needed? **No**

## Risks & Mitigations

- Risk: broadening the plugin proxy from GET-only to GET/POST/PUT enlarges what a permitted plugin can do with the account.
  - Mitigation: unchanged `proxy.decent_api` permission gate + `support/api/` allowlist + credentials never exposed to JS + server-side auth/ownership enforcement.
