### PR TITLE
Enforce plugin manifest permissions

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5979,7 +5979,7 @@ components:
           type: array
           items:
             type: string
-            enum: [log, api, emit, pluginStorage, pluginNotify, proxy.decent_api, proxy.decent_api.write]
+            enum: [log, api, emit, pluginStorage, events.machine, events.shots, proxy.decent_api, proxy.decent_api.write]
         settings:
           description: Plugin settings schema
           type: object

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2607,6 +2607,43 @@ paths:
                   id:
                     type: string
 
+  /api/v1/plugins/{id}/{endpoint}:
+    get:
+      summary: Call a plugin HTTP endpoint
+      description: >
+        Routes the request to a loaded plugin's declared HTTP endpoint. The
+        runtime applies this contract to every HTTP method. The plugin manifest
+        must declare the api permission; otherwise Decaid rejects the request
+        before dispatch.
+      tags: [Plugins]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Plugin ID
+        - name: endpoint
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Plugin-declared HTTP endpoint ID
+      responses:
+        "403":
+          description: Plugin manifest does not declare the api permission
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [error]
+                properties:
+                  error:
+                    type: string
+                    example: "PluginPermissionError: Plugin example.plugin requires manifest permission api"
+        default:
+          description: Plugin-defined status, headers, and body
+
   /api/v1/plugins/install:
     post:
       summary: Install a plugin from URL
@@ -5993,7 +6030,7 @@ components:
                 type: string
               type:
                 type: string
-                enum: ['websocket']
+                enum: ['websocket', 'http']
               data:
                 type: object
         loaded:

