### PR TITLE
plugin-host: add complete lifecycle disposal

### DIFF
--- a/doc/plans/archive/gh562-plugin-lifecycle/gh562-plugin-lifecycle.md
+++ b/doc/plans/archive/gh562-plugin-lifecycle/gh562-plugin-lifecycle.md
@@ -9,7 +9,7 @@ PluginManager previously owned a JavaScript runtime, host bridges, controller su
 - PluginManager and PluginLoaderService expose `active`, `disposing`, and `disposed` states and cache one teardown future.
 - Disposal becomes terminal synchronously. Public mutation is rejected once teardown starts, while private cleanup can continue using JavaScript until runtime disposal.
 - DE1 controller attachment is serialized. Controller and snapshot subscriptions are cancelled before replacements are installed, and both callbacks validate one monotonic attachment generation.
-- Each plugin generation is invalidated before `onUnload`. Host messages carry that generation, so deferred messages cannot target a replacement plugin or recreate state during teardown.
+- Each plugin generation is invalidated before `onUnload`. Host messages carry that generation, so deferred messages cannot target a replacement plugin or recreate state during teardown. Storage writes from the retiring generation are the only permitted teardown messages and finish before the runtime is removed.
 - Plugin unload uses JavaScript `finally` for registry deletion, rejects pending work, cancels bridge promises and timers, removes bridge tokens, and marks the Dart runtime disposed after host cleanup.
 - Manager disposal detaches controllers, unloads every plugin, cancels remaining work, removes runtime channel registrations, closes the event stream, and calls `JavascriptRuntime.dispose()` exactly once.
 - Loader disposal waits for accepted initialization and queued load work before delegating to manager disposal.

--- a/doc/plans/archive/gh562-plugin-lifecycle/gh562-plugin-lifecycle.md
+++ b/doc/plans/archive/gh562-plugin-lifecycle/gh562-plugin-lifecycle.md
@@ -13,7 +13,7 @@ PluginManager previously owned a JavaScript runtime, host bridges, controller su
 - Plugin unload uses JavaScript `finally` for registry deletion, rejects pending work, cancels bridge promises and timers, removes bridge tokens, and marks the Dart runtime disposed after host cleanup.
 - Manager disposal detaches controllers, unloads every plugin, cancels remaining work, removes runtime channel registrations, closes the event stream, and calls `JavascriptRuntime.dispose()` exactly once.
 - Loader disposal waits for accepted initialization and queued load work before delegating to manager disposal.
-- The process-wide loader is disposed only for `AppLifecycleState.detached`. Backgrounding and keyed application restarts continue to reuse it.
+- The process-wide loader is disposed for `AppLifecycleState.detached` and before cancelable desktop exit requests complete. Backgrounding and keyed application restarts continue to reuse it.
 
 ## Runtime boundary
 

