### PR TITLE
fix: decouple shot startup from scale samples

### DIFF
--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -22,6 +22,8 @@ class ScaleController {
   String? get lastConnectedDeviceId => _lastConnectedDeviceId;
   int _connectionGeneration = 0;
   int get connectionGeneration => _connectionGeneration;
+  WeightSnapshot? _currentWeightSnapshot;
+  WeightSnapshot? get currentWeightSnapshot => _currentWeightSnapshot;
 
   final Logger log = Logger('ScaleController');
 
@@ -41,6 +43,7 @@ class ScaleController {
     if (!_weightSnapshotController.isClosed) {
       _weightSnapshotController.close();
     }
+    _currentWeightSnapshot = null;
   }
 
   Future<void> connectToScale(Scale scale) async {
@@ -140,6 +143,7 @@ class ScaleController {
 
   void _onDisconnect() {
     _connectionGeneration++;
+    _currentWeightSnapshot = null;
     _scaleSnapshot?.cancel();
     _scaleConnection?.cancel();
     _scale = null;
@@ -262,17 +266,17 @@ class ScaleController {
         snapshot.timestamp.isBefore(_flowSettleUntil!);
     final displayFlow = settling ? 0.0 : weightFlowAverage.average;
 
-    _weightSnapshotController.add(
-      WeightSnapshot(
-        timestamp: snapshot.timestamp,
-        weight: snapshot.weight,
-        weightFlow: displayFlow,
-        controlWeightFlow: controlFlow,
-        battery: snapshot.batteryLevel,
-        timerValue: snapshot.timerValue,
-        connectionGeneration: _connectionGeneration,
-      ),
+    final weightSnapshot = WeightSnapshot(
+      timestamp: snapshot.timestamp,
+      weight: snapshot.weight,
+      weightFlow: displayFlow,
+      controlWeightFlow: controlFlow,
+      battery: snapshot.batteryLevel,
+      timerValue: snapshot.timerValue,
+      connectionGeneration: _connectionGeneration,
     );
+    _currentWeightSnapshot = weightSnapshot;
+    _weightSnapshotController.add(weightSnapshot);
   }
 
   void _processConnection(ConnectionState d) {

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -20,6 +20,8 @@ class ScaleController {
   /// device went away. Overwritten on the next successful connect.
   String? _lastConnectedDeviceId;
   String? get lastConnectedDeviceId => _lastConnectedDeviceId;
+  int _connectionGeneration = 0;
+  int get connectionGeneration => _connectionGeneration;
 
   final Logger log = Logger('ScaleController');
 
@@ -137,6 +139,7 @@ class ScaleController {
   }
 
   void _onDisconnect() {
+    _connectionGeneration++;
     _scaleSnapshot?.cancel();
     _scaleConnection?.cancel();
     _scale = null;
@@ -267,6 +270,7 @@ class ScaleController {
         controlWeightFlow: controlFlow,
         battery: snapshot.batteryLevel,
         timerValue: snapshot.timerValue,
+        connectionGeneration: _connectionGeneration,
       ),
     );
   }
@@ -287,6 +291,7 @@ class WeightSnapshot {
   final double controlWeightFlow;
   final int? battery;
   final Duration? timerValue;
+  final int connectionGeneration;
   WeightSnapshot({
     required this.timestamp,
     required this.weight,
@@ -294,6 +299,7 @@ class WeightSnapshot {
     double? controlWeightFlow,
     this.battery,
     this.timerValue,
+    this.connectionGeneration = 0,
   }) : controlWeightFlow = controlWeightFlow ?? weightFlow;
 
   Map<String, dynamic> toJson() {

--- a/lib/src/controllers/scale_controller.dart
+++ b/lib/src/controllers/scale_controller.dart
@@ -22,6 +22,7 @@ class ScaleController {
   String? get lastConnectedDeviceId => _lastConnectedDeviceId;
   int _connectionGeneration = 0;
   int get connectionGeneration => _connectionGeneration;
+  bool _snapshotSessionActive = false;
   WeightSnapshot? _currentWeightSnapshot;
   WeightSnapshot? get currentWeightSnapshot => _currentWeightSnapshot;
 
@@ -43,6 +44,7 @@ class ScaleController {
     if (!_weightSnapshotController.isClosed) {
       _weightSnapshotController.close();
     }
+    _snapshotSessionActive = false;
     _currentWeightSnapshot = null;
   }
 
@@ -98,6 +100,7 @@ class ScaleController {
       _connectionController.add(ConnectionState.disconnected);
       throw StateError('Scale failed to connect (state: ${state.name})');
     }
+    _snapshotSessionActive = true;
     // Subscribe to connection state AFTER onConnect succeeds, so we don't
     // get poisoned by a BehaviorSubject replaying a stale 'disconnected'
     // state from before reconnection.
@@ -136,6 +139,7 @@ class ScaleController {
       _connectionController.add(ConnectionState.disconnected);
       throw StateError('Adopted scale not connected (state: ${state.name})');
     }
+    _snapshotSessionActive = true;
     _scale = scale;
     _lastConnectedDeviceId = scale.deviceId;
     _scaleConnection = scale.connectionState.listen(_processConnection);
@@ -143,6 +147,7 @@ class ScaleController {
 
   void _onDisconnect() {
     _connectionGeneration++;
+    _snapshotSessionActive = false;
     _currentWeightSnapshot = null;
     _scaleSnapshot?.cancel();
     _scaleConnection?.cancel();
@@ -248,6 +253,9 @@ class ScaleController {
   }
 
   void _processSnapshot(ScaleSnapshot snapshot) {
+    if (!_snapshotSessionActive) {
+      return;
+    }
     _lastSnapshotTime = snapshot.timestamp;
 
     _kalmanEstimator ??= KalmanFlowEstimator(initialWeight: snapshot.weight);

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -140,6 +140,7 @@ class ShotSequencer {
 
     _scaleConnected = scaleConnected;
     _scaleConnectionGeneration = scaleController.connectionGeneration;
+    _latestScale = scaleController.currentWeightSnapshot;
     _scaleConnectionSubscription = scaleController.connectionState.listen(
       _onScaleConnection,
     );
@@ -147,9 +148,12 @@ class ShotSequencer {
       _onScaleWeight,
     );
     _snapshotSubscription = de1controller.connectedDe1().currentSnapshot.listen(
-      (machine) => _processSnapshot(
-        ShotSnapshot(machine: machine, scale: _scaleFor(machine)),
-      ),
+      (machine) {
+        _syncScaleConnectionGeneration();
+        _processSnapshot(
+          ShotSnapshot(machine: machine, scale: _scaleFor(machine)),
+        );
+      },
       onError: (error) => _log.warning("Error processing DE1 snapshot: $error"),
     );
   }
@@ -267,31 +271,49 @@ class ShotSequencer {
   StreamSubscription<device.ConnectionState>? _scaleConnectionSubscription;
 
   void _onScaleConnection(device.ConnectionState state) {
-    final generation = scaleController.connectionGeneration;
+    _syncScaleConnectionGeneration();
     final connected = state == device.ConnectionState.connected;
-    if (!connected || generation != _scaleConnectionGeneration) {
+    if (!connected) {
       _latestScale = null;
-      _scaleConnectionGeneration = generation;
     }
     _scaleConnected = connected;
-    if (!connected &&
-        !_scaleLost &&
-        _state != ShotState.idle &&
-        _state != ShotState.finished) {
-      _scaleLost = true;
-      _continueScaleless = true;
-      _log.warning(
-        'Scale disconnected during shot (state: ${_state.name}). '
-        'Stop-at-weight disabled for remainder of this shot.',
-      );
+    if (!connected) {
+      _continueWithoutScale();
     }
   }
 
   void _onScaleWeight(WeightSnapshot snapshot) {
+    _syncScaleConnectionGeneration();
     if (_scaleConnected &&
-        snapshot.connectionGeneration == _scaleConnectionGeneration) {
+        !_scaleLost &&
+        snapshot.connectionGeneration == _scaleConnectionGeneration &&
+        snapshot.connectionGeneration == scaleController.connectionGeneration) {
       _latestScale = snapshot;
     }
+  }
+
+  void _syncScaleConnectionGeneration() {
+    final generation = scaleController.connectionGeneration;
+    if (generation == _scaleConnectionGeneration) {
+      return;
+    }
+    _latestScale = null;
+    _scaleConnectionGeneration = generation;
+    _continueWithoutScale();
+  }
+
+  void _continueWithoutScale() {
+    if (_scaleLost ||
+        _state == ShotState.idle ||
+        _state == ShotState.finished) {
+      return;
+    }
+    _scaleLost = true;
+    _continueScaleless = true;
+    _log.warning(
+      'Scale connection changed during shot (state: ${_state.name}). '
+      'Stop-at-weight disabled for remainder of this shot.',
+    );
   }
 
   WeightSnapshot? _scaleFor(MachineSnapshot machine) {
@@ -301,6 +323,7 @@ class ShotSequencer {
         !_scaleConnected ||
         scale == null ||
         scale.connectionGeneration != _scaleConnectionGeneration ||
+        scale.connectionGeneration != scaleController.connectionGeneration ||
         machine.timestamp.difference(scale.timestamp).abs() >=
             _scaleFreshWindow) {
       return null;

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -138,60 +138,34 @@ class ShotSequencer {
       return;
     }
 
-    if (!scaleConnected) {
-      _log.info("Continuing without scale");
-      _snapshotSubscription = de1controller
-          .connectedDe1()
-          .currentSnapshot
-          .map((snapshot) => ShotSnapshot(machine: snapshot))
-          .listen(
-            _processSnapshot,
-            onError: (error) =>
-                _log.warning("Error processing DE1 snapshot: $error"),
-          );
-    } else {
-      _log.info("Scale connected, combining streams");
-      final combinedStream = de1controller
-          .connectedDe1()
-          .currentSnapshot
-          .withLatestFrom(
-            scaleController.weightSnapshot,
-            (machine, weight) => ShotSnapshot(machine: machine, scale: weight),
-          );
-
-      _snapshotSubscription = combinedStream.listen(
-        _processSnapshot,
-        onError: (error) =>
-            _log.warning("Error processing combined snapshot: $error"),
-      );
-
-      // Monitor scale connection during shot
-      _scaleConnectionSubscription = scaleController.connectionState.listen((
-        state,
-      ) {
-        if (state == device.ConnectionState.disconnected && !_scaleLost) {
-          if (_state != ShotState.idle && _state != ShotState.finished) {
-            _scaleLost = true;
-            _log.warning(
-              'Scale disconnected during shot (state: ${_state.name}). '
-              'Stop-at-weight disabled for remainder of this shot.',
-            );
-          }
-        }
-      });
-    }
+    _scaleConnected = scaleConnected;
+    _scaleConnectionGeneration = scaleController.connectionGeneration;
+    _scaleConnectionSubscription = scaleController.connectionState.listen(
+      _onScaleConnection,
+    );
+    _scaleWeightSubscription = scaleController.weightSnapshot.listen(
+      _onScaleWeight,
+    );
+    _snapshotSubscription = de1controller.connectedDe1().currentSnapshot.listen(
+      (machine) => _processSnapshot(
+        ShotSnapshot(machine: machine, scale: _scaleFor(machine)),
+      ),
+      onError: (error) => _log.warning("Error processing DE1 snapshot: $error"),
+    );
   }
 
   void dispose() {
     _log.fine("dispose");
     _snapshotSubscription?.cancel();
     _scaleConnectionSubscription?.cancel();
+    _scaleWeightSubscription?.cancel();
     _rawShotDataStream.close();
     _shotDataStream.close();
     _decisionStream.close();
   }
 
-  StreamSubscription<ShotSnapshot>? _snapshotSubscription;
+  StreamSubscription<MachineSnapshot>? _snapshotSubscription;
+  StreamSubscription<WeightSnapshot>? _scaleWeightSubscription;
 
   final StreamController<ShotSnapshot> _rawShotDataStream =
       StreamController.broadcast();
@@ -272,6 +246,11 @@ class ShotSequencer {
   final double targetYield;
   ShotState _state = ShotState.idle;
   bool _scaleLost = false;
+  bool _scaleConnected = false;
+  bool _continueScaleless = false;
+  int _scaleConnectionGeneration = 0;
+  WeightSnapshot? _latestScale;
+  static const Duration _scaleFreshWindow = Duration(seconds: 2);
 
   /// Whether this shot's scale has been tared for the pour yet. Flips `true`
   /// when the app issues the pour-time tare (the preheating→pouring
@@ -286,6 +265,48 @@ class ShotSequencer {
   /// for, so the scale's own readings are trusted as-is.
   bool _scaleTared = false;
   StreamSubscription<device.ConnectionState>? _scaleConnectionSubscription;
+
+  void _onScaleConnection(device.ConnectionState state) {
+    final generation = scaleController.connectionGeneration;
+    final connected = state == device.ConnectionState.connected;
+    if (!connected || generation != _scaleConnectionGeneration) {
+      _latestScale = null;
+      _scaleConnectionGeneration = generation;
+    }
+    _scaleConnected = connected;
+    if (!connected &&
+        !_scaleLost &&
+        _state != ShotState.idle &&
+        _state != ShotState.finished) {
+      _scaleLost = true;
+      _continueScaleless = true;
+      _log.warning(
+        'Scale disconnected during shot (state: ${_state.name}). '
+        'Stop-at-weight disabled for remainder of this shot.',
+      );
+    }
+  }
+
+  void _onScaleWeight(WeightSnapshot snapshot) {
+    if (_scaleConnected &&
+        snapshot.connectionGeneration == _scaleConnectionGeneration) {
+      _latestScale = snapshot;
+    }
+  }
+
+  WeightSnapshot? _scaleFor(MachineSnapshot machine) {
+    final scale = _latestScale;
+    if (_continueScaleless ||
+        _scaleLost ||
+        !_scaleConnected ||
+        scale == null ||
+        scale.connectionGeneration != _scaleConnectionGeneration ||
+        machine.timestamp.difference(scale.timestamp).abs() >=
+            _scaleFreshWindow) {
+      return null;
+    }
+    return scale;
+  }
 
   void _processSnapshot(ShotSnapshot snapshot) {
     _log.finest("Processing snapshot");
@@ -302,6 +323,7 @@ class ShotSequencer {
           weightFlow: 0,
           battery: raw.battery,
           timerValue: raw.timerValue,
+          connectionGeneration: raw.connectionGeneration,
         ),
       );
     }
@@ -403,6 +425,13 @@ class ShotSequencer {
           _maxFrameSeen = -1;
           _finalStopReason = null;
 
+          if (scale == null) {
+            _continueScaleless = true;
+            _log.info(
+              'No fresh scale sample at shot start; continuing scaleless',
+            );
+          }
+
           if (_bypassSAW == false && scale != null && !_scaleLost) {
             _log.info(
               "Machine getting ready. Taring scale and resetting timer...",
@@ -440,6 +469,9 @@ class ShotSequencer {
         }
         if (machine.state.substate == MachineSubstate.preinfusion ||
             machine.state.substate == MachineSubstate.pouring) {
+          if (scale == null) {
+            _continueScaleless = true;
+          }
           if (_bypassSAW == false && scale != null && !_scaleLost) {
             _log.info("Taring scale again and starting timer.");
             scaleController.tare().catchError(

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -58,16 +58,23 @@ class _TestDe1Controller extends De1Controller {
 class _TestScaleController extends ScaleController {
   final TestScale testScale;
   final BehaviorSubject<ConnectionState> _connectionState;
-  final BehaviorSubject<WeightSnapshot> _weight = BehaviorSubject();
+  final StreamController<WeightSnapshot> _weight;
+  int generation = 0;
 
-  _TestScaleController(this.testScale)
-    : _connectionState = BehaviorSubject.seeded(ConnectionState.connected);
+  _TestScaleController(this.testScale, {bool replayWeights = true})
+    : _connectionState = BehaviorSubject.seeded(ConnectionState.connected),
+      _weight = replayWeights
+          ? BehaviorSubject<WeightSnapshot>()
+          : StreamController<WeightSnapshot>.broadcast();
 
   @override
   Stream<ConnectionState> get connectionState => _connectionState.stream;
 
   @override
   ConnectionState get currentConnectionState => _connectionState.value;
+
+  @override
+  int get connectionGeneration => generation;
 
   @override
   Stream<WeightSnapshot> get weightSnapshot => _weight.stream;
@@ -84,19 +91,27 @@ class _TestScaleController extends ScaleController {
     double weight, {
     double weightFlow = 0.0,
     double? controlWeightFlow,
+    DateTime? timestamp,
   }) {
     _weight.add(
       WeightSnapshot(
-        timestamp: DateTime(2026, 1, 15, 8, 0),
+        timestamp: timestamp ?? DateTime(2026, 1, 15, 8, 0),
         weight: weight,
         weightFlow: weightFlow,
         controlWeightFlow: controlWeightFlow,
+        connectionGeneration: generation,
       ),
     );
   }
 
   void simulateDisconnect() {
+    generation++;
     _connectionState.add(ConnectionState.disconnected);
+  }
+
+  void simulateReconnect() {
+    generation++;
+    _connectionState.add(ConnectionState.connected);
   }
 
   @override
@@ -335,9 +350,154 @@ void main() {
       );
     }
 
+    test(
+      'machine lifecycle starts without a post-subscription scale sample',
+      () {
+        fakeAsync((async) {
+          final nonReplayingScale = _TestScaleController(
+            testScale,
+            replayWeights: false,
+          );
+          nonReplayingScale.emitWeight(0);
+          final shotSequencer = ShotSequencer(
+            scaleController: nonReplayingScale,
+            de1controller: de1Controller,
+            persistenceController: persistenceController,
+            targetProfile: profile,
+            targetYield: 36.0,
+            bypassSAW: false,
+            blockOnNoScale: false,
+            weightFlowMultiplier: 0.0,
+            volumeFlowMultiplier: 0.0,
+            stepExitArbiterEnabled: true,
+          );
+          final snapshots = <ShotSnapshot>[];
+          shotSequencer.shotData.listen(snapshots.add);
+
+          driveToPouring(shotSequencer);
+          async.elapse(const Duration(milliseconds: 10));
+
+          expect(shotSequencer.currentState, ShotState.pouring);
+          expect(snapshots, isNotEmpty);
+          expect(snapshots.every((snapshot) => snapshot.scale == null), isTrue);
+
+          shotSequencer.dispose();
+          nonReplayingScale.dispose();
+        });
+      },
+    );
+
+    test('continues scaleless when the first scale sample arrives late', () {
+      fakeAsync((async) {
+        final nonReplayingScale = _TestScaleController(
+          testScale,
+          replayWeights: false,
+        );
+        final shotSequencer = ShotSequencer(
+          scaleController: nonReplayingScale,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 36.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
+        );
+        final snapshots = <ShotSnapshot>[];
+        shotSequencer.shotData.listen(snapshots.add);
+
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.preparingForShot,
+        );
+        nonReplayingScale.emitWeight(40);
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouring,
+        );
+        nonReplayingScale.emitWeight(40);
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouring,
+        );
+        async.elapse(const Duration(milliseconds: 10));
+
+        expect(shotSequencer.currentState, ShotState.pouring);
+        expect(testDe1.requestedStates, isEmpty);
+        expect(snapshots.every((snapshot) => snapshot.scale == null), isTrue);
+
+        shotSequencer.dispose();
+        nonReplayingScale.dispose();
+      });
+    });
+
+    test('does not associate a stale scale sample', () {
+      fakeAsync((async) {
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 36.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
+        );
+        scaleController.emitWeight(
+          0,
+          timestamp: DateTime(2026, 1, 15, 7, 59, 57),
+        );
+
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.preparingForShot,
+        );
+        async.elapse(const Duration(milliseconds: 10));
+
+        expect(shotSequencer.currentState, ShotState.preheating);
+        expect(testScale.tareCallCount, 0);
+
+        shotSequencer.dispose();
+      });
+    });
+
+    test('does not associate a sample from an older scale connection', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0);
+        scaleController.simulateDisconnect();
+        scaleController.simulateReconnect();
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 36.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
+        );
+
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.preparingForShot,
+        );
+        async.elapse(const Duration(milliseconds: 10));
+
+        expect(shotSequencer.currentState, ShotState.preheating);
+        expect(testScale.tareCallCount, 0);
+
+        shotSequencer.dispose();
+      });
+    });
+
     test('disables SAW when scale disconnects during pouring', () {
       fakeAsync((async) {
-        // Emit initial weight so withLatestFrom has a value to combine with
         scaleController.emitWeight(0.0);
 
         final shotSequencer = ShotSequencer(
@@ -366,7 +526,6 @@ void main() {
         // With the fix, SAW should be disabled because scale is disconnected.
         scaleController.emitWeight(40.0);
 
-        // Emit a machine snapshot to trigger processing of the combined stream
         testDe1.emitStateAndSubstate(
           MachineState.espresso,
           MachineSubstate.pouring,
@@ -374,8 +533,6 @@ void main() {
         async.elapse(Duration(milliseconds: 10));
 
         // SAW should NOT have fired because scale is disconnected.
-        // The bug: requestedStates will contain MachineState.idle because
-        // withLatestFrom still combines with the stale weight.
         expect(
           testDe1.requestedStates,
           isEmpty,
@@ -426,7 +583,6 @@ void main() {
       'does not crash when scale disconnects and timer stop is attempted',
       () {
         fakeAsync((async) {
-          // Emit initial weight so withLatestFrom has a value
           scaleController.emitWeight(0.0);
 
           final shotSequencer = ShotSequencer(
@@ -481,7 +637,6 @@ void main() {
 
     test('SAW still works normally when scale stays connected', () {
       fakeAsync((async) {
-        // Emit initial weight so withLatestFrom has a value
         scaleController.emitWeight(0.0);
 
         final shotSequencer = ShotSequencer(

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -60,6 +60,7 @@ class _TestScaleController extends ScaleController {
   final BehaviorSubject<ConnectionState> _connectionState;
   final StreamController<WeightSnapshot> _weight;
   int generation = 0;
+  WeightSnapshot? _currentWeight;
 
   _TestScaleController(this.testScale, {bool replayWeights = true})
     : _connectionState = BehaviorSubject.seeded(ConnectionState.connected),
@@ -80,6 +81,9 @@ class _TestScaleController extends ScaleController {
   Stream<WeightSnapshot> get weightSnapshot => _weight.stream;
 
   @override
+  WeightSnapshot? get currentWeightSnapshot => _currentWeight;
+
+  @override
   Scale connectedScale() {
     if (_connectionState.value != ConnectionState.connected) {
       throw 'No scale connected';
@@ -93,24 +97,35 @@ class _TestScaleController extends ScaleController {
     double? controlWeightFlow,
     DateTime? timestamp,
   }) {
-    _weight.add(
-      WeightSnapshot(
-        timestamp: timestamp ?? DateTime(2026, 1, 15, 8, 0),
-        weight: weight,
-        weightFlow: weightFlow,
-        controlWeightFlow: controlWeightFlow,
-        connectionGeneration: generation,
-      ),
+    final snapshot = WeightSnapshot(
+      timestamp: timestamp ?? DateTime(2026, 1, 15, 8, 0),
+      weight: weight,
+      weightFlow: weightFlow,
+      controlWeightFlow: controlWeightFlow,
+      connectionGeneration: generation,
     );
+    _currentWeight = snapshot;
+    _weight.add(snapshot);
   }
 
   void simulateDisconnect() {
     generation++;
+    _currentWeight = null;
     _connectionState.add(ConnectionState.disconnected);
   }
 
   void simulateReconnect() {
     generation++;
+    _currentWeight = null;
+    _connectionState.add(ConnectionState.connected);
+  }
+
+  void simulateHandoff() {
+    generation++;
+    _currentWeight = null;
+  }
+
+  void announceConnected() {
     _connectionState.add(ConnectionState.connected);
   }
 
@@ -351,7 +366,7 @@ void main() {
     }
 
     test(
-      'machine lifecycle starts without a post-subscription scale sample',
+      'fresh pre-subscription scale sample remains active for replayed start',
       () {
         fakeAsync((async) {
           final nonReplayingScale = _TestScaleController(
@@ -359,6 +374,10 @@ void main() {
             replayWeights: false,
           );
           nonReplayingScale.emitWeight(0);
+          testDe1.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.preparingForShot,
+          );
           final shotSequencer = ShotSequencer(
             scaleController: nonReplayingScale,
             de1controller: de1Controller,
@@ -374,18 +393,65 @@ void main() {
           final snapshots = <ShotSnapshot>[];
           shotSequencer.shotData.listen(snapshots.add);
 
-          driveToPouring(shotSequencer);
+          async.elapse(const Duration(milliseconds: 10));
+          expect(shotSequencer.currentState, ShotState.preheating);
+
+          testDe1.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.pouring,
+          );
+          nonReplayingScale.emitWeight(40);
+          testDe1.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.pouring,
+          );
           async.elapse(const Duration(milliseconds: 10));
 
-          expect(shotSequencer.currentState, ShotState.pouring);
-          expect(snapshots, isNotEmpty);
-          expect(snapshots.every((snapshot) => snapshot.scale == null), isTrue);
+          expect(testDe1.requestedStates, contains(MachineState.idle));
+          expect(snapshots.any((snapshot) => snapshot.scale != null), isTrue);
 
           shotSequencer.dispose();
           nonReplayingScale.dispose();
         });
       },
     );
+
+    test('scale handoff during a shot stays scaleless', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0);
+        final shotSequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 36.0,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0.0,
+          volumeFlowMultiplier: 0.0,
+          stepExitArbiterEnabled: true,
+        );
+        final snapshots = <ShotSnapshot>[];
+        shotSequencer.shotData.listen(snapshots.add);
+
+        driveToPouring(shotSequencer);
+        async.elapse(const Duration(milliseconds: 10));
+        scaleController.simulateHandoff();
+        scaleController.announceConnected();
+        scaleController.emitWeight(40);
+        testDe1.emitStateAndSubstate(
+          MachineState.espresso,
+          MachineSubstate.pouring,
+        );
+        async.elapse(const Duration(milliseconds: 10));
+
+        expect(shotSequencer.scaleLost, isTrue);
+        expect(testDe1.requestedStates, isEmpty);
+        expect(snapshots.last.scale, isNull);
+
+        shotSequencer.dispose();
+      });
+    });
 
     test('continues scaleless when the first scale sample arrives late', () {
       fakeAsync((async) {

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -129,7 +129,7 @@ void main() {
     controller.dispose();
   });
 
-  test('weight snapshots carry their scale connection generation', () async {
+  test('weight snapshots cache their scale connection generation', () async {
     final controller = ScaleController();
     final first = _TrackingScale('A');
     final second = _TrackingScale('B');
@@ -140,11 +140,14 @@ void main() {
     first.emitAt(DateTime.utc(2026, 8, 8), 1);
     await Future<void>.delayed(Duration.zero);
     final firstGeneration = frames.single.connectionGeneration;
+    expect(controller.currentWeightSnapshot, same(frames.single));
 
     await controller.connectToScale(second);
+    expect(controller.currentWeightSnapshot, isNull);
     second.emitAt(DateTime.utc(2026, 8, 8, 0, 0, 1), 2);
     await Future<void>.delayed(Duration.zero);
 
+    expect(controller.currentWeightSnapshot, same(frames.last));
     expect(frames.last.connectionGeneration, controller.connectionGeneration);
     expect(frames.last.connectionGeneration, isNot(firstGeneration));
 

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -131,22 +131,25 @@ void main() {
 
   test('weight snapshots cache their scale connection generation', () async {
     final controller = ScaleController();
-    final first = _TrackingScale('A');
-    final second = _TrackingScale('B');
+    final scale = _TrackingScale('A');
     final frames = <WeightSnapshot>[];
     final subscription = controller.weightSnapshot.listen(frames.add);
 
-    await controller.connectToScale(first);
-    first.emitAt(DateTime.utc(2026, 8, 8), 1);
+    await controller.connectToScale(scale);
+    scale.emitAt(DateTime.now(), 40);
     await Future<void>.delayed(Duration.zero);
     final firstGeneration = frames.single.connectionGeneration;
     expect(controller.currentWeightSnapshot, same(frames.single));
 
-    await controller.connectToScale(second);
+    await controller.connectToScale(scale);
+    await Future<void>.delayed(Duration.zero);
     expect(controller.currentWeightSnapshot, isNull);
-    second.emitAt(DateTime.utc(2026, 8, 8, 0, 0, 1), 2);
+    expect(frames, hasLength(1));
+
+    scale.emitAt(DateTime.now(), 2);
     await Future<void>.delayed(Duration.zero);
 
+    expect(frames, hasLength(2));
     expect(controller.currentWeightSnapshot, same(frames.last));
     expect(frames.last.connectionGeneration, controller.connectionGeneration);
     expect(frames.last.connectionGeneration, isNot(firstGeneration));

--- a/test/unit/controllers/scale_controller_test.dart
+++ b/test/unit/controllers/scale_controller_test.dart
@@ -129,6 +129,29 @@ void main() {
     controller.dispose();
   });
 
+  test('weight snapshots carry their scale connection generation', () async {
+    final controller = ScaleController();
+    final first = _TrackingScale('A');
+    final second = _TrackingScale('B');
+    final frames = <WeightSnapshot>[];
+    final subscription = controller.weightSnapshot.listen(frames.add);
+
+    await controller.connectToScale(first);
+    first.emitAt(DateTime.utc(2026, 8, 8), 1);
+    await Future<void>.delayed(Duration.zero);
+    final firstGeneration = frames.single.connectionGeneration;
+
+    await controller.connectToScale(second);
+    second.emitAt(DateTime.utc(2026, 8, 8, 0, 0, 1), 2);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(frames.last.connectionGeneration, controller.connectionGeneration);
+    expect(frames.last.connectionGeneration, isNot(firstGeneration));
+
+    await subscription.cancel();
+    controller.dispose();
+  });
+
   test('a scale whose onConnect throws surfaces as disconnected and leaks no '
       'snapshot subscription', () async {
     final controller = ScaleController();


### PR DESCRIPTION
## Summary

DE1-01 decouples shot lifecycle processing from scale telemetry.

`ShotSequencer` previously used `withLatestFrom`, so a connected scale that had not emitted after subscription could suppress the DE1 preparing frame and prevent the application shot from starting. The fix now:

- subscribes directly to machine snapshots;
- caches the latest confirmed-session weight in `ScaleController`;
- associates scale data only when it is fresh and from the live connection generation;
- continues the shot scaleless when no valid sample exists at startup or the scale generation changes mid-shot;
- rejects replayed pre-connection snapshots so an old weight cannot be relabeled as a new connection generation.

Scale protocols, API contracts, storage schemas, and normal SAW behavior with a valid current sample are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra

## Scope

- [x] Machine state / shot logic
- [x] Scale / weight / flow
- [ ] BLE transport / device comms
- [ ] REST or WebSocket API
- [ ] Profiles / workflows
- [ ] UI / skins / plugins
- [ ] Storage
- [ ] CI / build

## Linked Issues

- DE1-01

## Root Cause

Machine lifecycle delivery was coupled to a non-replaying scale stream. Production machine telemetry replays its latest frame, but production scale telemetry does not, so the sequencer could receive the replayed preparing frame before any usable scale sample and permanently miss shot startup.

Caching scale data introduced two additional connection-boundary requirements now covered here: samples must match the controller's live generation, and replayed device snapshots must not be accepted until the new connection session is confirmed.

## Regression Coverage

- A non-replaying scale with no sample does not block machine lifecycle transitions.
- A fresh sample emitted before sequencer construction survives the replayed machine start and preserves SAW.
- A genuinely late first sample does not attach partway through a scaleless shot.
- Stale and prior-generation samples are rejected.
- A scale handoff during a shot remains scaleless.
- Reconnecting the same `BehaviorSubject`-backed scale does not relabel its retained old sample; only new telemetry is cached and published.

Tests: `test/controllers/shot_sequencer_test.dart` and `test/unit/controllers/scale_controller_test.dart`.

## Documentation Obligations

- [x] N/A: no API, profile, skin, plugin, or user workflow documentation changed.

## Security Impact

- New or changed REST endpoints: No
- New or changed WebSocket topics: No
- New network calls: No
- BLE/USB protocol surface changed: No
- File-system access changed: No
- Plugin sandbox boundary changed: No

## User-Visible Change

A physical espresso shot now advances through application shot states even when scale telemetry is missing. Weight-based behavior remains available when a fresh confirmed-session sample exists; otherwise the shot explicitly continues scaleless.

## Verification

| Check | Result |
| --- | --- |
| Formatter check on changed files | Pass, 0 changed |
| `flutter analyze` | Pass, no issues |
| ScaleController + ShotSequencer tests | Pass, 52/52 |
| Neighboring shot-state, Bengle SAW, and hot-water tests | Pass, 15/15 |
| Full Windows suite | 2,814 passed; 10 unrelated environment/baseline failures |

The full-suite failures are outside the changed controllers: Windows plugin-loader path/concurrency cases, an ignored bundled-skin test asset, and a leftover import temp-directory cleanup assertion. The focused controller tests and analyzer are green.

Real DE1 and scale hardware were not exercised.

## Compatibility and Migration

- Backward compatible: Yes
- Configuration changes: None
- Database migration: None
- Operator action: None

## Risks and Mitigations

- A missing or stale scale sample disables weight-based decisions for that shot rather than acting on unsafe data.
- A scale reconnect or handoff cannot attach a replacement generation mid-shot.
- Replayed device snapshots are ignored until the new connection session is confirmed.