### PR TITLE
ci: install DYE2 plugin from allofmeng/dye2 release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -95,7 +95,7 @@ List user-visible changes (including defaults, config, behavior). If none, write
 - [ ] `dart format lib test` — no remaining changes
 - [ ] `flutter analyze` — clean (no new warnings)
 - [ ] `flutter test` — all pass
-- [ ] `(cd packages/dye2-plugin && npm run build)` — plugin builds
+- [ ] `./scripts/fetch_dye2_plugin.sh` — DYE2 plugin installed into `assets/plugins/dye2.reaplugin/`
 
 ### Manual verification (if applicable)
 

--- a/.github/workflows/develop-builds.yml
+++ b/.github/workflows/develop-builds.yml
@@ -72,16 +72,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Android APK
         run: ./flutter_with_commit.sh build apk --release
@@ -128,16 +123,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ---- Import signing certificate ----
       - name: Import signing certificate
@@ -273,16 +263,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Linux app (unsigned)
         run: ./flutter_with_commit.sh build linux --release
@@ -335,16 +320,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Linux app (ARM64)
         run: ./flutter_with_commit.sh build linux --release
@@ -393,16 +373,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build IPA
         run: ./flutter_with_commit.sh build ipa --release --dart-define=APP_STORE=true --no-codesign
@@ -465,16 +440,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Windows app (unsigned)
         shell: bash

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,13 +46,6 @@ jobs:
           cache: true
           pub-cache: true
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: packages/dye2-plugin/package-lock.json
-
       - name: Flutter pub get
         run: flutter pub get
 
@@ -61,11 +54,11 @@ jobs:
       # so populate them before any flutter command that touches assets
       # (analyze emits asset_directory_does_not_exist; test loads the
       # bundled_skins manifest at runtime).
-      - name: Build DYE2 plugin
-        working-directory: packages/dye2-plugin
-        run: |
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Tests only assert manifest shape (non-empty list of string IDs) and
       # `flutter analyze` only needs the asset dir to exist. Skip the real
@@ -116,21 +109,14 @@ jobs:
           cache: true
           pub-cache: true
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: packages/dye2-plugin/package-lock.json
-
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Build DYE2 plugin
-        working-directory: packages/dye2-plugin
-        run: |
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Linux app (unsigned)
         run: flutter build linux --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,16 +57,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Android APK
         run: ./flutter_with_commit.sh build apk --release
@@ -113,16 +108,11 @@ jobs:
           flutter pub get
           brew install automake libtool
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install FlutterFire CLI
         run: dart pub global activate flutterfire_cli
@@ -260,16 +250,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Linux app (unsigned)
         run: ./flutter_with_commit.sh build linux --release
@@ -322,16 +307,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Linux app (ARM64)
         run: ./flutter_with_commit.sh build linux --release
@@ -382,16 +362,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Windows app (unsigned)
         shell: bash
@@ -448,16 +423,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Build DYE2 plugin
-        run: |
-          cd packages/dye2-plugin
-          npm ci
-          npm run build
+      - name: Fetch DYE2 plugin
+        shell: bash
+        run: ./scripts/fetch_dye2_plugin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build IPA
         run: ./flutter_with_commit.sh build ipa --release --dart-define=APP_STORE=true --no-codesign

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,11 @@ Thanks for contributing. This guide tells you what's required to land a PR — i
 
 ## Local Setup
 