--- a/doc/plans/archive/gh562-plugin-lifecycle/gh562-plugin-lifecycle.md
+++ b/doc/plans/archive/gh562-plugin-lifecycle/gh562-plugin-lifecycle.md
@@ -1,0 +1,20 @@
+# Plugin subsystem disposal
+
+## Context
+
+PluginManager previously owned a JavaScript runtime, host bridges, controller subscriptions, timers, pending operations, and an event stream without a terminal lifecycle. PluginLoaderService also accepted new work indefinitely and the process-level application lifecycle never released either service.
+
+## Decisions
+
+- PluginManager and PluginLoaderService expose `active`, `disposing`, and `disposed` states and cache one teardown future.
+- Disposal becomes terminal synchronously. Public mutation is rejected once teardown starts, while private cleanup can continue using JavaScript until runtime disposal.
+- DE1 controller attachment is serialized. Controller and snapshot subscriptions are cancelled before replacements are installed, and both callbacks validate one monotonic attachment generation.
+- Each plugin generation is invalidated before `onUnload`. Host messages carry that generation, so deferred messages cannot target a replacement plugin or recreate state during teardown.
+- Plugin unload uses JavaScript `finally` for registry deletion, rejects pending work, cancels bridge promises and timers, removes bridge tokens, and marks the Dart runtime disposed after host cleanup.
+- Manager disposal detaches controllers, unloads every plugin, cancels remaining work, removes runtime channel registrations, closes the event stream, and calls `JavascriptRuntime.dispose()` exactly once.
+- Loader disposal waits for accepted initialization and queued load work before delegating to manager disposal.
+- The process-wide loader is disposed only for `AppLifecycleState.detached`. Backgrounding and keyed application restarts continue to reuse it.
+
+## Runtime boundary
+
+The pinned `flutter_js` API exposes synchronous `JavascriptRuntime.dispose()`. Decaid now calls that contract exactly once, but native JavaScriptCore and QuickJS allocation behavior inside `flutter_js` remains owned by that dependency and is not repaired here.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -702,7 +702,7 @@ class AppLifecycleObserver with WidgetsBindingObserver {
   StreamSubscription? _machineStateSubscription;
   StreamSubscription? _stateStreamSubscription;
   int? _lastMachineState;
-  bool _detaching = false;
+  Future<void>? _detachFuture;
 
   AppLifecycleObserver({
     this.updateCheckService,
@@ -724,14 +724,14 @@ class AppLifecycleObserver with WidgetsBindingObserver {
 
     // Monitor machine state changes for sleep-to-idle transitions
     _machineStateSubscription = de1Controller?.de1.listen((machine) {
-      if (_detaching) return;
+      if (_detachFuture != null) return;
       _stateStreamSubscription?.cancel();
 
       if (machine == null) return;
 
       // Check if machine transitioned from sleep to idle
       _stateStreamSubscription = machine.currentSnapshot.listen((snapshot) {
-        if (_detaching) return;
+        if (_detachFuture != null) return;
         final currentState = snapshot.state.state.index;
 
         // Detect transition from sleep (0) to idle (2)
@@ -751,10 +751,8 @@ class AppLifecycleObserver with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.detached && !_detaching) {
-      _detaching = true;
-      _memTimer.cancel();
-      unawaited(_handleDetached());
+    if (state == AppLifecycleState.detached) {
+      unawaited(_detach());
     }
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden) {
@@ -777,6 +775,22 @@ class AppLifecycleObserver with WidgetsBindingObserver {
       }
       _wasBackgrounded = false;
     }
+  }
+
+  @override
+  Future<AppExitResponse> didRequestAppExit() async {
+    await _detach();
+    return AppExitResponse.exit;
+  }
+
+  Future<void> _detach() {
+    final existing = _detachFuture;
+    if (existing != null) return existing;
+
+    _memTimer.cancel();
+    final detaching = _handleDetached();
+    _detachFuture = detaching;
+    return detaching;
   }
 
   Future<void> _handleDetached() async {
@@ -1068,9 +1082,11 @@ class _AppRootState extends State<AppRoot> {
                   LogicalKeyboardKey.keyQ,
                   meta: true,
                 ),
-                onSelected: () {
-                  SystemNavigator.pop();
-                },
+                onSelected: () => unawaited(
+                  ServicesBinding.instance.exitApplication(
+                    AppExitType.cancelable,
+                  ),
+                ),
               ),
             ],
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -475,7 +475,7 @@ void main(List<String> args) async {
   );
   // Don't initialize plugins yet - wait for permissions to be granted
   // pluginService.initialize() will be called from PermissionsView after permissions are granted
-  pluginService.pluginManager.de1Controller = de1Controller;
+  await pluginService.pluginManager.attachDe1Controller(de1Controller);
   // Broadcast a `shotStored` plugin event once a shot is persisted, so plugins
   // can react to the exact newly-stored shot (no timer/latest-lookup race).
   persistenceController.onShotStored = (shotId) =>
@@ -651,6 +651,7 @@ void main(List<String> args) async {
       updateCheckService: updateCheckService,
       de1Controller: de1Controller,
       displayController: displayController,
+      pluginLoaderService: pluginService,
     ),
   );
 
@@ -694,6 +695,7 @@ class AppLifecycleObserver with WidgetsBindingObserver {
   final UpdateCheckService? updateCheckService;
   final De1Controller? de1Controller;
   final DisplayController? displayController;
+  final PluginLoaderService? pluginLoaderService;
 
   late Timer _memTimer;
   bool _wasBackgrounded = false;
@@ -705,6 +707,7 @@ class AppLifecycleObserver with WidgetsBindingObserver {
     this.updateCheckService,
     this.de1Controller,
     this.displayController,
+    this.pluginLoaderService,
   }) {
     _memTimer = Timer.periodic(Duration(minutes: 5), (t) {
       final rss = ProcessInfo.currentRss / (1024 * 1024);
@@ -745,6 +748,10 @@ class AppLifecycleObserver with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.detached) {
+      _memTimer.cancel();
+      unawaited(_handleDetached());
+    }
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden) {
       // STOP charts, timers, streams
@@ -765,6 +772,28 @@ class AppLifecycleObserver with WidgetsBindingObserver {
         _showUpdateNotification();
       }
       _wasBackgrounded = false;
+    }
+  }
+
+  Future<void> _handleDetached() async {
+    final stateSubscription = _stateStreamSubscription;
+    _stateStreamSubscription = null;
+    final machineSubscription = _machineStateSubscription;
+    _machineStateSubscription = null;
+    try {
+      await stateSubscription?.cancel();
+    } catch (error, stackTrace) {
+      _log.warning('State subscription detach failed', error, stackTrace);
+    }
+    try {
+      await machineSubscription?.cancel();
+    } catch (error, stackTrace) {
+      _log.warning('Machine subscription detach failed', error, stackTrace);
+    }
+    try {
+      await pluginLoaderService?.dispose();
+    } catch (error, stackTrace) {
+      _log.severe('Plugin loader disposal failed', error, stackTrace);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui' show AppExitResponse, AppExitType;
 import 'package:collection/collection.dart';
 // import 'package:flutter/scheduler.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -702,6 +702,7 @@ class AppLifecycleObserver with WidgetsBindingObserver {
   StreamSubscription? _machineStateSubscription;
   StreamSubscription? _stateStreamSubscription;
   int? _lastMachineState;
+  bool _detaching = false;
 
   AppLifecycleObserver({
     this.updateCheckService,
@@ -723,12 +724,14 @@ class AppLifecycleObserver with WidgetsBindingObserver {
 
     // Monitor machine state changes for sleep-to-idle transitions
     _machineStateSubscription = de1Controller?.de1.listen((machine) {
+      if (_detaching) return;
       _stateStreamSubscription?.cancel();
 
       if (machine == null) return;
 
       // Check if machine transitioned from sleep to idle
       _stateStreamSubscription = machine.currentSnapshot.listen((snapshot) {
+        if (_detaching) return;
         final currentState = snapshot.state.state.index;
 
         // Detect transition from sleep (0) to idle (2)
@@ -748,7 +751,8 @@ class AppLifecycleObserver with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.detached) {
+    if (state == AppLifecycleState.detached && !_detaching) {
+      _detaching = true;
       _memTimer.cancel();
       unawaited(_handleDetached());
     }
@@ -776,19 +780,19 @@ class AppLifecycleObserver with WidgetsBindingObserver {
   }
 
   Future<void> _handleDetached() async {
-    final stateSubscription = _stateStreamSubscription;
-    _stateStreamSubscription = null;
     final machineSubscription = _machineStateSubscription;
     _machineStateSubscription = null;
-    try {
-      await stateSubscription?.cancel();
-    } catch (error, stackTrace) {
-      _log.warning('State subscription detach failed', error, stackTrace);
-    }
     try {
       await machineSubscription?.cancel();
     } catch (error, stackTrace) {
       _log.warning('Machine subscription detach failed', error, stackTrace);
+    }
+    final stateSubscription = _stateStreamSubscription;
+    _stateStreamSubscription = null;
+    try {
+      await stateSubscription?.cancel();
+    } catch (error, stackTrace) {
+      _log.warning('State subscription detach failed', error, stackTrace);
     }
     try {
       await pluginLoaderService?.dispose();

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -25,6 +25,8 @@ class PluginSettingsValidationException implements Exception {
   String toString() => message;
 }
 
+enum PluginLoaderLifecycle { active, disposing, disposed }
+
 class PluginLoaderService {
   static const _loadTimeout = Duration(seconds: 1);
   static const _maxConsecutiveLoadFailures = 3;
@@ -40,6 +42,9 @@ class PluginLoaderService {
   Map<String, Map<String, dynamic>> _volatileSecureSettings = {};
   Future<void> _pluginLoadQueue = Future.value();
   final Map<String, Future<void>> _pluginSettingsLocks = {};
+  Future<void>? _initialization;
+  Future<void>? _disposeFuture;
+  PluginLoaderLifecycle _lifecycle = PluginLoaderLifecycle.active;
 
   PluginLoaderService({
     required KeyValueStoreService kvStore,
@@ -52,13 +57,24 @@ class PluginLoaderService {
        );
 
   bool _initialized = false;
+  PluginLoaderLifecycle get lifecycle => _lifecycle;
 
-  Future<void> initialize() async {
+  void _ensureActive() {
+    if (_lifecycle != PluginLoaderLifecycle.active) {
+      throw StateError('PluginLoaderService is ${_lifecycle.name}');
+    }
+  }
+
+  Future<void> initialize() {
+    _ensureActive();
     if (_initialized) {
       _log.fine('PluginLoaderService already initialized');
-      return;
+      return Future.value();
     }
+    return _initialization ??= _initialize();
+  }
 
+  Future<void> _initialize() async {
     // Get application documents directory
     final appDocDir = await getApplicationDocumentsDirectory();
     _pluginsDir = Directory('${appDocDir.path}/plugins');
@@ -90,6 +106,7 @@ class PluginLoaderService {
   /// user will provide filesystem path and permissions, REA should copy the contents over to
   /// the plugins folder
   Future<void> addPlugin(String sourcePath) async {
+    _ensureActive();
     final source = File(sourcePath);
     final sourceDir = Directory(sourcePath);
 
@@ -145,6 +162,7 @@ class PluginLoaderService {
   /// Remove/uninstall a plugin
   /// This will unload the plugin if it's loaded and delete its files
   Future<void> removePlugin(String pluginId) async {
+    _ensureActive();
     // The id would be joined into a filesystem path; reject unsafe ids
     // before any unload, cache, or directory operation.
     if (!isSafePathComponent(pluginId)) {
@@ -179,12 +197,14 @@ class PluginLoaderService {
   /// Load plugin into the runtime
   /// by using the PluginManager loadPlugin method
   Future<void> loadPlugin(String pluginId) {
+    _ensureActive();
     final load = _pluginLoadQueue.then((_) => _loadPlugin(pluginId));
     _pluginLoadQueue = load.then<void>((_) {}, onError: (_, _) {});
     return load;
   }
 
   Future<void> _loadPlugin(String pluginId) async {
+    _ensureActive();
     if (!_availablePluginsCache.containsKey(pluginId)) {
       throw Exception('Plugin not found: $pluginId');
     }
@@ -224,6 +244,7 @@ class PluginLoaderService {
   /// Unload a plugin
   /// by using the PluginManager unloadPlugin method
   Future<void> unloadPlugin(String pluginId) async {
+    _ensureActive();
     await pluginManager.unloadPlugin(pluginId);
     _log.info('Plugin unloaded: $pluginId');
   }
@@ -231,6 +252,7 @@ class PluginLoaderService {
   /// Reload a plugin (unload and load again)
   /// Useful when plugin settings change
   Future<void> reloadPlugin(String pluginId) async {
+    _ensureActive();
     if (!isPluginLoaded(pluginId)) {
       throw Exception('Plugin not loaded: $pluginId');
     }
@@ -249,6 +271,7 @@ class PluginLoaderService {
 
   /// Store a setting in prefs, whether a specific plugin should be autoloaded at initialize
   Future<void> setPluginAutoLoad(String pluginId, bool enabled) async {
+    _ensureActive();
     if (enabled) {
       await _prefs.remove(_loadFailureKey(pluginId));
       if (_prefs.getString(_loadingPluginKey) == pluginId) {
@@ -280,6 +303,7 @@ class PluginLoaderService {
     String pluginId,
     Map<String, dynamic> settings,
   ) => _withPluginSettingsLock(pluginId, () async {
+    _ensureActive();
     final manifest = _availablePluginsCache[pluginId];
     if (manifest == null) {
       throw Exception('Plugin not found: $pluginId');
@@ -777,10 +801,55 @@ class PluginLoaderService {
 
   /// Nukes the plugins folder
   Future<void> reset() async {
+    _ensureActive();
     for (var plugin in availablePlugins) {
       final path = getPluginDirectory(plugin.id);
       final dir = Directory(path);
       await dir.delete(recursive: true);
+    }
+  }
+
+  Future<void> dispose() {
+    final existing = _disposeFuture;
+    if (existing != null) return existing;
+
+    _lifecycle = PluginLoaderLifecycle.disposing;
+    final disposal = _dispose();
+    _disposeFuture = disposal;
+    return disposal;
+  }
+
+  Future<void> _dispose() async {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    Future<void> waitFor(String name, Future<void>? work) async {
+      if (work == null) return;
+      try {
+        await work;
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+        _log.warning(
+          'Plugin loader disposal failed during $name',
+          error,
+          stackTrace,
+        );
+      }
+    }
+
+    try {
+      await waitFor('initialization', _initialization);
+      await waitFor('plugin load queue', _pluginLoadQueue);
+      await waitFor('manager disposal', pluginManager.dispose());
+    } finally {
+      _availablePluginsCache.clear();
+      _initialized = false;
+      _lifecycle = PluginLoaderLifecycle.disposed;
+    }
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStackTrace!);
     }
   }
 }

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -71,7 +71,16 @@ class PluginLoaderService {
       _log.fine('PluginLoaderService already initialized');
       return Future.value();
     }
-    return _initialization ??= _initialize();
+    return _initialization ??= _initializeWithRetry();
+  }
+
+  Future<void> _initializeWithRetry() async {
+    try {
+      await _initialize();
+    } catch (_) {
+      _initialization = null;
+      rethrow;
+    }
   }
 
   Future<void> _initialize() async {

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -18,6 +18,8 @@ import '../services/account/decent_proxy_service.dart';
 
 enum _PendingOpKind { fetch, pluginHttp, decentProxy }
 
+enum PluginManagerLifecycle { active, disposing, disposed }
+
 class _PendingOp {
   _PendingOp({
     required this.kind,
@@ -70,8 +72,21 @@ class PluginManager {
   De1Controller? _de1controller;
   StreamSubscription<De1Interface?>? _de1Subscription;
   StreamSubscription<MachineSnapshot>? _snapshotSubscription;
+  Future<void> _attachmentQueue = Future.value();
+  Future<void> _snapshotQueue = Future.value();
+  int _attachmentGeneration = 0;
+  PluginManagerLifecycle _lifecycle = PluginManagerLifecycle.active;
+  Future<void>? _disposeFuture;
 
   De1Controller? get de1Controller => _de1controller;
+  PluginManagerLifecycle get lifecycle => _lifecycle;
+  int get attachmentGeneration => _attachmentGeneration;
+  int get activeSubscriptionCount =>
+      (_de1Subscription == null ? 0 : 1) +
+      (_snapshotSubscription == null ? 0 : 1);
+  int get trackedPluginGenerationCount => _pluginGenerations.length;
+  int get bridgeTokenCount => _decentProxyBridgeTokens.length;
+  int? pluginGeneration(String pluginId) => _pluginGenerations[pluginId];
 
   PluginManager({
     required this.kvStore,
@@ -90,6 +105,87 @@ class PluginManager {
     // js.enableXhr();
     // js.enableFetch();
     _bootstrapJs();
+  }
+
+  void _ensureActive() {
+    if (_lifecycle != PluginManagerLifecycle.active) {
+      throw StateError('PluginManager is ${_lifecycle.name}');
+    }
+  }
+
+  Future<void> dispose() {
+    final existing = _disposeFuture;
+    if (existing != null) return existing;
+
+    _lifecycle = PluginManagerLifecycle.disposing;
+    _attachmentGeneration += 1;
+    final disposal = _dispose();
+    _disposeFuture = disposal;
+    return disposal;
+  }
+
+  Future<void> _dispose() async {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    Future<void> runStage(String name, FutureOr<void> Function() action) async {
+      try {
+        await action();
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+        _log.warning(
+          'PluginManager disposal failed during $name',
+          error,
+          stackTrace,
+        );
+      }
+    }
+
+    try {
+      await runStage('attachment queue', () => _attachmentQueue);
+      await runStage('snapshot queue', () => _snapshotQueue);
+      await runStage('controller detachment', _cancelControllerSubscriptions);
+      for (final pluginId in _plugins.keys.toList()) {
+        await runStage(
+          'plugin unload: $pluginId',
+          () => _unloadPlugin(pluginId),
+        );
+      }
+      await runStage('async operation cleanup', _cancelAllOperations);
+      await runStage('bridge cleanup', () {
+        JavascriptRuntime.channelFunctionsRegistered.remove(
+          js.getEngineInstanceId(),
+        );
+      });
+      await runStage('event stream closure', _emitController.close);
+      await runStage('JavaScript runtime disposal', js.dispose);
+    } finally {
+      for (final record in _timers.values) {
+        record.timer.cancel();
+      }
+      _timers.clear();
+      for (final op in _pendingOps.values) {
+        op.timeout?.cancel();
+        try {
+          op.request?.abort();
+        } catch (_) {}
+      }
+      _pendingOps.clear();
+      _httpClient?.close(force: true);
+      _httpClient = null;
+      _plugins.clear();
+      _pluginGenerations.clear();
+      _decentProxyBridgeTokens.clear();
+      _de1Subscription = null;
+      _snapshotSubscription = null;
+      _de1controller = null;
+      _lifecycle = PluginManagerLifecycle.disposed;
+    }
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStackTrace!);
+    }
   }
 
   // ─────────────────────────────────────────────
@@ -216,20 +312,38 @@ class PluginManager {
           pending.resolve(response);
         }
 
+        function __cancelDecentProxyRequestsForPlugin(pluginId, error) {
+          const pendingByPlugin = __mapGet(__pendingDecentProxyRequests, pluginId);
+          if (!pendingByPlugin) return;
+          __mapDelete(__pendingDecentProxyRequests, pluginId);
+          for (const pending of pendingByPlugin.values()) {
+            pending.reject(new __NativeError(error));
+          }
+        }
+
+        function __cancelAllDecentProxyRequests(error) {
+          for (const pluginId of Array.from(__pendingDecentProxyRequests.keys())) {
+            __cancelDecentProxyRequestsForPlugin(pluginId, error);
+          }
+        }
+
         Object.defineProperty(globalThis, "__reaprimePluginBridge", {
           value: __nativeFreeze({
             decentProxy: __decentProxy,
-            completeDecentProxyRequest: __completeDecentProxyRequest
+            completeDecentProxyRequest: __completeDecentProxyRequest,
+            cancelForPlugin: __cancelDecentProxyRequestsForPlugin,
+            cancelAll: __cancelAllDecentProxyRequests
           }),
           writable: false,
           configurable: false,
           enumerable: false
         });
         
-        globalThis.__sendApiResponse = function (pluginId, requestId, response) {
+        globalThis.__sendApiResponse = function (pluginId, generation, requestId, response) {
           console.log("sending plugin api response", pluginId);
           sendMessage("host", JSON.stringify({
             pluginId: pluginId,
+            generation: generation,
             type: "httpResponse",
             requestId: requestId,
             payload: response
@@ -306,9 +420,14 @@ class PluginManager {
           });
           return id;
         };
-        globalThis.__timerClear = function (pluginId, id) {
+        globalThis.__timerClear = function (pluginId, generation, id) {
           if (__timers.delete(id)) {
-            __sendHostMessage({ pluginId: pluginId, type: "timerClear", timerId: id });
+            __sendHostMessage({
+              pluginId: pluginId,
+              generation: generation,
+              type: "timerClear",
+              timerId: id
+            });
           }
         };
         globalThis.__fireTimer = function (id) {
@@ -330,24 +449,27 @@ class PluginManager {
         };
 
         globalThis.host = {
-          log(pluginId, message) {
+          log(pluginId, generation, message) {
             sendMessage("host", JSON.stringify({
               pluginId: pluginId,
+              generation: generation,
               type: "log",
               payload: { message: String(message) }
             }));
           },
-          emit(pluginId, eventName, payload) {
+          emit(pluginId, generation, eventName, payload) {
             sendMessage("host", JSON.stringify({
               pluginId: pluginId,
+              generation: generation,
               type: "emit",
               event: eventName,
               payload: payload
             }));
           },
-          storage(pluginId, command) {
+          storage(pluginId, generation, command) {
             sendMessage("host", JSON.stringify({
               pluginId: pluginId,
+              generation: generation,
               type: "pluginStorage",
               payload: command
             }));
@@ -421,6 +543,21 @@ class PluginManager {
           };
           pending.resolve(response);
         };
+
+        globalThis.__cancelFetchesForPlugin = function (pluginId, error) {
+          for (const [id, pending] of _pendingFetches) {
+            if (pending.pluginId !== pluginId) continue;
+            _pendingFetches.delete(id);
+            pending.reject(new Error(error));
+          }
+        };
+
+        globalThis.__cancelAllFetches = function (error) {
+          for (const pending of _pendingFetches.values()) {
+            pending.reject(new Error(error));
+          }
+          _pendingFetches.clear();
+        };
       })();
     ''');
 
@@ -429,21 +566,13 @@ class PluginManager {
         _log.finest("receiving: $raw");
         final msg = raw as Map<String, dynamic>;
         final pluginId = msg['pluginId'] as String?;
-        final type = msg['type'];
 
         if (pluginId == null) {
           _log.warning("JS message missing pluginId");
           return;
         }
 
-        if (type == 'log') {
-          _log.finest("[JS:$pluginId] ${msg['payload']?['message']}");
-        } else if (type == 'httpResponse') {
-          // Handle HTTP responses from plugin
-          _handlePluginApiResponse(pluginId, msg);
-        } else {
-          unawaited(_handleMessageSafely(pluginId, msg));
-        }
+        unawaited(_handleMessageSafely(pluginId, msg));
       } catch (e, st) {
         _log.warning("Invalid JS message", e, st);
       }
@@ -467,7 +596,22 @@ class PluginManager {
     // that sent the message, and a nested evaluate + job drain does not
     // settle promises on QuickJS (unhandled-rejection hang).
     await Future<void>.delayed(Duration.zero);
+    if (_lifecycle != PluginManagerLifecycle.active) return;
     try {
+      final type = msg['type'];
+      if (type == 'decentProxy') {
+        await _handleDecentProxyMessage(pluginId, msg);
+        return;
+      }
+      if (!_isCurrentPluginMessage(pluginId, msg)) return;
+      if (type == 'log') {
+        _log.finest("[JS:$pluginId] ${msg['payload']?['message']}");
+        return;
+      }
+      if (type == 'httpResponse') {
+        _handlePluginApiResponse(pluginId, msg);
+        return;
+      }
       await _handleMessage(pluginId, msg);
     } catch (e, st) {
       _log.warning("Error handling message from $pluginId", e, st);
@@ -476,11 +620,19 @@ class PluginManager {
 
   Future<void> _handleFetchSafely(Map<String, dynamic> msg) async {
     await Future<void>.delayed(Duration.zero);
+    if (_lifecycle != PluginManagerLifecycle.active) return;
     try {
       await _handleFetch(msg);
     } catch (e, st) {
       _log.warning("Invalid fetch message", e, st);
     }
+  }
+
+  bool _isCurrentPluginMessage(String pluginId, Map<String, dynamic> msg) {
+    final generation = msg['generation'];
+    return generation is num &&
+        generation.toInt() == _pluginGenerations[pluginId] &&
+        _plugins[pluginId]?.isAlive == true;
   }
 
   // ─────────────────────────────────────────────
@@ -493,9 +645,11 @@ class PluginManager {
     required String jsCode,
     required Map<String, dynamic> settings,
   }) async {
+    _ensureActive();
+    await _unloadPlugin(id);
+    _ensureActive();
     final generation = (_pluginGenerations[id] ?? 0) + 1;
     _pluginGenerations[id] = generation;
-    await unloadPlugin(id);
 
     final runtime = PluginRuntime(pluginId: id, manifest: manifest);
     final decentProxyBridgeToken = _newBridgeToken();
@@ -511,16 +665,16 @@ class PluginManager {
         const pluginId = "$id";
         const pluginGeneration = $generation;
         const setTimeout = (callback, delay) => globalThis.__timerSet(pluginId, pluginGeneration, callback, delay);
-        const clearTimeout = (id) => globalThis.__timerClear(pluginId, id);
+        const clearTimeout = (id) => globalThis.__timerClear(pluginId, pluginGeneration, id);
         const fetch = (input, init) => globalThis.__fetchFor
           ? globalThis.__fetchFor(pluginId, pluginGeneration, input, init)
           : globalThis.fetch(input, init);
         
         // Create the host object for this plugin
         const host = {
-          log: (msg) => globalThis.host.log(pluginId, msg),
-          emit: (type, payload) => globalThis.host.emit(pluginId, type, payload),
-          storage: (cmd) => globalThis.host.storage(pluginId, cmd),
+          log: (msg) => globalThis.host.log(pluginId, pluginGeneration, msg),
+          emit: (type, payload) => globalThis.host.emit(pluginId, pluginGeneration, type, payload),
+          storage: (cmd) => globalThis.host.storage(pluginId, pluginGeneration, cmd),
           decentProxy: (path, options = {}) => {
             return globalThis.__reaprimePluginBridge.decentProxy(
               pluginId,
@@ -587,12 +741,15 @@ class PluginManager {
       runtime.markRunning();
       _log.info("loaded: $id");
     } catch (e, st) {
-      _plugins.remove(id);
-      _decentProxyBridgeTokens.remove(id);
-      js.evaluate('''
-      delete globalThis.__plugins__["$id"];
-    ''');
-      _cleanupPluginResources(id);
+      try {
+        await _unloadPlugin(id);
+      } catch (cleanupError, cleanupStackTrace) {
+        _log.warning(
+          'Failed to clean up plugin after load failure: $id',
+          cleanupError,
+          cleanupStackTrace,
+        );
+      }
       // WARNING, not SEVERE: a plugin failing to load is almost always a
       // user-installed third-party plugin with a bad manifest id or a JS
       // syntax error, not an app defect. The caller (e.g. PluginsSettingsView)
@@ -605,37 +762,78 @@ class PluginManager {
   }
 
   Future<void> unloadPlugin(String id) async {
-    final runtime = _plugins.remove(id);
-    _decentProxyBridgeTokens.remove(id);
+    _ensureActive();
+    await _unloadPlugin(id);
+  }
+
+  Future<void> _unloadPlugin(String id) async {
+    final runtime = _plugins[id];
     if (runtime == null) return;
 
+    runtime.markStopping();
+    _pluginGenerations[id] = (_pluginGenerations[id] ?? 0) + 1;
+    _decentProxyBridgeTokens.remove(id);
+
     try {
-      js.evaluate('''
+      final result = js.evaluate('''
         (function () {
+          const plugin = globalThis.__plugins__["$id"];
           try {
-            const plugin = globalThis.__plugins__["$id"];
             plugin?.onUnload?.();
+          } finally {
             delete globalThis.__plugins__["$id"];
-          } catch (e) {
-            console.error("Unload failed ($id)", e);
           }
         })();
       ''');
+      if (result.isError) {
+        _log.warning('Plugin onUnload failed: $id: ${result.stringResult}');
+      }
     } catch (e, st) {
       _log.warning("Error during plugin unload: $id", e, st);
     }
 
-    runtime.markDisposed();
-    _cleanupPluginResources(id);
-    _log.info("unloaded: $id");
+    try {
+      _cleanupPluginResources(id);
+    } finally {
+      runtime.markDisposed();
+      _plugins.remove(id);
+      _log.info("unloaded: $id");
+    }
   }
 
   void _cleanupPluginResources(String pluginId) {
     // Reject operations first: settling promises drains pending jobs, which
     // can run plugin rejection handlers that schedule new timers. The timer
     // sweep after must be the last word.
-    _rejectOpsForPlugin(pluginId);
-    _cancelTimersForPlugin(pluginId);
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    void attempt(void Function() action) {
+      try {
+        action();
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
+
+    attempt(() => _rejectOpsForPlugin(pluginId));
+    attempt(() {
+      js.evaluate('''
+          globalThis.__cancelFetchesForPlugin(
+            ${jsonEncode(pluginId)}, "plugin unloaded"
+          );
+          globalThis.__reaprimePluginBridge.cancelForPlugin(
+            ${jsonEncode(pluginId)}, "plugin unloaded"
+          );
+        ''');
+      while (js.executePendingJob() > 0) {}
+    });
+    attempt(() => _cancelTimersForPlugin(pluginId));
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStackTrace!);
+    }
   }
 
   // ─────────────────────────────────────────────
@@ -643,6 +841,7 @@ class PluginManager {
   // ─────────────────────────────────────────────
 
   void broadcastEvent(String name, dynamic payload) {
+    _ensureActive();
     for (final plugin in _plugins.values) {
       if (plugin.isAlive) {
         dispatchEvent(plugin.pluginId, name, payload);
@@ -651,7 +850,10 @@ class PluginManager {
   }
 
   void dispatchEvent(String pluginId, String name, dynamic payload) {
-    if (!_plugins.containsKey(pluginId)) return;
+    _ensureActive();
+    final runtime = _plugins[pluginId];
+    if (runtime?.isAlive != true) return;
+    final generation = _pluginGenerations[pluginId] ?? 0;
 
     String requestId = "";
     if (payload is Map<String, dynamic> && payload['requestId'] is String) {
@@ -675,12 +877,12 @@ class PluginManager {
             // Handle async response
             response.then((res) => {
               if (globalThis.__sendApiResponse) {
-                globalThis.__sendApiResponse("$pluginId", "$requestId", res);
+                globalThis.__sendApiResponse("$pluginId", $generation, "$requestId", res);
               }
             }).catch((err) => {
               console.error("HTTP request handler error:", err);
               if (globalThis.__sendApiResponse) {
-                globalThis.__sendApiResponse("$pluginId", "$requestId", {
+                globalThis.__sendApiResponse("$pluginId", $generation, "$requestId", {
                   status: 500,
                   headers: {'Content-Type': 'application/json'},
                   body: JSON.stringify({error: err.toString()})
@@ -690,13 +892,13 @@ class PluginManager {
           } else if (response) {
             // Handle sync response
             if (globalThis.__sendApiResponse) {
-              globalThis.__sendApiResponse("$pluginId", "$requestId", response);
+              globalThis.__sendApiResponse("$pluginId", $generation, "$requestId", response);
             }
           }
         } catch (e) {
           console.error("HTTP request handler error:", e);
           if (globalThis.__sendApiResponse) {
-            globalThis.__sendApiResponse("$pluginId", "$requestId", {
+            globalThis.__sendApiResponse("$pluginId", $generation, "$requestId", {
               status: 500,
               headers: {'Content-Type': 'application/json'},
               body: JSON.stringify({error: e.toString()})
@@ -731,7 +933,11 @@ class PluginManager {
 
       case 'pluginStorage':
         final cmd = PluginStorageCommand.fromPlugin(payload);
-        await _handlePluginStorage(pluginId, cmd);
+        await _handlePluginStorage(
+          pluginId,
+          (msg['generation'] as num).toInt(),
+          cmd,
+        );
         break;
 
       case 'timerSet':
@@ -789,6 +995,7 @@ class PluginManager {
   void _fireTimer(int id) {
     final record = _timers.remove(id);
     if (record == null) return;
+    if (_lifecycle != PluginManagerLifecycle.active) return;
     js.evaluate('globalThis.__fireTimer($id);');
     while (js.executePendingJob() > 0) {}
   }
@@ -806,17 +1013,51 @@ class PluginManager {
   }
 
   void cancelAllOperations() {
-    for (final op in _pendingOps.values.toList()) {
-      _completeOp(op, error: 'manager disposal');
+    _ensureActive();
+    _cancelAllOperations();
+  }
+
+  void _cancelAllOperations() {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    void attempt(void Function() action) {
+      try {
+        action();
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
     }
+
+    for (final op in _pendingOps.values.toList()) {
+      attempt(() {
+        _completeOp(op, error: 'manager disposal');
+      });
+    }
+    attempt(() {
+      _httpClient?.close(force: true);
+      _httpClient = null;
+    });
+    attempt(() {
+      js.evaluate('''
+          globalThis.__cancelAllFetches("manager disposal");
+          globalThis.__reaprimePluginBridge.cancelAll("manager disposal");
+        ''');
+      while (js.executePendingJob() > 0) {}
+    });
     for (final record in _timers.values) {
       record.timer.cancel();
     }
     _timers.clear();
-    _httpClient?.close(force: true);
-    _httpClient = null;
-    js.evaluate('globalThis.__cancelAllTimers();');
-    while (js.executePendingJob() > 0) {}
+    attempt(() {
+      js.evaluate('globalThis.__cancelAllTimers();');
+      while (js.executePendingJob() > 0) {}
+    });
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStackTrace!);
+    }
   }
 
   // ─────────────────────────────────────────────
@@ -851,9 +1092,19 @@ class PluginManager {
   }
 
   void _rejectOpsForPlugin(String pluginId) {
+    Object? firstError;
+    StackTrace? firstStackTrace;
     for (final op
         in _pendingOps.values.where((op) => op.pluginId == pluginId).toList()) {
-      _completeOp(op, error: 'plugin unloaded');
+      try {
+        _completeOp(op, error: 'plugin unloaded');
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
     }
   }
 
@@ -922,6 +1173,19 @@ class PluginManager {
       return;
     }
 
+    if (generation != _pluginGenerations[pluginId] ||
+        _plugins[pluginId]?.isAlive != true) {
+      final op = _PendingOp(
+        kind: _PendingOpKind.decentProxy,
+        pluginId: pluginId,
+        generation: generation,
+        requestId: requestId,
+      );
+      _pendingOps[op.key] = op;
+      _completeOp(op, error: 'Plugin generation changed');
+      return;
+    }
+
     final op = _PendingOp(
       kind: _PendingOpKind.decentProxy,
       pluginId: pluginId,
@@ -964,6 +1228,7 @@ class PluginManager {
     String? body,
     String? contentType,
   }) async {
+    _ensureActive();
     return _decentProxyBridge.proxyForPlugin(
       pluginId: pluginId,
       manifest: manifest,
@@ -988,6 +1253,7 @@ class PluginManager {
 
   Future<void> _handlePluginStorage(
     String pluginId,
+    int generation,
     PluginStorageCommand cmd,
   ) async {
     // Use pluginId as namespace for storage isolation
@@ -996,6 +1262,9 @@ class PluginManager {
     switch (cmd.type) {
       case PluginStorageCommandType.read:
         final value = await kvStore.get(key: cmd.key, namespace: namespace);
+        if (!_isCurrentPluginMessage(pluginId, {'generation': generation})) {
+          return;
+        }
         dispatchEvent(pluginId, "storageRead", {
           "key": cmd.key,
           "value": value,
@@ -1004,6 +1273,9 @@ class PluginManager {
 
       case PluginStorageCommandType.write:
         await kvStore.set(key: cmd.key, namespace: namespace, value: cmd.data);
+        if (!_isCurrentPluginMessage(pluginId, {'generation': generation})) {
+          return;
+        }
         dispatchEvent(pluginId, "storageWrite", cmd.data);
         break;
     }
@@ -1025,6 +1297,13 @@ class PluginManager {
       );
       return;
     }
+    final generation = msg['generation'];
+    if (op.pluginId != pluginId ||
+        generation is! num ||
+        generation.toInt() != op.generation ||
+        generation.toInt() != _pluginGenerations[pluginId]) {
+      return;
+    }
     _completeOp(op, result: response);
   }
 
@@ -1032,6 +1311,10 @@ class PluginManager {
     String pluginId,
     String requestId,
   ) {
+    _ensureActive();
+    if (_plugins[pluginId]?.isAlive != true) {
+      throw StateError('Plugin is not loaded: $pluginId');
+    }
     final op = _PendingOp(
       kind: _PendingOpKind.pluginHttp,
       pluginId: pluginId,
@@ -1053,24 +1336,104 @@ class PluginManager {
 
   List<PluginRuntime> get loadedPlugins => _plugins.values.toList();
 
-  set de1Controller(De1Controller? controller) {
-    _de1Subscription?.cancel();
-    _snapshotSubscription?.cancel();
+  Future<void> attachDe1Controller(De1Controller? controller) {
+    _ensureActive();
+    final generation = ++_attachmentGeneration;
+    final attachment = _attachmentQueue.then(
+      (_) => _replaceDe1Controller(controller, generation),
+    );
+    _attachmentQueue = attachment.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
+    );
+    return attachment;
+  }
+
+  Future<void> _replaceDe1Controller(
+    De1Controller? controller,
+    int generation,
+  ) async {
+    await _cancelControllerSubscriptions();
+    if (_lifecycle != PluginManagerLifecycle.active ||
+        generation != _attachmentGeneration) {
+      return;
+    }
 
     _de1controller = controller;
     if (controller == null) return;
 
     _de1Subscription = controller.de1.listen((de1) {
-      _snapshotSubscription?.cancel();
-      if (de1 != null) {
-        _snapshotSubscription = de1.currentSnapshot.listen((snap) {
-          broadcastEvent('stateUpdate', snap.toJson());
-        });
+      if (_lifecycle != PluginManagerLifecycle.active ||
+          generation != _attachmentGeneration) {
+        return;
       }
+      final replacement = _snapshotQueue.then(
+        (_) => _replaceSnapshotSubscription(de1, generation),
+      );
+      _snapshotQueue = replacement.then<void>(
+        (_) {},
+        onError: (Object error, StackTrace stackTrace) {
+          _log.warning(
+            'Failed to replace plugin snapshot subscription',
+            error,
+            stackTrace,
+          );
+        },
+      );
     });
   }
 
+  Future<void> _replaceSnapshotSubscription(
+    De1Interface? de1,
+    int generation,
+  ) async {
+    final previous = _snapshotSubscription;
+    _snapshotSubscription = null;
+    await previous?.cancel();
+    if (_lifecycle != PluginManagerLifecycle.active ||
+        generation != _attachmentGeneration ||
+        de1 == null) {
+      return;
+    }
+
+    _snapshotSubscription = de1.currentSnapshot.listen((snapshot) {
+      if (_lifecycle != PluginManagerLifecycle.active ||
+          generation != _attachmentGeneration) {
+        return;
+      }
+      broadcastEvent('stateUpdate', snapshot.toJson());
+    });
+  }
+
+  Future<void> _cancelControllerSubscriptions() async {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+    final snapshot = _snapshotSubscription;
+    _snapshotSubscription = null;
+    try {
+      await snapshot?.cancel();
+    } catch (error, stackTrace) {
+      firstError = error;
+      firstStackTrace = stackTrace;
+    }
+
+    final de1 = _de1Subscription;
+    _de1Subscription = null;
+    try {
+      await de1?.cancel();
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+    _de1controller = null;
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
+    }
+  }
+
   Future<void> _handleFetch(Map<String, dynamic> msg) async {
+    _ensureActive();
     final id = msg['id'];
     final pluginId = msg['pluginId'] as String?;
     if (id is! int || pluginId == null) {

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -154,11 +154,6 @@ class PluginManager {
         );
       }
       await runStage('async operation cleanup', _cancelAllOperations);
-      await runStage('bridge cleanup', () {
-        JavascriptRuntime.channelFunctionsRegistered.remove(
-          js.getEngineInstanceId(),
-        );
-      });
       await runStage('event stream closure', _emitController.close);
       await runStage('JavaScript runtime disposal', js.dispose);
     } finally {

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -78,6 +78,8 @@ class PluginManager {
   int _snapshotGeneration = 0;
   PluginManagerLifecycle _lifecycle = PluginManagerLifecycle.active;
   Future<void>? _disposeFuture;
+  final Map<String, int> _retiringPluginGenerations = {};
+  final Map<(String, int), Set<Future<void>>> _pluginStorageOperations = {};
 
   De1Controller? get de1Controller => _de1controller;
   PluginManagerLifecycle get lifecycle => _lifecycle;
@@ -172,6 +174,8 @@ class PluginManager {
       _httpClient = null;
       _plugins.clear();
       _pluginGenerations.clear();
+      _retiringPluginGenerations.clear();
+      _pluginStorageOperations.clear();
       _decentProxyBridgeTokens.clear();
       _de1Subscription = null;
       _snapshotSubscription = null;
@@ -568,7 +572,13 @@ class PluginManager {
           return;
         }
 
-        unawaited(_handleMessageSafely(pluginId, msg));
+        final operation = _handleMessageSafely(pluginId, msg);
+        final generation = msg['generation'];
+        if (msg['type'] == 'pluginStorage' && generation is num) {
+          _trackPluginStorageOperation(pluginId, generation.toInt(), operation);
+        } else {
+          unawaited(operation);
+        }
       } catch (e, st) {
         _log.warning("Invalid JS message", e, st);
       }
@@ -592,14 +602,19 @@ class PluginManager {
     // that sent the message, and a nested evaluate + job drain does not
     // settle promises on QuickJS (unhandled-rejection hang).
     await Future<void>.delayed(Duration.zero);
-    if (_lifecycle != PluginManagerLifecycle.active) return;
+    final retiringStorageWrite = _isRetiringPluginStorageWrite(pluginId, msg);
+    if (_lifecycle != PluginManagerLifecycle.active && !retiringStorageWrite) {
+      return;
+    }
     try {
       final type = msg['type'];
       if (type == 'decentProxy') {
         await _handleDecentProxyMessage(pluginId, msg);
         return;
       }
-      if (!_isCurrentPluginMessage(pluginId, msg)) return;
+      if (!_isCurrentPluginMessage(pluginId, msg) && !retiringStorageWrite) {
+        return;
+      }
       if (type == 'log') {
         _log.finest("[JS:$pluginId] ${msg['payload']?['message']}");
         return;
@@ -629,6 +644,48 @@ class PluginManager {
     return generation is num &&
         generation.toInt() == _pluginGenerations[pluginId] &&
         _plugins[pluginId]?.isAlive == true;
+  }
+
+  bool _isRetiringPluginStorageWrite(
+    String pluginId,
+    Map<String, dynamic> msg,
+  ) {
+    final generation = msg['generation'];
+    final payload = msg['payload'];
+    return msg['type'] == 'pluginStorage' &&
+        generation is num &&
+        generation.toInt() == _retiringPluginGenerations[pluginId] &&
+        payload is Map &&
+        payload['type'] == 'write' &&
+        _plugins[pluginId]?.state == PluginRuntimeState.stopping;
+  }
+
+  void _trackPluginStorageOperation(
+    String pluginId,
+    int generation,
+    Future<void> operation,
+  ) {
+    final key = (pluginId, generation);
+    final operations = _pluginStorageOperations.putIfAbsent(key, () => {});
+    operations.add(operation);
+    unawaited(
+      operation.whenComplete(() {
+        operations.remove(operation);
+        if (operations.isEmpty) _pluginStorageOperations.remove(key);
+      }),
+    );
+  }
+
+  Future<void> _drainPluginStorageOperations(
+    String pluginId,
+    int generation,
+  ) async {
+    final key = (pluginId, generation);
+    while (true) {
+      final operations = _pluginStorageOperations[key]?.toList() ?? const [];
+      if (operations.isEmpty) return;
+      await Future.wait(operations);
+    }
   }
 
   // ─────────────────────────────────────────────
@@ -766,31 +823,37 @@ class PluginManager {
     final runtime = _plugins[id];
     if (runtime == null) return;
 
+    final retiringGeneration = _pluginGenerations[id] ?? 0;
     runtime.markStopping();
-    _pluginGenerations[id] = (_pluginGenerations[id] ?? 0) + 1;
+    _retiringPluginGenerations[id] = retiringGeneration;
+    _pluginGenerations[id] = retiringGeneration + 1;
     _decentProxyBridgeTokens.remove(id);
 
     try {
-      final result = js.evaluate('''
-        (function () {
-          const plugin = globalThis.__plugins__["$id"];
-          try {
-            plugin?.onUnload?.();
-          } finally {
-            delete globalThis.__plugins__["$id"];
-          }
-        })();
-      ''');
-      if (result.isError) {
-        _log.warning('Plugin onUnload failed: $id: ${result.stringResult}');
+      try {
+        final result = js.evaluate('''
+          (function () {
+            const plugin = globalThis.__plugins__["$id"];
+            try {
+              plugin?.onUnload?.();
+            } finally {
+              delete globalThis.__plugins__["$id"];
+            }
+          })();
+        ''');
+        if (result.isError) {
+          _log.warning('Plugin onUnload failed: $id: ${result.stringResult}');
+        }
+      } catch (e, st) {
+        _log.warning("Error during plugin unload: $id", e, st);
       }
-    } catch (e, st) {
-      _log.warning("Error during plugin unload: $id", e, st);
-    }
-
-    try {
-      _cleanupPluginResources(id);
+      try {
+        _cleanupPluginResources(id);
+      } finally {
+        await _drainPluginStorageOperations(id, retiringGeneration);
+      }
     } finally {
+      _retiringPluginGenerations.remove(id);
       runtime.markDisposed();
       _plugins.remove(id);
       _log.info("unloaded: $id");

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -75,6 +75,7 @@ class PluginManager {
   Future<void> _attachmentQueue = Future.value();
   Future<void> _snapshotQueue = Future.value();
   int _attachmentGeneration = 0;
+  int _snapshotGeneration = 0;
   PluginManagerLifecycle _lifecycle = PluginManagerLifecycle.active;
   Future<void>? _disposeFuture;
 
@@ -1363,12 +1364,14 @@ class PluginManager {
     if (controller == null) return;
 
     _de1Subscription = controller.de1.listen((de1) {
+      final snapshotGeneration = ++_snapshotGeneration;
       if (_lifecycle != PluginManagerLifecycle.active ||
           generation != _attachmentGeneration) {
         return;
       }
       final replacement = _snapshotQueue.then(
-        (_) => _replaceSnapshotSubscription(de1, generation),
+        (_) =>
+            _replaceSnapshotSubscription(de1, generation, snapshotGeneration),
       );
       _snapshotQueue = replacement.then<void>(
         (_) {},
@@ -1385,20 +1388,23 @@ class PluginManager {
 
   Future<void> _replaceSnapshotSubscription(
     De1Interface? de1,
-    int generation,
+    int attachmentGeneration,
+    int snapshotGeneration,
   ) async {
     final previous = _snapshotSubscription;
     _snapshotSubscription = null;
     await previous?.cancel();
     if (_lifecycle != PluginManagerLifecycle.active ||
-        generation != _attachmentGeneration ||
+        attachmentGeneration != _attachmentGeneration ||
+        snapshotGeneration != _snapshotGeneration ||
         de1 == null) {
       return;
     }
 
     _snapshotSubscription = de1.currentSnapshot.listen((snapshot) {
       if (_lifecycle != PluginManagerLifecycle.active ||
-          generation != _attachmentGeneration) {
+          attachmentGeneration != _attachmentGeneration ||
+          snapshotGeneration != _snapshotGeneration) {
         return;
       }
       broadcastEvent('stateUpdate', snapshot.toJson());

--- a/lib/src/plugins/plugin_runtime.dart
+++ b/lib/src/plugins/plugin_runtime.dart
@@ -1,7 +1,7 @@
 import 'package:logging/logging.dart';
 import 'plugin_manifest.dart';
 
-enum PluginRuntimeState { loading, running, disposed }
+enum PluginRuntimeState { loading, running, stopping, disposed }
 
 class PluginRuntime {
   final String pluginId;
@@ -17,6 +17,10 @@ class PluginRuntime {
 
   void markRunning() {
     state = PluginRuntimeState.running;
+  }
+
+  void markStopping() {
+    state = PluginRuntimeState.stopping;
   }
 
   void markDisposed() {

--- a/lib/src/settings/advanced_page.dart
+++ b/lib/src/settings/advanced_page.dart
@@ -1,4 +1,7 @@
+import 'dart:ui' show AppExitType;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/settings/common.dart';
 import 'package:reaprime/src/settings/feature_flags.dart';
@@ -232,9 +235,17 @@ class AdvancedPage extends StatelessWidget {
                       color: Theme.of(context).colorScheme.error,
                     ),
                   ),
-                  onTap: () {
+                  onTap: () async {
+                    if (Platform.isWindows ||
+                        Platform.isMacOS ||
+                        Platform.isLinux) {
+                      await ServicesBinding.instance.exitApplication(
+                        AppExitType.cancelable,
+                      );
+                      return;
+                    }
                     if (Platform.isAndroid) {
-                      ForegroundTaskService.stop();
+                      await ForegroundTaskService.stop();
                     }
                     exit(0);
                   },

--- a/test/app_lifecycle_observer_test.dart
+++ b/test/app_lifecycle_observer_test.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/main.dart' as app;
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+
+class _FakePluginLoaderService extends Fake implements PluginLoaderService {
+  final disposed = Completer<void>();
+  int disposeCalls = 0;
+
+  @override
+  Future<void> dispose() {
+    disposeCalls += 1;
+    return disposed.future;
+  }
+}
+
+void main() {
+  testWidgets('detached disposes the process plugin loader', (tester) async {
+    final loader = _FakePluginLoaderService();
+    final observer = app.AppLifecycleObserver(pluginLoaderService: loader);
+
+    observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+    await tester.pump();
+    expect(loader.disposeCalls, 0);
+
+    observer.didChangeAppLifecycleState(AppLifecycleState.detached);
+    await tester.pump();
+    expect(loader.disposeCalls, 1);
+
+    loader.disposed.complete();
+    await tester.pump();
+  });
+}

--- a/test/app_lifecycle_observer_test.dart
+++ b/test/app_lifecycle_observer_test.dart
@@ -3,7 +3,13 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/main.dart' as app;
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+
+import 'helpers/test_de1.dart';
 
 class _FakePluginLoaderService extends Fake implements PluginLoaderService {
   final disposed = Completer<void>();
@@ -13,6 +19,35 @@ class _FakePluginLoaderService extends Fake implements PluginLoaderService {
   Future<void> dispose() {
     disposeCalls += 1;
     return disposed.future;
+  }
+}
+
+class _StreamDe1Controller extends De1Controller {
+  _StreamDe1Controller(this.machineStream)
+    : super(controller: DeviceController(const []));
+
+  final Stream<De1Interface?> machineStream;
+
+  @override
+  Stream<De1Interface?> get de1 => machineStream;
+}
+
+class _SlowCancelDe1 extends TestDe1 {
+  _SlowCancelDe1(this.releaseCancellation);
+
+  final Completer<void> releaseCancellation;
+  late final StreamController<MachineSnapshot> snapshots =
+      StreamController<MachineSnapshot>(
+        onCancel: () => releaseCancellation.future,
+      );
+
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => snapshots.stream;
+
+  @override
+  Future<void> dispose() async {
+    await snapshots.close();
+    await super.dispose();
   }
 }
 
@@ -31,5 +66,37 @@ void main() {
 
     loader.disposed.complete();
     await tester.pump();
+  });
+
+  testWidgets('detached cannot install a replacement state subscription', (
+    tester,
+  ) async {
+    final loader = _FakePluginLoaderService();
+    final releaseCancellation = Completer<void>();
+    final firstMachine = _SlowCancelDe1(releaseCancellation);
+    final secondMachine = TestDe1(deviceId: 'second');
+    final machines = StreamController<De1Interface?>.broadcast(sync: true);
+    final controller = _StreamDe1Controller(machines.stream);
+    final observer = app.AppLifecycleObserver(
+      de1Controller: controller,
+      pluginLoaderService: loader,
+    );
+
+    machines.add(firstMachine);
+    expect(firstMachine.snapshots.hasListener, isTrue);
+    loader.disposed.complete();
+
+    observer.didChangeAppLifecycleState(AppLifecycleState.detached);
+    machines.add(secondMachine);
+    releaseCancellation.complete();
+    await tester.pump();
+    await tester.pump();
+
+    expect(secondMachine.snapshotSubject.hasListener, isFalse);
+
+    await machines.close();
+    await controller.dispose();
+    await firstMachine.dispose();
+    await secondMachine.dispose();
   });
 }

--- a/test/app_lifecycle_observer_test.dart
+++ b/test/app_lifecycle_observer_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' show AppExitResponse;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -52,6 +53,26 @@ class _SlowCancelDe1 extends TestDe1 {
 }
 
 void main() {
+  testWidgets('desktop exit waits for plugin loader disposal', (tester) async {
+    final loader = _FakePluginLoaderService();
+    final observer = app.AppLifecycleObserver(pluginLoaderService: loader);
+    var exitCompleted = false;
+
+    final exit = observer.didRequestAppExit();
+    unawaited(exit.then((_) => exitCompleted = true));
+    await tester.pump();
+
+    expect(loader.disposeCalls, 1);
+    expect(exitCompleted, isFalse);
+
+    loader.disposed.complete();
+    await expectLater(exit, completion(AppExitResponse.exit));
+
+    observer.didChangeAppLifecycleState(AppLifecycleState.detached);
+    await tester.pump();
+    expect(loader.disposeCalls, 1);
+  });
+
   testWidgets('detached disposes the process plugin loader', (tester) async {
     final loader = _FakePluginLoaderService();
     final observer = app.AppLifecycleObserver(pluginLoaderService: loader);

--- a/test/plugin_loader_service_lifecycle_test.dart
+++ b/test/plugin_loader_service_lifecycle_test.dart
@@ -1,9 +1,12 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 
 import 'plugins/plugin_test_helpers.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('dispose is shared and rejects later loader work', () async {
     final service = PluginLoaderService(kvStore: FakeKeyValueStoreService());
 
@@ -19,6 +22,31 @@ void main() {
     expect(() => service.loadPlugin('late.plugin'), throwsStateError);
     await expectLater(service.reloadPlugin('late.plugin'), throwsStateError);
     await expectLater(service.removePlugin('late.plugin'), throwsStateError);
+    await service.dispose();
+  });
+
+  test('failed initialization can be retried', () async {
+    var attempts = 0;
+    const channel = MethodChannel('plugins.flutter.io/path_provider');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async {
+          attempts += 1;
+          throw StateError('path unavailable');
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+    final service = PluginLoaderService(kvStore: FakeKeyValueStoreService());
+
+    final first = service.initialize();
+    final concurrent = service.initialize();
+    expect(identical(first, concurrent), isTrue);
+    await expectLater(first, throwsA(isA<PlatformException>()));
+
+    await expectLater(service.initialize(), throwsA(isA<PlatformException>()));
+    expect(attempts, 2);
+
     await service.dispose();
   });
 }

--- a/test/plugin_loader_service_lifecycle_test.dart
+++ b/test/plugin_loader_service_lifecycle_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+
+import 'plugins/plugin_test_helpers.dart';
+
+void main() {
+  test('dispose is shared and rejects later loader work', () async {
+    final service = PluginLoaderService(kvStore: FakeKeyValueStoreService());
+
+    final first = service.dispose();
+    final second = service.dispose();
+
+    expect(identical(first, second), isTrue);
+    expect(service.lifecycle, PluginLoaderLifecycle.disposing);
+    await Future.wait([first, second]);
+    expect(service.lifecycle, PluginLoaderLifecycle.disposed);
+    expect(service.pluginManager.lifecycle.name, 'disposed');
+    expect(service.initialize, throwsStateError);
+    expect(() => service.loadPlugin('late.plugin'), throwsStateError);
+    await expectLater(service.reloadPlugin('late.plugin'), throwsStateError);
+    await expectLater(service.removePlugin('late.plugin'), throwsStateError);
+    await service.dispose();
+  });
+}

--- a/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
+++ b/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
@@ -74,6 +74,7 @@ void main() {
       }
     });
     result.future.whenComplete(sub.cancel);
+    addTearDown(sub.cancel);
     await manager.loadPlugin(
       id: pluginId,
       manifest: proxyManifest(),
@@ -99,7 +100,7 @@ void main() {
     final manager = await buildManager(
       (request) async => http.Response('{"serial":"SN001"}', 200),
     );
-    addTearDown(manager.cancelAllOperations);
+    addTearDown(manager.dispose);
 
     final result = await loadProxyPlugin(manager);
     expect((await result.future.timeout(const Duration(seconds: 5))), 'ok');
@@ -110,7 +111,7 @@ void main() {
     final manager = await buildManager(
       (request) async => throw http.ClientException('connection refused'),
     );
-    addTearDown(manager.cancelAllOperations);
+    addTearDown(manager.dispose);
 
     final result = await loadProxyPlugin(manager);
     expect(
@@ -125,7 +126,7 @@ void main() {
       await Future<void>.delayed(const Duration(seconds: 10));
       return http.Response('{"serial":"SN001"}', 200);
     }, decentProxyTimeout: const Duration(milliseconds: 200));
-    addTearDown(manager.cancelAllOperations);
+    addTearDown(manager.dispose);
 
     final result = await loadProxyPlugin(manager);
     final value = await result.future.timeout(const Duration(seconds: 5));
@@ -139,14 +140,14 @@ void main() {
       await Future<void>.delayed(const Duration(seconds: 10));
       return http.Response('{"serial":"SN001"}', 200);
     });
-    addTearDown(manager.cancelAllOperations);
+    addTearDown(manager.dispose);
 
     final result = await loadProxyPlugin(manager);
     await Future<void>.delayed(const Duration(milliseconds: 100));
     await manager.unloadPlugin(pluginId);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
 
-    final value = await result.future.timeout(const Duration(seconds: 5));
-    expect(value, startsWith('err:'));
+    expect(result.isCompleted, isFalse);
     expect(manager.activePendingOpCount, 0);
   });
 
@@ -155,7 +156,7 @@ void main() {
       await Future<void>.delayed(const Duration(seconds: 10));
       return http.Response('{"serial":"SN001"}', 200);
     });
-    addTearDown(manager.cancelAllOperations);
+    addTearDown(manager.dispose);
 
     final result = await loadProxyPlugin(manager);
     await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -170,7 +171,7 @@ void main() {
     final manager = await buildManager(
       (request) async => http.Response('{"serial":"SN001"}', 200),
     );
-    addTearDown(manager.cancelAllOperations);
+    addTearDown(manager.dispose);
 
     final result = Completer<String>();
     final sub = manager.emitStream.listen((e) {
@@ -216,15 +217,13 @@ void main() {
       }
       return http.Response('{"serial":"NEW-GEN"}', 200);
     });
-    addTearDown(manager.cancelAllOperations);
+    addTearDown(manager.dispose);
 
     final firstGen = await loadProxyPlugin(manager);
     await Future<void>.delayed(const Duration(milliseconds: 100));
     await manager.unloadPlugin(pluginId);
-    expect(
-      (await firstGen.future.timeout(const Duration(seconds: 5))),
-      startsWith('err:'),
-    );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(firstGen.isCompleted, isFalse);
 
     final secondGen = await loadProxyPlugin(manager);
     expect((await secondGen.future.timeout(const Duration(seconds: 5))), 'ok');

--- a/test/plugins/plugin_manager_fetch_test.dart
+++ b/test/plugins/plugin_manager_fetch_test.dart
@@ -34,9 +34,7 @@ void main() {
     );
   });
 
-  tearDown(() {
-    manager.cancelAllOperations();
-  });
+  tearDown(() async => manager.dispose());
 
   Future<String> runFetch(
     String url, {
@@ -216,12 +214,11 @@ void main() {
     });
     await Future<void>.delayed(const Duration(milliseconds: 100));
     await manager.unloadPlugin('fetch.plugin');
-    final value = await result.future
-        .timeout(const Duration(seconds: 5))
-        .whenComplete(sub.cancel);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
 
-    expect(value, startsWith('rejected:'));
+    expect(result.isCompleted, isFalse);
     expect(manager.activePendingOpCount, 0);
+    await sub.cancel();
   });
 
   test(

--- a/test/plugins/plugin_manager_lifecycle_test.dart
+++ b/test/plugins/plugin_manager_lifecycle_test.dart
@@ -181,6 +181,30 @@ void main() {
     );
   });
 
+  test('reload persists storage written during onUnload', () async {
+    final store = FakeKeyValueStoreService();
+    final manager = PluginManager(kvStore: store);
+    addTearDown(manager.dispose);
+    await _loadPlugin(
+      manager,
+      'storage.plugin',
+      onUnload: '''
+        host.storage({
+          type: "write",
+          key: "lastEstimation",
+          data: { value: 42 }
+        });
+      ''',
+    );
+
+    await _loadPlugin(manager, 'storage.plugin');
+
+    expect(
+      await store.get(namespace: 'storage.plugin', key: 'lastEstimation'),
+      {'value': 42},
+    );
+  });
+
   test('dispose unloads every plugin and clears owned resources', () async {
     final manager = PluginManager(kvStore: FakeKeyValueStoreService());
     await _loadPlugin(

--- a/test/plugins/plugin_manager_lifecycle_test.dart
+++ b/test/plugins/plugin_manager_lifecycle_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 
 import '../helpers/test_de1.dart';
@@ -68,6 +69,22 @@ class _StreamDe1Controller extends De1Controller {
 
   @override
   Stream<De1Interface?> get de1 => machineStream;
+}
+
+class _SyncSnapshotDe1 extends TestDe1 {
+  _SyncSnapshotDe1({required super.deviceId});
+
+  final StreamController<MachineSnapshot> snapshots =
+      StreamController<MachineSnapshot>.broadcast(sync: true);
+
+  @override
+  Stream<MachineSnapshot> get currentSnapshot => snapshots.stream;
+
+  @override
+  Future<void> dispose() async {
+    await snapshots.close();
+    await super.dispose();
+  }
 }
 
 Future<void> _loadPlugin(
@@ -273,6 +290,55 @@ void main() {
     await firstMachine.dispose();
     await secondMachine.dispose();
   });
+
+  test(
+    'machine replacement invalidates snapshots before queue cleanup',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      final machines = StreamController<De1Interface?>.broadcast(sync: true);
+      final controller = _StreamDe1Controller(machines.stream);
+      final firstMachine = _SyncSnapshotDe1(deviceId: 'first');
+      final secondMachine = TestDe1(deviceId: 'second');
+      final values = <double>[];
+
+      await _loadPlugin(
+        manager,
+        'events.plugin',
+        onEvent:
+            'if (event.name === "stateUpdate") host.emit("state", event.payload.groupTemperature);',
+      );
+      final eventSubscription = manager.emitStream.listen((event) {
+        if (event['event'] == 'state') {
+          values.add((event['payload'] as num).toDouble());
+        }
+      });
+
+      await manager.attachDe1Controller(controller);
+      machines.add(firstMachine);
+      await Future<void>.delayed(Duration.zero);
+      values.clear();
+
+      machines.add(secondMachine);
+      firstMachine.snapshots.add(
+        firstMachine.snapshotSubject.value.copyWith(groupTemperature: 11),
+      );
+      await Future<void>.delayed(Duration.zero);
+      secondMachine.emitSnapshot(
+        secondMachine.snapshotSubject.value.copyWith(groupTemperature: 22),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(values, isNot(contains(11)));
+      expect(values, contains(22));
+
+      await manager.dispose();
+      await eventSubscription.cancel();
+      await machines.close();
+      await controller.dispose();
+      await firstMachine.dispose();
+      await secondMachine.dispose();
+    },
+  );
 
   test('rapid controller replacements serialize', () async {
     final firstMachines = StreamController<De1Interface?>.broadcast();

--- a/test/plugins/plugin_manager_lifecycle_test.dart
+++ b/test/plugins/plugin_manager_lifecycle_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ffi';
 
 import 'package:flutter_js/flutter_js.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -20,7 +19,7 @@ class _CountingRuntime extends JavascriptRuntime {
   int disposeCalls = 0;
 
   @override
-  JsEvalResult callFunction(Pointer<NativeType> fn, Pointer<NativeType> obj) =>
+  JsEvalResult callFunction(dynamic fn, dynamic obj) =>
       delegate.callFunction(fn, obj);
 
   @override

--- a/test/plugins/plugin_manager_lifecycle_test.dart
+++ b/test/plugins/plugin_manager_lifecycle_test.dart
@@ -1,0 +1,332 @@
+import 'dart:async';
+import 'dart:ffi';
+
+import 'package:flutter_js/flutter_js.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+
+import '../helpers/test_de1.dart';
+import 'plugin_test_helpers.dart';
+
+class _CountingRuntime extends JavascriptRuntime {
+  _CountingRuntime(this.delegate, {this.throwOnDispose = false});
+
+  final JavascriptRuntime delegate;
+  final bool throwOnDispose;
+  int disposeCalls = 0;
+
+  @override
+  JsEvalResult callFunction(Pointer<NativeType> fn, Pointer<NativeType> obj) =>
+      delegate.callFunction(fn, obj);
+
+  @override
+  T? convertValue<T>(JsEvalResult jsValue) => delegate.convertValue(jsValue);
+
+  @override
+  void dispose() {
+    disposeCalls += 1;
+    delegate.dispose();
+    if (throwOnDispose) throw StateError('runtime disposal failed');
+  }
+
+  @override
+  JsEvalResult evaluate(String code, {String? sourceUrl}) =>
+      delegate.evaluate(code, sourceUrl: sourceUrl);
+
+  @override
+  Future<JsEvalResult> evaluateAsync(String code, {String? sourceUrl}) =>
+      delegate.evaluateAsync(code, sourceUrl: sourceUrl);
+
+  @override
+  int executePendingJob() => delegate.executePendingJob();
+
+  @override
+  String getEngineInstanceId() => delegate.getEngineInstanceId();
+
+  @override
+  void initChannelFunctions() {}
+
+  @override
+  String jsonStringify(JsEvalResult jsValue) => delegate.jsonStringify(jsValue);
+
+  @override
+  bool setupBridge(String channelName, void Function(dynamic args) fn) =>
+      delegate.setupBridge(channelName, fn);
+
+  @override
+  void setInspectable(bool inspectable) => delegate.setInspectable(inspectable);
+}
+
+class _StreamDe1Controller extends De1Controller {
+  _StreamDe1Controller(this.machineStream)
+    : super(controller: DeviceController(const []));
+
+  final Stream<De1Interface?> machineStream;
+
+  @override
+  Stream<De1Interface?> get de1 => machineStream;
+}
+
+Future<void> _loadPlugin(
+  PluginManager manager,
+  String id, {
+  String onUnload = '',
+  String onLoad = '',
+  String onEvent = '',
+}) {
+  return manager.loadPlugin(
+    id: id,
+    manifest: testManifest(id),
+    settings: const {},
+    jsCode:
+        '''
+      function createPlugin(host) {
+        return {
+          id: "$id",
+          onLoad() { $onLoad },
+          onUnload() { $onUnload },
+          onEvent(event) { $onEvent }
+        };
+      }
+    ''',
+  );
+}
+
+void main() {
+  test(
+    'empty disposal is shared, terminal, and disposes runtime once',
+    () async {
+      final runtime = _CountingRuntime(getJavascriptRuntime(xhr: false));
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        js: runtime,
+      );
+      final engineId = runtime.getEngineInstanceId();
+      final streamDone = expectLater(manager.emitStream, emitsDone);
+
+      final first = manager.dispose();
+      final second = manager.dispose();
+
+      expect(identical(first, second), isTrue);
+      expect(manager.lifecycle, PluginManagerLifecycle.disposing);
+      await Future.wait([first, second]);
+      await streamDone;
+      expect(manager.lifecycle, PluginManagerLifecycle.disposed);
+      expect(runtime.disposeCalls, 1);
+      expect(
+        JavascriptRuntime.channelFunctionsRegistered.containsKey(engineId),
+        isFalse,
+      );
+      await manager.dispose();
+      expect(runtime.disposeCalls, 1);
+    },
+  );
+
+  test('failed runtime disposal still leaves the manager disposed', () async {
+    final runtime = _CountingRuntime(
+      getJavascriptRuntime(xhr: false),
+      throwOnDispose: true,
+    );
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      js: runtime,
+    );
+
+    await expectLater(manager.dispose(), throwsStateError);
+
+    expect(manager.lifecycle, PluginManagerLifecycle.disposed);
+    expect(runtime.disposeCalls, 1);
+    await expectLater(manager.dispose(), throwsStateError);
+    expect(runtime.disposeCalls, 1);
+  });
+
+  test('unload deletes registry entry when onUnload throws', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await _loadPlugin(manager, 'throwing.plugin', onUnload: 'throw "boom";');
+
+    await manager.unloadPlugin('throwing.plugin');
+
+    expect(manager.loadedPlugins, isEmpty);
+    expect(
+      manager.js
+          .evaluate('typeof globalThis.__plugins__["throwing.plugin"]')
+          .stringResult,
+      'undefined',
+    );
+  });
+
+  test('dispose unloads every plugin and clears owned resources', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    await _loadPlugin(
+      manager,
+      'first.plugin',
+      onLoad: 'setTimeout(() => {}, 60000);',
+      onUnload: 'throw "boom";',
+    );
+    await _loadPlugin(manager, 'second.plugin');
+    final pendingHttp = expectLater(
+      manager.registerPendingHttp('second.plugin', 'pending'),
+      throwsA(isA<PluginHttpError>()),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    await manager.dispose();
+    await pendingHttp;
+
+    expect(manager.loadedPlugins, isEmpty);
+    expect(manager.activeTimerCount, 0);
+    expect(manager.activePendingOpCount, 0);
+    expect(manager.activeSubscriptionCount, 0);
+    expect(manager.trackedPluginGenerationCount, 0);
+    expect(manager.bridgeTokenCount, 0);
+    expect(manager.de1Controller, isNull);
+  });
+
+  test('mutations fail as soon as disposal starts', () async {
+    final releaseCancellation = Completer<void>();
+    final controllerStream = StreamController<De1Interface?>(
+      onCancel: () => releaseCancellation.future,
+    );
+    final controller = _StreamDe1Controller(controllerStream.stream);
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    await manager.attachDe1Controller(controller);
+
+    final disposal = manager.dispose();
+    var disposalDone = false;
+    disposal.then((_) => disposalDone = true);
+
+    expect(manager.lifecycle, PluginManagerLifecycle.disposing);
+    expect(
+      () => manager.dispatchEvent('missing', 'event', const {}),
+      throwsStateError,
+    );
+    await expectLater(_loadPlugin(manager, 'late.plugin'), throwsStateError);
+    expect(() => manager.attachDe1Controller(null), throwsStateError);
+    expect(
+      () => manager.registerPendingHttp('late.plugin', 'request'),
+      throwsStateError,
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(disposalDone, isFalse);
+
+    releaseCancellation.complete();
+    await disposal;
+    await controllerStream.close();
+    await controller.dispose();
+  });
+
+  test('controller replacement only dispatches the newest generation', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    final firstMachines = StreamController<De1Interface?>.broadcast(sync: true);
+    final secondMachines = StreamController<De1Interface?>.broadcast(
+      sync: true,
+    );
+    final firstController = _StreamDe1Controller(firstMachines.stream);
+    final secondController = _StreamDe1Controller(secondMachines.stream);
+    final firstMachine = TestDe1(deviceId: 'first');
+    final secondMachine = TestDe1(deviceId: 'second');
+    final values = <double>[];
+
+    await _loadPlugin(
+      manager,
+      'events.plugin',
+      onEvent:
+          'if (event.name === "stateUpdate") host.emit("state", event.payload.groupTemperature);',
+    );
+    final eventSubscription = manager.emitStream.listen((event) {
+      if (event['event'] == 'state') {
+        values.add((event['payload'] as num).toDouble());
+      }
+    });
+
+    await manager.attachDe1Controller(firstController);
+    firstMachines.add(firstMachine);
+    await Future<void>.delayed(Duration.zero);
+    values.clear();
+
+    await manager.attachDe1Controller(secondController);
+    firstMachine.emitSnapshot(
+      firstMachine.snapshotSubject.value.copyWith(groupTemperature: 11),
+    );
+    secondMachines.add(secondMachine);
+    await Future<void>.delayed(Duration.zero);
+    secondMachine.emitSnapshot(
+      secondMachine.snapshotSubject.value.copyWith(groupTemperature: 22),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(values, isNot(contains(11)));
+    expect(values, contains(22));
+    expect(manager.attachmentGeneration, 2);
+    expect(manager.activeSubscriptionCount, 2);
+
+    await manager.dispose();
+    await eventSubscription.cancel();
+    await firstMachines.close();
+    await secondMachines.close();
+    await firstController.dispose();
+    await secondController.dispose();
+    await firstMachine.dispose();
+    await secondMachine.dispose();
+  });
+
+  test('rapid controller replacements serialize', () async {
+    final firstMachines = StreamController<De1Interface?>.broadcast();
+    final secondMachines = StreamController<De1Interface?>.broadcast();
+    final thirdMachines = StreamController<De1Interface?>.broadcast();
+    final first = _StreamDe1Controller(firstMachines.stream);
+    final second = _StreamDe1Controller(secondMachines.stream);
+    final third = _StreamDe1Controller(thirdMachines.stream);
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+
+    final firstAttach = manager.attachDe1Controller(first);
+    final secondAttach = manager.attachDe1Controller(second);
+    final thirdAttach = manager.attachDe1Controller(third);
+    await Future.wait([firstAttach, secondAttach, thirdAttach]);
+    expect(manager.de1Controller, same(third));
+    expect(manager.attachmentGeneration, 3);
+    expect(manager.activeSubscriptionCount, 1);
+
+    await manager.dispose();
+    await firstMachines.close();
+    await secondMachines.close();
+    await thirdMachines.close();
+    await first.dispose();
+    await second.dispose();
+    await third.dispose();
+  });
+
+  test(
+    'old plugin generation host messages are ignored after reload',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      final events = <String>[];
+      final subscription = manager.emitStream.listen(
+        (event) => events.add(event['event'] as String),
+      );
+      addTearDown(subscription.cancel);
+      await _loadPlugin(manager, 'generation.plugin');
+      final oldGeneration = manager.pluginGeneration('generation.plugin');
+      await manager.unloadPlugin('generation.plugin');
+      await _loadPlugin(manager, 'generation.plugin');
+
+      manager.js.evaluate('''
+      sendMessage("host", JSON.stringify({
+        pluginId: "generation.plugin",
+        generation: $oldGeneration,
+        type: "emit",
+        event: "stale",
+        payload: null
+      }));
+    ''');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(events, isEmpty);
+    },
+  );
+}

--- a/test/plugins/plugin_manager_lifecycle_test.dart
+++ b/test/plugins/plugin_manager_lifecycle_test.dart
@@ -54,8 +54,17 @@ class _CountingRuntime extends JavascriptRuntime {
   String jsonStringify(JsEvalResult jsValue) => delegate.jsonStringify(jsValue);
 
   @override
-  bool setupBridge(String channelName, void Function(dynamic args) fn) =>
-      delegate.setupBridge(channelName, fn);
+  bool setupBridge(
+    String channelName,
+    JavascriptMessageCallback fn, {
+    bool fireAndForget = false,
+    Duration timeout = const Duration(seconds: 30),
+  }) => delegate.setupBridge(
+    channelName,
+    fn,
+    fireAndForget: fireAndForget,
+    timeout: timeout,
+  );
 
   @override
   void setInspectable(bool inspectable) => delegate.setInspectable(inspectable);
@@ -121,7 +130,6 @@ void main() {
         kvStore: FakeKeyValueStoreService(),
         js: runtime,
       );
-      final engineId = runtime.getEngineInstanceId();
       final streamDone = expectLater(manager.emitStream, emitsDone);
 
       final first = manager.dispose();
@@ -133,10 +141,7 @@ void main() {
       await streamDone;
       expect(manager.lifecycle, PluginManagerLifecycle.disposed);
       expect(runtime.disposeCalls, 1);
-      expect(
-        JavascriptRuntime.channelFunctionsRegistered.containsKey(engineId),
-        isFalse,
-      );
+      expect(runtime.delegate.channelFunctions, isEmpty);
       await manager.dispose();
       expect(runtime.disposeCalls, 1);
     },

--- a/test/plugins/plugin_manager_timers_test.dart
+++ b/test/plugins/plugin_manager_timers_test.dart
@@ -12,9 +12,7 @@ void main() {
     manager = PluginManager(kvStore: FakeKeyValueStoreService());
   });
 
-  tearDown(() {
-    manager.cancelAllOperations();
-  });
+  tearDown(() async => manager.dispose());
 
   Future<List<String>> collectEvents(Duration window) async {
     final events = <String>[];

--- a/test/plugins/plugin_manager_workload_test.dart
+++ b/test/plugins/plugin_manager_workload_test.dart
@@ -52,7 +52,7 @@ void main() {
           ),
         ),
       );
-      addTearDown(manager.cancelAllOperations);
+      addTearDown(manager.dispose);
 
       final done = Completer<void>();
       final sub = manager.emitStream.listen((e) {


### PR DESCRIPTION
## Summary

- Problem: PluginManager and PluginLoaderService had no terminal lifecycle, leaving subscriptions, timers, pending operations, host bridges, and the JavaScript runtime without complete teardown.
- Why it matters: stale callbacks could reach disposed or reloaded plugin generations, while process teardown leaked plugin-owned resources.
- What changed: added idempotent lifecycle disposal, serialized DE1 attachment, generation-guarded callbacks, complete unload cleanup, loader teardown, and detached-only application wiring.
- What did NOT change (scope boundary): public plugin events/APIs and native JavaScriptCore/QuickJS ownership inside flutter_js.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [x] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes #562
- Related #561

## Root Cause (if bug fix)

- Root cause: plugin services had no terminal ownership boundary, and controller replacement cancelled subscriptions without awaiting completion.
- Missing detection or guardrail: no lifecycle-specific tests covered concurrent disposal, stale generations, event-stream completion, or outer application teardown.
- Contributing context (if known): #561 added bounded async ownership but intentionally left subsystem disposal for this follow-up.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (simulate=1 + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: test/plugins/plugin_manager_lifecycle_test.dart, test/plugin_loader_service_lifecycle_test.dart, test/app_lifecycle_observer_test.dart
- Scenario the test should lock in: teardown is shared, terminal, complete, generation-safe, and invoked only on process detachment.
- If no new test added, why not: N/A

## Documentation Obligations (required)

- [ ] API spec updated: assets/api/rest_v1.yml or assets/api/websocket_v1.yml (if REST/WebSocket changed)
- [ ] API docs updated: doc/Api.md (if user-facing endpoint changed)
- [ ] Plugin docs updated: doc/Plugins.md (if events/API changed)
- [ ] Skin docs updated: doc/Skins.md (if skin behavior changed)
- [ ] Profile docs updated: doc/Profiles.md (if profile handling changed)
- [ ] Device docs updated: doc/DeviceManagement.md (if device flows changed)
- [x] N/A - no public docs, events, or API contracts changed

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? No
- Plugin sandbox boundary changed? Yes
- If any Yes, explain risk and mitigation: host messages now carry and validate plugin generations so stale deferred work cannot target a reloaded plugin or recreate state after teardown.

## User-Visible Changes

None.

## Verification

### Local gates (run before pushing)

- [x] dart format lib test - no remaining changes
- [x] flutter analyze - clean (no new warnings)
- [ ] flutter test - full run completed with 2,821 passes and 9 unrelated baseline/environment failures: eight existing Windows _copyDirectory failures and one absent generated bundled-skin manifest
- [ ] ./scripts/fetch_dye2_plugin.sh - DYE2 plugin installed into assets/plugins/dye2.reaplugin/

### Manual verification (if applicable)

- OS / platform tested: Windows
- Simulated devices? (simulate=1): No
- Real hardware? (DE1/Bengle/scale): No
- What you personally verified and how: 10 focused lifecycle tests and 25 affected plugin ownership tests passed; flutter analyze reported no issues.
- Edge cases checked: empty/error-path disposal, concurrent disposal, throwing onUnload, stale generations, controller replacement, pending cancellation, event completion, and detached application teardown.
- What you did not verify: real hardware, native JavaScriptCore/QuickJS allocation behavior, and generated bundled-skin assets.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- If any No or Yes, explain exact steps: No migration or configuration changes are required.

## Risks & Mitigations

- Risk: asynchronous callbacks race with plugin unload or process detachment.
  - Mitigation: lifecycle guards, monotonically increasing generations, serialized subscription replacement, and focused race/teardown tests.