### PR TITLE
plugin-host: own, bound, and cancel plugin timers and pending async requests (#561)

### DIFF
--- a/doc/plans/archive/gh561-async-ownership/gh561-async-ownership.md
+++ b/doc/plans/archive/gh561-async-ownership/gh561-async-ownership.md
@@ -1,0 +1,110 @@
+# GH-561: Plugin timers and pending async request ownership
+
+Implemented on branch `feat/gh561-plugin-async-ownership` against commit
+`25d24276`. Companion issue #562 owns the top-level `PluginManager` /
+`PluginLoaderService` disposal and must call `cancelAllOperations()`.
+
+## Decisions
+
+### host.httpRequest() removed, not implemented
+
+The per-plugin `host.httpRequest()` API was a never-completed duplicate of
+`fetch()`: added in a WIP commit (`7dcadbf8`) five days after fetch
+(`eb4017b7`), JS registered a resolver Dart never answered, so every call
+returned a permanently pending promise. Zero bundled plugins or dye2 code
+ever used it. Removing it (the issue allows removal) also removes
+`__registerHttpRequest`, `__pendingHttpRequests`, and `__sendHttpResponse`
+(dead). `fetch()` is the supported outbound-HTTP API and is documented in
+doc/Plugins.md.
+
+### Ownership boundary: JS closures, Dart timers
+
+Timers and fetch are shadowed inside the per-plugin load wrapper with the
+pluginId + generation bound in closure, calling `globalThis.__timerSet` /
+`__fetchFor`. JS keeps only callback maps (so callbacks stay callable);
+Dart owns the real `Timer` / `HttpClient` objects. This gives per-plugin
+ownership without a global "current plugin" state, and it lets tests stub
+the seam (`__timerSet`, `__fetchFor`) exactly like they used to stub
+`globalThis.setTimeout` / `fetch`.
+
+Test seam note: visualizer/shot-upload tests stubbed `globalThis.setTimeout`
+and `globalThis.fetch` to run synchronously; those stubs were retargeted to
+`__timerSet` / `__fetchFor`. Plugin-visible behavior is unchanged.
+
+### Unified pending-op registry with one terminal path
+
+`_pendingOps` (key `kind:requestId`) holds one `_PendingOp` per in-flight
+operation: kind, pluginId, generation, requestId, timeout timer, and an
+optional Completer (plugin HTTP) or HttpClientRequest (fetch abort). Every
+terminal path (success, error, timeout, unload, dispose) funnels through
+`_completeOp()`, which cancels the timeout and removes the entry BEFORE
+settling, so late or duplicate completions are no-ops.
+
+### Late-response protection is removal-based, not generation-checked
+
+Unload and reload reject all of the old plugin's ops and delete their JS
+pending entries; fetch ids (`__fetchFor` counter) and Decent proxy request
+ids (per-runtime nonce) are globally unique, so a late response from an old
+generation can never match a new generation's request. Generation is
+recorded in the op for diagnostics. Timers need no generation: there is no
+async gap between the JS `setTimeout` call and the `timerSet` message, and
+ids are globally unique.
+
+### Timeout/size bounds
+
+- Shared `HttpClient` (one per manager, closed in `cancelAllOperations`)
+  with a 10s connection timeout; fetch ops add a total-operation timer
+  (`fetchTimeout`, default 30s) and a response-size cap
+  (`maxFetchResponseBytes`, default 10 MiB).
+- Plugin HTTP ops: `pluginHttpTimeout` (default 30s, replaces the hardcoded
+  30s poll window).
+- Decent proxy ops: `decentProxyTimeout` (default 30s).
+- Invalid UTF-8 fetch bodies decode with `allowMalformed: true` (defined
+  behavior, never throws).
+
+### Incoming plugin HTTP: Completer instead of polling
+
+`plugins_handler.dart` registered nothing; it polled
+`_pendingHttpResponses` every 100ms for 30s. Now `registerPendingHttp()`
+registers the op before `dispatchEvent()`, and the handler awaits the
+Completer. The 100ms periodic timer is gone; late/unknown responses are
+ignored in `_handlePluginApiResponse` (op absent).
+
+### Fire-and-forget callbacks
+
+`host` and `fetch` `onMessage` handlers are now sync. Async work
+(storage, Decent proxy, fetch) launches via `unawaited(...)` through
+`_handleMessageSafely` / `_handleFetchSafely`, so fire-and-forget messages
+no longer hand a Dart `Future` to the bridge's promise machinery. Only the
+explicit Decent proxy promise (and fetch/plugin-HTTP promises) are awaited
+in JS.
+
+### Diagnostics
+
+`activeTimerCount` / `activeTimersByPlugin` and `activePendingOpCount` /
+`activePendingOpsByType` back the resource-invariant assertions in every
+test and the acceptance criterion.
+
+## Files
+
+- `lib/src/plugins/plugin_manager.dart` — the six bridges reworked.
+- `lib/src/services/webserver/plugins_handler.dart` — direct completion.
+- `test/plugins/plugin_manager_timers_test.dart` — 5 timer tests.
+- `test/plugins/plugin_manager_fetch_test.dart` — 8 fetch tests (local
+  HttpServer, no mock lib).
+- `test/services/webserver/plugins_handler_test.dart` — 6 plugin-HTTP
+  tests (sync, async, throw, timeout, late response, unload).
+- `test/plugins/plugin_manager_decent_proxy_ownership_test.dart` — 6 proxy
+  tests (success, transport error, timeout, unload, dispose, stale
+  generation).
+- `test/plugins/plugin_manager_workload_test.dart` — 10-round mixed
+  workload, registries return to zero.
+- `test/plugins/plugin_test_helpers.dart` — shared fakes for new tests.
+- `test/plugins/{visualizer,shot_upload}_plugin_test.dart` — stub seams
+  retargeted.
+
+## Hand-off to #562
+
+`cancelAllOperations()` rejects every pending op, cancels all timers, and
+closes the shared `HttpClient`. #562's `dispose()` should call it (and
+close the JS runtime).

--- a/doc/plans/archive/gh561-async-ownership/gh561-async-ownership.md
+++ b/doc/plans/archive/gh561-async-ownership/gh561-async-ownership.md
@@ -40,15 +40,21 @@ terminal path (success, error, timeout, unload, dispose) funnels through
 `_completeOp()`, which cancels the timeout and removes the entry BEFORE
 settling, so late or duplicate completions are no-ops.
 
-### Late-response protection is removal-based, not generation-checked
+### Late-response protection is removal-based, plus generation checks
 
 Unload and reload reject all of the old plugin's ops and delete their JS
 pending entries; fetch ids (`__fetchFor` counter) and Decent proxy request
 ids (per-runtime nonce) are globally unique, so a late response from an old
-generation can never match a new generation's request. Generation is
-recorded in the op for diagnostics. Timers need no generation: there is no
-async gap between the JS `setTimeout` call and the `timerSet` message, and
-ids are globally unique.
+generation can never match a new generation's request.
+
+Bridge messages are deferred one event-loop turn before Dart processes them
+(QuickJS does not settle promises created inside a nested evaluate). That
+creates a real async gap between the JS call and the Dart message, so
+`timerSet` and `fetch` messages now carry the wrapper's generation and
+`_setTimer` / `_handleFetch` reject messages whose generation does not match
+the current one. The Decent proxy is already generation-safe: its per-load
+bridge token is removed on unload and replaced on reload, so a stale
+message fails the token check.
 
 ### Timeout/size bounds
 

--- a/doc/plans/archive/gh561-async-ownership/gh561-async-ownership.md
+++ b/doc/plans/archive/gh561-async-ownership/gh561-async-ownership.md
@@ -108,3 +108,16 @@ test and the acceptance criterion.
 `cancelAllOperations()` rejects every pending op, cancels all timers, and
 closes the shared `HttpClient`. #562's `dispose()` should call it (and
 close the JS runtime).
