### PR TITLE
README: iPad Full support with SideStep one-click install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The API provides:
 | **macOS** | ✅ Full support | Desktop development and testing |
 | **Linux** | ✅ Full support | ARM64 and x86_64 |
 | **Windows** | ✅ Full support | Desktop operation |
-| **iOS** | ⚠️ Experimental | Limited testing |
+| **iPad** | ✅ Full support | [Install to your iPad now with SideStep](https://decentespresso.com/downloads) |
 
 ### Background Operation
 


### PR DESCRIPTION
Changes the platform table row:

- **Before:** \`| **iOS** | ⚠️ Experimental | Limited testing |\`
- **After:** \`| **iPad** | ✅ Full support | [Install to your iPad now with SideStep](https://decentespresso.com/downloads) |\`

**Why a link instead of the button itself:** GitHub sanitizes README HTML — I verified with GitHub's `/markdown` API that it strips `<script>` and removes `sidestep://` links, so the interactive one-click button can't run in a README. The row links to https://decentespresso.com/downloads, which hosts the working button.

**Note (not changed here):** two other spots still reference iOS as experimental — the cross-platform list near the top and "iOS: 15.0 or later (experimental)" in requirements. Happy to update those too if you want them aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)