--- a/assets/plugins/decent-profile.reaplugin/manifest.json
+++ b/assets/plugins/decent-profile.reaplugin/manifest.json
@@ -7,8 +7,8 @@
   "apiVersion": 1,
   "permissions": [
     "log",
-    "emit",
-    "pluginStorage"
+    "api",
+    "emit"
   ],
   "settings": {
     "roastDegree": {

--- a/assets/plugins/decent-profile.reaplugin/manifest.json
+++ b/assets/plugins/decent-profile.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Stephane Ribes and Alwaysdialingin",
   "name": "Decent Profile Generator",
   "description": "Generates optimized espresso profiles based on bean and grind characteristics. Configure settings to match your current beans, then connect to the profileGenerated WebSocket event to receive the computed profile. The UI can also upload the generated profile to your library and load it onto the connected machine. http://localhost:8080/api/v1/plugins/decent-profile.reaplugin/ui",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/decent-profile.reaplugin/plugin.js
+++ b/assets/plugins/decent-profile.reaplugin/plugin.js
@@ -529,13 +529,6 @@ function createPlugin(host) {
       log("Unloaded");
     },
 
-    onEvent: function(event) {
-      if (event.name === "stateUpdate") {
-        // Machine state available if needed for future enhancements
-        // e.g. auto-push profile when machine enters idle state
-      }
-    },
-
     __httpRequestHandler: function(request) {
       if (request.endpoint === "ui") {
         var override = request && request.query && request.query.layout;

--- a/assets/plugins/shot-upload.reaplugin/manifest.json
+++ b/assets/plugins/shot-upload.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Decent shot upload",
   "description": "Uploads your espresso shots to your Decent account at decentespresso.com so you can see your shot history and charts. Uses your existing Decent login; only your own machines are accepted. Off by default: enable Upload shots automatically to opt in.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/shot-upload.reaplugin/manifest.json
+++ b/assets/plugins/shot-upload.reaplugin/manifest.json
@@ -10,7 +10,8 @@
     "api",
     "emit",
     "pluginStorage",
-    "proxy.decent_api.write"
+    "proxy.decent_api.write",
+    "events.shots"
   ],
   "settings": {
     "AutoUpload": {

--- a/assets/plugins/time-to-ready.reaplugin/manifest.json
+++ b/assets/plugins/time-to-ready.reaplugin/manifest.json
@@ -7,8 +7,9 @@
   "apiVersion": 1,
   "permissions": [
     "log",
-    "api",
-    "emit"
+    "emit",
+    "pluginStorage",
+    "events.machine"
   ],
   "settings": {
     "Stabilisation": {

--- a/assets/plugins/time-to-ready.reaplugin/manifest.json
+++ b/assets/plugins/time-to-ready.reaplugin/manifest.json
@@ -3,7 +3,7 @@
   "author": "Decent Espresso",
   "name": "Time To Ready",
   "description": "Examines current machine state and reports estimated time until it's ready for brewing",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "apiVersion": 1,
   "permissions": [
     "log",

--- a/assets/plugins/visualizer.reaplugin/manifest.json
+++ b/assets/plugins/visualizer.reaplugin/manifest.json
@@ -9,7 +9,9 @@
     "log",
     "api",
     "emit",
-    "pluginStorage"
+    "pluginStorage",
+    "events.machine",
+    "events.shots"
   ],
   "settings": {
     "Username": {

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -263,7 +263,8 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 | POST | `/api/v1/plugins/:id/disable` | Unload plugin + disable auto-load | |
 | DELETE | `/api/v1/plugins/:id` | Remove plugin (unload + delete files) | |
 | POST | `/api/v1/plugins/install` | Install from URL (not yet implemented — returns 501) | |
-| GET/WS | `/api/v1/plugins/:id/:endpoint` | Plugin HTTP/WebSocket proxy | |
+| ANY | `/api/v1/plugins/:id/:endpoint` | Plugin HTTP endpoint; requires `api` and returns 403 without it | |
+| WS | `/ws/v1/plugins/:id/:endpoint` | Plugin WebSocket endpoint | |
 
 Plugin setting updates use patch semantics for every field: an omitted field
 preserves the existing value, a field sent as `null` clears it, and a secure

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -29,7 +29,8 @@ A Decaid plugin consists of two required files:
     "log",
     "api",
     "emit",
-    "pluginStorage"
+    "pluginStorage",
+    "events.machine"
   ],
   "settings": {
     "SettingName": {
@@ -57,13 +58,21 @@ A Decaid plugin consists of two required files:
 
 - **id**: Unique identifier using reverse domain notation (e.g., `com.example.plugin`)
 - **permissions**: Array of capabilities the plugin needs:
-  - `log`: Access to logging
-  - `api`: Ability to make HTTP requests
-  - `emit`: Emit events to the Flutter app
-  - `pluginStorage`: Persistent storage
-  - `proxy.decent_api`: Call the linked Decent account proxy through `host.decentProxy`
+  - `log`: Call `host.log`
+  - `api`: Use plugin `fetch` and expose declared HTTP endpoints
+  - `emit`: Call `host.emit`
+  - `pluginStorage`: Call `host.storage`
+  - `events.machine`: Receive `stateUpdate`
+  - `events.shots`: Receive `shotStored` and `shotUpdated`
+  - `proxy.decent_api`: Send read requests through `host.decentProxy`
+  - `proxy.decent_api.write`: Send allowlisted write requests through `host.decentProxy`
 - **settings**: User-configurable options with `type` (`string`, `number`, `boolean`) and optional `secure` flag for credentials such as passwords. Secure values use platform credential storage, are supplied in memory to `onLoad(settings)`, and are never returned by the REST API.
-- **api**: Events this plugin emits, used for documentation and type checking
+- **api**: HTTP and WebSocket endpoints exposed by the plugin
+
+Unknown permission names make the manifest invalid. Calls without their required
+permission throw or reject with `PluginPermissionError` and are logged by Decaid.
+`setTimeout` and `clearTimeout` are baseline runtime facilities and need no
+manifest permission.
 
 ### 2. `plugin.js` - Main plugin implementation
 
@@ -104,13 +113,13 @@ function createPlugin(host) {
 The `host` object provides these methods:
 
 ### `host.log(message)`
-Log messages to the Flutter app's logger.
+Log messages to the Flutter app's logger. Requires `log`.
 
 ### `host.emit(eventName, payload)`
-Emit events to the Flutter app. These can be listened to by other parts of the application.
+Emit events to the Flutter app. Requires `emit`.
 
 ### `host.storage(command)`
-Interact with persistent storage. Commands:
+Interact with persistent storage. Requires `pluginStorage`. Commands:
 ```javascript
 // Read from storage
 host.storage({
@@ -159,6 +168,9 @@ The returned object has `{ status, headers, body }`. `GET` (read) needs `proxy.d
 
 Plugins receive events in the `onEvent` method:
 
+Machine broadcasts require `events.machine`. Shot lifecycle broadcasts require
+`events.shots`.
+
 - **`stateUpdate`**: Machine state changes (temperature, pressure, flow, etc.)
 
   ```javascript
@@ -188,6 +200,7 @@ Plugins receive events in the `onEvent` method:
   ```
 
 - **`storageWrite`**: Confirmation of storage write
+- **`shotStored`**: A shot finished persisting
 - **`shotUpdated`**: A stored shot was edited via `PUT /api/v1/shots/<id>` (e.g. metadata changes — notes, enjoyment, bean/grinder). Broadcast to every plugin so they can react to edits (the Visualizer plugin uses it to forward-sync edited metadata).
 
   ```javascript
@@ -234,6 +247,9 @@ Will open a websocket through which Decaid will forward all the `timeToReady` ev
 ## HTTP Requests
 
 Plugins can make HTTP requests using the standard `fetch` API (polyfilled by the host):
+
+Plugin `fetch` requires `api`. Declared HTTP endpoints also require `api` before
+Decaid dispatches a request to the plugin.
 
 ```javascript
 // Basic GET request

--- a/doc/plans/archive/plugin-permission-enforcement/plugin-permission-enforcement.md
+++ b/doc/plans/archive/plugin-permission-enforcement/plugin-permission-enforcement.md
@@ -1,0 +1,26 @@
+# Plugin Permission Enforcement
+
+## Capability model
+
+- `log` gates `host.log`.
+- `api` gates plugin `fetch` and declared HTTP endpoints.
+- `emit` gates `host.emit`.
+- `pluginStorage` gates `host.storage`.
+- `proxy.decent_api` and `proxy.decent_api.write` retain their existing read and allowlisted-write rules.
+- `events.machine` gates `stateUpdate` delivery.
+- `events.shots` gates `shotStored` and `shotUpdated` delivery.
+- Timers remain baseline runtime facilities.
+- `pluginNotify` is removed until a notification host API exists.
+
+## Implementation
+
+1. Reject undeclared calls at the plugin JS surface with `PluginPermissionError`.
+2. Recheck every capability in Dart and log denials with plugin ID and wire name.
+3. Reject unknown manifest permission names.
+4. Correct bundled manifests and validate the pinned DYE2 manifest after download.
+5. Add allowed and denied tests for each capability and event subscription.
+6. Update plugin documentation and the REST schema permission enum.
+
+## Verification
+
+Run formatting, focused plugin tests, `flutter analyze`, and the full Flutter test suite.

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -529,11 +529,16 @@ class PluginManager {
             __timers.delete(id);
           }
         };
-        globalThis.__cancelTimersForBridgeToken = function (bridgeToken) {
-          for (const [id, record] of __timers) {
-            if (record.bridgeToken === bridgeToken) __timers.delete(id);
-          }
-        };
+        Object.defineProperty(globalThis, "__cancelTimersForBridgeToken", {
+          value: function (bridgeToken) {
+            for (const [id, record] of __timers) {
+              if (record.bridgeToken === bridgeToken) __timers.delete(id);
+            }
+          },
+          writable: false,
+          configurable: false,
+          enumerable: false
+        });
         globalThis.__cancelAllTimers = function () {
           __timers.clear();
         };

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -706,9 +706,9 @@ class PluginManager {
         }
 
         final operation = _handleMessageSafely(pluginId, msg);
-        final generation = msg['generation'];
-        if (msg['type'] == 'pluginStorage' && generation is num) {
-          _trackPluginStorageOperation(pluginId, generation.toInt(), operation);
+        final generation = _messageGeneration(pluginId, msg);
+        if (msg['type'] == 'pluginStorage' && generation != null) {
+          _trackPluginStorageOperation(pluginId, generation, operation);
         } else {
           unawaited(operation);
         }
@@ -734,27 +734,31 @@ class PluginManager {
     String pluginId,
     Map<String, dynamic> msg,
   ) async {
-    // Yield before processing: channel callbacks run inside the JS evaluate
-    // that sent the message, and a nested evaluate + job drain does not
-    // settle promises on QuickJS (unhandled-rejection hang).
-    await Future<void>.delayed(Duration.zero);
     final retiringStorageWrite = _isRetiringPluginStorageWrite(pluginId, msg);
     if (_lifecycle != PluginManagerLifecycle.active && !retiringStorageWrite) {
       return;
     }
     try {
       final type = msg['type'];
+      if (type == 'log') {
+        if (_messageGeneration(pluginId, msg) != _pluginGenerations[pluginId] ||
+            !_plugins.containsKey(pluginId)) {
+          return;
+        }
+        if (_hasPermission(pluginId, PluginPermissions.log)) {
+          _log.finest("[JS:$pluginId] ${msg['payload']?['message']}");
+        }
+        return;
+      }
+      // Yield before processing: channel callbacks run inside the JS evaluate
+      // that sent the message, and a nested evaluate + job drain does not
+      // settle promises on QuickJS (unhandled-rejection hang).
+      await Future<void>.delayed(Duration.zero);
       if (type == 'decentProxy') {
         await _handleDecentProxyMessage(pluginId, msg);
         return;
       }
       if (!_isCurrentPluginMessage(pluginId, msg) && !retiringStorageWrite) {
-        return;
-      }
-      if (type == 'log') {
-        if (_hasPermission(pluginId, PluginPermissions.log)) {
-          _log.finest("[JS:$pluginId] ${msg['payload']?['message']}");
-        }
         return;
       }
       if (type == 'httpResponse') {
@@ -789,10 +793,19 @@ class PluginManager {
     }
   }
 
-  bool _isCurrentPluginMessage(String pluginId, Map<String, dynamic> msg) {
+  int? _messageGeneration(String pluginId, Map<String, dynamic> msg) {
     final generation = msg['generation'];
-    return generation is num &&
-        generation.toInt() == _pluginGenerations[pluginId] &&
+    if (generation is num) return generation.toInt();
+    final bridgeToken = msg['bridgeToken'];
+    if (bridgeToken is! String ||
+        _pluginIdsByBridgeToken[bridgeToken] != pluginId) {
+      return null;
+    }
+    return _retiringPluginGenerations[pluginId] ?? _pluginGenerations[pluginId];
+  }
+
+  bool _isCurrentPluginMessage(String pluginId, Map<String, dynamic> msg) {
+    return _messageGeneration(pluginId, msg) == _pluginGenerations[pluginId] &&
         _plugins[pluginId]?.isAlive == true;
   }
 
@@ -800,11 +813,10 @@ class PluginManager {
     String pluginId,
     Map<String, dynamic> msg,
   ) {
-    final generation = msg['generation'];
     final payload = msg['payload'];
     return msg['type'] == 'pluginStorage' &&
-        generation is num &&
-        generation.toInt() == _retiringPluginGenerations[pluginId] &&
+        _messageGeneration(pluginId, msg) ==
+            _retiringPluginGenerations[pluginId] &&
         payload is Map &&
         payload['type'] == 'write' &&
         _plugins[pluginId]?.state == PluginRuntimeState.stopping;
@@ -1159,11 +1171,9 @@ class PluginManager {
 
       case 'pluginStorage':
         final cmd = PluginStorageCommand.fromPlugin(payload);
-        await _handlePluginStorage(
-          pluginId,
-          (msg['generation'] as num).toInt(),
-          cmd,
-        );
+        final generation = _messageGeneration(pluginId, msg);
+        if (generation == null) return;
+        await _handlePluginStorage(pluginId, generation, cmd);
         break;
 
       case 'permissionDenied':
@@ -1540,16 +1550,15 @@ class PluginManager {
       );
       return;
     }
-    final generation = msg['generation'];
+    final generation = _messageGeneration(pluginId, msg);
     if (op.pluginId != pluginId) {
       _log.warning(
         'Rejected HTTP response for $requestId from $pluginId; owned by ${op.pluginId}',
       );
       return;
     }
-    if (generation is! num ||
-        generation.toInt() != op.generation ||
-        generation.toInt() != _pluginGenerations[pluginId]) {
+    if (generation != op.generation ||
+        generation != _pluginGenerations[pluginId]) {
       _log.warning(
         'Rejected stale HTTP response for $requestId from $pluginId',
       );

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -58,6 +58,8 @@ class PluginManager {
   final DecentProxyService? decentProxyService;
   late final PluginDecentProxyBridge _decentProxyBridge;
   final Map<String, String> _decentProxyBridgeTokens = {};
+  final Set<String> _loggedPermissionDenials = {};
+  final Map<String, Set<PluginPermissions>> _closingPluginPermissions = {};
 
   final StreamController<Map<String, dynamic>> _emitController =
       StreamController.broadcast();
@@ -187,6 +189,25 @@ class PluginManager {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);
     }
   }
+
+  bool _hasPermission(String pluginId, PluginPermissions permission) {
+    final permissions =
+        _plugins[pluginId]?.manifest.permissions ??
+        _closingPluginPermissions[pluginId];
+    final allowed = permissions?.contains(permission) ?? false;
+    if (!allowed) {
+      final denial = '$pluginId:${permission.wireName}';
+      if (_loggedPermissionDenials.add(denial)) {
+        _log.warning(
+          'Plugin $pluginId denied permission ${permission.wireName}',
+        );
+      }
+    }
+    return allowed;
+  }
+
+  String _permissionError(String pluginId, PluginPermissions permission) =>
+      'PluginPermissionError: Plugin $pluginId requires manifest permission ${permission.wireName}';
 
   // ─────────────────────────────────────────────
   // JS bootstrap (ONCE)
@@ -473,6 +494,13 @@ class PluginManager {
               type: "pluginStorage",
               payload: command
             }));
+          },
+          permissionDenied(pluginId, permission) {
+            sendMessage("host", JSON.stringify({
+              pluginId: pluginId,
+              type: "permissionDenied",
+              payload: permission
+            }));
           }
         };
       })();
@@ -616,14 +644,25 @@ class PluginManager {
         return;
       }
       if (type == 'log') {
-        _log.finest("[JS:$pluginId] ${msg['payload']?['message']}");
+        if (_hasPermission(pluginId, PluginPermissions.log)) {
+          _log.finest("[JS:$pluginId] ${msg['payload']?['message']}");
+        }
         return;
       }
       if (type == 'httpResponse') {
-        _handlePluginApiResponse(pluginId, msg);
+        if (_hasPermission(pluginId, PluginPermissions.api)) {
+          _handlePluginApiResponse(pluginId, msg);
+        }
         return;
       }
-      await _handleMessage(pluginId, msg);
+      final permission = switch (type) {
+        'emit' => PluginPermissions.emit,
+        'pluginStorage' => PluginPermissions.pluginStorage,
+        _ => null,
+      };
+      if (permission == null || _hasPermission(pluginId, permission)) {
+        await _handleMessage(pluginId, msg);
+      }
     } catch (e, st) {
       _log.warning("Error handling message from $pluginId", e, st);
     }
@@ -717,18 +756,47 @@ class PluginManager {
       (function () {
         const pluginId = "$id";
         const pluginGeneration = $generation;
+        class PluginPermissionError extends Error {
+          constructor(permission) {
+            super("Plugin " + pluginId + " requires manifest permission " + permission);
+            this.name = "PluginPermissionError";
+          }
+        }
+        const requirePermission = (permission) => {
+          globalThis.host.permissionDenied(pluginId, permission);
+          throw new PluginPermissionError(permission);
+        };
+        const rejectPermission = (permission) => {
+          globalThis.host.permissionDenied(pluginId, permission);
+          return Promise.reject(new PluginPermissionError(permission));
+        };
         const setTimeout = (callback, delay) => globalThis.__timerSet(pluginId, pluginGeneration, callback, delay);
         const clearTimeout = (id) => globalThis.__timerClear(pluginId, pluginGeneration, id);
-        const fetch = (input, init) => globalThis.__fetchFor
-          ? globalThis.__fetchFor(pluginId, pluginGeneration, input, init)
-          : globalThis.fetch(input, init);
+        const fetch = ${manifest.permissions.contains(PluginPermissions.api)}
+          ? (input, init) => globalThis.__fetchFor
+            ? globalThis.__fetchFor(pluginId, pluginGeneration, input, init)
+            : globalThis.fetch(input, init)
+          : () => rejectPermission("api");
         
         // Create the host object for this plugin
         const host = {
-          log: (msg) => globalThis.host.log(pluginId, pluginGeneration, msg),
-          emit: (type, payload) => globalThis.host.emit(pluginId, pluginGeneration, type, payload),
-          storage: (cmd) => globalThis.host.storage(pluginId, pluginGeneration, cmd),
+          log: ${manifest.permissions.contains(PluginPermissions.log)}
+            ? (msg) => globalThis.host.log(pluginId, pluginGeneration, msg)
+            : () => requirePermission("log"),
+          emit: ${manifest.permissions.contains(PluginPermissions.emit)}
+            ? (type, payload) => globalThis.host.emit(pluginId, pluginGeneration, type, payload)
+            : () => requirePermission("emit"),
+          storage: ${manifest.permissions.contains(PluginPermissions.pluginStorage)}
+            ? (cmd) => globalThis.host.storage(pluginId, pluginGeneration, cmd)
+            : () => requirePermission("pluginStorage"),
           decentProxy: (path, options = {}) => {
+            const method = String(options.method || "GET").toUpperCase();
+            if (method === "GET" && !${manifest.permissions.contains(PluginPermissions.proxyDecentApi)}) {
+              return rejectPermission("proxy.decent_api");
+            }
+            if (method === "POST" && !${manifest.permissions.contains(PluginPermissions.proxyDecentApiWrite)}) {
+              return rejectPermission("proxy.decent_api.write");
+            }
             return globalThis.__reaprimePluginBridge.decentProxy(
               pluginId,
               pluginGeneration,
@@ -820,8 +888,10 @@ class PluginManager {
   }
 
   Future<void> _unloadPlugin(String id) async {
+    _loggedPermissionDenials.removeWhere((denial) => denial.startsWith('$id:'));
     final runtime = _plugins[id];
     if (runtime == null) return;
+    _closingPluginPermissions[id] = runtime.manifest.permissions;
 
     final retiringGeneration = _pluginGenerations[id] ?? 0;
     runtime.markStopping();
@@ -856,6 +926,7 @@ class PluginManager {
       _retiringPluginGenerations.remove(id);
       runtime.markDisposed();
       _plugins.remove(id);
+      _closingPluginPermissions.remove(id);
       _log.info("unloaded: $id");
     }
   }
@@ -913,6 +984,12 @@ class PluginManager {
     final runtime = _plugins[pluginId];
     if (runtime?.isAlive != true) return;
     final generation = _pluginGenerations[pluginId] ?? 0;
+    final permission = switch (name) {
+      'stateUpdate' => PluginPermissions.eventsMachine,
+      'shotStored' || 'shotUpdated' => PluginPermissions.eventsShots,
+      _ => null,
+    };
+    if (permission != null && !_hasPermission(pluginId, permission)) return;
 
     String requestId = "";
     if (payload is Map<String, dynamic> && payload['requestId'] is String) {
@@ -997,6 +1074,13 @@ class PluginManager {
           (msg['generation'] as num).toInt(),
           cmd,
         );
+        break;
+
+      case 'permissionDenied':
+        final permission = payload is String
+            ? PluginPermissions.fromString(payload)
+            : null;
+        if (permission != null) _hasPermission(pluginId, permission);
         break;
 
       case 'timerSet':
@@ -1521,6 +1605,14 @@ class PluginManager {
       js.evaluate(
         'globalThis.__handleFetchResponse('
         '${jsonEncode({'id': id, 'error': 'plugin generation changed'})});',
+      );
+      while (js.executePendingJob() > 0) {}
+      return;
+    }
+    if (!_hasPermission(pluginId, PluginPermissions.api)) {
+      js.evaluate(
+        'globalThis.__handleFetchResponse('
+        '${jsonEncode({'id': id, 'error': _permissionError(pluginId, PluginPermissions.api)})});',
       );
       while (js.executePendingJob() > 0) {}
       return;

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -491,7 +491,12 @@ class PluginManager {
         // Timer bridge: JS holds callbacks, Dart owns real Timers.
         const __timers = new Map();
         let __timerSeq = 0;
-        globalThis.__debugTimers = __timers;
+        Object.defineProperty(globalThis, "__debugTimerCount", {
+          value: () => __timers.size,
+          writable: false,
+          configurable: false,
+          enumerable: false
+        });
         globalThis.__timerSet = function (bridgeToken, generation, callback, delay) {
           const id = ++__timerSeq;
           __timers.set(id, { bridgeToken: bridgeToken, generation: generation, callback: callback });

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -57,7 +57,8 @@ class PluginManager {
   final KeyValueStoreService kvStore;
   final DecentProxyService? decentProxyService;
   late final PluginDecentProxyBridge _decentProxyBridge;
-  final Map<String, String> _decentProxyBridgeTokens = {};
+  final Map<String, String> _pluginBridgeTokens = {};
+  final Map<String, String> _pluginIdsByBridgeToken = {};
   final Set<String> _loggedPermissionDenials = {};
   final Map<String, Set<PluginPermissions>> _closingPluginPermissions = {};
 
@@ -90,7 +91,7 @@ class PluginManager {
       (_de1Subscription == null ? 0 : 1) +
       (_snapshotSubscription == null ? 0 : 1);
   int get trackedPluginGenerationCount => _pluginGenerations.length;
-  int get bridgeTokenCount => _decentProxyBridgeTokens.length;
+  int get bridgeTokenCount => _pluginBridgeTokens.length;
   int? pluginGeneration(String pluginId) => _pluginGenerations[pluginId];
 
   PluginManager({
@@ -178,7 +179,8 @@ class PluginManager {
       _pluginGenerations.clear();
       _retiringPluginGenerations.clear();
       _pluginStorageOperations.clear();
-      _decentProxyBridgeTokens.clear();
+      _pluginBridgeTokens.clear();
+      _pluginIdsByBridgeToken.clear();
       _de1Subscription = null;
       _snapshotSubscription = null;
       _de1controller = null;
@@ -209,6 +211,30 @@ class PluginManager {
   String _permissionError(String pluginId, PluginPermissions permission) =>
       'PluginPermissionError: Plugin $pluginId requires manifest permission ${permission.wireName}';
 
+  String? _pluginIdForBridgeMessage(Map<String, dynamic> msg, String channel) {
+    final token = msg['bridgeToken'];
+    final pluginId = token is String ? _pluginIdsByBridgeToken[token] : null;
+    if (pluginId == null) {
+      _log.warning(
+        'Rejected $channel message with invalid plugin bridge token',
+      );
+      return null;
+    }
+    final claimedPluginId = msg['pluginId'];
+    if (claimedPluginId != null && claimedPluginId != pluginId) {
+      _log.warning(
+        'Rejected $channel message claiming plugin $claimedPluginId as $pluginId',
+      );
+      return null;
+    }
+    return pluginId;
+  }
+
+  void _removePluginBridgeToken(String pluginId) {
+    final token = _pluginBridgeTokens.remove(pluginId);
+    if (token != null) _pluginIdsByBridgeToken.remove(token);
+  }
+
   // ─────────────────────────────────────────────
   // JS bootstrap (ONCE)
   // ─────────────────────────────────────────────
@@ -216,6 +242,7 @@ class PluginManager {
   void _bootstrapJs() {
     js.evaluate(r'''
       (function () {
+        "use strict";
         if (globalThis.__plugins__) return;
 
         globalThis.__plugins__ = Object.create(null);
@@ -228,6 +255,7 @@ class PluginManager {
         const __nativeFreeze = Object.freeze.bind(Object);
         const __nativeReflectApply = Reflect.apply.bind(Reflect);
         const __nativePromiseThen = Promise.prototype.then;
+        const __nativePromiseResolve = Promise.resolve;
         const __nativePromiseCatch = Promise.prototype.catch;
         const __nativePromiseFinally = Promise.prototype.finally;
         const __nativeMapHas = Map.prototype.has;
@@ -360,16 +388,51 @@ class PluginManager {
           enumerable: false
         });
         
-        globalThis.__sendApiResponse = function (pluginId, generation, requestId, response) {
-          console.log("sending plugin api response", pluginId);
-          sendMessage("host", JSON.stringify({
-            pluginId: pluginId,
+        function __sendApiResponse(bridgeToken, generation, requestId, response) {
+          __sendHostMessage({
+            bridgeToken: bridgeToken,
             generation: generation,
             type: "httpResponse",
             requestId: requestId,
             payload: response
-          }));
-        };
+          });
+        }
+
+        function __sendApiError(bridgeToken, generation, requestId, error) {
+          __sendApiResponse(bridgeToken, generation, requestId, {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ error: String(error) })
+          });
+        }
+
+        Object.defineProperty(globalThis, "__dispatchPluginHttp", {
+          value: function (pluginId, bridgeToken, generation, requestId, event) {
+            const plugin = globalThis.__plugins__[pluginId];
+            if (!plugin || typeof plugin.__httpRequestHandler !== "function") return;
+            try {
+              const response = plugin.__httpRequestHandler(event);
+              if (response && typeof response.then === "function") {
+                const promise = __nativeReflectApply(
+                  __nativePromiseResolve,
+                  __NativePromise,
+                  [response]
+                );
+                __nativeReflectApply(__nativePromiseThen, promise, [
+                  (result) => __sendApiResponse(bridgeToken, generation, requestId, result),
+                  (error) => __sendApiError(bridgeToken, generation, requestId, error)
+                ]);
+              } else if (response) {
+                __sendApiResponse(bridgeToken, generation, requestId, response);
+              }
+            } catch (error) {
+              __sendApiError(bridgeToken, generation, requestId, error);
+            }
+          },
+          writable: false,
+          configurable: false,
+          enumerable: false
+        });
 
         // Provide btoa function if not available
         if (typeof globalThis.btoa === 'undefined') {
@@ -429,11 +492,11 @@ class PluginManager {
         const __timers = new Map();
         let __timerSeq = 0;
         globalThis.__debugTimers = __timers;
-        globalThis.__timerSet = function (pluginId, generation, callback, delay) {
+        globalThis.__timerSet = function (bridgeToken, generation, callback, delay) {
           const id = ++__timerSeq;
-          __timers.set(id, { pluginId: pluginId, generation: generation, callback: callback });
+          __timers.set(id, { bridgeToken: bridgeToken, generation: generation, callback: callback });
           __sendHostMessage({
-            pluginId: pluginId,
+            bridgeToken: bridgeToken,
             generation: generation,
             type: "timerSet",
             timerId: id,
@@ -441,11 +504,12 @@ class PluginManager {
           });
           return id;
         };
-        globalThis.__timerClear = function (pluginId, generation, id) {
-          if (__timers.delete(id)) {
+        globalThis.__timerClear = function (bridgeToken, id) {
+          const record = __timers.get(id);
+          if (record && record.bridgeToken === bridgeToken && __timers.delete(id)) {
             __sendHostMessage({
-              pluginId: pluginId,
-              generation: generation,
+              bridgeToken: bridgeToken,
+              generation: record.generation,
               type: "timerClear",
               timerId: id
             });
@@ -460,56 +524,65 @@ class PluginManager {
             __timers.delete(id);
           }
         };
-        globalThis.__cancelTimersForPlugin = function (pluginId) {
+        globalThis.__cancelTimersForBridgeToken = function (bridgeToken) {
           for (const [id, record] of __timers) {
-            if (record.pluginId === pluginId) __timers.delete(id);
+            if (record.bridgeToken === bridgeToken) __timers.delete(id);
           }
         };
         globalThis.__cancelAllTimers = function () {
           __timers.clear();
         };
 
-        globalThis.host = {
-          log(pluginId, generation, message) {
-            sendMessage("host", JSON.stringify({
-              pluginId: pluginId,
-              generation: generation,
-              type: "log",
-              payload: { message: String(message) }
-            }));
-          },
-          emit(pluginId, generation, eventName, payload) {
-            sendMessage("host", JSON.stringify({
-              pluginId: pluginId,
-              generation: generation,
-              type: "emit",
-              event: eventName,
-              payload: payload
-            }));
-          },
-          storage(pluginId, generation, command) {
-            sendMessage("host", JSON.stringify({
-              pluginId: pluginId,
-              generation: generation,
-              type: "pluginStorage",
-              payload: command
-            }));
-          },
-          permissionDenied(pluginId, permission) {
-            sendMessage("host", JSON.stringify({
-              pluginId: pluginId,
-              type: "permissionDenied",
-              payload: permission
-            }));
-          }
-        };
+        Object.defineProperty(globalThis, "host", {
+          value: __nativeFreeze({
+            log(bridgeToken, generation, message) {
+              __sendHostMessage({
+                bridgeToken: bridgeToken,
+                generation: generation,
+                type: "log",
+                payload: { message: String(message) }
+              });
+            },
+            emit(bridgeToken, generation, eventName, payload) {
+              __sendHostMessage({
+                bridgeToken: bridgeToken,
+                generation: generation,
+                type: "emit",
+                event: eventName,
+                payload: payload
+              });
+            },
+            storage(bridgeToken, generation, command) {
+              __sendHostMessage({
+                bridgeToken: bridgeToken,
+                generation: generation,
+                type: "pluginStorage",
+                payload: command
+              });
+            },
+            permissionDenied(bridgeToken, generation, permission) {
+              __sendHostMessage({
+                bridgeToken: bridgeToken,
+                generation: generation,
+                type: "permissionDenied",
+                payload: permission
+              });
+            }
+          }),
+          writable: false,
+          configurable: false,
+          enumerable: true
+        });
       })();
   ''');
 
     js.evaluate(r'''
       (function () {
+        "use strict";
         if (globalThis.fetch) return;
 
+        const nativeSendMessage = sendMessage;
+        const nativeJsonStringify = JSON.stringify.bind(JSON);
         let _fetchSeq = 0;
         const _pendingFetches = new Map();
 
@@ -525,18 +598,18 @@ class PluginManager {
           };
         }
 
-        globalThis.__fetchFor = function (pluginId, generation, input, init = {}) {
+        globalThis.__fetchFor = function (bridgeToken, generation, input, init = {}) {
           const id = ++_fetchSeq;
           return new Promise((resolve, reject) => {
-            if (!pluginId) {
+            if (!bridgeToken) {
               reject(new Error("fetch is only available to plugins"));
               return;
             }
-            _pendingFetches.set(id, { pluginId: pluginId, generation: generation, resolve: resolve, reject: reject });
+            _pendingFetches.set(id, { bridgeToken: bridgeToken, generation: generation, resolve: resolve, reject: reject });
 
-            sendMessage("fetch", JSON.stringify({
+            nativeSendMessage("fetch", nativeJsonStringify({
               id,
-              pluginId,
+              bridgeToken,
               generation,
               url: String(input),
               method: init.method || "GET",
@@ -572,9 +645,9 @@ class PluginManager {
           pending.resolve(response);
         };
 
-        globalThis.__cancelFetchesForPlugin = function (pluginId, error) {
+        globalThis.__cancelFetchesForBridgeToken = function (bridgeToken, error) {
           for (const [id, pending] of _pendingFetches) {
-            if (pending.pluginId !== pluginId) continue;
+            if (pending.bridgeToken !== bridgeToken) continue;
             _pendingFetches.delete(id);
             pending.reject(new Error(error));
           }
@@ -586,6 +659,29 @@ class PluginManager {
           }
           _pendingFetches.clear();
         };
+
+        Object.defineProperty(globalThis, "__lockPluginHostBridge", {
+          value: function () {
+            if (globalThis.__reaprimePluginHostBridge) return;
+            Object.defineProperty(globalThis, "__reaprimePluginHostBridge", {
+              value: Object.freeze({
+                log: globalThis.host.log,
+                emit: globalThis.host.emit,
+                storage: globalThis.host.storage,
+                permissionDenied: globalThis.host.permissionDenied,
+                fetch: globalThis.__fetchFor,
+                timerSet: globalThis.__timerSet,
+                timerClear: globalThis.__timerClear
+              }),
+              writable: false,
+              configurable: false,
+              enumerable: false
+            });
+          },
+          writable: false,
+          configurable: false,
+          enumerable: false
+        });
       })();
     ''');
 
@@ -593,10 +689,9 @@ class PluginManager {
       try {
         _log.finest("receiving: $raw");
         final msg = raw as Map<String, dynamic>;
-        final pluginId = msg['pluginId'] as String?;
+        final pluginId = _pluginIdForBridgeMessage(msg, 'host');
 
         if (pluginId == null) {
-          _log.warning("JS message missing pluginId");
           return;
         }
 
@@ -615,7 +710,10 @@ class PluginManager {
     js.onMessage("fetch", (raw) {
       try {
         final msg = raw as Map<String, dynamic>;
-        unawaited(_handleFetchSafely(msg));
+        final pluginId = _pluginIdForBridgeMessage(msg, 'fetch');
+        if (pluginId != null) {
+          unawaited(_handleFetchSafely(pluginId, msg));
+        }
       } catch (e, st) {
         _log.warning("Invalid fetch message", e, st);
       }
@@ -668,11 +766,14 @@ class PluginManager {
     }
   }
 
-  Future<void> _handleFetchSafely(Map<String, dynamic> msg) async {
+  Future<void> _handleFetchSafely(
+    String pluginId,
+    Map<String, dynamic> msg,
+  ) async {
     await Future<void>.delayed(Duration.zero);
     if (_lifecycle != PluginManagerLifecycle.active) return;
     try {
-      await _handleFetch(msg);
+      await _handleFetch(pluginId, msg);
     } catch (e, st) {
       _log.warning("Invalid fetch message", e, st);
     }
@@ -742,12 +843,14 @@ class PluginManager {
     _ensureActive();
     final generation = (_pluginGenerations[id] ?? 0) + 1;
     _pluginGenerations[id] = generation;
+    js.evaluate('globalThis.__lockPluginHostBridge();');
 
     final runtime = PluginRuntime(pluginId: id, manifest: manifest);
-    final decentProxyBridgeToken = _newBridgeToken();
+    final pluginBridgeToken = _newBridgeToken();
 
     _plugins[id] = runtime;
-    _decentProxyBridgeTokens[id] = decentProxyBridgeToken;
+    _pluginBridgeTokens[id] = pluginBridgeToken;
+    _pluginIdsByBridgeToken[pluginBridgeToken] = id;
 
     try {
       // Direct injection approach with standard factory name
@@ -756,6 +859,8 @@ class PluginManager {
       (function () {
         const pluginId = "$id";
         const pluginGeneration = $generation;
+        const pluginBridgeToken = ${jsonEncode(pluginBridgeToken)};
+        const pluginHostBridge = globalThis.__reaprimePluginHostBridge;
         class PluginPermissionError extends Error {
           constructor(permission) {
             super("Plugin " + pluginId + " requires manifest permission " + permission);
@@ -763,31 +868,29 @@ class PluginManager {
           }
         }
         const requirePermission = (permission) => {
-          globalThis.host.permissionDenied(pluginId, permission);
+          pluginHostBridge.permissionDenied(pluginBridgeToken, pluginGeneration, permission);
           throw new PluginPermissionError(permission);
         };
         const rejectPermission = (permission) => {
-          globalThis.host.permissionDenied(pluginId, permission);
+          pluginHostBridge.permissionDenied(pluginBridgeToken, pluginGeneration, permission);
           return Promise.reject(new PluginPermissionError(permission));
         };
-        const setTimeout = (callback, delay) => globalThis.__timerSet(pluginId, pluginGeneration, callback, delay);
-        const clearTimeout = (id) => globalThis.__timerClear(pluginId, pluginGeneration, id);
+        const setTimeout = (callback, delay) => pluginHostBridge.timerSet(pluginBridgeToken, pluginGeneration, callback, delay);
+        const clearTimeout = (id) => pluginHostBridge.timerClear(pluginBridgeToken, id);
         const fetch = ${manifest.permissions.contains(PluginPermissions.api)}
-          ? (input, init) => globalThis.__fetchFor
-            ? globalThis.__fetchFor(pluginId, pluginGeneration, input, init)
-            : globalThis.fetch(input, init)
+          ? (input, init) => pluginHostBridge.fetch(pluginBridgeToken, pluginGeneration, input, init)
           : () => rejectPermission("api");
         
         // Create the host object for this plugin
         const host = {
           log: ${manifest.permissions.contains(PluginPermissions.log)}
-            ? (msg) => globalThis.host.log(pluginId, pluginGeneration, msg)
+            ? (msg) => pluginHostBridge.log(pluginBridgeToken, pluginGeneration, msg)
             : () => requirePermission("log"),
           emit: ${manifest.permissions.contains(PluginPermissions.emit)}
-            ? (type, payload) => globalThis.host.emit(pluginId, pluginGeneration, type, payload)
+            ? (type, payload) => pluginHostBridge.emit(pluginBridgeToken, pluginGeneration, type, payload)
             : () => requirePermission("emit"),
           storage: ${manifest.permissions.contains(PluginPermissions.pluginStorage)}
-            ? (cmd) => globalThis.host.storage(pluginId, pluginGeneration, cmd)
+            ? (cmd) => pluginHostBridge.storage(pluginBridgeToken, pluginGeneration, cmd)
             : () => requirePermission("pluginStorage"),
           decentProxy: (path, options = {}) => {
             const method = String(options.method || "GET").toUpperCase();
@@ -800,7 +903,7 @@ class PluginManager {
             return globalThis.__reaprimePluginBridge.decentProxy(
               pluginId,
               pluginGeneration,
-              ${jsonEncode(decentProxyBridgeToken)},
+              pluginBridgeToken,
               path,
               options.method || "GET",
               options.query || {},
@@ -889,15 +992,18 @@ class PluginManager {
 
   Future<void> _unloadPlugin(String id) async {
     _loggedPermissionDenials.removeWhere((denial) => denial.startsWith('$id:'));
+    final pluginBridgeToken = _pluginBridgeTokens[id];
     final runtime = _plugins[id];
-    if (runtime == null) return;
+    if (runtime == null) {
+      _removePluginBridgeToken(id);
+      return;
+    }
     _closingPluginPermissions[id] = runtime.manifest.permissions;
 
     final retiringGeneration = _pluginGenerations[id] ?? 0;
     runtime.markStopping();
     _retiringPluginGenerations[id] = retiringGeneration;
     _pluginGenerations[id] = retiringGeneration + 1;
-    _decentProxyBridgeTokens.remove(id);
 
     try {
       try {
@@ -918,7 +1024,7 @@ class PluginManager {
         _log.warning("Error during plugin unload: $id", e, st);
       }
       try {
-        _cleanupPluginResources(id);
+        _cleanupPluginResources(id, pluginBridgeToken);
       } finally {
         await _drainPluginStorageOperations(id, retiringGeneration);
       }
@@ -927,11 +1033,12 @@ class PluginManager {
       runtime.markDisposed();
       _plugins.remove(id);
       _closingPluginPermissions.remove(id);
+      _removePluginBridgeToken(id);
       _log.info("unloaded: $id");
     }
   }
 
-  void _cleanupPluginResources(String pluginId) {
+  void _cleanupPluginResources(String pluginId, String? pluginBridgeToken) {
     // Reject operations first: settling promises drains pending jobs, which
     // can run plugin rejection handlers that schedule new timers. The timer
     // sweep after must be the last word.
@@ -949,17 +1056,20 @@ class PluginManager {
 
     attempt(() => _rejectOpsForPlugin(pluginId));
     attempt(() {
+      final fetchCancellation = pluginBridgeToken == null
+          ? ''
+          : '''globalThis.__cancelFetchesForBridgeToken(
+            ${jsonEncode(pluginBridgeToken)}, "plugin unloaded"
+          );''';
       js.evaluate('''
-          globalThis.__cancelFetchesForPlugin(
-            ${jsonEncode(pluginId)}, "plugin unloaded"
-          );
-          globalThis.__reaprimePluginBridge.cancelForPlugin(
-            ${jsonEncode(pluginId)}, "plugin unloaded"
-          );
-        ''');
+        $fetchCancellation
+        globalThis.__reaprimePluginBridge.cancelForPlugin(
+          ${jsonEncode(pluginId)}, "plugin unloaded"
+        );
+      ''');
       while (js.executePendingJob() > 0) {}
     });
-    attempt(() => _cancelTimersForPlugin(pluginId));
+    attempt(() => _cancelTimersForPlugin(pluginId, pluginBridgeToken));
 
     if (firstError != null) {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);
@@ -991,58 +1101,28 @@ class PluginManager {
     };
     if (permission != null && !_hasPermission(pluginId, permission)) return;
 
-    String requestId = "";
-    if (payload is Map<String, dynamic> && payload['requestId'] is String) {
-      requestId = payload['requestId'];
-    }
+    final requestIdValue = payload is Map<String, dynamic>
+        ? payload['requestId']
+        : null;
+    final requestId = requestIdValue is String ? requestIdValue : null;
+    final pluginBridgeToken = _pluginBridgeTokens[pluginId];
+    final httpDispatch =
+        name == 'httpRequest' && requestId != null && pluginBridgeToken != null
+        ? '''globalThis.__dispatchPluginHttp(
+          ${jsonEncode(pluginId)},
+          ${jsonEncode(pluginBridgeToken)},
+          $generation,
+          ${jsonEncode(requestId)},
+          ${jsonEncode(payload)}
+        );'''
+        : '';
 
     js.evaluate('''
     __dispatchToPlugin("$pluginId", {
       name: "$name",
       payload: ${jsonEncode(payload)}
     });
-    
-    // Special handling for HTTP requests
-    if ("$name" === "httpRequest") {
-      const plugin = globalThis.__plugins__["$pluginId"];
-      if (plugin && typeof plugin.__httpRequestHandler === "function") {
-        try {
-          const response = plugin.__httpRequestHandler(${jsonEncode(payload)});
-          const responseThen = response.then;
-          if (response &&  responseThen) {
-            // Handle async response
-            response.then((res) => {
-              if (globalThis.__sendApiResponse) {
-                globalThis.__sendApiResponse("$pluginId", $generation, "$requestId", res);
-              }
-            }).catch((err) => {
-              console.error("HTTP request handler error:", err);
-              if (globalThis.__sendApiResponse) {
-                globalThis.__sendApiResponse("$pluginId", $generation, "$requestId", {
-                  status: 500,
-                  headers: {'Content-Type': 'application/json'},
-                  body: JSON.stringify({error: err.toString()})
-                });
-              }
-            });
-          } else if (response) {
-            // Handle sync response
-            if (globalThis.__sendApiResponse) {
-              globalThis.__sendApiResponse("$pluginId", $generation, "$requestId", response);
-            }
-          }
-        } catch (e) {
-          console.error("HTTP request handler error:", e);
-          if (globalThis.__sendApiResponse) {
-            globalThis.__sendApiResponse("$pluginId", $generation, "$requestId", {
-              status: 500,
-              headers: {'Content-Type': 'application/json'},
-              body: JSON.stringify({error: e.toString()})
-            });
-          }
-        }
-      }
-    }
+    $httpDispatch
   ''');
     while (js.executePendingJob() > 0) {}
   }
@@ -1093,7 +1173,7 @@ class PluginManager {
         break;
 
       case 'timerClear':
-        _clearTimer((msg['timerId'] as num?)?.toInt() ?? 0);
+        _clearTimer(pluginId, (msg['timerId'] as num?)?.toInt() ?? 0);
         break;
 
       case 'decentProxy':
@@ -1123,6 +1203,9 @@ class PluginManager {
     // Deferred bridge messages can arrive after a reload; a timer from an
     // older generation must not register against the current plugin.
     if (generation != (_pluginGenerations[pluginId] ?? 0)) return;
+    final existing = _timers[id];
+    if (existing != null && existing.pluginId != pluginId) return;
+    existing?.timer.cancel();
     _timers[id] = (
       pluginId: pluginId,
       timer: Timer(Duration(milliseconds: delayMs < 0 ? 0 : delayMs), () {
@@ -1131,7 +1214,9 @@ class PluginManager {
     );
   }
 
-  void _clearTimer(int id) {
+  void _clearTimer(String pluginId, int id) {
+    final record = _timers[id];
+    if (record?.pluginId != pluginId) return;
     _timers.remove(id)?.timer.cancel();
   }
 
@@ -1143,7 +1228,7 @@ class PluginManager {
     while (js.executePendingJob() > 0) {}
   }
 
-  void _cancelTimersForPlugin(String pluginId) {
+  void _cancelTimersForPlugin(String pluginId, String? pluginBridgeToken) {
     _timers.removeWhere((id, record) {
       if (record.pluginId == pluginId) {
         record.timer.cancel();
@@ -1151,7 +1236,12 @@ class PluginManager {
       }
       return false;
     });
-    js.evaluate('globalThis.__cancelTimersForPlugin(${jsonEncode(pluginId)});');
+    if (pluginBridgeToken != null) {
+      js.evaluate(
+        'globalThis.__cancelTimersForBridgeToken('
+        '${jsonEncode(pluginBridgeToken)});',
+      );
+    }
     while (js.executePendingJob() > 0) {}
   }
 
@@ -1303,7 +1393,7 @@ class PluginManager {
     final generation = msg['generation'] is num
         ? (msg['generation'] as num).toInt()
         : 0;
-    if (msg['bridgeToken'] != _decentProxyBridgeTokens[pluginId]) {
+    if (msg['bridgeToken'] != _pluginBridgeTokens[pluginId]) {
       _log.warning('Decent proxy message from $pluginId has invalid token');
       final op = _PendingOp(
         kind: _PendingOpKind.decentProxy,
@@ -1441,10 +1531,18 @@ class PluginManager {
       return;
     }
     final generation = msg['generation'];
-    if (op.pluginId != pluginId ||
-        generation is! num ||
+    if (op.pluginId != pluginId) {
+      _log.warning(
+        'Rejected HTTP response for $requestId from $pluginId; owned by ${op.pluginId}',
+      );
+      return;
+    }
+    if (generation is! num ||
         generation.toInt() != op.generation ||
         generation.toInt() != _pluginGenerations[pluginId]) {
+      _log.warning(
+        'Rejected stale HTTP response for $requestId from $pluginId',
+      );
       return;
     }
     _completeOp(op, result: response);
@@ -1580,11 +1678,10 @@ class PluginManager {
     }
   }
 
-  Future<void> _handleFetch(Map<String, dynamic> msg) async {
+  Future<void> _handleFetch(String pluginId, Map<String, dynamic> msg) async {
     _ensureActive();
     final id = msg['id'];
-    final pluginId = msg['pluginId'] as String?;
-    if (id is! int || pluginId == null) {
+    if (id is! int) {
       _log.warning('Invalid fetch message');
       return;
     }

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -68,7 +68,7 @@ enum PluginPermissions {
 
   static PluginPermissions? fromString(String value) {
     return PluginPermissions.values.firstWhereOrNull(
-      (e) => e.wireName == value || e.name == value,
+      (e) => e.wireName == value,
     );
   }
 }

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -57,7 +57,8 @@ enum PluginPermissions {
   api('api'),
   emit('emit'),
   pluginStorage('pluginStorage'),
-  pluginNotify('pluginNotify'),
+  eventsMachine('events.machine'),
+  eventsShots('events.shots'),
   proxyDecentApi('proxy.decent_api'),
   proxyDecentApiWrite('proxy.decent_api.write');
 
@@ -77,13 +78,15 @@ extension PluginPermissionsFromJson on PluginPermissions {
     if (json is! List<dynamic>) {
       return <PluginPermissions>{};
     }
-    final rawPermissions = Set<String>.from(json);
-    return rawPermissions.fold(<PluginPermissions>[], (acc, e) {
-      final perm = PluginPermissions.fromString(e);
-      if (perm != null) {
-        acc.add(perm);
+    return json.map((value) {
+      if (value is! String) {
+        throw FormatException('Invalid plugin permission: $value');
       }
-      return acc;
+      final permission = PluginPermissions.fromString(value);
+      if (permission == null) {
+        throw FormatException('Unknown plugin permission: $value');
+      }
+      return permission;
     }).toSet();
   }
 }

--- a/lib/src/plugins/plugin_types.dart
+++ b/lib/src/plugins/plugin_types.dart
@@ -32,10 +32,3 @@ class PluginStorageCommand {
     );
   }
 }
-
-class PluginToastNotifyCommand {
-  static final id = PluginPermissions.pluginNotify.name;
-  final String message;
-
-  PluginToastNotifyCommand({required this.message});
-}

--- a/lib/src/services/webserver/plugins_handler.dart
+++ b/lib/src/services/webserver/plugins_handler.dart
@@ -164,6 +164,13 @@ final class PluginsHandler {
     if (manifest == null) {
       return jsonNotFound({'error': 'plugin with $id not loaded'});
     }
+    if (!manifest.permissions.contains(PluginPermissions.api)) {
+      _log.warning('Plugin $id denied permission api');
+      return jsonForbidden({
+        'error':
+            'PluginPermissionError: Plugin $id requires manifest permission api',
+      });
+    }
 
     final apiEndpoint = manifest.api?.endpoints.firstWhereOrNull(
       (e) => e.id == endpoint,

--- a/scripts/fetch_dye2_plugin.sh
+++ b/scripts/fetch_dye2_plugin.sh
@@ -92,6 +92,13 @@ if [ "$manifest_api_version" != "$expected_api_version" ]; then
   exit 1
 fi
 
+for permission in log api; do
+  if ! jq -e --arg permission "$permission" '.permissions | index($permission) != null' "$manifest" >/dev/null; then
+    echo "fetch_dye2_plugin: manifest.json is missing permission '$permission'" >&2
+    exit 1
+  fi
+done
+
 if ! grep -q 'createPlugin' "$plugin_js"; then
   echo "fetch_dye2_plugin: plugin.js has no 'createPlugin' entry point" >&2
   exit 1

--- a/test/plugins/bundled_plugin_permissions_test.dart
+++ b/test/plugins/bundled_plugin_permissions_test.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+
+void main() {
+  const requiredPermissions = <String, Set<PluginPermissions>>{
+    'time-to-ready.reaplugin': {
+      PluginPermissions.log,
+      PluginPermissions.emit,
+      PluginPermissions.pluginStorage,
+      PluginPermissions.eventsMachine,
+    },
+    'visualizer.reaplugin': {
+      PluginPermissions.log,
+      PluginPermissions.api,
+      PluginPermissions.emit,
+      PluginPermissions.pluginStorage,
+      PluginPermissions.eventsMachine,
+      PluginPermissions.eventsShots,
+    },
+    'settings.reaplugin': {PluginPermissions.log, PluginPermissions.api},
+    'dye2.reaplugin': {PluginPermissions.log, PluginPermissions.api},
+    'decent-profile.reaplugin': {
+      PluginPermissions.log,
+      PluginPermissions.api,
+      PluginPermissions.emit,
+    },
+    'shot-upload.reaplugin': {
+      PluginPermissions.log,
+      PluginPermissions.api,
+      PluginPermissions.emit,
+      PluginPermissions.pluginStorage,
+      PluginPermissions.proxyDecentApiWrite,
+      PluginPermissions.eventsShots,
+    },
+  };
+
+  for (final entry in requiredPermissions.entries) {
+    test('${entry.key} declares every capability it uses', () async {
+      final json = jsonDecode(
+        await File('assets/plugins/${entry.key}/manifest.json').readAsString(),
+      );
+      final manifest = PluginManifest.fromJson(json as Map<String, dynamic>);
+
+      expect(manifest.permissions, containsAll(entry.value));
+    });
+  }
+}

--- a/test/plugins/bundled_plugin_permissions_test.dart
+++ b/test/plugins/bundled_plugin_permissions_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 void main() {
@@ -36,6 +37,12 @@ void main() {
       PluginPermissions.eventsShots,
     },
   };
+  const versionsBeforePermissionEnforcement = <String, String>{
+    'time-to-ready.reaplugin': '1.0.2',
+    'visualizer.reaplugin': '1.5.3',
+    'decent-profile.reaplugin': '1.1.0',
+    'shot-upload.reaplugin': '0.1.0',
+  };
 
   for (final entry in requiredPermissions.entries) {
     test('${entry.key} declares every capability it uses', () async {
@@ -45,6 +52,13 @@ void main() {
       final manifest = PluginManifest.fromJson(json as Map<String, dynamic>);
 
       expect(manifest.permissions, containsAll(entry.value));
+      final previousVersion = versionsBeforePermissionEnforcement[entry.key];
+      if (previousVersion != null) {
+        expect(
+          Version.parse(manifest.version),
+          greaterThan(Version.parse(previousVersion)),
+        );
+      }
     });
   }
 }

--- a/test/plugins/plugin_manager_decent_proxy_bridge_test.dart
+++ b/test/plugins/plugin_manager_decent_proxy_bridge_test.dart
@@ -74,7 +74,7 @@ class FakeKeyValueStoreService implements KeyValueStoreService {
 void main() {
   PluginManifest manifest({
     required String id,
-    Set<PluginPermissions> permissions = const {},
+    Set<PluginPermissions> permissions = const {PluginPermissions.emit},
   }) {
     return PluginManifest(
       id: id,
@@ -225,7 +225,10 @@ void main() {
         id: 'privileged.plugin',
         manifest: manifest(
           id: 'privileged.plugin',
-          permissions: {PluginPermissions.proxyDecentApi},
+          permissions: {
+            PluginPermissions.emit,
+            PluginPermissions.proxyDecentApi,
+          },
         ),
         settings: {},
         jsCode: r'''

--- a/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
+++ b/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
@@ -38,7 +38,10 @@ void main() {
       description: 'Test',
       version: '1.0.0',
       apiVersion: 1,
-      permissions: const {PluginPermissions.proxyDecentApi},
+      permissions: const {
+        PluginPermissions.emit,
+        PluginPermissions.proxyDecentApi,
+      },
       settings: const {},
       api: PluginApi(endpoints: const []),
     );

--- a/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
+++ b/test/plugins/plugin_manager_decent_proxy_ownership_test.dart
@@ -170,20 +170,14 @@ void main() {
     expect(manager.activePendingOpCount, 0);
   });
 
-  test('invalid bridge token rejects the promise', () async {
-    final manager = await buildManager(
-      (request) async => http.Response('{"serial":"SN001"}', 200),
-    );
+  test('invalid bridge token cannot create an operation', () async {
+    var calls = 0;
+    final manager = await buildManager((request) async {
+      calls += 1;
+      return http.Response('{"serial":"SN001"}', 200);
+    });
     addTearDown(manager.dispose);
 
-    final result = Completer<String>();
-    final sub = manager.emitStream.listen((e) {
-      if (result.isCompleted) return;
-      final event = e['event'] as String;
-      final payload = e['payload'] as Map<String, dynamic>;
-      if (event == 'proxyError') result.complete('err:${payload['message']}');
-    });
-    result.future.whenComplete(sub.cancel);
     await manager.loadPlugin(
       id: pluginId,
       manifest: proxyManifest(),
@@ -196,17 +190,15 @@ void main() {
             onLoad() {
               globalThis.__reaprimePluginBridge.decentProxy(
                 "$pluginId", 0, "bogus-token", "support/api/sn"
-              )
-                .then(() => host.emit("proxyResult", {}))
-                .catch((error) => host.emit("proxyError", { message: String(error) }));
+              );
             }
           };
         }
       ''',
     );
 
-    final value = await result.future.timeout(const Duration(seconds: 5));
-    expect(value, startsWith('err:'));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(calls, 0);
     expect(manager.activePendingOpCount, 0);
   });
 

--- a/test/plugins/plugin_manager_fetch_test.dart
+++ b/test/plugins/plugin_manager_fetch_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 import 'plugin_test_helpers.dart';
 
@@ -40,11 +41,14 @@ void main() {
     String url, {
     Map<String, dynamic>? init,
     Duration? wait,
+    Set<PluginPermissions>? permissions,
   }) async {
     final result = Completer<String>();
     await manager.loadPlugin(
       id: 'fetch.plugin',
-      manifest: testManifest('fetch.plugin'),
+      manifest: permissions == null
+          ? testManifest('fetch.plugin')
+          : testManifest('fetch.plugin', permissions: permissions),
       settings: {},
       jsCode:
           '''
@@ -55,7 +59,7 @@ void main() {
               fetch(${jsonEncode(url)}, ${jsonEncode(init ?? {})})
                 .then((res) => res.text())
                 .then((text) => host.emit("result", "ok:" + text))
-                .catch((e) => host.emit("result", "err:" + e.message));
+                .catch((e) => host.emit("result", "err:" + e.name + ":" + e.message));
             }
           };
         }
@@ -82,6 +86,70 @@ void main() {
 
     expect(result, 'ok:{"hello":"world"}');
     expect(manager.activePendingOpCount, 0);
+  });
+
+  test('fetch rejects without api permission before network access', () async {
+    var requests = 0;
+    final server = await startServer((res) async {
+      requests += 1;
+      res.write('unexpected');
+    });
+    addTearDown(server.close);
+
+    final result = await runFetch(
+      'http://127.0.0.1:${server.port}/data',
+      permissions: const {PluginPermissions.emit},
+    );
+
+    expect(result, contains('PluginPermissionError'));
+    expect(result, contains('api'));
+    expect(requests, 0);
+  });
+
+  test('Dart rejects direct fetch bridge calls without api', () async {
+    var requests = 0;
+    final server = await startServer((res) async {
+      requests += 1;
+      res.write('unexpected');
+    });
+    addTearDown(server.close);
+    final result = Completer<String>();
+    final subscription = manager.emitStream.listen((event) {
+      if (!result.isCompleted) result.complete(event['payload'] as String);
+    });
+    addTearDown(subscription.cancel);
+
+    await manager.loadPlugin(
+      id: 'fetch.plugin',
+      manifest: testManifest(
+        'fetch.plugin',
+        permissions: const {PluginPermissions.emit},
+      ),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "fetch.plugin",
+            onLoad() {
+              globalThis.__fetchFor(
+                "fetch.plugin",
+                1,
+                "http://127.0.0.1:${server.port}/data"
+              )
+                .then(() => host.emit("result", "unexpected"))
+                .catch((error) => host.emit("result", String(error)));
+            }
+          };
+        }
+      ''',
+    );
+
+    expect(
+      await result.future.timeout(const Duration(seconds: 5)),
+      contains('api'),
+    );
+    expect(requests, 0);
   });
 
   test(

--- a/test/plugins/plugin_manager_fetch_test.dart
+++ b/test/plugins/plugin_manager_fetch_test.dart
@@ -132,8 +132,8 @@ void main() {
           return {
             id: "fetch.plugin",
             onLoad() {
-              globalThis.__fetchFor(
-                "fetch.plugin",
+              globalThis.__reaprimePluginHostBridge.fetch(
+                pluginBridgeToken,
                 1,
                 "http://127.0.0.1:${server.port}/data"
               )

--- a/test/plugins/plugin_manager_lifecycle_test.dart
+++ b/test/plugins/plugin_manager_lifecycle_test.dart
@@ -7,6 +7,7 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 import '../helpers/test_de1.dart';
 import 'plugin_test_helpers.dart';
@@ -104,7 +105,16 @@ Future<void> _loadPlugin(
 }) {
   return manager.loadPlugin(
     id: id,
-    manifest: testManifest(id),
+    manifest: testManifest(
+      id,
+      permissions: const {
+        PluginPermissions.log,
+        PluginPermissions.api,
+        PluginPermissions.emit,
+        PluginPermissions.pluginStorage,
+        PluginPermissions.eventsMachine,
+      },
+    ),
     settings: const {},
     jsCode:
         '''

--- a/test/plugins/plugin_manager_permissions_test.dart
+++ b/test/plugins/plugin_manager_permissions_test.dart
@@ -236,6 +236,49 @@ void main() {
     );
   });
 
+  test('timer cleanup cannot expose another plugin token', () async {
+    const privilegedPluginId = 'privileged.unload.plugin';
+    final events = <Map<String, dynamic>>[];
+    final subscription = manager.emitStream.listen(events.add);
+    addTearDown(subscription.cancel);
+
+    await manager.loadPlugin(
+      id: privilegedPluginId,
+      manifest: testManifest(
+        privilegedPluginId,
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.pluginStorage,
+        },
+      ),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return { id: "$privilegedPluginId" };
+        }
+      ''',
+    );
+
+    await load(const {}, '''
+      globalThis.__cancelTimersForBridgeToken = function(bridgeToken) {
+        globalThis.host.emit(bridgeToken, "spoofed", "payload");
+        globalThis.host.storage(bridgeToken, {
+          type: "write", key: "spoofed", data: "payload"
+        });
+      };
+    ''');
+
+    await manager.unloadPlugin(privilegedPluginId);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(events, isEmpty);
+    expect(
+      await store.get(namespace: privilegedPluginId, key: 'spoofed'),
+      isNull,
+    );
+  });
+
   test('host.decentProxy rejects with PluginPermissionError', () async {
     final event = manager.emitStream.first;
 

--- a/test/plugins/plugin_manager_permissions_test.dart
+++ b/test/plugins/plugin_manager_permissions_test.dart
@@ -188,6 +188,54 @@ void main() {
     },
   );
 
+  test('timer debug state cannot expose another plugin token', () async {
+    const privilegedPluginId = 'privileged.timer.plugin';
+    final events = <Map<String, dynamic>>[];
+    final subscription = manager.emitStream.listen(events.add);
+    addTearDown(subscription.cancel);
+
+    await manager.loadPlugin(
+      id: privilegedPluginId,
+      manifest: testManifest(
+        privilegedPluginId,
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.pluginStorage,
+        },
+      ),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$privilegedPluginId",
+            onLoad() { setTimeout(() => {}, 60000); }
+          };
+        }
+      ''',
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(manager.activeTimerCount, 1);
+
+    await load(const {}, '''
+      const timers = globalThis.__debugTimers;
+      if (timers) {
+        const victim = [...timers.values()][0];
+        globalThis.host.emit(victim.bridgeToken, "spoofed", "payload");
+        globalThis.host.storage(victim.bridgeToken, {
+          type: "write", key: "spoofed", data: "payload"
+        });
+      }
+    ''');
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(events, isEmpty);
+    expect(
+      await store.get(namespace: privilegedPluginId, key: 'spoofed'),
+      isNull,
+    );
+  });
+
   test('host.decentProxy rejects with PluginPermissionError', () async {
     final event = manager.emitStream.first;
 

--- a/test/plugins/plugin_manager_permissions_test.dart
+++ b/test/plugins/plugin_manager_permissions_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+
+import 'plugin_test_helpers.dart';
+
+void main() {
+  const pluginId = 'permissions.plugin';
+
+  late FakeKeyValueStoreService store;
+  late PluginManager manager;
+
+  setUp(() {
+    store = FakeKeyValueStoreService();
+    manager = PluginManager(kvStore: store);
+  });
+
+  tearDown(() {
+    manager.cancelAllOperations();
+  });
+
+  Future<void> load(
+    Set<PluginPermissions> permissions,
+    String onLoad, {
+    String onEvent = '',
+  }) {
+    return manager.loadPlugin(
+      id: pluginId,
+      manifest: testManifest(pluginId, permissions: permissions),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            onLoad() { $onLoad },
+            onEvent(event) { $onEvent }
+          };
+        }
+      ''',
+    );
+  }
+
+  Matcher permissionError(String permission) => throwsA(
+    predicate(
+      (error) =>
+          error.toString().contains('PluginPermissionError') &&
+          error.toString().contains(permission),
+    ),
+  );
+
+  test('host.log allows declared permission and rejects omission', () async {
+    final previousLevel = Logger.root.level;
+    Logger.root.level = Level.ALL;
+    final records = <LogRecord>[];
+    final subscription = Logger.root.onRecord.listen(records.add);
+    addTearDown(() async {
+      Logger.root.level = previousLevel;
+      await subscription.cancel();
+    });
+
+    await load({PluginPermissions.log}, 'host.log("allowed");');
+
+    expect(
+      records.any(
+        (record) => record.message.contains('[JS:$pluginId] allowed'),
+      ),
+      isTrue,
+    );
+
+    await expectLater(
+      load(const {}, 'host.log("denied");'),
+      permissionError('log'),
+    );
+  });
+
+  test('host.emit allows declared permission and rejects omission', () async {
+    final event = manager.emitStream.first;
+
+    await load({PluginPermissions.emit}, 'host.emit("allowed", 1);');
+
+    expect((await event)['event'], 'allowed');
+
+    await expectLater(
+      load(const {}, 'host.emit("denied", 1);'),
+      permissionError('emit'),
+    );
+  });
+
+  test(
+    'host.storage allows declared permission and rejects omission',
+    () async {
+      await load({
+        PluginPermissions.pluginStorage,
+      }, 'host.storage({type: "write", key: "allowed", data: "yes"});');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(await store.get(namespace: pluginId, key: 'allowed'), 'yes');
+
+      await expectLater(
+        load(
+          const {},
+          'host.storage({type: "write", key: "denied", data: "no"});',
+        ),
+        permissionError('pluginStorage'),
+      );
+    },
+  );
+
+  test('Dart rejects direct bridge calls without permissions', () async {
+    final previousLevel = Logger.root.level;
+    Logger.root.level = Level.ALL;
+    final records = <LogRecord>[];
+    final subscription = Logger.root.onRecord.listen(records.add);
+    final events = <Map<String, dynamic>>[];
+    final eventSubscription = manager.emitStream.listen(events.add);
+    addTearDown(() async {
+      Logger.root.level = previousLevel;
+      await subscription.cancel();
+      await eventSubscription.cancel();
+    });
+
+    await load(const {}, '''
+      globalThis.host.log("$pluginId", "bypass");
+      globalThis.host.emit("$pluginId", "bypass", null);
+      globalThis.host.storage("$pluginId", {
+        type: "write", key: "bypass", data: "no"
+      });
+    ''');
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(events, isEmpty);
+    expect(await store.get(namespace: pluginId, key: 'bypass'), isNull);
+    for (final permission in ['log', 'emit', 'pluginStorage']) {
+      expect(
+        records.any(
+          (record) =>
+              record.message.contains(pluginId) &&
+              record.message.contains(permission),
+        ),
+        isTrue,
+      );
+    }
+  });
+
+  test('host.decentProxy rejects with PluginPermissionError', () async {
+    final event = manager.emitStream.first;
+
+    await load(
+      {PluginPermissions.emit},
+      '''
+      host.decentProxy("support/api/sn")
+        .catch((error) => host.emit("error", error.name + ":" + error.message));
+    ''',
+    );
+
+    expect((await event)['payload'], contains('PluginPermissionError'));
+  });
+
+  test('host.decentProxy POST requires write permission', () async {
+    final event = manager.emitStream.first;
+
+    await load(
+      {PluginPermissions.emit, PluginPermissions.proxyDecentApi},
+      '''
+      host.decentProxy("support/api/shot_upload", {method: "POST"})
+        .catch((error) => host.emit("error", error.name + ":" + error.message));
+    ''',
+    );
+
+    expect((await event)['payload'], contains('proxy.decent_api.write'));
+  });
+
+  test('timers require no manifest permission', () async {
+    await load(
+      const {},
+      'setTimeout(() => globalThis.__timerFired = true, 0);',
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(
+      manager.js.evaluate('String(globalThis.__timerFired)').stringResult,
+      'true',
+    );
+  });
+
+  test('stateUpdate requires events.machine', () async {
+    await load(
+      {PluginPermissions.eventsMachine},
+      '',
+      onEvent: 'globalThis.__eventCount = (globalThis.__eventCount || 0) + 1;',
+    );
+
+    manager.dispatchEvent(pluginId, 'stateUpdate', const {});
+
+    expect(
+      manager.js.evaluate('String(globalThis.__eventCount)').stringResult,
+      '1',
+    );
+  });
+
+  test('stateUpdate is withheld without events.machine', () async {
+    await load(
+      const {},
+      '',
+      onEvent: 'globalThis.__eventCount = (globalThis.__eventCount || 0) + 1;',
+    );
+
+    manager.dispatchEvent(pluginId, 'stateUpdate', const {});
+
+    expect(
+      manager.js.evaluate('String(globalThis.__eventCount || 0)').stringResult,
+      '0',
+    );
+  });
+
+  test('shot events require events.shots', () async {
+    await load(
+      {PluginPermissions.eventsShots},
+      '',
+      onEvent: 'globalThis.__eventCount = (globalThis.__eventCount || 0) + 1;',
+    );
+
+    manager.dispatchEvent(pluginId, 'shotStored', const {});
+    manager.dispatchEvent(pluginId, 'shotUpdated', const {});
+
+    expect(
+      manager.js.evaluate('String(globalThis.__eventCount)').stringResult,
+      '2',
+    );
+  });
+
+  test('shot events are withheld without events.shots', () async {
+    await load(
+      const {},
+      '',
+      onEvent: 'globalThis.__eventCount = (globalThis.__eventCount || 0) + 1;',
+    );
+
+    manager.dispatchEvent(pluginId, 'shotStored', const {});
+    manager.dispatchEvent(pluginId, 'shotUpdated', const {});
+
+    expect(
+      manager.js.evaluate('String(globalThis.__eventCount || 0)').stringResult,
+      '0',
+    );
+  });
+}

--- a/test/plugins/plugin_manager_permissions_test.dart
+++ b/test/plugins/plugin_manager_permissions_test.dart
@@ -122,9 +122,11 @@ void main() {
     });
 
     await load(const {}, '''
-      globalThis.host.log("$pluginId", "bypass");
-      globalThis.host.emit("$pluginId", "bypass", null);
-      globalThis.host.storage("$pluginId", {
+      globalThis.__reaprimePluginHostBridge.log(pluginBridgeToken, "bypass");
+      globalThis.__reaprimePluginHostBridge.emit(
+        pluginBridgeToken, "bypass", null
+      );
+      globalThis.__reaprimePluginHostBridge.storage(pluginBridgeToken, {
         type: "write", key: "bypass", data: "no"
       });
     ''');
@@ -143,6 +145,48 @@ void main() {
       );
     }
   });
+
+  test(
+    'raw bridge cannot borrow another plugin permission or storage',
+    () async {
+      const privilegedPluginId = 'privileged.plugin';
+      final events = <Map<String, dynamic>>[];
+      final subscription = manager.emitStream.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      await manager.loadPlugin(
+        id: privilegedPluginId,
+        manifest: testManifest(
+          privilegedPluginId,
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.pluginStorage,
+          },
+        ),
+        settings: {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          return { id: "$privilegedPluginId" };
+        }
+      ''',
+      );
+
+      await load(const {}, '''
+      globalThis.host.emit("$privilegedPluginId", "spoofed", "payload");
+      globalThis.host.storage("$privilegedPluginId", {
+        type: "write", key: "spoofed", data: "payload"
+      });
+    ''');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(events, isEmpty);
+      expect(
+        await store.get(namespace: privilegedPluginId, key: 'spoofed'),
+        isNull,
+      );
+    },
+  );
 
   test('host.decentProxy rejects with PluginPermissionError', () async {
     final event = manager.emitStream.first;

--- a/test/plugins/plugin_manager_timers_test.dart
+++ b/test/plugins/plugin_manager_timers_test.dart
@@ -24,8 +24,9 @@ void main() {
     return events;
   }
 
-  String jsTimerCount() =>
-      manager.js.evaluate('String(globalThis.__debugTimers.size)').stringResult;
+  String jsTimerCount() => manager.js
+      .evaluate('String(globalThis.__debugTimerCount())')
+      .stringResult;
 
   Future<void> loadTimerPlugin(String jsBody) async {
     await manager.loadPlugin(

--- a/test/plugins/plugin_manager_workload_test.dart
+++ b/test/plugins/plugin_manager_workload_test.dart
@@ -22,7 +22,11 @@ void main() {
       description: 'Test',
       version: '1.0.0',
       apiVersion: 1,
-      permissions: const {PluginPermissions.proxyDecentApi},
+      permissions: const {
+        PluginPermissions.api,
+        PluginPermissions.emit,
+        PluginPermissions.proxyDecentApi,
+      },
       settings: const {},
       api: PluginApi(endpoints: const []),
     );

--- a/test/plugins/plugin_manifest_permissions_test.dart
+++ b/test/plugins/plugin_manifest_permissions_test.dart
@@ -60,6 +60,10 @@ void main() {
     expect(PluginPermissions.fromString('pluginNotify'), isNull);
   });
 
+  test('rejects Dart enum names as manifest permission aliases', () {
+    expect(PluginPermissions.fromString('eventsShots'), isNull);
+  });
+
   test('serializes permissions using manifest wire values', () {
     final manifest = PluginManifest(
       id: 'test.plugin',

--- a/test/plugins/plugin_manifest_permissions_test.dart
+++ b/test/plugins/plugin_manifest_permissions_test.dart
@@ -13,6 +13,8 @@ void main() {
       'permissions': [
         'log',
         'api',
+        'events.machine',
+        'events.shots',
         'proxy.decent_api',
         'proxy.decent_api.write',
       ],
@@ -22,11 +24,40 @@ void main() {
 
     expect(manifest.permissions, contains(PluginPermissions.log));
     expect(manifest.permissions, contains(PluginPermissions.api));
+    expect(manifest.permissions, contains(PluginPermissions.eventsMachine));
+    expect(manifest.permissions, contains(PluginPermissions.eventsShots));
     expect(manifest.permissions, contains(PluginPermissions.proxyDecentApi));
     expect(
       manifest.permissions,
       contains(PluginPermissions.proxyDecentApiWrite),
     );
+  });
+
+  test('rejects unknown manifest permissions', () {
+    expect(
+      () => PluginManifest.fromJson(<String, dynamic>{
+        'id': 'test.plugin',
+        'name': 'Test Plugin',
+        'author': 'Test',
+        'description': 'Test',
+        'version': '1.0.0',
+        'apiVersion': 1,
+        'permissions': ['pluginStorag'],
+        'settings': <String, dynamic>{},
+        'api': <dynamic>[],
+      }),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          contains('pluginStorag'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects removed pluginNotify permission', () {
+    expect(PluginPermissions.fromString('pluginNotify'), isNull);
   });
 
   test('serializes permissions using manifest wire values', () {

--- a/test/plugins/plugin_test_helpers.dart
+++ b/test/plugins/plugin_test_helpers.dart
@@ -46,7 +46,16 @@ class FakeKeyValueStoreService implements KeyValueStoreService {
   }
 }
 
-PluginManifest testManifest(String id) {
+PluginManifest testManifest(
+  String id, {
+  Set<PluginPermissions> permissions = const {
+    PluginPermissions.log,
+    PluginPermissions.api,
+    PluginPermissions.emit,
+    PluginPermissions.pluginStorage,
+  },
+  PluginApi? api,
+}) {
   return PluginManifest(
     id: id,
     name: id,
@@ -54,8 +63,8 @@ PluginManifest testManifest(String id) {
     description: 'Test',
     version: '1.0.0',
     apiVersion: 1,
-    permissions: const {},
+    permissions: permissions,
     settings: {},
-    api: PluginApi(endpoints: []),
+    api: api ?? PluginApi(endpoints: []),
   );
 }

--- a/test/services/webserver/plugins_handler_test.dart
+++ b/test/services/webserver/plugins_handler_test.dart
@@ -37,7 +37,9 @@ class _SettingsPluginLoaderService extends Fake implements PluginLoaderService {
 void main() {
   const pluginId = 'http.plugin';
 
-  PluginManifest httpManifest() {
+  PluginManifest httpManifest({
+    Set<PluginPermissions> permissions = const {PluginPermissions.api},
+  }) {
     return PluginManifest(
       id: pluginId,
       name: pluginId,
@@ -45,7 +47,7 @@ void main() {
       description: 'Test',
       version: '1.0.0',
       apiVersion: 1,
-      permissions: const {},
+      permissions: permissions,
       settings: const {},
       api: PluginApi(
         endpoints: [
@@ -163,6 +165,44 @@ void main() {
 
     expect(response.statusCode, 200);
     expect(await response.readAsString(), '{"echo":null}');
+    expect(manager.activePendingOpCount, 0);
+  });
+
+  test('HTTP plugin endpoint rejects missing api permission', () async {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      pluginHttpTimeout: const Duration(seconds: 5),
+    );
+    addTearDown(manager.cancelAllOperations);
+    await manager.loadPlugin(
+      id: pluginId,
+      manifest: httpManifest(permissions: const {}),
+      settings: {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          return {
+            id: "$pluginId",
+            handleHttpRequest: () => ({status: 200, headers: {}, body: "no"})
+          };
+        }
+      ''',
+    );
+    final app = Router().plus;
+    PluginsHandler(
+      pluginManager: manager,
+      pluginService: _FakePluginLoaderService(),
+    ).addRoutes(app);
+
+    final response = await app.call(
+      Request(
+        'GET',
+        Uri.parse('http://localhost/api/v1/plugins/$pluginId/hello'),
+      ),
+    );
+
+    expect(response.statusCode, 403);
+    expect(await response.readAsString(), contains('api'));
     expect(manager.activePendingOpCount, 0);
   });
 


### PR DESCRIPTION
## Summary

- Problem: Plugin manifests advertised optional capabilities, but logging, fetch, event emission, storage, and inbound events were not enforced. The first enforcement pass still trusted a plugin-controlled ID at the Dart bridge.
- Why it matters: A plugin could claim another loaded plugin's ID, borrow its permissions, and access its storage namespace.
- What changed: Enforced manifest permissions, corrected bundled manifests, and bound every plugin-to-Dart bridge message to an opaque per-plugin token. Dart derives identity from the token and verifies HTTP/timer ownership rather than trusting JavaScript IDs.
- What did NOT change (scope boundary): Timers remain baseline facilities; existing Decent proxy path and write allowlists remain in force; notifications remain unavailable; plugins still share one JavaScript context.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore / infra
- [x] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [x] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [x] Docs / specs

## Linked Issues

- Closes: N/A
- Related: N/A

## Root Cause (if bug fix)

- Root cause: `PluginManager` exposed host functions broadly, and Dart authorization trusted `msg['pluginId']` supplied by plugin-controlled JavaScript.
- Missing detection or guardrail: Tests exercised direct bridge calls only with the attacking plugin's own ID, not a permission-bearing victim ID.
- Contributing context (if known): Bundled manifests had already drifted from implementation usage, including Time To Ready storage access.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Integration test (mock transport edge)
  - [ ] End-to-end test (`simulate=1` + curl/websocat)
  - [ ] Existing coverage already sufficient
- Target test or file: `test/plugins/plugin_manager_permissions_test.dart`, `test/plugins/plugin_manager_fetch_test.dart`, `test/plugins/plugin_manager_decent_proxy_ownership_test.dart`, and `test/services/webserver/plugins_handler_test.dart`.
- Scenario the test should lock in: Plugin A cannot claim permission-bearing plugin B's ID to emit events or access B's storage, and all bridge paths derive identity from the opaque token.
- If no new test added, why not: N/A; the two-plugin spoof regression was added.

## Documentation Obligations (required)

- [x] API spec updated: `assets/api/rest_v1.yml`
- [x] API docs reviewed: plugin endpoint permission semantics are documented in `doc/Plugins.md`; `doc/Api.md` has no matching plugin contract section.
- [x] Plugin docs updated: `doc/Plugins.md`
- [x] Skin docs reviewed: no skin behavior changed.
- [x] Profile docs reviewed: no profile handling changed.
- [x] Device docs reviewed: no device flows changed.

## Security Impact (required)

- New or changed REST endpoints? `Yes` - existing plugin HTTP endpoints now require `api` and return 403 on denial.
- New or changed WebSocket topics? `No`
- New or changed network calls? `No`
- BLE/USB surface changed? `No`
- File system access changed? `No`
- Plugin sandbox boundary changed? `Yes`
- If any `Yes`, explain risk and mitigation: Frozen host bridges carry opaque per-plugin tokens. Dart resolves identity from the token, rejects ID mismatches, checks HTTP/timer ownership, and logs invalid bridge messages without logging tokens.

## User-Visible Changes

Plugin permission declarations now match callable capabilities. Plugins with missing or misspelled permissions fail clearly instead of silently receiving access.

## Verification

### Local gates (run before pushing)

- [x] `dart format` - changed files formatted
- [x] `flutter analyze` - no issues
- [x] `flutter test` - full suite passed in serialized and default-concurrency runs
- [ ] `./scripts/fetch_dye2_plugin.sh` - Git Bash lacks `jq`; the extracted pinned v0.1.4 manifest passed the bundled permission audit.

### Manual verification (if applicable)

- OS / platform tested: Windows
- Simulated devices? (`simulate=1`): `No`
- Real hardware? (DE1/Bengle/scale): `No`
- What you personally verified and how: Ran 72 focused plugin/HTTP tests, the full suite twice, analyzer, formatter, and raw diff checks.
- Edge cases checked: Cross-plugin ID spoofing, direct host/fetch bridge calls, proxy token rejection, HTTP response ownership, timer ownership, unload callbacks, and event subscriptions.
- What you did **not** verify: Live `sb-dev` smoke testing was skipped to avoid interfering with concurrent Flutter/Dart agents. The DYE2 fetch script could not complete locally because Git Bash lacks `jq`.

### Evidence

- [x] Test output (passing focused and full suites)
- [x] Log assertions for permission denials
- [ ] Screenshot / recording (no UI changes)
- [ ] curl / websocat output (live smoke skipped)

## Compatibility & Migration

- Backward compatible? `No` for plugins whose manifests omit capabilities they use; bundled manifests were corrected before enforcement.
- Config / env changes needed? `No`
- Database migration needed? `No`
- Exact steps: Third-party plugin authors must declare `log`, `api`, `emit`, `pluginStorage`, `events.machine`, and/or `events.shots` when using those surfaces.

## Risks & Mitigations

- Risk: Existing third-party plugins with incomplete manifests will be denied capabilities after upgrade.
- Mitigation: Denials throw `PluginPermissionError`, log the plugin ID and capability, and the updated documentation lists every enforced permission. Bridge identity comes from opaque tokens, not JavaScript-supplied IDs.