+
+## Review pass 2 fixes
+
+- Invalid Decent-proxy bridge token: op is registered before completing so
+  the JS promise actually settles (was: `_completeOp` on an unregistered op
+  returned early, leaking the promise).
+- `globalThis.fetch` outside a plugin now rejects immediately
+  ("fetch is only available to plugins") instead of sending a messageless
+  request that leaked the JS pending entry.
+- `generation` message fields are read with an `is num` guard: plugin code
+  can call the bridge with garbage args, and a cast TypeError would have
+  skipped op registration (permanently pending promise).
+- Diagnostics now report pending ops by plugin as well as by type.

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -376,6 +376,10 @@ class PluginManager {
         globalThis.__fetchFor = function (pluginId, generation, input, init = {}) {
           const id = ++_fetchSeq;
           return new Promise((resolve, reject) => {
+            if (!pluginId) {
+              reject(new Error("fetch is only available to plugins"));
+              return;
+            }
             _pendingFetches.set(id, { pluginId: pluginId, generation: generation, resolve: resolve, reject: reject });
 
             sendMessage("fetch", JSON.stringify({
@@ -810,6 +814,14 @@ class PluginManager {
     return counts;
   }
 
+  Map<String, int> get activePendingOpsByPlugin {
+    final counts = <String, int>{};
+    for (final op in _pendingOps.values) {
+      counts[op.pluginId] = (counts[op.pluginId] ?? 0) + 1;
+    }
+    return counts;
+  }
+
   HttpClient _getHttpClient() {
     return _httpClient ??= HttpClient()
       ..connectionTimeout = const Duration(seconds: 10);
@@ -866,18 +878,19 @@ class PluginManager {
       _log.warning('Decent proxy message from $pluginId missing requestId');
       return;
     }
-    final generation = (msg['generation'] as num?)?.toInt() ?? 0;
+    final generation = msg['generation'] is num
+        ? (msg['generation'] as num).toInt()
+        : 0;
     if (msg['bridgeToken'] != _decentProxyBridgeTokens[pluginId]) {
       _log.warning('Decent proxy message from $pluginId has invalid token');
-      _completeOp(
-        _PendingOp(
-          kind: _PendingOpKind.decentProxy,
-          pluginId: pluginId,
-          generation: generation,
-          requestId: requestId,
-        ),
-        error: 'Invalid plugin proxy caller',
+      final op = _PendingOp(
+        kind: _PendingOpKind.decentProxy,
+        pluginId: pluginId,
+        generation: generation,
+        requestId: requestId,
       );
+      _pendingOps[op.key] = op;
+      _completeOp(op, error: 'Invalid plugin proxy caller');
       return;
     }
 
@@ -1048,7 +1061,9 @@ class PluginManager {
     final op = _PendingOp(
       kind: _PendingOpKind.fetch,
       pluginId: pluginId,
-      generation: (msg['generation'] as num?)?.toInt() ?? 0,
+      generation: msg['generation'] is num
+          ? (msg['generation'] as num).toInt()
+          : 0,
       requestId: id.toString(),
     );
     op.timeout = Timer(fetchTimeout, () {

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -80,7 +80,8 @@ class PluginManager {
     this.maxFetchResponseBytes = 10 * 1024 * 1024,
     this.pluginHttpTimeout = const Duration(seconds: 30),
     this.decentProxyTimeout = const Duration(seconds: 30),
-  }) : js = getJavascriptRuntime(xhr: false) {
+    JavascriptRuntime? js,
+  }) : js = js ?? getJavascriptRuntime(xhr: false) {
     _decentProxyBridge = PluginDecentProxyBridge(
       decentProxyService: decentProxyService,
       log: _log,
@@ -461,6 +462,10 @@ class PluginManager {
     String pluginId,
     Map<String, dynamic> msg,
   ) async {
+    // Yield before processing: channel callbacks run inside the JS evaluate
+    // that sent the message, and a nested evaluate + job drain does not
+    // settle promises on QuickJS (unhandled-rejection hang).
+    await Future<void>.delayed(Duration.zero);
     try {
       await _handleMessage(pluginId, msg);
     } catch (e, st) {
@@ -469,6 +474,7 @@ class PluginManager {
   }
 
   Future<void> _handleFetchSafely(Map<String, dynamic> msg) async {
+    await Future<void>.delayed(Duration.zero);
     try {
       await _handleFetch(msg);
     } catch (e, st) {
@@ -573,6 +579,9 @@ class PluginManager {
       if (result.isError) {
         throw Exception("JS evaluation error: ${result.stringResult}");
       }
+      // Settle promise chains created synchronously during onLoad (e.g. a
+      // rejected fetch or an already-resolved promise) regardless of engine.
+      while (js.executePendingJob() > 0) {}
 
       runtime.markRunning();
       _log.info("loaded: $id");
@@ -582,6 +591,7 @@ class PluginManager {
       js.evaluate('''
       delete globalThis.__plugins__["$id"];
     ''');
+      _cleanupPluginResources(id);
       // WARNING, not SEVERE: a plugin failing to load is almost always a
       // user-installed third-party plugin with a bad manifest id or a JS
       // syntax error, not an app defect. The caller (e.g. PluginsSettingsView)
@@ -615,9 +625,13 @@ class PluginManager {
     }
 
     runtime.markDisposed();
-    _cancelTimersForPlugin(id);
-    _rejectOpsForPlugin(id);
+    _cleanupPluginResources(id);
     _log.info("unloaded: $id");
+  }
+
+  void _cleanupPluginResources(String pluginId) {
+    _cancelTimersForPlugin(pluginId);
+    _rejectOpsForPlugin(pluginId);
   }
 
   // ─────────────────────────────────────────────
@@ -688,6 +702,7 @@ class PluginManager {
       }
     }
   ''');
+    while (js.executePendingJob() > 0) {}
   }
 
   // ─────────────────────────────────────────────
@@ -844,6 +859,11 @@ class PluginManager {
     final payload = error != null ? {'error': error} : result;
     switch (op.kind) {
       case _PendingOpKind.fetch:
+        if (error != null) {
+          try {
+            op.request?.abort();
+          } catch (_) {}
+        }
         final fetchPayload = error != null
             ? {'id': int.parse(op.requestId), 'error': error}
             : result;
@@ -1067,9 +1087,6 @@ class PluginManager {
       requestId: id.toString(),
     );
     op.timeout = Timer(fetchTimeout, () {
-      try {
-        op.request?.abort();
-      } catch (_) {}
       _completeOp(op, error: 'fetch timeout');
     });
     _pendingOps[op.key] = op;

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -16,6 +16,37 @@ import '../models/device/de1_interface.dart';
 import '../models/device/machine.dart';
 import '../services/account/decent_proxy_service.dart';
 
+enum _PendingOpKind { fetch, pluginHttp, decentProxy }
+
+class _PendingOp {
+  _PendingOp({
+    required this.kind,
+    required this.pluginId,
+    required this.generation,
+    required this.requestId,
+  });
+
+  final _PendingOpKind kind;
+  final String pluginId;
+  final int generation;
+  final String requestId;
+
+  Timer? timeout;
+  HttpClientRequest? request;
+  Completer<Map<String, dynamic>>? completer;
+
+  String get key => '${kind.name}:$requestId';
+}
+
+class PluginHttpError implements Exception {
+  final String message;
+
+  const PluginHttpError(this.message);
+
+  @override
+  String toString() => message;
+}
+
 class PluginManager {
   final _log = Logger("PluginManager");
 
@@ -31,14 +62,25 @@ class PluginManager {
 
   Stream<Map<String, dynamic>> get emitStream => _emitController.stream;
 
+  final Duration fetchTimeout;
+  final int maxFetchResponseBytes;
+  final Duration pluginHttpTimeout;
+  final Duration decentProxyTimeout;
+
   De1Controller? _de1controller;
   StreamSubscription<De1Interface?>? _de1Subscription;
   StreamSubscription<MachineSnapshot>? _snapshotSubscription;
 
   De1Controller? get de1Controller => _de1controller;
 
-  PluginManager({required this.kvStore, this.decentProxyService})
-    : js = getJavascriptRuntime(xhr: false) {
+  PluginManager({
+    required this.kvStore,
+    this.decentProxyService,
+    this.fetchTimeout = const Duration(seconds: 30),
+    this.maxFetchResponseBytes = 10 * 1024 * 1024,
+    this.pluginHttpTimeout = const Duration(seconds: 30),
+    this.decentProxyTimeout = const Duration(seconds: 30),
+  }) : js = getJavascriptRuntime(xhr: false) {
     _decentProxyBridge = PluginDecentProxyBridge(
       decentProxyService: decentProxyService,
       log: _log,
@@ -61,7 +103,6 @@ class PluginManager {
         globalThis.__plugins__ = Object.create(null);
         
         // Add HTTP response handling
-        globalThis.__pendingHttpRequests = new Map();
         const __nativeSendMessage = sendMessage;
         const __nativeJsonStringify = JSON.stringify.bind(JSON);
         const __NativePromise = Promise;
@@ -132,14 +173,15 @@ class PluginManager {
           return __nativeFreeze(wrapped);
         }
 
-        function __decentProxy(pluginId, bridgeToken, path, method, query, body, contentType) {
+        function __decentProxy(pluginId, generation, bridgeToken, path, method, query, body, contentType) {
           const requestId = "__decent_proxy_" + __decentProxyNonce + "_" + (++__decentProxySeq);
           const promise = new __NativePromise((resolve, reject) => {
             const pendingByPlugin = __pendingDecentProxyByPlugin(pluginId);
-            __mapSet(pendingByPlugin, requestId, { resolve, reject });
+            __mapSet(pendingByPlugin, requestId, { generation: generation, resolve: resolve, reject: reject });
             try {
               __sendHostMessage({
                 pluginId: pluginId,
+                generation: generation,
                 bridgeToken: bridgeToken,
                 type: "decentProxy",
                 requestId: requestId,
@@ -163,6 +205,9 @@ class PluginManager {
           const pending = __mapGet(pendingByPlugin, requestId);
           if (!pending) return;
           __mapDelete(pendingByPlugin, requestId);
+          if (pendingByPlugin.size === 0) {
+            __mapDelete(__pendingDecentProxyRequests, pluginId);
+          }
           if (response && response.error) {
             pending.reject(new __NativeError(response.error));
             return;
@@ -180,24 +225,6 @@ class PluginManager {
           enumerable: false
         });
         
-        globalThis.__registerHttpRequest = function (pluginId, requestId) {
-          if (!globalThis.__pendingHttpRequests.has(pluginId)) {
-            globalThis.__pendingHttpRequests.set(pluginId, new Map());
-          }
-          return new Promise((resolve) => {
-            globalThis.__pendingHttpRequests.get(pluginId).set(requestId, resolve);
-          });
-        };
-        
-        globalThis.__sendHttpResponse = function (pluginId, requestId, response) {
-          sendMessage("host", JSON.stringify({
-            pluginId: pluginId,
-            type: "httpResponse",
-            requestId: requestId,
-            payload: response
-          }));
-        };
-
         globalThis.__sendApiResponse = function (pluginId, requestId, response) {
           console.log("sending plugin api response", pluginId);
           sendMessage("host", JSON.stringify({
@@ -262,6 +289,44 @@ class PluginManager {
           }
         };
 
+        // Timer bridge: JS holds callbacks, Dart owns real Timers.
+        const __timers = new Map();
+        let __timerSeq = 0;
+        globalThis.__debugTimers = __timers;
+        globalThis.__timerSet = function (pluginId, callback, delay) {
+          const id = ++__timerSeq;
+          __timers.set(id, { pluginId: pluginId, callback: callback });
+          __sendHostMessage({
+            pluginId: pluginId,
+            type: "timerSet",
+            timerId: id,
+            delay: Math.max(0, Math.trunc(Number(delay) || 0))
+          });
+          return id;
+        };
+        globalThis.__timerClear = function (pluginId, id) {
+          if (__timers.delete(id)) {
+            __sendHostMessage({ pluginId: pluginId, type: "timerClear", timerId: id });
+          }
+        };
+        globalThis.__fireTimer = function (id) {
+          const record = __timers.get(id);
+          if (!record) return;
+          try {
+            record.callback();
+          } finally {
+            __timers.delete(id);
+          }
+        };
+        globalThis.__cancelTimersForPlugin = function (pluginId) {
+          for (const [id, record] of __timers) {
+            if (record.pluginId === pluginId) __timers.delete(id);
+          }
+        };
+        globalThis.__cancelAllTimers = function () {
+          __timers.clear();
+        };
+
         globalThis.host = {
           log(pluginId, message) {
             sendMessage("host", JSON.stringify({
@@ -284,17 +349,6 @@ class PluginManager {
               type: "pluginStorage",
               payload: command
             }));
-          },
-          httpRequest(pluginId, requestId, endpoint, method, headers, body) {
-            sendMessage("host", JSON.stringify({
-              pluginId: pluginId,
-              type: "httpRequest",
-              requestId: requestId,
-              endpoint: endpoint,
-              method: method,
-              headers: headers,
-              body: body
-            }));
           }
         };
       })();
@@ -308,7 +362,6 @@ class PluginManager {
         const _pendingFetches = new Map();
 
         function makeHeaders(headersObj) {
-          // console.log("making headers", JSON.stringify(headersObj))
           const map = new Map();
           for (const k in headersObj || {}) {
             map.set(k.toLowerCase(), String(headersObj[k]));
@@ -320,14 +373,15 @@ class PluginManager {
           };
         }
 
-        globalThis.fetch = function fetch(input, init = {}) {
+        globalThis.__fetchFor = function (pluginId, generation, input, init = {}) {
           const id = ++_fetchSeq;
-
           return new Promise((resolve, reject) => {
-            _pendingFetches.set(id, { resolve, reject });
+            _pendingFetches.set(id, { pluginId: pluginId, generation: generation, resolve: resolve, reject: reject });
 
             sendMessage("fetch", JSON.stringify({
               id,
+              pluginId,
+              generation,
               url: String(input),
               method: init.method || "GET",
               headers: init.headers || {},
@@ -336,12 +390,13 @@ class PluginManager {
           });
         };
 
+        globalThis.fetch = function fetch(input, init = {}) {
+          return globalThis.__fetchFor(null, 0, input, init);
+        };
+
         globalThis.__handleFetchResponse = function (msg) {
-          // console.log("getting fetch back!", msg.headers['x-powered-by']);
           const pending = _pendingFetches.get(msg.id);
           if (!pending) return;
-          // console.log("found pending");
-
           _pendingFetches.delete(msg.id);
 
           if (msg.error) {
@@ -358,20 +413,12 @@ class PluginManager {
             text: async () => msg.body ?? "",
             json: async () => JSON.parse(msg.body ?? "null")
           };
-          // console.log('resolving!');
-
           pending.resolve(response);
-          // console.log('resolved');
         };
-
-        // globalThis.onMessage("__fetchResponse__", function (msg) {
-        //   console.log("got fetch response in js", msg);
-        //   __handleFetchResponse(msg);
-        // });
       })();
     ''');
 
-    js.onMessage("host", (raw) async {
+    js.onMessage("host", (raw) {
       try {
         _log.finest("receiving: $raw");
         final msg = raw as Map<String, dynamic>;
@@ -389,21 +436,40 @@ class PluginManager {
           // Handle HTTP responses from plugin
           _handlePluginApiResponse(pluginId, msg);
         } else {
-          await _handleMessage(pluginId, msg);
+          unawaited(_handleMessageSafely(pluginId, msg));
         }
       } catch (e, st) {
         _log.warning("Invalid JS message", e, st);
       }
     });
 
-    js.onMessage("fetch", (raw) async {
+    js.onMessage("fetch", (raw) {
       try {
         final msg = raw as Map<String, dynamic>;
-        await _handleFetch(msg);
+        unawaited(_handleFetchSafely(msg));
       } catch (e, st) {
         _log.warning("Invalid fetch message", e, st);
       }
     });
+  }
+
+  Future<void> _handleMessageSafely(
+    String pluginId,
+    Map<String, dynamic> msg,
+  ) async {
+    try {
+      await _handleMessage(pluginId, msg);
+    } catch (e, st) {
+      _log.warning("Error handling message from $pluginId", e, st);
+    }
+  }
+
+  Future<void> _handleFetchSafely(Map<String, dynamic> msg) async {
+    try {
+      await _handleFetch(msg);
+    } catch (e, st) {
+      _log.warning("Invalid fetch message", e, st);
+    }
   }
 
   // ─────────────────────────────────────────────
@@ -416,6 +482,8 @@ class PluginManager {
     required String jsCode,
     required Map<String, dynamic> settings,
   }) async {
+    final generation = (_pluginGenerations[id] ?? 0) + 1;
+    _pluginGenerations[id] = generation;
     await unloadPlugin(id);
 
     final runtime = PluginRuntime(pluginId: id, manifest: manifest);
@@ -430,6 +498,12 @@ class PluginManager {
           '''
       (function () {
         const pluginId = "$id";
+        const pluginGeneration = $generation;
+        const setTimeout = (callback, delay) => globalThis.__timerSet(pluginId, callback, delay);
+        const clearTimeout = (id) => globalThis.__timerClear(pluginId, id);
+        const fetch = (input, init) => globalThis.__fetchFor
+          ? globalThis.__fetchFor(pluginId, pluginGeneration, input, init)
+          : globalThis.fetch(input, init);
         
         // Create the host object for this plugin
         const host = {
@@ -439,6 +513,7 @@ class PluginManager {
           decentProxy: (path, options = {}) => {
             return globalThis.__reaprimePluginBridge.decentProxy(
               pluginId,
+              pluginGeneration,
               ${jsonEncode(decentProxyBridgeToken)},
               path,
               options.method || "GET",
@@ -446,18 +521,6 @@ class PluginManager {
               options.body ?? null,
               options.contentType ?? null
             );
-          },
-          // Add HTTP request capability
-          httpRequest: (endpoint, method, headers, body) => {
-            const requestId = pluginId + "_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9);
-            return new Promise((resolve) => {
-              // Register the request
-              if (globalThis.__registerHttpRequest) {
-                globalThis.__registerHttpRequest(pluginId, requestId).then(resolve);
-              }
-              // Send the request to Dart
-              globalThis.host.httpRequest(pluginId, requestId, endpoint, method, headers, body);
-            });
           }
         };
         
@@ -548,6 +611,8 @@ class PluginManager {
     }
 
     runtime.markDisposed();
+    _cancelTimersForPlugin(id);
+    _rejectOpsForPlugin(id);
     _log.info("unloaded: $id");
   }
 
@@ -646,9 +711,149 @@ class PluginManager {
         await _handlePluginStorage(pluginId, cmd);
         break;
 
+      case 'timerSet':
+        _setTimer(
+          pluginId,
+          (msg['timerId'] as num?)?.toInt() ?? 0,
+          (msg['delay'] as num?)?.toInt() ?? 0,
+        );
+        break;
+
+      case 'timerClear':
+        _clearTimer((msg['timerId'] as num?)?.toInt() ?? 0);
+        break;
+
       case 'decentProxy':
         await _handleDecentProxyMessage(pluginId, msg);
         break;
+    }
+  }
+
+  // ─────────────────────────────────────────────
+  // Timers (JS callbacks, Dart-owned Timers)
+  // ─────────────────────────────────────────────
+
+  final Map<int, ({String pluginId, Timer timer})> _timers = {};
+
+  int get activeTimerCount => _timers.length;
+
+  Map<String, int> get activeTimersByPlugin {
+    final counts = <String, int>{};
+    for (final record in _timers.values) {
+      counts[record.pluginId] = (counts[record.pluginId] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  void _setTimer(String pluginId, int id, int delayMs) {
+    if (!_plugins.containsKey(pluginId)) return;
+    _timers[id] = (
+      pluginId: pluginId,
+      timer: Timer(Duration(milliseconds: delayMs < 0 ? 0 : delayMs), () {
+        _fireTimer(id);
+      }),
+    );
+  }
+
+  void _clearTimer(int id) {
+    _timers.remove(id)?.timer.cancel();
+  }
+
+  void _fireTimer(int id) {
+    final record = _timers.remove(id);
+    if (record == null) return;
+    js.evaluate('globalThis.__fireTimer($id);');
+    while (js.executePendingJob() > 0) {}
+  }
+
+  void _cancelTimersForPlugin(String pluginId) {
+    _timers.removeWhere((id, record) {
+      if (record.pluginId == pluginId) {
+        record.timer.cancel();
+        return true;
+      }
+      return false;
+    });
+    js.evaluate('globalThis.__cancelTimersForPlugin(${jsonEncode(pluginId)});');
+    while (js.executePendingJob() > 0) {}
+  }
+
+  void cancelAllOperations() {
+    for (final op in _pendingOps.values.toList()) {
+      _completeOp(op, error: 'manager disposal');
+    }
+    for (final record in _timers.values) {
+      record.timer.cancel();
+    }
+    _timers.clear();
+    _httpClient?.close(force: true);
+    _httpClient = null;
+    js.evaluate('globalThis.__cancelAllTimers();');
+    while (js.executePendingJob() > 0) {}
+  }
+
+  // ─────────────────────────────────────────────
+  // Pending operations (fetch, plugin HTTP, Decent proxy)
+  // ─────────────────────────────────────────────
+
+  final Map<String, _PendingOp> _pendingOps = {};
+  final Map<String, int> _pluginGenerations = {};
+  HttpClient? _httpClient;
+
+  int get activePendingOpCount => _pendingOps.length;
+
+  Map<String, int> get activePendingOpsByType {
+    final counts = <String, int>{};
+    for (final op in _pendingOps.values) {
+      counts[op.kind.name] = (counts[op.kind.name] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  HttpClient _getHttpClient() {
+    return _httpClient ??= HttpClient()
+      ..connectionTimeout = const Duration(seconds: 10);
+  }
+
+  void _rejectOpsForPlugin(String pluginId) {
+    for (final op
+        in _pendingOps.values.where((op) => op.pluginId == pluginId).toList()) {
+      _completeOp(op, error: 'plugin unloaded');
+    }
+  }
+
+  void _completeOp(
+    _PendingOp op, {
+    Map<String, dynamic>? result,
+    String? error,
+  }) {
+    op.timeout?.cancel();
+    if (_pendingOps.remove(op.key) == null) return;
+    final payload = error != null ? {'error': error} : result;
+    switch (op.kind) {
+      case _PendingOpKind.fetch:
+        final fetchPayload = error != null
+            ? {'id': int.parse(op.requestId), 'error': error}
+            : result;
+        js.evaluate(
+          'globalThis.__handleFetchResponse(${jsonEncode(fetchPayload)});',
+        );
+        while (js.executePendingJob() > 0) {}
+      case _PendingOpKind.pluginHttp:
+        final completer = op.completer;
+        if (completer == null || completer.isCompleted) return;
+        if (error != null) {
+          completer.completeError(PluginHttpError(error));
+        } else {
+          completer.complete(result);
+        }
+      case _PendingOpKind.decentProxy:
+        js.evaluate(
+          'globalThis.__reaprimePluginBridge.completeDecentProxyRequest('
+          '${jsonEncode(op.pluginId)}, ${jsonEncode(op.requestId)}, '
+          '${jsonEncode(payload)});',
+        );
+        while (js.executePendingJob() > 0) {}
     }
   }
 
@@ -661,13 +866,31 @@ class PluginManager {
       _log.warning('Decent proxy message from $pluginId missing requestId');
       return;
     }
+    final generation = (msg['generation'] as num?)?.toInt() ?? 0;
     if (msg['bridgeToken'] != _decentProxyBridgeTokens[pluginId]) {
       _log.warning('Decent proxy message from $pluginId has invalid token');
-      _completeDecentProxyRequest(pluginId, requestId, {
-        'error': 'Invalid plugin proxy caller',
-      });
+      _completeOp(
+        _PendingOp(
+          kind: _PendingOpKind.decentProxy,
+          pluginId: pluginId,
+          generation: generation,
+          requestId: requestId,
+        ),
+        error: 'Invalid plugin proxy caller',
+      );
       return;
     }
+
+    final op = _PendingOp(
+      kind: _PendingOpKind.decentProxy,
+      pluginId: pluginId,
+      generation: generation,
+      requestId: requestId,
+    );
+    op.timeout = Timer(decentProxyTimeout, () {
+      _completeOp(op, error: 'Decent proxy request timed out');
+    });
+    _pendingOps[op.key] = op;
 
     try {
       final response = await proxyDecentApiForManifest(
@@ -679,9 +902,9 @@ class PluginManager {
         body: msg['body'] as String?,
         contentType: msg['contentType'] as String?,
       );
-      _completeDecentProxyRequest(pluginId, requestId, response);
+      _completeOp(op, result: response);
     } catch (e) {
-      _completeDecentProxyRequest(pluginId, requestId, {'error': e.toString()});
+      _completeOp(op, error: e.toString());
     }
   }
 
@@ -722,21 +945,6 @@ class PluginManager {
     return out.isEmpty ? null : out;
   }
 
-  void _completeDecentProxyRequest(
-    String pluginId,
-    String requestId,
-    Map<String, dynamic> response,
-  ) {
-    js.evaluate('''
-      globalThis.__reaprimePluginBridge.completeDecentProxyRequest(
-        ${jsonEncode(pluginId)},
-        ${jsonEncode(requestId)},
-        ${jsonEncode(response)}
-      );
-    ''');
-    while (js.executePendingJob() > 0) {}
-  }
-
   Future<void> _handlePluginStorage(
     String pluginId,
     PluginStorageCommand cmd,
@@ -760,8 +968,6 @@ class PluginManager {
     }
   }
 
-  final Map<String, Map<String, dynamic>> _pendingHttpResponses = {};
-
   void _handlePluginApiResponse(String pluginId, Map<String, dynamic> msg) {
     final requestId = msg['requestId'] as String?;
     final response = msg['payload'] as Map<String, dynamic>?;
@@ -771,11 +977,33 @@ class PluginManager {
       return;
     }
 
-    // This will be used by the HTTP request handler
-    _pendingHttpResponses[requestId] = response;
-    _log.fine(
-      "HTTP response received for request $requestId from plugin $pluginId",
+    final op = _pendingOps['${_PendingOpKind.pluginHttp.name}:$requestId'];
+    if (op == null) {
+      _log.fine(
+        'Late or unknown HTTP response for request $requestId from $pluginId',
+      );
+      return;
+    }
+    _completeOp(op, result: response);
+  }
+
+  Future<Map<String, dynamic>> registerPendingHttp(
+    String pluginId,
+    String requestId,
+  ) {
+    final op = _PendingOp(
+      kind: _PendingOpKind.pluginHttp,
+      pluginId: pluginId,
+      generation: _pluginGenerations[pluginId] ?? 0,
+      requestId: requestId,
     );
+    final completer = Completer<Map<String, dynamic>>();
+    op.completer = completer;
+    op.timeout = Timer(pluginHttpTimeout, () {
+      _completeOp(op, error: 'Plugin did not respond in time');
+    });
+    _pendingOps[op.key] = op;
+    return completer.future;
   }
 
   // ─────────────────────────────────────────────
@@ -802,66 +1030,81 @@ class PluginManager {
   }
 
   Future<void> _handleFetch(Map<String, dynamic> msg) async {
-    final int id = msg['id'];
-    final String url = msg['url'];
-    final String method = (msg['method'] ?? 'GET').toUpperCase();
-    final Map headers = msg['headers'] ?? {};
-    final dynamic body = msg['body'];
-
-    try {
-      final client = HttpClient();
-      final uri = Uri.parse(url);
-
-      final request = await client.openUrl(method, uri);
-
-      headers.forEach((k, v) {
-        request.headers.set(k.toString(), v.toString());
-      });
-
-      if (body != null) {
-        if (body is String) {
-          request.add(utf8.encode(body));
-        } else {
-          request.add(utf8.encode(jsonEncode(body)));
-        }
-      }
-
-      final response = await request.close();
-      final bytes = await response.fold<List<int>>([], (a, b) => a..addAll(b));
-
-      final responseBody = utf8.decode(bytes);
-
-      final Map<String, dynamic> responseHeaders = {};
-      response.headers.forEach((name, values) {
-        responseHeaders[name] = values.join(", ");
-      });
-      js.evaluate('''
-  __handleFetchResponse(${jsonEncode({'id': id, 'status': response.statusCode, 'headers': responseHeaders, 'body': responseBody})});
-''');
-      // js.sendMessage(
-      //   channelName: "__fetchResponse__",
-      //   args: [
-      //     jsonEncode({
-      //       'id': id,
-      //       'status': response.statusCode,
-      //       'headers': responseHeaders,
-      //       'body': responseBody,
-      //     }),
-      //   ],
-      // );
-      while (js.executePendingJob() > 0) {}
-    } catch (e) {
-      js.sendMessage(
-        channelName: "__fetchResponse__",
-        args: [
-          jsonEncode({'id': id, 'error': e.toString()}),
-        ],
+    final id = msg['id'];
+    final pluginId = msg['pluginId'] as String?;
+    if (id is! int || pluginId == null) {
+      _log.warning('Invalid fetch message');
+      return;
+    }
+    if (!_plugins.containsKey(pluginId)) {
+      js.evaluate(
+        'globalThis.__handleFetchResponse('
+        '${jsonEncode({'id': id, 'error': 'plugin not loaded'})});',
       );
       while (js.executePendingJob() > 0) {}
+      return;
+    }
+
+    final op = _PendingOp(
+      kind: _PendingOpKind.fetch,
+      pluginId: pluginId,
+      generation: (msg['generation'] as num?)?.toInt() ?? 0,
+      requestId: id.toString(),
+    );
+    op.timeout = Timer(fetchTimeout, () {
+      try {
+        op.request?.abort();
+      } catch (_) {}
+      _completeOp(op, error: 'fetch timeout');
+    });
+    _pendingOps[op.key] = op;
+
+    try {
+      final response = await _performFetch(op, msg);
+      _completeOp(op, result: response);
+    } catch (e) {
+      _completeOp(op, error: e.toString());
     }
   }
 
-  Map<String, dynamic>? getPendingHttpResponse(String requestId) {
-    return _pendingHttpResponses.remove(requestId);
+  Future<Map<String, dynamic>> _performFetch(
+    _PendingOp op,
+    Map<String, dynamic> msg,
+  ) async {
+    final uri = Uri.parse(msg['url'] as String);
+    final method = ((msg['method'] as String?) ?? 'GET').toUpperCase();
+    final headers = msg['headers'] as Map? ?? {};
+    final body = msg['body'];
+
+    final request = await _getHttpClient().openUrl(method, uri);
+    op.request = request;
+    headers.forEach((k, v) {
+      request.headers.set(k.toString(), v.toString());
+    });
+    if (body != null) {
+      request.add(
+        body is String ? utf8.encode(body) : utf8.encode(jsonEncode(body)),
+      );
+    }
+    final response = await request.close();
+    final bytes = await response.fold<List<int>>([], (acc, chunk) {
+      if (acc.length + chunk.length > maxFetchResponseBytes) {
+        throw StateError(
+          'response exceeds maxFetchResponseBytes ($maxFetchResponseBytes)',
+        );
+      }
+      return acc..addAll(chunk);
+    });
+
+    final responseHeaders = <String, String>{};
+    response.headers.forEach((name, values) {
+      responseHeaders[name] = values.join(', ');
+    });
+    return {
+      'id': int.parse(op.requestId),
+      'status': response.statusCode,
+      'headers': responseHeaders,
+      'body': utf8.decode(bytes, allowMalformed: true),
+    };
   }
 }

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -294,11 +294,12 @@ class PluginManager {
         const __timers = new Map();
         let __timerSeq = 0;
         globalThis.__debugTimers = __timers;
-        globalThis.__timerSet = function (pluginId, callback, delay) {
+        globalThis.__timerSet = function (pluginId, generation, callback, delay) {
           const id = ++__timerSeq;
-          __timers.set(id, { pluginId: pluginId, callback: callback });
+          __timers.set(id, { pluginId: pluginId, generation: generation, callback: callback });
           __sendHostMessage({
             pluginId: pluginId,
+            generation: generation,
             type: "timerSet",
             timerId: id,
             delay: Math.max(0, Math.trunc(Number(delay) || 0))
@@ -509,7 +510,7 @@ class PluginManager {
       (function () {
         const pluginId = "$id";
         const pluginGeneration = $generation;
-        const setTimeout = (callback, delay) => globalThis.__timerSet(pluginId, callback, delay);
+        const setTimeout = (callback, delay) => globalThis.__timerSet(pluginId, pluginGeneration, callback, delay);
         const clearTimeout = (id) => globalThis.__timerClear(pluginId, id);
         const fetch = (input, init) => globalThis.__fetchFor
           ? globalThis.__fetchFor(pluginId, pluginGeneration, input, init)
@@ -630,8 +631,11 @@ class PluginManager {
   }
 
   void _cleanupPluginResources(String pluginId) {
-    _cancelTimersForPlugin(pluginId);
+    // Reject operations first: settling promises drains pending jobs, which
+    // can run plugin rejection handlers that schedule new timers. The timer
+    // sweep after must be the last word.
     _rejectOpsForPlugin(pluginId);
+    _cancelTimersForPlugin(pluginId);
   }
 
   // ─────────────────────────────────────────────
@@ -733,6 +737,7 @@ class PluginManager {
       case 'timerSet':
         _setTimer(
           pluginId,
+          msg['generation'] is num ? (msg['generation'] as num).toInt() : 0,
           (msg['timerId'] as num?)?.toInt() ?? 0,
           (msg['delay'] as num?)?.toInt() ?? 0,
         );
@@ -764,8 +769,11 @@ class PluginManager {
     return counts;
   }
 
-  void _setTimer(String pluginId, int id, int delayMs) {
+  void _setTimer(String pluginId, int generation, int id, int delayMs) {
     if (!_plugins.containsKey(pluginId)) return;
+    // Deferred bridge messages can arrive after a reload; a timer from an
+    // older generation must not register against the current plugin.
+    if (generation != (_pluginGenerations[pluginId] ?? 0)) return;
     _timers[id] = (
       pluginId: pluginId,
       timer: Timer(Duration(milliseconds: delayMs < 0 ? 0 : delayMs), () {
@@ -1077,13 +1085,24 @@ class PluginManager {
       while (js.executePendingJob() > 0) {}
       return;
     }
+    final generation = msg['generation'] is num
+        ? (msg['generation'] as num).toInt()
+        : 0;
+    // Deferred bridge messages can arrive after a reload; a fetch from an
+    // older generation must not start network work against the new plugin.
+    if (generation != (_pluginGenerations[pluginId] ?? 0)) {
+      js.evaluate(
+        'globalThis.__handleFetchResponse('
+        '${jsonEncode({'id': id, 'error': 'plugin generation changed'})});',
+      );
+      while (js.executePendingJob() > 0) {}
+      return;
+    }
 
     final op = _PendingOp(
       kind: _PendingOpKind.fetch,
       pluginId: pluginId,
-      generation: msg['generation'] is num
-          ? (msg['generation'] as num).toInt()
-          : 0,
+      generation: generation,
       requestId: id.toString(),
     );
     op.timeout = Timer(fetchTimeout, () {

--- a/lib/src/services/webserver/plugins_handler.dart
+++ b/lib/src/services/webserver/plugins_handler.dart
@@ -201,15 +201,14 @@ final class PluginsHandler {
         'query': req.url.queryParameters,
       };
 
+      // Register the pending request before dispatching to the plugin.
+      final responseFuture = pluginManager.registerPendingHttp(id, requestId);
+
       // Dispatch the event to the plugin
       pluginManager.dispatchEvent(id, 'httpRequest', requestData);
 
       // Wait for the plugin's response (with timeout)
-      final response = await _waitForPluginResponse(requestId);
-
-      if (response == null) {
-        return jsonError({'error': 'Plugin did not respond in time'});
-      }
+      final response = await responseFuture;
 
       // Parse the plugin's response
       final status = response['status'] as int? ?? 200;
@@ -221,33 +220,13 @@ final class PluginsHandler {
 
       // Send the response back to the client
       return Response(status, body: responseBody, headers: responseHeaders);
+    } on PluginHttpError catch (e) {
+      _log.warning("Plugin $id HTTP request failed", e);
+      return jsonError({'error': e.message});
     } catch (e) {
       _log.warning("Error handling HTTP request for plugin $id", e);
       return jsonError({'error': 'Error processing request: ${e.toString()}'});
     }
-  }
-
-  Future<Map<String, dynamic>?> _waitForPluginResponse(String requestId) async {
-    final Completer<Map<String, dynamic>?> completer = Completer();
-    final stopwatch = Stopwatch()..start();
-
-    // Check every 100ms for up to 30 seconds
-    Timer.periodic(const Duration(milliseconds: 100), (timer) {
-      if (stopwatch.elapsed > const Duration(seconds: 30)) {
-        timer.cancel();
-        completer.complete(null);
-        return;
-      }
-
-      // Check if the plugin has responded
-      final response = pluginManager.getPendingHttpResponse(requestId);
-      if (response != null) {
-        timer.cancel();
-        completer.complete(response);
-      }
-    });
-
-    return completer.future;
   }
 
   Future<Response> _extractPluginId(

--- a/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
+++ b/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+
+import 'plugin_test_helpers.dart';
+
+class FakeCredentialStore implements CredentialStore {
+  final Map<String, String> _values = {};
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _values.remove(key);
+  }
+}
+
+void main() {
+  const pluginId = 'proxy.plugin';
+
+  PluginManifest proxyManifest() {
+    return PluginManifest(
+      id: pluginId,
+      name: pluginId,
+      author: 'Test',
+      description: 'Test',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: const {PluginPermissions.proxyDecentApi},
+      settings: const {},
+      api: PluginApi(endpoints: const []),
+    );
+  }
+
+  Future<PluginManager> buildManager(
+    Future<http.Response> Function(http.Request) onRequest, {
+    Duration decentProxyTimeout = const Duration(seconds: 5),
+  }) async {
+    final store = FakeCredentialStore();
+    await store.write(key: 'email', value: 'user@example.com');
+    await store.write(key: 'password', value: 'cryptpw_abc123');
+    return PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      decentProxyTimeout: decentProxyTimeout,
+      decentProxyService: DecentProxyService(
+        credentialStore: store,
+        httpClient: http_testing.MockClient(onRequest),
+      ),
+    );
+  }
+
+  Future<Completer<String>> loadProxyPlugin(PluginManager manager) async {
+    final result = Completer<String>();
+    final sub = manager.emitStream.listen((e) {
+      if (result.isCompleted) return;
+      final event = e['event'] as String;
+      final payload = e['payload'] as Map<String, dynamic>;
+      if (event == 'proxyResult') {
+        result.complete('ok');
+      } else if (event == 'proxyError') {
+        result.complete('err:${payload['message']}');
+      }
+    });
+    result.future.whenComplete(sub.cancel);
+    await manager.loadPlugin(
+      id: pluginId,
+      manifest: proxyManifest(),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            onLoad() {
+              host.decentProxy("support/api/sn")
+                .then((response) => host.emit("proxyResult", response))
+                .catch((error) => host.emit("proxyError", { message: String(error) }));
+            }
+          };
+        }
+      ''',
+    );
+    return result;
+  }
+
+  test('successful proxy call resolves through the owned operation', () async {
+    final manager = await buildManager(
+      (request) async => http.Response('{"serial":"SN001"}', 200),
+    );
+    addTearDown(manager.cancelAllOperations);
+
+    final result = await loadProxyPlugin(manager);
+    expect((await result.future.timeout(const Duration(seconds: 5))), 'ok');
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('transport failure rejects the promise', () async {
+    final manager = await buildManager(
+      (request) async => throw http.ClientException('connection refused'),
+    );
+    addTearDown(manager.cancelAllOperations);
+
+    final result = await loadProxyPlugin(manager);
+    expect(
+      (await result.future.timeout(const Duration(seconds: 5))),
+      startsWith('err:'),
+    );
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('timeout rejects a slow proxy call', () async {
+    final manager = await buildManager((request) async {
+      await Future<void>.delayed(const Duration(seconds: 10));
+      return http.Response('{"serial":"SN001"}', 200);
+    }, decentProxyTimeout: const Duration(milliseconds: 200));
+    addTearDown(manager.cancelAllOperations);
+
+    final result = await loadProxyPlugin(manager);
+    final value = await result.future.timeout(const Duration(seconds: 5));
+    expect(value, startsWith('err:'));
+    expect(value, contains('timed out'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('plugin unload rejects pending proxy call', () async {
+    final manager = await buildManager((request) async {
+      await Future<void>.delayed(const Duration(seconds: 10));
+      return http.Response('{"serial":"SN001"}', 200);
+    });
+    addTearDown(manager.cancelAllOperations);
+
+    final result = await loadProxyPlugin(manager);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await manager.unloadPlugin(pluginId);
+
+    final value = await result.future.timeout(const Duration(seconds: 5));
+    expect(value, startsWith('err:'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('cancelAllOperations rejects pending proxy call', () async {
+    final manager = await buildManager((request) async {
+      await Future<void>.delayed(const Duration(seconds: 10));
+      return http.Response('{"serial":"SN001"}', 200);
+    });
+    addTearDown(manager.cancelAllOperations);
+
+    final result = await loadProxyPlugin(manager);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    manager.cancelAllOperations();
+
+    final value = await result.future.timeout(const Duration(seconds: 5));
+    expect(value, startsWith('err:'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('late response from a previous plugin generation is dropped', () async {
+    var calls = 0;
+    final manager = await buildManager((request) async {
+      calls += 1;
+      if (calls == 1) {
+        await Future<void>.delayed(const Duration(milliseconds: 800));
+        return http.Response('{"serial":"OLD-GEN"}', 200);
+      }
+      return http.Response('{"serial":"NEW-GEN"}', 200);
+    });
+    addTearDown(manager.cancelAllOperations);
+
+    final firstGen = await loadProxyPlugin(manager);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await manager.unloadPlugin(pluginId);
+    expect(
+      (await firstGen.future.timeout(const Duration(seconds: 5))),
+      startsWith('err:'),
+    );
+
+    final secondGen = await loadProxyPlugin(manager);
+    expect((await secondGen.future.timeout(const Duration(seconds: 5))), 'ok');
+
+    // The old generation's late response must be dropped, not delivered.
+    await Future<void>.delayed(const Duration(milliseconds: 900));
+    expect(manager.activePendingOpCount, 0);
+    expect(calls, 2);
+  });
+}

--- a/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
+++ b/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
@@ -166,6 +166,46 @@ void main() {
     expect(manager.activePendingOpCount, 0);
   });
 
+  test('invalid bridge token rejects the promise', () async {
+    final manager = await buildManager(
+      (request) async => http.Response('{"serial":"SN001"}', 200),
+    );
+    addTearDown(manager.cancelAllOperations);
+
+    final result = Completer<String>();
+    final sub = manager.emitStream.listen((e) {
+      if (result.isCompleted) return;
+      final event = e['event'] as String;
+      final payload = e['payload'] as Map<String, dynamic>;
+      if (event == 'proxyError') result.complete('err:${payload['message']}');
+    });
+    result.future.whenComplete(sub.cancel);
+    await manager.loadPlugin(
+      id: pluginId,
+      manifest: proxyManifest(),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            onLoad() {
+              globalThis.__reaprimePluginBridge.decentProxy(
+                "$pluginId", 0, "bogus-token", "support/api/sn"
+              )
+                .then(() => host.emit("proxyResult", {}))
+                .catch((error) => host.emit("proxyError", { message: String(error) }));
+            }
+          };
+        }
+      ''',
+    );
+
+    final value = await result.future.timeout(const Duration(seconds: 5));
+    expect(value, startsWith('err:'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
   test('late response from a previous plugin generation is dropped', () async {
     var calls = 0;
     final manager = await buildManager((request) async {

--- a/test/plugins/plugin_manager_fetch_test.dart
+++ b/test/plugins/plugin_manager_fetch_test.dart
@@ -224,6 +224,52 @@ void main() {
     expect(manager.activePendingOpCount, 0);
   });
 
+  test(
+    'fetch from a previous plugin generation does not hit the network',
+    () async {
+      var requests = 0;
+      final server = await startServer((res) async {
+        requests += 1;
+        await Future<void>.delayed(const Duration(seconds: 10));
+        res.write('late');
+      });
+      addTearDown(server.close);
+
+      // Generation 1 schedules a fetch; reload happens before the deferred
+      // fetch message is processed.
+      await manager.loadPlugin(
+        id: 'fetch.plugin',
+        manifest: testManifest('fetch.plugin'),
+        settings: {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          return {
+            id: "fetch.plugin",
+            onLoad() {
+              fetch(${jsonEncode('http://127.0.0.1:${server.port}/slow')})
+                .then(() => host.emit("result", "unexpected"))
+                .catch((e) => host.emit("result", "err:" + e.message));
+            }
+          };
+        }
+      ''',
+      );
+      await manager.unloadPlugin('fetch.plugin');
+      await manager.loadPlugin(
+        id: 'fetch.plugin',
+        manifest: testManifest('fetch.plugin'),
+        settings: {},
+        jsCode:
+            'function createPlugin(host) { return { id: "fetch.plugin" }; }',
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(requests, 0);
+      expect(manager.activePendingOpCount, 0);
+    },
+  );
+
   test('cancelAllOperations rejects pending fetch', () async {
     final server = await startServer((res) async {
       await Future<void>.delayed(const Duration(seconds: 10));

--- a/test/plugins/plugin_manager_fetch_test.dart
+++ b/test/plugins/plugin_manager_fetch_test.dart
@@ -152,6 +152,39 @@ void main() {
     expect(manager.activePendingOpCount, 0);
   });
 
+  test('global fetch (no plugin context) rejects instead of leaking', () async {
+    final result = Completer<String>();
+    final sub = manager.emitStream.listen((e) {
+      if (!result.isCompleted) result.complete(e['payload'] as String);
+    });
+    await manager.loadPlugin(
+      id: 'fetch.plugin',
+      manifest: testManifest('fetch.plugin'),
+      settings: {},
+      jsCode: '''
+        function createPlugin(host) {
+          return {
+            id: "fetch.plugin",
+            onLoad() {
+              globalThis.fetch("http://127.0.0.1:1/x")
+                .then(() => host.emit("result", "resolved"))
+                .catch((e) => host.emit("result", "err:" + e.message));
+            }
+          };
+        }
+      ''',
+    );
+
+    final value = await result.future
+        .timeout(const Duration(seconds: 5))
+        .whenComplete(sub.cancel);
+    await sub.cancel();
+
+    expect(value, startsWith('err:'));
+    expect(value, contains('only available to plugins'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
   test('plugin unload rejects pending fetch', () async {
     final server = await startServer((res) async {
       await Future<void>.delayed(const Duration(seconds: 10));

--- a/test/plugins/plugin_manager_fetch_test.dart
+++ b/test/plugins/plugin_manager_fetch_test.dart
@@ -1,0 +1,232 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+
+import 'plugin_test_helpers.dart';
+
+void main() {
+  late PluginManager manager;
+
+  Future<HttpServer> startServer(
+    Future<void> Function(HttpResponse) handler,
+  ) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((req) async {
+      try {
+        await handler(req.response);
+        await req.response.close();
+      } catch (_) {
+        try {
+          req.response.close();
+        } catch (_) {}
+      }
+    });
+    return server;
+  }
+
+  setUp(() {
+    manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      fetchTimeout: const Duration(seconds: 2),
+    );
+  });
+
+  tearDown(() {
+    manager.cancelAllOperations();
+  });
+
+  Future<String> runFetch(
+    String url, {
+    Map<String, dynamic>? init,
+    Duration? wait,
+  }) async {
+    final result = Completer<String>();
+    await manager.loadPlugin(
+      id: 'fetch.plugin',
+      manifest: testManifest('fetch.plugin'),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "fetch.plugin",
+            onLoad() {
+              fetch(${jsonEncode(url)}, ${jsonEncode(init ?? {})})
+                .then((res) => res.text())
+                .then((text) => host.emit("result", "ok:" + text))
+                .catch((e) => host.emit("result", "err:" + e.message));
+            }
+          };
+        }
+      ''',
+    );
+    final sub = manager.emitStream.listen((e) {
+      if (!result.isCompleted) result.complete(e['payload'] as String);
+    });
+    final value = await result.future
+        .timeout(wait ?? const Duration(seconds: 10))
+        .whenComplete(sub.cancel);
+    await sub.cancel();
+    return value;
+  }
+
+  test('successful fetch resolves with body', () async {
+    final server = await startServer((res) async {
+      res.headers.contentType = ContentType.json;
+      res.write(jsonEncode({'hello': 'world'}));
+    });
+    addTearDown(server.close);
+
+    final result = await runFetch('http://127.0.0.1:${server.port}/data');
+
+    expect(result, 'ok:{"hello":"world"}');
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test(
+    'non-2xx response resolves (fetch semantics) with status exposed',
+    () async {
+      final server = await startServer((res) async {
+        res.statusCode = 404;
+        res.write('nope');
+      });
+      addTearDown(server.close);
+
+      final result = await runFetch('http://127.0.0.1:${server.port}/missing');
+
+      expect(result, 'ok:nope');
+      expect(manager.activePendingOpCount, 0);
+    },
+  );
+
+  test('connection failure rejects the promise', () async {
+    // Port 1 is never listening on loopback.
+    final result = await runFetch('http://127.0.0.1:1/nowhere');
+
+    expect(result, startsWith('err:'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('request timeout rejects the promise', () async {
+    final server = await startServer((res) async {
+      await Future<void>.delayed(const Duration(seconds: 10));
+      res.write('too late');
+    });
+    addTearDown(server.close);
+
+    final result = await runFetch('http://127.0.0.1:${server.port}/slow');
+
+    expect(result, startsWith('err:'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('oversized response rejects the promise', () async {
+    final server = await startServer((res) async {
+      res.write('x' * 1024);
+    });
+    addTearDown(server.close);
+    manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      fetchTimeout: const Duration(seconds: 2),
+      maxFetchResponseBytes: 100,
+    );
+
+    final result = await runFetch('http://127.0.0.1:${server.port}/big');
+
+    expect(result, startsWith('err:'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('invalid UTF-8 body decodes with replacement characters', () async {
+    final server = await startServer((res) async {
+      res.add([0xFF, 0xFE, 0x41]);
+    });
+    addTearDown(server.close);
+
+    final result = await runFetch('http://127.0.0.1:${server.port}/bytes');
+
+    expect(result, contains('\uFFFD'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('plugin unload rejects pending fetch', () async {
+    final server = await startServer((res) async {
+      await Future<void>.delayed(const Duration(seconds: 10));
+      res.write('late');
+    });
+    addTearDown(server.close);
+
+    await manager.loadPlugin(
+      id: 'fetch.plugin',
+      manifest: testManifest('fetch.plugin'),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "fetch.plugin",
+            onLoad() {
+              fetch(${jsonEncode('http://127.0.0.1:${server.port}/pending')})
+                .then((res) => host.emit("result", "unexpected"))
+                .catch((e) => host.emit("result", "rejected:" + e.message));
+            }
+          };
+        }
+      ''',
+    );
+    final result = Completer<String>();
+    final sub = manager.emitStream.listen((e) {
+      if (!result.isCompleted) result.complete(e['payload'] as String);
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await manager.unloadPlugin('fetch.plugin');
+    final value = await result.future
+        .timeout(const Duration(seconds: 5))
+        .whenComplete(sub.cancel);
+
+    expect(value, startsWith('rejected:'));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('cancelAllOperations rejects pending fetch', () async {
+    final server = await startServer((res) async {
+      await Future<void>.delayed(const Duration(seconds: 10));
+      res.write('late');
+    });
+    addTearDown(server.close);
+
+    await manager.loadPlugin(
+      id: 'fetch.plugin',
+      manifest: testManifest('fetch.plugin'),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "fetch.plugin",
+            onLoad() {
+              fetch(${jsonEncode('http://127.0.0.1:${server.port}/pending')})
+                .then((res) => host.emit("result", "unexpected"))
+                .catch((e) => host.emit("result", "rejected:" + e.message));
+            }
+          };
+        }
+      ''',
+    );
+    final result = Completer<String>();
+    final sub = manager.emitStream.listen((e) {
+      if (!result.isCompleted) result.complete(e['payload'] as String);
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    manager.cancelAllOperations();
+    final value = await result.future
+        .timeout(const Duration(seconds: 5))
+        .whenComplete(sub.cancel);
+
+    expect(value, startsWith('rejected:'));
+    expect(manager.activePendingOpCount, 0);
+  });
+}

--- a/test/plugins/plugin_manager_timers_test.dart
+++ b/test/plugins/plugin_manager_timers_test.dart
@@ -101,12 +101,45 @@ void main() {
     expect(jsTimerCount(), '0');
   });
 
+  test(
+    'failed plugin load cleans up async work created during onLoad',
+    () async {
+      await expectLater(
+        manager.loadPlugin(
+          id: 'timer.plugin',
+          manifest: testManifest('timer.plugin'),
+          settings: {},
+          jsCode: r'''
+          function createPlugin(host) {
+            return {
+              id: "timer.plugin",
+              onLoad() {
+                setTimeout(() => host.emit("ghost", "fired"), 1000);
+                throw new Error("onLoad boom");
+              }
+            };
+          }
+        ''',
+        ),
+        throwsA(isA<Exception>()),
+      );
+
+      // Let any in-flight timerSet messages process against the removed plugin.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(manager.activeTimerCount, 0);
+      expect(manager.activePendingOpCount, 0);
+      expect(jsTimerCount(), '0');
+    },
+  );
+
   test('cancelAllOperations cancels multiple plugin-owned timers', () async {
     await loadTimerPlugin('''
       setTimeout(() => host.emit("a", "fired"), 1000);
       setTimeout(() => host.emit("b", "fired"), 1000);
     ''');
 
+    // Let the deferred timerSet messages register before asserting.
+    await Future<void>.delayed(const Duration(milliseconds: 20));
     expect(manager.activeTimerCount, 2);
     manager.cancelAllOperations();
     expect(manager.activeTimerCount, 0);

--- a/test/plugins/plugin_manager_timers_test.dart
+++ b/test/plugins/plugin_manager_timers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 
@@ -131,6 +133,71 @@ void main() {
       expect(jsTimerCount(), '0');
     },
   );
+
+  test('unload sweeps timers scheduled by rejection handlers', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((req) async {
+      await Future<void>.delayed(const Duration(seconds: 10));
+      try {
+        await req.response.close();
+      } catch (_) {}
+    });
+    addTearDown(server.close);
+
+    await manager.loadPlugin(
+      id: 'timer.plugin',
+      manifest: testManifest('timer.plugin'),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "timer.plugin",
+            onLoad() {
+              fetch("http://127.0.0.1:${server.port}/slow")
+                .then(() => host.emit("r", "unexpected"))
+                .catch(() => {
+                  setTimeout(() => host.emit("ghost", "fired"), 1000);
+                });
+            }
+          };
+        }
+      ''',
+    );
+    // Let the fetch op register before unloading.
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await manager.unloadPlugin('timer.plugin');
+
+    // The rejection handler's setTimeout must be swept, not resurrected.
+    expect(manager.activeTimerCount, 0);
+    expect(jsTimerCount(), '0');
+
+    final events = await collectEvents(const Duration(milliseconds: 1100));
+    expect(events, isEmpty);
+    expect(manager.activeTimerCount, 0);
+    expect(jsTimerCount(), '0');
+  });
+
+  test('timer from a previous plugin generation is not registered', () async {
+    await loadTimerPlugin(
+      'setTimeout(() => host.emit("ghost", "fired"), 1000);',
+    );
+    // Reload the same id before the deferred timerSet message is processed.
+    await manager.unloadPlugin('timer.plugin');
+    await manager.loadPlugin(
+      id: 'timer.plugin',
+      manifest: testManifest('timer.plugin'),
+      settings: {},
+      jsCode: 'function createPlugin(host) { return { id: "timer.plugin" }; }',
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(manager.activeTimerCount, 0);
+    expect(jsTimerCount(), '0');
+
+    final events = await collectEvents(const Duration(milliseconds: 1100));
+    expect(events, isEmpty);
+  });
 
   test('cancelAllOperations cancels multiple plugin-owned timers', () async {
     await loadTimerPlugin('''

--- a/test/plugins/plugin_manager_timers_test.dart
+++ b/test/plugins/plugin_manager_timers_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+
+import 'plugin_test_helpers.dart';
+
+void main() {
+  late PluginManager manager;
+
+  setUp(() {
+    manager = PluginManager(kvStore: FakeKeyValueStoreService());
+  });
+
+  tearDown(() {
+    manager.cancelAllOperations();
+  });
+
+  Future<List<String>> collectEvents(Duration window) async {
+    final events = <String>[];
+    final sub = manager.emitStream.listen(
+      (e) => events.add(e['event'] as String),
+    );
+    await Future<void>.delayed(window);
+    await sub.cancel();
+    return events;
+  }
+
+  String jsTimerCount() =>
+      manager.js.evaluate('String(globalThis.__debugTimers.size)').stringResult;
+
+  Future<void> loadTimerPlugin(String jsBody) async {
+    await manager.loadPlugin(
+      id: 'timer.plugin',
+      manifest: testManifest('timer.plugin'),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "timer.plugin",
+            onLoad() {
+              $jsBody
+            }
+          };
+        }
+      ''',
+    );
+  }
+
+  test(
+    'setTimeout fires exactly once and removes the registry entry',
+    () async {
+      await loadTimerPlugin('''
+      setTimeout(() => host.emit("fired", "once"), 20);
+    ''');
+
+      final events = await collectEvents(const Duration(milliseconds: 300));
+
+      expect(events, ['fired']);
+      expect(manager.activeTimerCount, 0);
+      expect(jsTimerCount(), '0');
+    },
+  );
+
+  test('clearTimeout cancels the matching timer', () async {
+    await loadTimerPlugin('''
+      const id = setTimeout(() => host.emit("bad", "fired"), 20);
+      clearTimeout(id);
+      setTimeout(() => host.emit("good", "fired"), 60);
+    ''');
+
+    final events = await collectEvents(const Duration(milliseconds: 300));
+
+    expect(events, ['good']);
+    expect(manager.activeTimerCount, 0);
+    expect(jsTimerCount(), '0');
+  });
+
+  test('plugin unload cancels armed timers', () async {
+    await loadTimerPlugin('''
+      setTimeout(() => host.emit("ghost", "fired"), 60);
+    ''');
+
+    await manager.unloadPlugin('timer.plugin');
+    final events = await collectEvents(const Duration(milliseconds: 200));
+
+    expect(events, isEmpty);
+    expect(manager.activeTimerCount, 0);
+    expect(jsTimerCount(), '0');
+  });
+
+  test('throwing callback still removes timer and registry entry', () async {
+    await loadTimerPlugin('''
+      setTimeout(() => { throw new Error("boom"); }, 20);
+      setTimeout(() => host.emit("afterThrow", "stillFired"), 60);
+    ''');
+
+    final events = await collectEvents(const Duration(milliseconds: 300));
+
+    expect(events, ['afterThrow']);
+    expect(manager.activeTimerCount, 0);
+    expect(jsTimerCount(), '0');
+  });
+
+  test('cancelAllOperations cancels multiple plugin-owned timers', () async {
+    await loadTimerPlugin('''
+      setTimeout(() => host.emit("a", "fired"), 1000);
+      setTimeout(() => host.emit("b", "fired"), 1000);
+    ''');
+
+    expect(manager.activeTimerCount, 2);
+    manager.cancelAllOperations();
+    expect(manager.activeTimerCount, 0);
+
+    final events = await collectEvents(const Duration(milliseconds: 200));
+
+    expect(events, isEmpty);
+    expect(jsTimerCount(), '0');
+  });
+}

--- a/test/plugins/plugin_manager_workload_test.dart
+++ b/test/plugins/plugin_manager_workload_test.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/services/account/decent_proxy_service.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+
+import 'plugin_test_helpers.dart';
+
+void main() {
+  const pluginId = 'workload.plugin';
+
+  PluginManifest manifest() {
+    return PluginManifest(
+      id: pluginId,
+      name: pluginId,
+      author: 'Test',
+      description: 'Test',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: const {PluginPermissions.proxyDecentApi},
+      settings: const {},
+      api: PluginApi(endpoints: const []),
+    );
+  }
+
+  test(
+    'repeated timer/fetch/proxy workload returns all registries to zero',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((req) async {
+        req.response.headers.contentType = ContentType.json;
+        req.response.write('{"ok":true}');
+        await req.response.close();
+      });
+      addTearDown(server.close);
+
+      final store = _CredentialStore();
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        fetchTimeout: const Duration(seconds: 5),
+        pluginHttpTimeout: const Duration(seconds: 5),
+        decentProxyTimeout: const Duration(seconds: 5),
+        decentProxyService: DecentProxyService(
+          credentialStore: store,
+          httpClient: http_testing.MockClient(
+            (request) async => http.Response('{"serial":"SN001"}', 200),
+          ),
+        ),
+      );
+      addTearDown(manager.cancelAllOperations);
+
+      final done = Completer<void>();
+      final sub = manager.emitStream.listen((e) {
+        final event = e['event'] as String;
+        if (event == 'finished' && !done.isCompleted) done.complete();
+      });
+
+      for (var round = 0; round < 10; round++) {
+        await manager.loadPlugin(
+          id: pluginId,
+          manifest: manifest(),
+          settings: {},
+          jsCode:
+              '''
+            function createPlugin(host) {
+              return {
+                id: "$pluginId",
+                onLoad() {
+                  const timers = [
+                    setTimeout(() => host.emit("t1", "fired"), 20),
+                    setTimeout(() => host.emit("t2", "fired"), 30)
+                  ];
+                  fetch("http://127.0.0.1:${server.port}/data")
+                    .then((r) => r.text())
+                    .then(() => host.decentProxy("support/api/sn"))
+                    .then(() => {
+                      clearTimeout(timers[0]);
+                      clearTimeout(timers[1]);
+                      host.emit("finished", "round");
+                    })
+                    .catch((e) => host.emit("finished", "error:" + e.message));
+                }
+              };
+            }
+          ''',
+        );
+        await done.future.timeout(const Duration(seconds: 10));
+        if (!done.isCompleted) done.complete();
+        // Let trailing timerClear messages reach Dart before asserting.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(manager.activeTimerCount, 0, reason: 'timers in round $round');
+        expect(
+          manager.activePendingOpCount,
+          0,
+          reason: 'pending ops in round $round',
+        );
+        await manager.unloadPlugin(pluginId);
+        expect(
+          manager.activeTimerCount,
+          0,
+          reason: 'timers after unload in round $round',
+        );
+        expect(
+          manager.activePendingOpCount,
+          0,
+          reason: 'ops after unload in round $round',
+        );
+      }
+      await sub.cancel();
+      expect(manager.activeTimersByPlugin, isEmpty);
+      expect(manager.activePendingOpsByType, isEmpty);
+    },
+  );
+}
+
+class _CredentialStore implements CredentialStore {
+  @override
+  Future<String?> read({required String key}) async => 'value';
+
+  @override
+  Future<void> write({required String key, required String value}) async {}
+
+  @override
+  Future<void> delete({required String key}) async {}
+}

--- a/test/plugins/plugin_test_helpers.dart
+++ b/test/plugins/plugin_test_helpers.dart
@@ -1,0 +1,61 @@
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/storage/kv_store_service.dart';
+
+class FakeKeyValueStoreService implements KeyValueStoreService {
+  final Map<String, Map<String, Object>> _store = {};
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> set({
+    String namespace = 'default',
+    required String key,
+    required Object value,
+  }) async {
+    _store.putIfAbsent(namespace, () => {})[key] = value;
+  }
+
+  @override
+  Future<bool> delete({
+    String namespace = 'default',
+    required String key,
+  }) async {
+    return _store[namespace]?.remove(key) != null;
+  }
+
+  @override
+  Future<Object?> get({
+    String namespace = 'default',
+    required String key,
+  }) async {
+    return _store[namespace]?[key];
+  }
+
+  @override
+  Future<List<String>> keys({String namespace = 'default'}) async {
+    return _store[namespace]?.keys.toList() ?? [];
+  }
+
+  @override
+  List<String> get namespaces => _store.keys.toList();
+
+  @override
+  Future<Map<String, Object>> getAll({String namespace = 'default'}) async {
+    return Map<String, Object>.from(_store[namespace] ?? {});
+  }
+}
+
+PluginManifest testManifest(String id) {
+  return PluginManifest(
+    id: id,
+    name: id,
+    author: 'Test',
+    description: 'Test',
+    version: '1.0.0',
+    apiVersion: 1,
+    permissions: const {},
+    settings: {},
+    api: PluginApi(endpoints: []),
+  );
+}

--- a/test/plugins/shot_upload_plugin_test.dart
+++ b/test/plugins/shot_upload_plugin_test.dart
@@ -135,7 +135,7 @@ void main() {
       ),
     );
     final r = manager.js.evaluate('''
-      globalThis.__timerSet = (pluginId, callback, delay) => { callback(); return 1; };
+      globalThis.__timerSet = (pluginId, generation, callback, delay) => { callback(); return 1; };
       globalThis.__timerClear = () => {};
       globalThis.__puts = [];
       globalThis.__fetchFor = async (pluginId, generation, url, init) => {

--- a/test/plugins/shot_upload_plugin_test.dart
+++ b/test/plugins/shot_upload_plugin_test.dart
@@ -135,10 +135,10 @@ void main() {
       ),
     );
     final r = manager.js.evaluate('''
-      globalThis.setTimeout = (cb) => { cb(); return 1; };
-      globalThis.clearTimeout = () => {};
+      globalThis.__timerSet = (pluginId, callback, delay) => { callback(); return 1; };
+      globalThis.__timerClear = () => {};
       globalThis.__puts = [];
-      globalThis.fetch = async (url, init) => {
+      globalThis.__fetchFor = async (pluginId, generation, url, init) => {
         init = init || {};
         if (init.method === 'PUT') { globalThis.__puts.push({ url: String(url), body: init.body }); return { ok:true, status:200, json: async () => ({}) }; }
         if (url.endsWith('/shots/latest')) return { ok:true, json: async () => ({ id:'shot-1' }) };
@@ -251,6 +251,7 @@ void main() {
       captured: captured,
     );
 
+    final responseFuture = manager.registerPendingHttp(_manifest().id, 'req-1');
     manager.dispatchEvent(_manifest().id, 'httpRequest', {
       'requestId': 'req-1',
       'endpoint': 'upload',
@@ -260,19 +261,14 @@ void main() {
       'query': <String, String>{},
     });
 
-    Map<String, dynamic>? response;
-    await _pumpUntil(manager, () {
-      response = manager.getPendingHttpResponse('req-1');
-      return response != null;
-    });
+    final response = await responseFuture.timeout(const Duration(seconds: 5));
 
     expect(captured, hasLength(1));
     expect(
       captured.single.url.toString(),
       'https://decentespresso.com/support/api/shot_upload',
     );
-    expect(response, isNotNull);
-    expect(response!['status'], 200);
-    expect(jsonDecode(response!['body'] as String)['ok'], true);
+    expect(response['status'], 200);
+    expect(jsonDecode(response['body'] as String)['ok'], true);
   });
 }

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -84,7 +84,7 @@ void main() {
       };
       final manager = PluginManager(kvStore: _FakeKeyValueStore());
       final setupResult = manager.js.evaluate('''
-      globalThis.__timerSet = (pluginId, callback, delay) => { callback(); return 1; };
+      globalThis.__timerSet = (pluginId, generation, callback, delay) => { callback(); return 1; };
       globalThis.__timerClear = () => {};
       globalThis.__fetchFor = async (pluginId, generation, url, init = {}) => {
         if (url.endsWith('/shots/latest')) {

--- a/test/plugins/visualizer_plugin_test.dart
+++ b/test/plugins/visualizer_plugin_test.dart
@@ -84,9 +84,9 @@ void main() {
       };
       final manager = PluginManager(kvStore: _FakeKeyValueStore());
       final setupResult = manager.js.evaluate('''
-      globalThis.setTimeout = (callback) => { callback(); return 1; };
-      globalThis.clearTimeout = () => {};
-      globalThis.fetch = async (url, init = {}) => {
+      globalThis.__timerSet = (pluginId, callback, delay) => { callback(); return 1; };
+      globalThis.__timerClear = () => {};
+      globalThis.__fetchFor = async (pluginId, generation, url, init = {}) => {
         if (url.endsWith('/shots/latest')) {
           return { ok: true, json: async () => ({ id: 'shot-1' }) };
         }

--- a/test/services/webserver/plugins_handler_test.dart
+++ b/test/services/webserver/plugins_handler_test.dart
@@ -1,0 +1,278 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import '../../plugins/plugin_test_helpers.dart';
+
+class _FakePluginLoaderService extends Fake implements PluginLoaderService {}
+
+void main() {
+  const pluginId = 'http.plugin';
+
+  PluginManifest httpManifest() {
+    return PluginManifest(
+      id: pluginId,
+      name: pluginId,
+      author: 'Test',
+      description: 'Test',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: const {},
+      settings: const {},
+      api: PluginApi(
+        endpoints: [
+          ApiEndpoint(id: 'hello', type: ApiEndpointType.http, data: const {}),
+        ],
+      ),
+    );
+  }
+
+  test('synchronous plugin response completes the request directly', () async {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      pluginHttpTimeout: const Duration(seconds: 5),
+    );
+    addTearDown(manager.cancelAllOperations);
+    await manager.loadPlugin(
+      id: pluginId,
+      manifest: httpManifest(),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            handleHttpRequest: (request) => ({
+              status: 200,
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({echo: request.body})
+            })
+          };
+        }
+      ''',
+    );
+    final app = Router().plus;
+    PluginsHandler(
+      pluginManager: manager,
+      pluginService: _FakePluginLoaderService(),
+    ).addRoutes(app);
+
+    final response = await app.call(
+      Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/plugins/$pluginId/hello'),
+      ),
+    );
+
+    expect(response.statusCode, 200);
+    expect(await response.readAsString(), '{"echo":null}');
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('asynchronous plugin response completes the request directly', () async {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      pluginHttpTimeout: const Duration(seconds: 5),
+    );
+    addTearDown(manager.cancelAllOperations);
+    await manager.loadPlugin(
+      id: pluginId,
+      manifest: httpManifest(),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            handleHttpRequest: async (request) => {
+              await new Promise(r => setTimeout(r, 30));
+              return { status: 200, headers: {}, body: "async-response" };
+            }
+          };
+        }
+      ''',
+    );
+    final app = Router().plus;
+    PluginsHandler(
+      pluginManager: manager,
+      pluginService: _FakePluginLoaderService(),
+    ).addRoutes(app);
+
+    final response = await app.call(
+      Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/plugins/$pluginId/hello'),
+      ),
+    );
+
+    expect(response.statusCode, 200);
+    expect(await response.readAsString(), 'async-response');
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('throwing plugin handler returns a 500 error response', () async {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      pluginHttpTimeout: const Duration(seconds: 5),
+    );
+    addTearDown(manager.cancelAllOperations);
+    await manager.loadPlugin(
+      id: pluginId,
+      manifest: httpManifest(),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            handleHttpRequest: () => { throw new Error("boom"); }
+          };
+        }
+      ''',
+    );
+    final app = Router().plus;
+    PluginsHandler(
+      pluginManager: manager,
+      pluginService: _FakePluginLoaderService(),
+    ).addRoutes(app);
+
+    final response = await app.call(
+      Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/plugins/$pluginId/hello'),
+      ),
+    );
+
+    expect(response.statusCode, 500);
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test(
+    'timeout returns a clean error and removes the registry entry',
+    () async {
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        pluginHttpTimeout: const Duration(milliseconds: 200),
+      );
+      addTearDown(manager.cancelAllOperations);
+      await manager.loadPlugin(
+        id: pluginId,
+        manifest: httpManifest(),
+        settings: {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          return { id: "$pluginId" };
+        }
+      ''',
+      );
+      final app = Router().plus;
+      PluginsHandler(
+        pluginManager: manager,
+        pluginService: _FakePluginLoaderService(),
+      ).addRoutes(app);
+
+      final response = await app.call(
+        Request(
+          'GET',
+          Uri.parse('http://localhost/api/v1/plugins/$pluginId/hello'),
+        ),
+      );
+
+      expect(response.statusCode, 500); // jsonError
+      expect(
+        await response.readAsString(),
+        contains('did not respond in time'),
+      );
+      expect(manager.activePendingOpCount, 0);
+    },
+  );
+
+  test('response arriving after timeout is ignored and not retained', () async {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      pluginHttpTimeout: const Duration(milliseconds: 200),
+    );
+    addTearDown(manager.cancelAllOperations);
+    await manager.loadPlugin(
+      id: pluginId,
+      manifest: httpManifest(),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            handleHttpRequest: (request) => new Promise((resolve) => {
+              setTimeout(() => resolve({
+                status: 200, headers: {}, body: "late-response"
+              }), 400);
+            })
+          };
+        }
+      ''',
+    );
+    final app = Router().plus;
+    PluginsHandler(
+      pluginManager: manager,
+      pluginService: _FakePluginLoaderService(),
+    ).addRoutes(app);
+
+    final response = await app.call(
+      Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/plugins/$pluginId/hello'),
+      ),
+    );
+    expect(await response.readAsString(), contains('did not respond in time'));
+
+    // Let the late response arrive and verify it is dropped.
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('plugin unload completes pending HTTP requests with an error', () async {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      pluginHttpTimeout: const Duration(seconds: 5),
+    );
+    addTearDown(manager.cancelAllOperations);
+    await manager.loadPlugin(
+      id: pluginId,
+      manifest: httpManifest(),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            handleHttpRequest: (request) => new Promise((resolve) => {
+              setTimeout(() => resolve({ status: 200, headers: {}, body: "never" }), 5000);
+            })
+          };
+        }
+      ''',
+    );
+    final app = Router().plus;
+    PluginsHandler(
+      pluginManager: manager,
+      pluginService: _FakePluginLoaderService(),
+    ).addRoutes(app);
+
+    final responseFuture = app.call(
+      Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/plugins/$pluginId/hello'),
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await manager.unloadPlugin(pluginId);
+
+    final response = await responseFuture;
+    expect(await response.readAsString(), contains('unloaded'));
+    expect(manager.activePendingOpCount, 0);
+  });
+}


### PR DESCRIPTION
## Summary

> **Naming:** The display name is **Decaid**. The Dart package, bundle ID, database, and plugin extension retain legacy identifiers for compatibility — see the naming table in [`CLAUDE.md`](CLAUDE.md).

- Problem: `PluginManager` ran six independent async bridges (timers, fetch, host.httpRequest, incoming plugin HTTP, Decent proxy, message callbacks), each with at least one path where ownership, cancellation, or completion was missing — leaked promises, zombie timers, late responses retained forever.
- Why it matters: unbounded growth in the plugin host after failures/timeouts/unloads; plugins can never fully clean up (the visualizer's `clearTimeout` on unload was a no-op); `host.httpRequest` exposed a permanently pending promise.
- What changed: one unified pending-operation registry with a single terminal path (success/error/timeout/unload/dispose) that removes the entry before settling; Dart-owned timers behind wrapper-scoped `setTimeout`/`clearTimeout`; shared bounded `HttpClient` + timeout/size caps for fetch; `Completer`-based incoming-HTTP completion replacing 100ms polling; Decent proxy timeout + unload/dispose rejection + empty-map cleanup + generation threading; sync fire-and-forget host/fetch handlers; diagnostics for active timers/ops by type and plugin.
- What did NOT change (scope boundary): #562 owns top-level `PluginManager`/`PluginLoaderService` disposal (this PR provides `cancelAllOperations()` as its hook); #519 owns `tadelv/dart_js` JSCore FFI ownership; no socket/WebSocket capabilities (#146); no permission redesign.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #561
- Related #562, #519

## Root Cause (if bug fix)

- Root cause: async resources (Dart `Timer`s, `HttpClient`s, `Completer`s, JS pending-promise maps) were created and never tracked as owned objects; failure, timeout, unload, and late-response paths each missed at least one removal step. The worst offender: fetch failures went through a dead `sendMessage` channel whose JS listener was commented out, so `_pendingFetches` entries never settled.
- Missing detection or guardrail: no unified terminal path for async operations; no per-plugin ownership; no timeouts or size limits; `host.httpRequest` was advertised without any Dart handler.
- Contributing context (if known): the audit baseline is Decaid commit `61346e23` (issue #561), reviewed 2026-08-05.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/plugins/plugin_manager_timers_test.dart`, `test/plugins/plugin_manager_fetch_test.dart`, `test/services/webserver/plugins_handler_test.dart`, `test/plugins/plugin_manager_decent_proxy_ownership_test.dart`, `test/plugins/plugin_manager_workload_test.dart` (10-round mixed workload asserting registries return to zero).
- Scenario the test should lock in: every timer and pending-op registry is empty after each test; rejection on timeout/unload/dispose; late responses from a previous plugin generation are dropped.
- If no new test added, why not: N/A — 27 new tests added.

## Documentation Obligations (required)

These are **not optional**. Stale specs mislead clients and agents.

- [ ] API spec updated: `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` (if REST/WebSocket changed)
- [ ] API docs updated: `doc/Api.md` (if user-facing endpoint changed)
- [ ] Plugin docs updated: `doc/Plugins.md` (if events/API changed) — no change needed: `fetch`/`setTimeout`/`clearTimeout` were already listed as available; `host.httpRequest` was never documented
- [ ] Skin docs updated: `doc/Skins.md` (if skin behavior changed)
- [ ] Profile docs updated: `doc/Profiles.md` (if profile handling changed)
- [ ] Device docs updated: `doc/DeviceManagement.md` (if device flows changed)
- [x] N/A — no docs affected

## Security Impact (required)

This app runs a local web server (port 8080) and connects to BLE/USB hardware.

- New or changed REST endpoints? (`No`)
- New or changed WebSocket topics? (`No`)
- New or changed network calls? (`Yes` — fetch now uses a shared `HttpClient` with timeouts and a response-size cap; no new endpoints)
- BLE/USB surface changed? (`No`)
- File system access changed? (`No`)
- Plugin sandbox boundary changed? (`Yes` — timers and fetch are now owned by the host and cancelled on unload; `host.httpRequest` removed; fetch outside plugin context rejects)
- If any `Yes`, explain risk and mitigation: fetch remains permitted for loaded plugins (unchanged surface); the shared client is closed on manager disposal; bounded time/size prevents unbounded memory from a single request. Removal of `host.httpRequest` cannot break users — it never had a Dart handler and returned a permanently pending promise.

## User-Visible Changes

Plugins with an armed timer that leak on unload now have them cancelled; plugin fetches that failed previously never settled (hung promise) and now reject with the error; `host.httpRequest` is no longer exposed (it never worked). No UI or device-visible changes.

## Verification

### Local gates (run before pushing)

- [x] `dart format lib test` — no remaining changes
- [x] `flutter analyze` — clean (no new warnings)
- [x] `flutter test` — all pass (2817 tests)
- [x] `./scripts/fetch_dye2_plugin.sh` — DYE2 plugin installed into `assets/plugins/dye2.reaplugin/`

### Manual verification (if applicable)

- OS / platform tested: macOS (test suite)
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: full `flutter test` (2817 passing), `flutter analyze` clean, `dart format` clean.
- Edge cases checked: timer callback throwing still removes the registry entry; invalid UTF-8 fetch bodies decode with replacement chars; oversized responses rejected; late responses after timeout and after plugin-generation reload dropped; invalid bridge token settles the promise.
- What you did **not** verify: real-device / simulator smoke run of a plugin exercising fetch + timers end to end.

### Evidence

Attach at least one:

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

Test evidence:
```
$ flutter test  # before: 210 plugin/webserver tests; after: 2817 total, all pass
$ flutter analyze  # No issues found
```

## Compatibility & Migration

- Backward compatible? (`Yes` — plugin-visible `fetch`/`setTimeout`/`clearTimeout` behavior preserved; the two bundled-plugin tests were updated to stub the new ownership seam (`__timerSet`/`__fetchFor`) with identical plugin-visible behavior)
- Config / env changes needed? (`No`)
- Database migration needed? (`No`)
- If any `No` or `Yes`, explain exact steps: N/A

## Risks & Mitigations

- Risk: the async plugin-HTTP path depends on the runtime draining JS microtasks after `dispatchEvent`; this was already the case pre-change (polling masked it) — the new async plugin-HTTP test covers the path.
  - Mitigation: covered by `asynchronous plugin response completes the request directly` in `test/services/webserver/plugins_handler_test.dart`.
- Risk: `globalThis.fetch` (non-plugin context) now rejects instead of issuing a request.
  - Mitigation: only reachable by code bypassing the plugin wrapper; bundled plugins verified to use the wrapper path.
