### PR TITLE
fix: handle plugin directory paths on Windows

### DIFF
--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:reaprime/src/services/storage/kv_store_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -569,13 +570,11 @@ class PluginLoaderService {
   Future<void> _copyDirectory(Directory source, Directory destination) async {
     await for (final entity in source.list(recursive: false)) {
       if (entity is File) {
-        final newFile = File(
-          '${destination.path}/${entity.path.split('/').last}',
-        );
+        final newFile = File('${destination.path}/${p.basename(entity.path)}');
         await entity.copy(newFile.path);
       } else if (entity is Directory) {
         final newDir = Directory(
-          '${destination.path}/${entity.path.split('/').last}',
+          '${destination.path}/${p.basename(entity.path)}',
         );
         newDir.createSync(recursive: true);
         await _copyDirectory(entity, newDir);


### PR DESCRIPTION
## Summary

- Problem: plugin directory copies extracted child names by splitting paths on forward slashes.
- Why it matters: Windows returns backslash-separated paths, causing bundled plugin installation and watchdog recovery to fail.
- What changed: use package:path basename() for copied files and directories.
- What did NOT change (scope boundary): plugin contents, update policy, APIs, and non-Windows behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra
- [ ] Plugin (DYE2 or bundled skin)

## Scope (select all touched areas)

- [ ] BLE transport / device comms
- [ ] REST API / handlers
- [ ] WebSocket API
- [ ] Machine state / shot logic
- [ ] Scale / weight / flow
- [ ] Profiles / beans / grinders / workflows
- [ ] WebUI skins
- [x] Plugins / JS runtime
- [ ] UI / Flutter widgets
- [ ] Storage / Drift database
- [ ] CI / build / infra
- [ ] Docs / specs

## Linked Issues

- Closes: N/A
- Related: #584 (the Windows failures were discovered while verifying that PR)

## Root Cause (if bug fix)

- Root cause: _copyDirectory() assumed POSIX separators when deriving each source entity's basename.
- Missing detection or guardrail: existing copy and watchdog tests were not previously run on Windows.
- Contributing context (if known): Dart accepts forward slashes in destination paths on Windows, which hid the invalid source-path split.

## Regression Test Plan (if bug fix or refactor)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Integration test (mock transport edge)
  - [ ] End-to-end test (simulate=1 + curl/websocat)
  - [x] Existing coverage already sufficient
- Target test or file: test/plugin_loader_service_appstore_test.dart and test/plugin_loader_service_watchdog_test.dart.
- Scenario the test should lock in: recursive plugin copies preserve child names on Windows.
- If no new test added, why not: the existing 25 tests reproduce all eight failures before the fix and pass afterward.

## Documentation Obligations (required)

- [ ] API spec updated: assets/api/rest_v1.yml or assets/api/websocket_v1.yml (if REST/WebSocket changed)
- [ ] API docs updated: doc/Api.md (if user-facing endpoint changed)
- [ ] Plugin docs updated: doc/Plugins.md (if events/API changed)
- [ ] Skin docs updated: doc/Skins.md (if skin behavior changed)
- [ ] Profile docs updated: doc/Profiles.md (if profile handling changed)
- [ ] Device docs updated: doc/DeviceManagement.md (if device flows changed)
- [x] N/A - no docs affected

## Security Impact (required)

- New or changed REST endpoints? No
- New or changed WebSocket topics? No
- New or changed network calls? No
- BLE/USB surface changed? No
- File system access changed? Yes
- Plugin sandbox boundary changed? No
- If any Yes, explain risk and mitigation: only child-name extraction changed; basename() prevents the Windows source path from being treated as a destination child name.

## User-Visible Changes

Bundled plugin installation and watchdog recovery now work on Windows.

## Verification

### Local gates (run before pushing)

- [x] dart format lib test - 687 files, 0 changed
- [x] flutter analyze - no issues
- [x] flutter test - 2,818 tests passed
- [x] DYE2 plugin installed into assets/plugins/dye2.reaplugin/ for the full suite

### Manual verification (if applicable)

- OS / platform tested: Windows 11
- Simulated devices? No
- Real hardware? No
- What you personally verified and how: reproduced eight failures on origin/main; both targeted files pass all 25 tests after the fix.
- Edge cases checked: nested directory copies and watchdog restore paths.
- What you did not verify: a packaged Windows release or real hardware.

### Evidence

- [x] Test output (failing before + passing after)
- [ ] Log snippets
- [ ] Screenshot / recording (UI changes)
- [ ] curl / websocat output (API changes)

## Compatibility & Migration

- Backward compatible? Yes
- Config / env changes needed? No
- Database migration needed? No
- If any No or Yes, explain exact steps: no migration or configuration changes are required.

## Risks & Mitigations

None.