-Requirements: Flutter (stable), the [GitHub CLI](https://cli.github.com) (`gh`, authenticated — used to fetch the DYE2 bundled plugin).
+Requirements: Flutter (stable), the [GitHub CLI](https://cli.github.com) (`gh`, authenticated — used to fetch the DYE2 bundled plugin), `jq` (validates the fetched plugin's manifest).
 
 ```bash
 flutter pub get
-./scripts/fetch_dye2_plugin.sh   # installs assets/plugins/dye2.reaplugin/ from the latest allofmeng/dye2 release
+./scripts/fetch_dye2_plugin.sh   # installs assets/plugins/dye2.reaplugin/ from the pinned allofmeng/dye2 release (scripts/fetch_dye2_plugin.sh)
 
 # Run with simulated hardware (no DE1 / scale required):
 flutter run --dart-define=simulate=1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,11 @@ Thanks for contributing. This guide tells you what's required to land a PR — i
 
 ## Local Setup
 
-Requirements: Flutter (stable), Node.js 20+ (for the DYE2 bundled plugin).
+Requirements: Flutter (stable), the [GitHub CLI](https://cli.github.com) (`gh`, authenticated — used to fetch the DYE2 bundled plugin).
 
 ```bash
 flutter pub get
-(cd packages/dye2-plugin && npm ci && npm run build)
+./scripts/fetch_dye2_plugin.sh   # installs assets/plugins/dye2.reaplugin/ from the latest allofmeng/dye2 release
 
 # Run with simulated hardware (no DE1 / scale required):
 flutter run --dart-define=simulate=1
@@ -80,7 +80,7 @@ Run these before pushing. Same checks that CI runs:
 ```bash
 flutter analyze                          # must be clean — no new warnings
 flutter test                             # all must pass
-(cd packages/dye2-plugin && npm run build)  # plugin must build
+./scripts/fetch_dye2_plugin.sh           # assets/plugins/dye2.reaplugin/ must exist
 ```
 
 `dart format` is currently **advisory** in CI — the codebase predates the Dart 3.7 "tall style" formatter. Format your own changes (`dart format lib test`) but don't reformat untouched files in the same PR.

--- a/doc/AI_REPO_MAP.md
+++ b/doc/AI_REPO_MAP.md
@@ -33,7 +33,7 @@ When you change X, also check Y and Z.
 | Profile/workflow serialization | `Workflow.fromJson()`, `ProfileDao`, `ProfileStorageService`, legacy field backfill, spec | Dual representation (`context` + legacy fields); both must stay in sync |
 | `ConnectionManager` | 7 collaborators (`DisconnectExpectations`, `StatusPublisher`, `ScanReportBuilder`, `DisconnectSupervisor`, `EarlyConnectWatcher`, `ScanOrchestrator`, `PolicyResolver`) | Delegate to the right collaborator rather than growing the manager |
 | `De1StateManager` | `ShotSequencer`, `SteamSequencer`, `ScaleController` (sleep/wake), `ConnectionManager` (reconnect) | Machine state transitions cascade to shot lifecycle, scale power, and reconnect logic |
-| Plugin API or permissions | `PluginManager`, `PluginHost`, `dye2-plugin`, `doc/Plugins.md`, bundled plugin assets | Plugin host + bundled plugin must stay compatible |
+| Plugin API or permissions | `PluginManager`, `PluginHost`, [allofmeng/dye2](https://github.com/allofmeng/dye2), `doc/Plugins.md`, bundled plugin assets | Plugin host + bundled plugin must stay compatible |
 | WebUI / skin serving | `lib/src/webui_support/`, `lib/src/services/webserver/webui/`, `doc/Skins.md` | Skin install, serving, and metadata are coupled |
 | Device discovery | `DeviceMatcher`, `BleServiceIdentifier`, `ScanStateGuardian`, `ScanOrchestrator`, `doc/DeviceManagement.md` | Name matching, service verification, and scan lifecycle are interdependent |
 | `BatteryController` / charging | `charging_logic.dart`, `De1Controller`, DE1 FW behavior (auto-re-enables charger) | Charger mode logic depends on DE1 FW quirks |
@@ -56,4 +56,4 @@ API smoke test: `scripts/sb-dev.sh start` then `curl` / `websocat` per `.agents/
 - `test/` test files — read only the ones relevant to the change.
 - `assets/` assets unrelated to API specs.
 - `ios/`, `android/`, `macos/`, `linux/`, `windows/` — platform-native project files. Only touch when adding platform capabilities.
-- `packages/dye2-plugin/` — bundled plugin; read only when changing plugin system or the DYE2 plugin itself.
+- `packages/dye2-plugin/` — DYE2 plugin source, **not built or bundled by Decaid**. The bundled copy is pinned and fetched from [allofmeng/dye2](https://github.com/allofmeng/dye2) releases via `scripts/fetch_dye2_plugin.sh` (see `doc/Plugins.md`). Do DYE2 compatibility work against that repo, not this in-tree copy.

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -412,16 +412,9 @@ it in Decaid UI.
 
 ## Reference Implementation: DYE2 Plugin
 
-The DYE2 (Describe Your Espresso) plugin in `packages/dye2-plugin/` is a production bundled plugin that demonstrates advanced patterns:
+The DYE2 (Describe Your Espresso) plugin ships from its own repo, [allofmeng/dye2](https://github.com/allofmeng/dye2), as a release asset. CI and local setup install it by running `./scripts/fetch_dye2_plugin.sh`, which downloads a pinned release tag (`DYE2_VERSION` in the script), verifies its checksum (`DYE2_SHA256`) and manifest contract (`id`, `version`, `apiVersion`), and unpacks it into `assets/plugins/dye2.reaplugin/`. Bump the pinned version/checksum in a normal PR when DYE2 ships a new release.
 
-- **TypeScript + Vite build pipeline** — compiles to flutter_js-compatible IIFE bundle
-- **REST API client** — calls back into the Decaid REST API for bean/grinder CRUD
-- **HTML template rendering** — server-side HTML generation with form handling
-- **Dev server** — Vite dev server for fast iteration without rebuilding the Flutter app
-
-See `packages/dye2-plugin/README.md` for architecture details, build instructions, and extension guide.
-
-The bundled copy is no longer built from `packages/dye2-plugin/`: CI and local setup install it from the latest [allofmeng/dye2](https://github.com/allofmeng/dye2) release via `./scripts/fetch_dye2_plugin.sh`, which unpacks the release asset into `assets/plugins/dye2.reaplugin/`. Pin a specific release with `DYE2_VERSION=v0.1.4`.
+`packages/dye2-plugin/` still holds the plugin's original TypeScript + Vite source and is useful as a reference for advanced patterns (REST API client, HTML template rendering, Vite dev server — see `packages/dye2-plugin/README.md`), but it is **not** built or bundled by Decaid anymore and is not authoritative for what ships. Treat [allofmeng/dye2](https://github.com/allofmeng/dye2) as the source of truth for the DYE2 plugin; update `packages/dye2-plugin/` only if it's being kept in sync deliberately.
 
 ## Plugin Lifecycle Management (REST API)
 
@@ -441,7 +434,7 @@ The bundled **settings plugin** (`settings.reaplugin`) provides a web UI for plu
 
 ## Next Steps
 
-1. Review the example plugins in `assets/plugins/` and the DYE2 plugin in `packages/dye2-plugin/`
+1. Review the example plugins in `assets/plugins/` and the DYE2 plugin at [allofmeng/dye2](https://github.com/allofmeng/dye2)
 2. Start with a simple plugin that logs `stateUpdate` events
 3. Add settings and persistent storage
 4. Implement HTTP communication with external services

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -421,6 +421,8 @@ The DYE2 (Describe Your Espresso) plugin in `packages/dye2-plugin/` is a product
 
 See `packages/dye2-plugin/README.md` for architecture details, build instructions, and extension guide.
 
+The bundled copy is no longer built from `packages/dye2-plugin/`: CI and local setup install it from the latest [allofmeng/dye2](https://github.com/allofmeng/dye2) release via `./scripts/fetch_dye2_plugin.sh`, which unpacks the release asset into `assets/plugins/dye2.reaplugin/`. Pin a specific release with `DYE2_VERSION=v0.1.4`.
+
 ## Plugin Lifecycle Management (REST API)
 
 Plugins can be managed via REST API:

--- a/scripts/fetch_dye2_plugin.sh
+++ b/scripts/fetch_dye2_plugin.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install the DYE2 plugin from its release repo into assets/plugins/dye2.reaplugin/.
+#
+# Usage:
+#   fetch_dye2_plugin.sh
+#
+# Environment:
+#   DYE2_REPO     Release repo (default allofmeng/dye2).
+#   DYE2_VERSION  Release tag, e.g. v0.1.4 (default: latest release).
+#   GH_TOKEN      GitHub token for `gh` (set to secrets.GITHUB_TOKEN in CI).
+#
+# The plugin used to be built from packages/dye2-plugin; it now ships as a
+# release asset (dye2.reaplugin-<tag>.zip) containing the dye2.reaplugin/
+# folder that pubspec.yaml declares as an asset directory.
+set -euo pipefail
+
+repo="${DYE2_REPO:-allofmeng/dye2}"
+version="${DYE2_VERSION:-}"
+plugins_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/assets/plugins"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+gh release download ${version:+"$version"} \
+  --repo "$repo" --pattern 'dye2.reaplugin-*.zip' --dir "$tmp"
+
+zip="$(ls "$tmp"/*.zip 2>/dev/null | head -n 1)"
+if [ -z "$zip" ]; then
+  echo "fetch_dye2_plugin: no dye2.reaplugin-*.zip asset in $repo ${version:-latest}" >&2
+  exit 1
+fi
+
+mkdir -p "$plugins_dir"
+rm -rf "$plugins_dir/dye2.reaplugin"
+# ponytail: unzip on ubuntu/macos, bsdtar on windows runners (no unzip there).
+if command -v unzip >/dev/null 2>&1; then
+  unzip -q "$zip" -d "$plugins_dir"
+else
+  tar -xf "$zip" -C "$plugins_dir"
+fi
+
+for f in manifest.json plugin.js; do
+  if [ ! -s "$plugins_dir/dye2.reaplugin/$f" ]; then
+    echo "fetch_dye2_plugin: $(basename "$zip") is missing dye2.reaplugin/$f" >&2
+    exit 1
+  fi
+done
+
+echo "fetch_dye2_plugin: installed $(basename "$zip") -> $plugins_dir/dye2.reaplugin"

--- a/scripts/fetch_dye2_plugin.sh
+++ b/scripts/fetch_dye2_plugin.sh
@@ -5,28 +5,52 @@
 #   fetch_dye2_plugin.sh
 #
 # Environment:
-#   DYE2_REPO     Release repo (default allofmeng/dye2).
-#   DYE2_VERSION  Release tag, e.g. v0.1.4 (default: latest release).
-#   GH_TOKEN      GitHub token for `gh` (set to secrets.GITHUB_TOKEN in CI).
+#   DYE2_REPO        Release repo (default allofmeng/dye2).
+#   DYE2_VERSION     Release tag to install (default: pinned version below).
+#   DYE2_SHA256      Expected sha256 of the release zip (default: pinned checksum below).
+#   DYE2_API_VERSION Expected manifest.json apiVersion (default: pinned value below).
+#   GH_TOKEN         GitHub token for `gh` (set to secrets.GITHUB_TOKEN in CI).
 #
 # The plugin used to be built from packages/dye2-plugin; it now ships as a
 # release asset (dye2.reaplugin-<tag>.zip) containing the dye2.reaplugin/
 # folder that pubspec.yaml declares as an asset directory.
+#
+# The version/checksum are pinned rather than defaulting to "latest" so a
+# given Decaid commit always bundles the same, reviewed DYE2 build. Bump
+# them together in a normal PR when DYE2 ships a new release.
 set -euo pipefail
 
+pinned_version="v0.1.4"
+pinned_sha256="fd8e43afa7d953c48ad23ca74aa76cb5314fde5602d07149f954e8e3497b81a6"
+pinned_api_version="1"
+
 repo="${DYE2_REPO:-allofmeng/dye2}"
-version="${DYE2_VERSION:-}"
+version="${DYE2_VERSION:-$pinned_version}"
+expected_sha256="${DYE2_SHA256:-$pinned_sha256}"
+expected_api_version="${DYE2_API_VERSION:-$pinned_api_version}"
 plugins_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/assets/plugins"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-gh release download ${version:+"$version"} \
+gh release download "$version" \
   --repo "$repo" --pattern 'dye2.reaplugin-*.zip' --dir "$tmp"
 
 zip="$(ls "$tmp"/*.zip 2>/dev/null | head -n 1)"
 if [ -z "$zip" ]; then
-  echo "fetch_dye2_plugin: no dye2.reaplugin-*.zip asset in $repo ${version:-latest}" >&2
+  echo "fetch_dye2_plugin: no dye2.reaplugin-*.zip asset in $repo $version" >&2
+  exit 1
+fi
+
+if command -v shasum >/dev/null 2>&1; then
+  actual_sha256="$(shasum -a 256 "$zip" | cut -d ' ' -f 1)"
+else
+  actual_sha256="$(sha256sum "$zip" | cut -d ' ' -f 1)"
+fi
+if [ "$actual_sha256" != "$expected_sha256" ]; then
+  echo "fetch_dye2_plugin: checksum mismatch for $(basename "$zip")" >&2
+  echo "  expected: $expected_sha256" >&2
+  echo "  actual:   $actual_sha256" >&2
   exit 1
 fi
 
@@ -39,11 +63,38 @@ else
   tar -xf "$zip" -C "$plugins_dir"
 fi
 
-for f in manifest.json plugin.js; do
-  if [ ! -s "$plugins_dir/dye2.reaplugin/$f" ]; then
-    echo "fetch_dye2_plugin: $(basename "$zip") is missing dye2.reaplugin/$f" >&2
+manifest="$plugins_dir/dye2.reaplugin/manifest.json"
+plugin_js="$plugins_dir/dye2.reaplugin/plugin.js"
+
+for f in "$manifest" "$plugin_js"; do
+  if [ ! -s "$f" ]; then
+    echo "fetch_dye2_plugin: $(basename "$zip") is missing $(basename "$f")" >&2
     exit 1
   fi
 done
+
+manifest_id="$(jq -r '.id' "$manifest")"
+if [ "$manifest_id" != "dye2.reaplugin" ]; then
+  echo "fetch_dye2_plugin: manifest.json id is '$manifest_id', expected 'dye2.reaplugin'" >&2
+  exit 1
+fi
+
+manifest_version="$(jq -r '.version' "$manifest")"
+expected_manifest_version="${version#v}"
+if [ "$manifest_version" != "$expected_manifest_version" ]; then
+  echo "fetch_dye2_plugin: manifest.json version is '$manifest_version', expected '$expected_manifest_version'" >&2
+  exit 1
+fi
+
+manifest_api_version="$(jq -r '.apiVersion' "$manifest")"
+if [ "$manifest_api_version" != "$expected_api_version" ]; then
+  echo "fetch_dye2_plugin: manifest.json apiVersion is '$manifest_api_version', expected '$expected_api_version'" >&2
+  exit 1
+fi
+
+if ! grep -q 'createPlugin' "$plugin_js"; then
+  echo "fetch_dye2_plugin: plugin.js has no 'createPlugin' entry point" >&2
+  exit 1
+fi
 
 echo "fetch_dye2_plugin: installed $(basename "$zip") -> $plugins_dir/dye2.reaplugin"


### PR DESCRIPTION
## Summary

- Problem: every CI job built the bundled DYE2 plugin from `packages/dye2-plugin` with `npm ci && npm run build`, but DYE2 now lives in its own repo (`allofmeng/dye2`) and ships as a release asset. CI was building a stale in-tree copy.
- Why it matters: builds bundled an out-of-date plugin (in-tree manifest is `0.1.0`, latest release is `0.1.4`), and every job carried a Node toolchain plus an `npm ci` only for that build.
- What changed: new `scripts/fetch_dye2_plugin.sh` downloads a repository-pinned DYE2 release (`v0.1.4`), verifies the ZIP against its pinned SHA-256, validates the manifest contract (`id`, `version`, `apiVersion`) and `createPlugin` entry point, then unpacks it into `assets/plugins/dye2.reaplugin/` — the asset directory `pubspec.yaml` already declares. All 12 build steps across `pr-checks.yml`, `develop-builds.yml`, and `release.yml` call it; the 12 `actions/setup-node` steps are removed (Node was used for nothing else). DYE2 updates now require a reviewed pin/checksum bump in Decaid.
- What did NOT change (scope boundary): `packages/dye2-plugin/` is left in place as a non-authoritative historical/reference copy (deleting it is a separate call). No Dart, app, runtime API, or release-artifact layout changes. Automatic plugin management and updates, similar to skins, remain future work.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore / infra
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [x] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #
- Related #

## Root Cause (if bug fix)

N/A

## Regression Test Plan (if bug fix or refactor)

N/A — infra change. The script fails closed if the pinned release asset is missing, its SHA-256 does not match, either required file is empty/missing, the manifest ID/version/API version differs from the pinned contract, or `plugin.js` lacks the expected `createPlugin` entry point. `flutter analyze` also fails loudly (`asset_directory_does_not_exist`) if the plugin folder never landed.

## Documentation Obligations (required)

- [ ] API spec updated
- [ ] API docs updated: `doc/Api.md`
- [x] Plugin docs updated: `doc/Plugins.md` (documents the external source of truth, pinned release/checksum, and non-authoritative in-tree copy)
- [ ] Skin docs updated: `doc/Skins.md`
- [ ] Profile docs updated: `doc/Profiles.md`
- [ ] Device docs updated: `doc/DeviceManagement.md`

Also updated: `CONTRIBUTING.md` local setup + local gates, `.github/pull_request_template.md` gate.

## Security Impact (required)

- New or changed REST endpoints? `No`
- New or changed WebSocket topics? `No`
- New or changed network calls? `Yes` — build-time only: `gh release download` against the public `allofmeng/dye2` repo, authenticated in CI with the job's `secrets.GITHUB_TOKEN` (workflows keep `permissions: contents: read`). No runtime network change.
- BLE/USB surface changed? `No`
- File system access changed? `No` — the script only writes `assets/plugins/dye2.reaplugin/`.
- Plugin sandbox boundary changed? `No`

Risk worth naming: the bundled plugin's provenance moves from in-tree source to a release artifact of another repo. Mitigation: Decaid pins the DYE2 tag, SHA-256, and expected API version in source control; the script verifies integrity and the consumer contract before the build proceeds. Future runtime plugin auto-updates are intentionally out of scope for this PR.

## User-Visible Changes

Builds now bundle DYE2 `0.1.4` instead of the in-tree `0.1.0` copy.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no Dart touched, no changes
- [x] `flutter analyze` — clean; the only warning is the pre-existing `assets/bundled_skins/` one (build output, not produced locally). The `dye2.reaplugin` asset warning is gone, confirming the fetch populated the dir.
- [x] `flutter test` — 2771 passing, 5 failing, all pre-existing and unrelated (see Evidence)
- [x] `./scripts/fetch_dye2_plugin.sh` — DYE2 plugin installed into `assets/plugins/dye2.reaplugin/`

Current PR CI at head `76a76cd`: format, analyze/tests, Linux build smoke, and Python tools all pass; both DYE2 fetch steps completed with the pinned checksum and contract validation.

### Manual verification (if applicable)

- OS / platform tested: macOS (darwin 25.5.0)
- Simulated devices? `No`
- Real hardware? `No`
- What you personally verified and how:
  - Ran `./scripts/fetch_dye2_plugin.sh`: downloaded `dye2.reaplugin-v0.1.4.zip`, unpacked `manifest.json` (`"version": "0.1.4"`) + `plugin.js` (1.4 MB) into `assets/plugins/dye2.reaplugin/`.
  - `flutter analyze` clean afterwards.
  - Parsed all three workflow files with PyYAML — valid, job counts unchanged (6 / 4 / 8).
  - `bash -n scripts/fetch_dye2_plugin.sh` — syntax OK.
- Edge cases checked: the extract falls back to `tar -xf` (bsdtar) where `unzip` is absent, which is the Windows runner case; every step uses `shell: bash` so `windows-2022` runs it under Git Bash.
- What you did **not** verify: the full develop/release matrices have not run yet. PR CI exercises the fetch, checksum/contract validation, analyze/tests, and Linux build on Ubuntu; macOS and Windows will exercise the same script on their next develop/release runs.

### Evidence

```
$ ./scripts/fetch_dye2_plugin.sh
fetch_dye2_plugin: installed dye2.reaplugin-v0.1.4.zip -> .../assets/plugins/dye2.reaplugin

$ flutter analyze
warning • The asset directory 'assets/bundled_skins/' doesn't exist ... • pubspec.yaml:183:7
1 issue found. (ran in 12.1s)

$ flutter test
03:52 +2776 -5: Some tests failed.
Failing tests:
  test/webui_storage_bundled_test.dart: bundled_skins manifest manifest.json can be loaded and contains skin IDs
  test/webui_support/webui_token_injection_test.dart: serveFolderAtPath offline falls back to localhost when getWifiIP returns empty string
  test/webui_support/webui_token_injection_test.dart: serveFolderAtPath offline falls back to localhost when getWifiIP returns null
  test/webui_support/webui_token_injection_test.dart: serveFolderAtPath offline falls back to localhost when getWifiIP throws (gh#337)
  test/webui_support/webui_token_injection_test.dart: serveFolderAtPath offline protects the skin API across origins
```

The 5 failures are local-environment gaps unrelated to this change (no Dart code touched): the bundled-skins test needs `assets/bundled_skins/`, which CI stubs or builds and this machine does not have, and the webui token tests exercise offline/network fallbacks.

## Compatibility & Migration

- Backward compatible? `Yes` for the app; `No` for the local dev setup.
- Config / env changes needed? `Yes` — contributors now need authenticated `gh` plus `jq` instead of Node 20+. GitHub's current hosted Ubuntu, macOS, and Windows images include `jq`; self-hosted runners must provide it. `CONTRIBUTING.md` updated.
- Database migration needed? `No`

## Risks & Mitigations

- Risk: CI now depends on the pinned `allofmeng/dye2` release asset being reachable; an unavailable asset breaks every build.
  - Mitigation: the script fails fast, verifies the pinned SHA-256 and manifest contract, and never falls forward to `latest`. Updating DYE2 requires a reviewed version/checksum change.
- Risk: `packages/dye2-plugin/` can drift further from the released plugin.
  - Mitigation: `doc/Plugins.md` and `doc/AI_REPO_MAP.md` now mark it non-authoritative and route DYE2 work to `allofmeng/dye2`; deletion can remain a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
