### PR TITLE
feat(plugins): install and update plugins from GitHub, ZIP and folders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Requirements: Flutter (stable), the [GitHub CLI](https://cli.github.com) (`gh`, 
 
 ```bash
 flutter pub get
-./scripts/fetch_dye2_plugin.sh   # installs assets/plugins/dye2.reaplugin/ from the pinned allofmeng/dye2 release (scripts/fetch_dye2_plugin.sh)
+./scripts/fetch_dye2_plugin.sh   # installs assets/plugins/dye2.reaplugin/ from the pinned decentespresso/dye2 release (scripts/fetch_dye2_plugin.sh)
 
 # Run with simulated hardware (no DE1 / scale required):
 flutter run --dart-define=simulate=1

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -3115,8 +3115,10 @@ paths:
     post:
       summary: Approve and install a permission-escalating update
       description: >
-        Installs the update recorded in pendingUpdate, accepting the added
-        permissions.
+        Installs the exact candidate recorded in pendingUpdate - the stored
+        release tag or commit - accepting its added permissions. If the source
+        moved since detection, the fetched candidate is refused, recorded as
+        the new pendingUpdate and has to be approved again.
       tags: [Plugins]
       parameters:
         - name: id
@@ -3144,7 +3146,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "409":
-          description: No update is awaiting approval
+          description: >
+            No update is awaiting approval, or the candidate no longer matches
+            the approved one
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2956,8 +2956,41 @@ paths:
 
   /api/v1/plugins/install:
     post:
-      summary: Install a plugin from URL
-      description: Installs a plugin from a remote URL (not yet implemented)
+      summary: Install a plugin from URL (not supported)
+      description: >
+        Installing from an arbitrary URL is not supported. Use
+        /api/v1/plugins/install/github-release or
+        /api/v1/plugins/install/github-branch.
+      tags: [Plugins]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+      responses:
+        "501":
+          description: Not supported; the response names the endpoints to use
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+
+  /api/v1/plugins/install/github-release:
+    post:
+      summary: Install a plugin from a GitHub release
+      description: >
+        Downloads a release asset, validates the package, and installs it. The
+        release tag must be X.Y.Z or vX.Y.Z and must equal the manifest version
+        after stripping the optional leading v. When the release carries several
+        .zip assets, assetName must name the one to install. Downgrades are
+        rejected; remove the plugin first to go back to an older version.
       tags: [Plugins]
       requestBody:
         required: true
@@ -2965,31 +2998,163 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - url
+              required: [repo]
               properties:
-                url:
+                repo:
                   type: string
-                  description: URL to install the plugin from
+                  description: owner/repo
+                assetName:
+                  type: string
+                  description: Release asset to install; required when several .zip assets exist
+                includePrerelease:
+                  type: boolean
+                  default: false
       responses:
-        "501":
-          description: Not yet implemented
+        "200":
+          description: Plugin installed
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
+                $ref: '#/components/schemas/PluginInstallResult'
         "400":
-          description: Missing url field
+          description: Invalid body, invalid package, or tag/version mismatch
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The release is older than the installed version
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Download or installation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/plugins/install/github-branch:
+    post:
+      summary: Install a plugin from a GitHub branch
+      description: >
+        Resolves the branch head, downloads the branch archive, validates the
+        package, and installs it. The resolved commit is stored and later drives
+        updates, so a branch-backed plugin updates even when its manifest
+        version does not change.
+      tags: [Plugins]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [repo]
+              properties:
+                repo:
+                  type: string
+                  description: owner/repo
+                branch:
+                  type: string
+                  default: main
+      responses:
+        "200":
+          description: Plugin installed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PluginInstallResult'
+        "400":
+          description: Invalid body or invalid package
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The branch carries an older version than the installed one
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Download or installation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/plugins/update:
+    post:
+      summary: Check every GitHub-backed plugin for updates
+      description: >
+        Runs the same check the app runs on its update cadence. Unchanged
+        plugins only get a new lastChecked; changed plugins are validated and
+        installed when the candidate keeps the same permissions or fewer, and
+        recorded as a pendingUpdate when it asks for more. One plugin failing
+        does not stop the others.
+      tags: [Plugins]
+      responses:
+        "200":
+          description: Update check finished
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  error:
+                  message:
                     type: string
+        "500":
+          description: The update check could not run
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/plugins/{id}/update/approve:
+    post:
+      summary: Approve and install a permission-escalating update
+      description: >
+        Installs the update recorded in pendingUpdate, accepting the added
+        permissions.
+      tags: [Plugins]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Plugin updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PluginInstallResult'
+        "400":
+          description: The candidate package is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Plugin not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: No update is awaiting approval
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Installation failed and the previous version was restored
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   # Profiles API
   # 
@@ -6659,6 +6824,89 @@ components:
         autoLoad:
           type: boolean
           description: Whether the plugin is set to auto-load on startup
+        source:
+          allOf:
+            - $ref: '#/components/schemas/PluginSource'
+          nullable: true
+          description: >
+            Where the installed copy came from. Null for plugins installed
+            before source tracking existed and for bundled plugins.
+        pendingUpdate:
+          allOf:
+            - $ref: '#/components/schemas/PluginPendingUpdate'
+          nullable: true
+          description: >
+            An update that was found but not installed because it requests
+            permissions the installed version does not hold.
+
+    PluginInstallResult:
+      type: object
+      properties:
+        message:
+          type: string
+        id:
+          type: string
+        version:
+          type: string
+        loaded:
+          type: boolean
+
+    PluginSource:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [github_release, github_branch, local_zip, local_folder]
+        repo:
+          type: string
+          nullable: true
+          description: owner/repo for GitHub-backed sources
+        branch:
+          type: string
+          nullable: true
+        commit:
+          type: string
+          nullable: true
+          description: Resolved branch head at install time; the branch update signal
+        releaseTag:
+          type: string
+          nullable: true
+        assetName:
+          type: string
+          nullable: true
+        includePrerelease:
+          type: boolean
+        installedAt:
+          type: string
+          format: date-time
+        lastChecked:
+          type: string
+          format: date-time
+          nullable: true
+        lastError:
+          type: string
+          nullable: true
+          description: Why the most recent update check or install failed
+
+    PluginPendingUpdate:
+      type: object
+      properties:
+        version:
+          type: string
+          description: Manifest version of the candidate
+        releaseTag:
+          type: string
+          nullable: true
+        commit:
+          type: string
+          nullable: true
+        addedPermissions:
+          type: array
+          items:
+            type: string
+        detectedAt:
+          type: string
+          format: date-time
 
     PluginSettings:
       type: object

--- a/doc/AI_REPO_MAP.md
+++ b/doc/AI_REPO_MAP.md
@@ -34,7 +34,7 @@ When you change X, also check Y and Z.
 | Profile/workflow serialization | `Workflow.fromJson()`, `ProfileDao`, `ProfileStorageService`, legacy field backfill, spec | Dual representation (`context` + legacy fields); both must stay in sync |
 | `ConnectionManager` | 7 collaborators (`DisconnectExpectations`, `StatusPublisher`, `ScanReportBuilder`, `DisconnectSupervisor`, `EarlyConnectWatcher`, `ScanOrchestrator`, `PolicyResolver`) | Delegate to the right collaborator rather than growing the manager |
 | `De1StateManager` | `ShotSequencer`, `SteamSequencer`, `ScaleController` (sleep/wake), `ConnectionManager` (reconnect) | Machine state transitions cascade to shot lifecycle, scale power, and reconnect logic |
-| Plugin API or permissions | `PluginManager`, `PluginHost`, [allofmeng/dye2](https://github.com/allofmeng/dye2), `doc/Plugins.md`, bundled plugin assets | Plugin host + bundled plugin must stay compatible |
+| Plugin API or permissions | `PluginManager`, `PluginHost`, [decentespresso/dye2](https://github.com/decentespresso/dye2), `doc/Plugins.md`, bundled plugin assets | Plugin host + bundled plugin must stay compatible |
 | WebUI / skin serving | `lib/src/webui_support/`, `lib/src/services/webserver/webui/`, `doc/Skins.md` | Skin install, serving, and metadata are coupled |
 | Device discovery | `DeviceMatcher`, `BleServiceIdentifier`, `ScanStateGuardian`, `ScanOrchestrator`, `doc/DeviceManagement.md` | Name matching, service verification, and scan lifecycle are interdependent |
 | `BatteryController` / charging | `charging_logic.dart`, `De1Controller`, DE1 FW behavior (auto-re-enables charger) | Charger mode logic depends on DE1 FW quirks |
@@ -57,4 +57,4 @@ API smoke test: `scripts/sb-dev.sh start` then `curl` / `websocat` per `.agents/
 - `test/` test files — read only the ones relevant to the change.
 - `assets/` assets unrelated to API specs.
 - `ios/`, `android/`, `macos/`, `linux/`, `windows/` — platform-native project files. Only touch when adding platform capabilities.
-- `packages/dye2-plugin/` — DYE2 plugin source, **not built or bundled by Decaid**. The bundled copy is pinned and fetched from [allofmeng/dye2](https://github.com/allofmeng/dye2) releases via `scripts/fetch_dye2_plugin.sh` (see `doc/Plugins.md`). Do DYE2 compatibility work against that repo, not this in-tree copy.
+- `packages/dye2-plugin/` — DYE2 plugin source, **not built or bundled by Decaid**. The bundled copy is pinned and fetched from [decentespresso/dye2](https://github.com/decentespresso/dye2) releases via `scripts/fetch_dye2_plugin.sh` (see `doc/Plugins.md`). Do DYE2 compatibility work against that repo, not this in-tree copy.

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -262,13 +262,18 @@ Settings fields include: `gatewayMode`, `themeMode`, `logLevel`, `weightFlowMult
 
 | Method | Path | Description | Handler |
 |--------|------|-------------|---------|
-| GET | `/api/v1/plugins` | List all plugins (with `loaded`, `autoLoad` fields) | `plugins_handler.dart` |
+| GET | `/api/v1/plugins` | List all plugins (with `loaded`, `autoLoad`, `source`, `pendingUpdate` fields) | `plugins_handler.dart` |
 | GET | `/api/v1/plugins/:id/settings` | Get plugin settings; secure fields return `{isSet}` only | |
 | POST | `/api/v1/plugins/:id/settings` | Patch plugin settings (omitted preserves, `null` clears) and return a redacted result | |
 | POST | `/api/v1/plugins/:id/enable` | Load plugin + enable auto-load | |
 | POST | `/api/v1/plugins/:id/disable` | Unload plugin + disable auto-load | |
 | DELETE | `/api/v1/plugins/:id` | Remove plugin (unload + delete files) | |
-| POST | `/api/v1/plugins/install` | Install from URL (not yet implemented — returns 501) | |
+| PUT | `/api/v1/plugins/:id/source` | Create or overwrite `manifest.json` + `plugin.js` | |
+| POST | `/api/v1/plugins/install` | Not supported — returns 501 naming the GitHub endpoints | |
+| POST | `/api/v1/plugins/install/github-release` | Install from a GitHub release asset; tag must equal the manifest version | |
+| POST | `/api/v1/plugins/install/github-branch` | Install from a GitHub branch; the resolved commit drives updates | |
+| POST | `/api/v1/plugins/update` | Check every GitHub-backed plugin for updates | |
+| POST | `/api/v1/plugins/:id/update/approve` | Install an update that asks for new permissions | |
 | ANY | `/api/v1/plugins/:id/:endpoint` | Plugin HTTP endpoint; requires `api` and returns 403 without it | |
 | WS | `/ws/v1/plugins/:id/:endpoint` | Plugin WebSocket endpoint | |
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -443,18 +443,103 @@ The DYE2 (Describe Your Espresso) plugin ships from its own repo, [allofmeng/dye
 
 `packages/dye2-plugin/` still holds the plugin's original TypeScript + Vite source and is useful as a reference for advanced patterns (REST API client, HTML template rendering, Vite dev server — see `packages/dye2-plugin/README.md`), but it is **not** built or bundled by Decaid anymore and is not authoritative for what ships. Treat [allofmeng/dye2](https://github.com/allofmeng/dye2) as the source of truth for the DYE2 plugin; update `packages/dye2-plugin/` only if it's being kept in sync deliberately.
 
+## Distribution and Updates
+
+A plugin can be installed from four sources:
+
+| Source | Tracked | Updates |
+|--------|---------|---------|
+| GitHub release | yes | new release tag |
+| GitHub branch | yes | new commit on the branch |
+| Local ZIP | no | none, it is a snapshot |
+| Local folder | no | none, it is a snapshot |
+
+Every install goes through the same validation: the package must resolve to a
+single plugin root holding both `manifest.json` and `plugin.js`, the manifest
+must parse, and the id must be a single safe path component. A GitHub archive or
+a release ZIP may wrap its content in one directory; more than one candidate
+root is rejected rather than guessed.
+
+Provenance for a tracked install is stored in a Decaid-owned
+`.rea_source.json` inside the plugin directory. It is not part of your plugin
+package, it is rewritten on every install, and it disappears when the plugin is
+removed.
+
+### Packaging a release
+
+For a GitHub release install:
+
+- tag the release `X.Y.Z` or `vX.Y.Z`;
+- the tag must equal `manifest.json`'s `version` after removing the leading `v`,
+  so `v1.4.0` requires `"version": "1.4.0"`. A mismatch is rejected;
+- attach exactly one `.zip` asset holding the plugin, either flat or inside one
+  wrapper directory. If a release carries several `.zip` assets, the installer
+  refuses to guess and the caller must name the asset.
+
+Branch installs have no tag rule. The resolved commit is the update signal, so a
+branch-backed plugin updates when the branch moves even if `version` never
+changes.
+
+```bash
+curl -X POST http://tablet:8080/api/v1/plugins/install/github-release \
+  -H 'content-type: application/json' \
+  -d '{"repo": "acme/my-plugin"}'
+
+curl -X POST http://tablet:8080/api/v1/plugins/install/github-branch \
+  -H 'content-type: application/json' \
+  -d '{"repo": "acme/my-plugin", "branch": "dev"}'
+```
+
+### Update rules
+
+Tracked plugins are checked on the app's normal update cadence, next to WebUI
+skin updates, and on demand from the Plugins settings screen or
+`POST /api/v1/plugins/update`. For each plugin:
+
+- an unchanged tag or commit only refreshes `lastChecked`;
+- a changed tag or commit is downloaded and validated before anything installed
+  is touched;
+- downgrade protection still applies to release installs: a lower version is
+  rejected, and going back requires removing the plugin first;
+- the swap is transactional. The plugin is unloaded only once the replacement is
+  ready, and a failed copy or a failed reload restores the previous files,
+  manifest and running plugin;
+- settings, secure settings and the auto-load preference survive an update. A
+  running plugin is restarted on the new version; a disabled one stays disabled;
+- one plugin's failure never stops the others; the failure is recorded in
+  `lastError`.
+
+### Permission escalation
+
+An automatic update installs only when the candidate manifest requests the same
+permissions as the installed version or fewer. If it asks for anything new, the
+update is not installed. It is recorded as a `pendingUpdate` carrying the
+candidate version and the added permissions, shown in the Plugins settings
+screen and in `GET /api/v1/plugins`, and installed only after explicit approval:
+
+```bash
+curl -X POST http://tablet:8080/api/v1/plugins/my.reaplugin/update/approve
+```
+
+Trusting a repository is not the same as trusting a new permission, so this
+holds regardless of where the plugin came from.
+
 ## Plugin Lifecycle Management (REST API)
 
 Plugins can be managed via REST API:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/v1/plugins` | List all plugins (includes `loaded`, `autoLoad` fields) |
+| GET | `/api/v1/plugins` | List all plugins (includes `loaded`, `autoLoad`, `source`, `pendingUpdate` fields) |
 | POST | `/api/v1/plugins/:id/enable` | Load plugin + enable auto-load on startup |
 | POST | `/api/v1/plugins/:id/disable` | Unload plugin + disable auto-load |
 | PUT | `/api/v1/plugins/:id/source` | Create or overwrite `manifest.json` + `plugin.js` |
 | DELETE | `/api/v1/plugins/:id` | Remove plugin (unload + delete files) |
-| POST | `/api/v1/plugins/install` | Install from URL (not yet implemented) |
+| POST | `/api/v1/plugins/install` | Not supported (501); use the GitHub endpoints below |
+| POST | `/api/v1/plugins/install/github-release` | Install from a GitHub release asset |
+| POST | `/api/v1/plugins/install/github-branch` | Install from a GitHub branch |
+| POST | `/api/v1/plugins/update` | Check every GitHub-backed plugin for updates |
+| POST | `/api/v1/plugins/:id/update/approve` | Install an update that requests new permissions |
 | GET | `/api/v1/plugins/:id/settings` | Get plugin settings |
 | POST | `/api/v1/plugins/:id/settings` | Update plugin settings |
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -498,7 +498,9 @@ skin updates, and on demand from the Plugins settings screen or
 
 - an unchanged tag or commit only refreshes `lastChecked`;
 - a changed tag or commit is downloaded and validated before anything installed
-  is touched;
+  is touched. A branch is resolved to a commit first and that commit's archive
+  is what gets downloaded, so a branch that moves mid-check cannot install
+  contents the recorded SHA does not describe;
 - an update must carry the plugin being updated: a candidate whose manifest id
   differs from the installed plugin is rejected before anything is touched;
 - downgrade protection applies to release and branch updates alike: a lower

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -439,9 +439,9 @@ it in Decaid UI.
 
 ## Reference Implementation: DYE2 Plugin
 
-The DYE2 (Describe Your Espresso) plugin ships from its own repo, [allofmeng/dye2](https://github.com/allofmeng/dye2), as a release asset. CI and local setup install it by running `./scripts/fetch_dye2_plugin.sh`, which downloads a pinned release tag (`DYE2_VERSION` in the script), verifies its checksum (`DYE2_SHA256`) and manifest contract (`id`, `version`, `apiVersion`), and unpacks it into `assets/plugins/dye2.reaplugin/`. Bump the pinned version/checksum in a normal PR when DYE2 ships a new release.
+The DYE2 (Describe Your Espresso) plugin ships from its own repo, [decentespresso/dye2](https://github.com/decentespresso/dye2), as a release asset. CI and local setup install it by running `./scripts/fetch_dye2_plugin.sh`, which downloads a pinned release tag (`DYE2_VERSION` in the script), verifies its checksum (`DYE2_SHA256`) and manifest contract (`id`, `version`, `apiVersion`), and unpacks it into `assets/plugins/dye2.reaplugin/`. Bump the pinned version/checksum in a normal PR when DYE2 ships a new release.
 
-`packages/dye2-plugin/` still holds the plugin's original TypeScript + Vite source and is useful as a reference for advanced patterns (REST API client, HTML template rendering, Vite dev server — see `packages/dye2-plugin/README.md`), but it is **not** built or bundled by Decaid anymore and is not authoritative for what ships. Treat [allofmeng/dye2](https://github.com/allofmeng/dye2) as the source of truth for the DYE2 plugin; update `packages/dye2-plugin/` only if it's being kept in sync deliberately.
+`packages/dye2-plugin/` still holds the plugin's original TypeScript + Vite source and is useful as a reference for advanced patterns (REST API client, HTML template rendering, Vite dev server — see `packages/dye2-plugin/README.md`), but it is **not** built or bundled by Decaid anymore and is not authoritative for what ships. Treat [decentespresso/dye2](https://github.com/decentespresso/dye2) as the source of truth for the DYE2 plugin; update `packages/dye2-plugin/` only if it's being kept in sync deliberately.
 
 ## Distribution and Updates
 
@@ -508,6 +508,29 @@ skin updates, and on demand from the Plugins settings screen or
   running plugin is restarted on the new version; a disabled one stays disabled;
 - one plugin's failure never stops the others; the failure is recorded in
   `lastError`.
+
+### Bundled plugins
+
+A bundled plugin is copied out of the app at startup and stays the app-owned
+floor: a newer bundled version replaces an older installed copy, an equal or
+older one does not.
+
+Bundled plugins published from a GitHub repo also take part in normal update
+checks. `bundledPluginRepos` in `plugin_source_service.dart` maps the plugin id
+to its canonical repo - today `dye2.reaplugin` to
+[decentespresso/dye2](https://github.com/decentespresso/dye2) - and the first
+update check or visit to the Plugins screen seeds `.rea_source.json` for it as
+a `github_release` source tagged with the installed manifest version. Existing
+installs from before source tracking are seeded the same way, so DYE2 starts
+receiving releases without a reinstall. The seeder also realigns the recorded
+tag when a newer bundled copy has been laid down, and never touches metadata
+that points somewhere else, so a plugin the user pointed at their own fork or
+branch keeps that source.
+
+No asset name is recorded for a bundled seed: DYE2 names its release asset
+after the version (`dye2.reaplugin-<version>.zip`), so pinning today's name
+would break tomorrow's release. The installer picks the release's single
+`.zip`, and a release with several zip assets asks for an explicit choice.
 
 ### Permission escalation
 
@@ -592,7 +615,7 @@ The bundled **settings plugin** (`settings.reaplugin`) provides a web UI for plu
 
 ## Next Steps
 
-1. Review the example plugins in `assets/plugins/` and the DYE2 plugin at [allofmeng/dye2](https://github.com/allofmeng/dye2)
+1. Review the example plugins in `assets/plugins/` and the DYE2 plugin at [decentespresso/dye2](https://github.com/decentespresso/dye2)
 2. Start with a simple plugin that logs `stateUpdate` events
 3. Add settings and persistent storage
 4. Implement HTTP communication with external services

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -499,8 +499,11 @@ skin updates, and on demand from the Plugins settings screen or
 - an unchanged tag or commit only refreshes `lastChecked`;
 - a changed tag or commit is downloaded and validated before anything installed
   is touched;
-- downgrade protection still applies to release installs: a lower version is
-  rejected, and going back requires removing the plugin first;
+- an update must carry the plugin being updated: a candidate whose manifest id
+  differs from the installed plugin is rejected before anything is touched;
+- downgrade protection applies to release and branch updates alike: a lower
+  version is rejected, and going back requires removing the plugin first. A
+  moved branch whose manifest version is unchanged still updates;
 - the swap is transactional. The plugin is unloaded only once the replacement is
   ready, and a failed copy or a failed reload restores the previous files,
   manifest and running plugin;
@@ -543,6 +546,17 @@ screen and in `GET /api/v1/plugins`, and installed only after explicit approval:
 ```bash
 curl -X POST http://tablet:8080/api/v1/plugins/my.reaplugin/update/approve
 ```
+
+Approval is bound to the exact candidate that was reviewed. The pending release
+tag or commit is the fetch target, not "whatever is latest now", and the fetched
+candidate is revalidated - same plugin id, same version, no permission beyond
+the approved ones - before anything is installed. A source that moved between
+detection and approval is refused with a 409, the new candidate is recorded as
+the pending update, and its delta has to be approved in turn.
+
+A pending update the app has already overtaken is cleared: when a newer bundled
+copy lands at or above the pending version, the stale approval prompt goes away.
+A genuinely newer pending update is kept.
 
 Trusting a repository is not the same as trusting a new permission, so this
 holds regardless of where the plugin came from.

--- a/doc/plans/archive/plugin-distribution/plugin-distribution-parity.md
+++ b/doc/plans/archive/plugin-distribution/plugin-distribution-parity.md
@@ -1,0 +1,142 @@
+# Plugin distribution parity with WebUI skins (issue 626)
+
+## Goal
+
+Plugins gain the same managed distribution model WebUI skins already have:
+install from a GitHub release, a GitHub branch, a local ZIP or a local folder,
+with provenance recorded for the GitHub-backed sources and automatic update
+checks on the existing update cadence. Permission escalation never installs
+unattended.
+
+## Layering
+
+```
+PluginManager            execution + permissions (unchanged)
+PluginLoaderService      storage, lifecycle, locks, staged swap, rollback
+PluginSourceService      provenance, GitHub fetch, update checks, approvals   <- new
+PluginsHandler / UI      transport
+```
+
+`PluginSourceService` owns nothing about execution. It stages a candidate on
+disk, validates it, decides whether the update may proceed, and hands the
+staged directory to `PluginLoaderService`, which performs the mutation under
+the existing per-plugin lock.
+
+## Package validation (`plugin_package.dart`)
+
+One validation path for every source. A staged directory is resolved to a
+single plugin root, then checked:
+
+- exactly one plugin root: either the staged directory itself contains
+  `manifest.json`, or exactly one immediate subdirectory does (GitHub archives
+  and release ZIPs wrap their content in one directory). More than one
+  candidate root is ambiguous and rejected rather than guessed.
+- `manifest.json` and `plugin.js` both present.
+- the manifest parses through `PluginManifest`.
+- the manifest id passes `isSafePathComponent`.
+
+Validation happens before any mutation of the installed plugin.
+
+## Transactional package install
+
+`PluginLoaderService.installPluginPackage(stagedDir)` replaces the guts of
+`addPlugin`:
+
+1. take the per-plugin mutation lock;
+2. reject downgrades through the existing `comparePluginVersions` policy;
+3. record loaded state, unload if loaded;
+4. rename the installed directory aside, copy the staged tree into place;
+5. reload if it was loaded;
+6. on any failure restore the renamed directory, the manifest cache and the
+   running plugin, then rethrow.
+
+`addPlugin` keeps its signature and delegates, so the folder-snapshot path in
+`PluginsSettingsView` and existing callers are unchanged. Settings and the
+auto-load preference live in `SharedPreferences` and are untouched by a package
+swap.
+
+## Provenance storage
+
+Source metadata is a Decaid-owned `.rea_source.json` inside the plugin
+directory - the same shape of decision as WebUI's `.rea_metadata.json`.
+Consequences that make this the cheap choice:
+
+- `removePlugin` deletes the directory, so removal clears the metadata with no
+  extra wiring or removal callbacks;
+- a package install writes the file after the swap, so it always describes the
+  content actually installed;
+- `updatePluginSource` (the REST source PUT) is a partial write of
+  `manifest.json` + `plugin.js`, so it leaves provenance alone.
+
+Recorded fields: source kind, `owner/repo`, branch, resolved commit, release
+tag, asset name, prerelease flag, `installedAt`, `lastChecked`, and a pending
+update block when an update is held back for permission approval.
+
+Local ZIP and folder installs write no metadata: they are untracked snapshots
+and never auto-update.
+
+## GitHub sources
+
+- **Release.** `GET /repos/{repo}/releases/latest`, or `/releases` when
+  prereleases are allowed. The tag must be `X.Y.Z` or `vX.Y.Z` and must equal
+  the manifest version after stripping the optional `v`. Assets: an explicit
+  asset name selects; otherwise exactly one `.zip` asset must exist - several
+  ZIP assets are an error asking for an explicit selection, not a guess.
+- **Branch.** `GET /repos/{repo}/commits/{branch}` resolves the head SHA, then
+  the branch archive is downloaded. The SHA is the update signal, so a branch
+  install updates even when `manifest.version` never changes.
+
+ZIP extraction reuses `extractArchiveToDirectory` from
+`webui_support/webui_zip_support.dart` (a pure, hardened helper - reusing it is
+not a coupling to WebUI storage). Extraction always targets a temporary
+staging directory, never the installed plugin directory.
+
+## Permission escalation
+
+The candidate's permission set is compared with the installed manifest's:
+
+- same or a strict subset: an automatic update may proceed;
+- anything added: the update is not installed. The pending block records the
+  candidate version/revision and the added permissions, and the plugin is
+  reported as approval-required until the user approves it, at which point the
+  same install path runs with the escalation accepted.
+
+A user-initiated install (UI or REST) is itself the approval, so the gate
+applies to automatic updates and to approving a recorded pending update.
+
+## Update checking
+
+`PluginSourceService.updateAllPlugins()` mirrors `WebUIStorage.updateAllSkins()`
+and is called from `UpdateCheckService` beside the skin update, on the existing
+timer. Per plugin: compare the tracked release tag or commit; unchanged means
+only `lastChecked` moves; changed means download, validate, apply the
+permission gate, then install or record a pending update. One plugin's failure
+is logged and never aborts the loop.
+
+## REST API
+
+Named to match the skin endpoints:
+
+| Method | Path |
+|--------|------|
+| POST | `/api/v1/plugins/install/github-release` |
+| POST | `/api/v1/plugins/install/github-branch` |
+| POST | `/api/v1/plugins/update` |
+| POST | `/api/v1/plugins/{id}/update/approve` |
+
+`GET /api/v1/plugins` gains a `source` block and a `pendingUpdate` block. No
+plugin settings values are exposed. The existing unimplemented
+`POST /api/v1/plugins/install` URL stub stays a 501 that points at the explicit
+endpoints; arbitrary remote ZIP URLs remain out of scope.
+
+## Native UI
+
+The install button becomes a menu: GitHub Release, GitHub Branch, ZIP file,
+Folder snapshot. The plugin card gains a compact source/state line and a
+`Check for updates` action. An approval-required plugin shows the added
+permissions and installs only after explicit confirmation.
+
+## Out of scope
+
+Bundled plugins keep the app-owned startup copy path. Arbitrary remote ZIP URL
+installation is not added.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,7 @@ import 'package:reaprime/src/controllers/workflow_device_sync.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/plugins/plugin_source_service.dart';
 import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/services/wifi/wifi_scale_discovery_service.dart';
 import 'package:reaprime/src/services/database/database.dart' hide Workflow;
@@ -435,6 +436,7 @@ void main(List<String> args) async {
   final updateCheckService = UpdateCheckService(
     settingsService: SharedPreferencesSettingsService(),
     webUIStorage: webUIStorage,
+    pluginSourceService: PluginSourceService(pluginService),
   );
 
   final macosUpdater = Platform.isMacOS ? MacOSUpdater() : null;

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/services/storage/kv_store_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_package.dart';
 import 'package:reaprime/src/plugins/plugin_runtime.dart';
 import 'package:reaprime/src/plugins/plugin_version.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart'
@@ -41,6 +42,7 @@ class PluginLoaderService {
   static const _maxConsecutiveLoadFailures = 3;
   static const _loadingPluginKey = 'plugin.watchdog.loading';
   static const _stagingSuffix = '.staged';
+  static const _backupSuffix = '.previous';
 
   final PluginManager pluginManager;
   final CredentialStore? _credentialStore;
@@ -116,55 +118,81 @@ class PluginLoaderService {
   }
 
   Future<void> addPlugin(String sourcePath) async {
-    final source = File(sourcePath);
-    final sourceDir = Directory(sourcePath);
-
-    Directory sourceDirectory;
-    File manifestFile;
-
-    if (source.existsSync()) {
+    if (File(sourcePath).existsSync()) {
       throw Exception(
         'File-based plugin installation not yet implemented. Please provide a directory path.',
       );
-    } else if (sourceDir.existsSync()) {
-      sourceDirectory = sourceDir;
-      manifestFile = File('${sourceDirectory.path}/manifest.json');
-      if (!manifestFile.existsSync()) {
-        throw Exception('manifest.json not found in plugin directory');
-      }
-    } else {
+    }
+    final sourceDir = Directory(sourcePath);
+    if (!sourceDir.existsSync()) {
       throw Exception('Source does not exist: $sourcePath');
     }
 
-    final manifestJson = jsonDecode(await manifestFile.readAsString());
-    final manifest = PluginManifest.fromJson(manifestJson);
+    await installPluginPackage(sourceDir);
+  }
 
-    if (!isSafePathComponent(manifest.id)) {
-      throw FormatException(
-        'Unsafe plugin id "${manifest.id}": must be a single safe path component',
-      );
-    }
+  Future<PluginManifest> installPluginPackage(
+    Directory stagedDir, {
+    bool allowDowngrade = false,
+  }) async {
+    final package = resolvePluginPackage(stagedDir);
+    final manifest = package.manifest;
+    final pluginId = manifest.id;
 
-    return _withPluginMutationLock(manifest.id, () async {
+    return _withPluginMutationLock(pluginId, () async {
       _ensureActive();
-      _ensureNotDowngrade(manifest);
+      if (!allowDowngrade) _ensureNotDowngrade(manifest);
 
-      final pluginDir = Directory('${_pluginsDir.path}/${manifest.id}');
-      if (pluginDir.existsSync()) {
-        if (isPluginLoaded(manifest.id)) {
-          await _unloadPlugin(manifest.id);
-        }
-        await pluginDir.delete(recursive: true);
-        _log.info('Replacing existing plugin: ${manifest.id}');
+      final pluginDir = Directory('${_pluginsDir.path}/$pluginId');
+      final backupDir = Directory('${pluginDir.path}$_backupSuffix');
+      final previousManifest = _availablePluginsCache[pluginId];
+      final wasLoaded = isPluginLoaded(pluginId);
+
+      if (wasLoaded) {
+        await _unloadPlugin(pluginId);
       }
 
-      pluginDir.createSync(recursive: true);
+      if (backupDir.existsSync()) backupDir.deleteSync(recursive: true);
+      final hadPrevious = pluginDir.existsSync();
+      if (hadPrevious) pluginDir.renameSync(backupDir.path);
 
-      await _copyDirectory(sourceDirectory, pluginDir);
+      try {
+        pluginDir.createSync(recursive: true);
+        await _copyDirectory(package.root, pluginDir);
+        _availablePluginsCache[pluginId] = manifest;
 
-      _availablePluginsCache[manifest.id] = manifest;
+        if (wasLoaded) {
+          await _queuedLoad(pluginId);
+        }
+      } catch (e) {
+        _log.warning('Rolling back failed install of plugin $pluginId', e);
+        if (pluginDir.existsSync()) pluginDir.deleteSync(recursive: true);
+        if (hadPrevious) {
+          backupDir.renameSync(pluginDir.path);
+          if (previousManifest == null) {
+            _availablePluginsCache.remove(pluginId);
+          } else {
+            _availablePluginsCache[pluginId] = previousManifest;
+            if (wasLoaded) {
+              try {
+                await _queuedLoad(pluginId);
+              } catch (e2) {
+                _log.warning(
+                  'Failed to reload previous version of plugin $pluginId',
+                  e2,
+                );
+              }
+            }
+          }
+        } else {
+          _availablePluginsCache.remove(pluginId);
+        }
+        rethrow;
+      }
 
-      _log.info('Plugin installed: ${manifest.id}');
+      if (backupDir.existsSync()) backupDir.deleteSync(recursive: true);
+      _log.info('Plugin installed: $pluginId (${manifest.version})');
+      return manifest;
     });
   }
 

--- a/lib/src/plugins/plugin_package.dart
+++ b/lib/src/plugins/plugin_package.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/util/safe_path.dart';
+
+class PluginPackageException implements FormatException {
+  @override
+  final String message;
+
+  PluginPackageException(this.message);
+
+  @override
+  int? get offset => null;
+
+  @override
+  dynamic get source => null;
+
+  @override
+  String toString() => message;
+}
+
+class PluginPackage {
+  final Directory root;
+  final PluginManifest manifest;
+  final Map<String, dynamic> manifestJson;
+
+  const PluginPackage({
+    required this.root,
+    required this.manifest,
+    required this.manifestJson,
+  });
+}
+
+const _manifestName = 'manifest.json';
+const _sourceName = 'plugin.js';
+
+PluginPackage resolvePluginPackage(Directory staged) {
+  if (!staged.existsSync()) {
+    throw PluginPackageException('Plugin package not found: ${staged.path}');
+  }
+
+  final root = _resolveRoot(staged);
+
+  if (!File('${root.path}/$_sourceName').existsSync()) {
+    throw PluginPackageException('Plugin package has no $_sourceName');
+  }
+
+  final Map<String, dynamic> manifestJson;
+  try {
+    manifestJson =
+        jsonDecode(File('${root.path}/$_manifestName').readAsStringSync())
+            as Map<String, dynamic>;
+  } catch (e) {
+    throw PluginPackageException('Invalid $_manifestName: $e');
+  }
+
+  final PluginManifest manifest;
+  try {
+    manifest = PluginManifest.fromJson(manifestJson);
+  } catch (e) {
+    throw PluginPackageException('Invalid $_manifestName: $e');
+  }
+
+  if (!isSafePathComponent(manifest.id)) {
+    throw PluginPackageException(
+      'Unsafe plugin id "${manifest.id}": must be a single safe path component',
+    );
+  }
+
+  return PluginPackage(
+    root: root,
+    manifest: manifest,
+    manifestJson: manifestJson,
+  );
+}
+
+Directory _resolveRoot(Directory staged) {
+  if (File('${staged.path}/$_manifestName').existsSync()) return staged;
+
+  final candidates = staged
+      .listSync()
+      .whereType<Directory>()
+      .where((dir) => File('${dir.path}/$_manifestName').existsSync())
+      .toList();
+
+  if (candidates.length == 1) return candidates.single;
+  if (candidates.isEmpty) {
+    throw PluginPackageException('Plugin package has no $_manifestName');
+  }
+  throw PluginPackageException(
+    'Plugin package has ${candidates.length} plugin roots; '
+    'expected exactly one',
+  );
+}

--- a/lib/src/plugins/plugin_source.dart
+++ b/lib/src/plugins/plugin_source.dart
@@ -1,0 +1,150 @@
+enum PluginSourceKind {
+  githubRelease('github_release'),
+  githubBranch('github_branch'),
+  localZip('local_zip'),
+  localFolder('local_folder');
+
+  final String wireName;
+
+  const PluginSourceKind(this.wireName);
+
+  static PluginSourceKind? fromWireName(String? value) {
+    for (final kind in PluginSourceKind.values) {
+      if (kind.wireName == value) return kind;
+    }
+    return null;
+  }
+
+  bool get isManaged =>
+      this == PluginSourceKind.githubRelease ||
+      this == PluginSourceKind.githubBranch;
+}
+
+class PluginPendingUpdate {
+  final String version;
+  final String? releaseTag;
+  final String? commit;
+  final List<String> addedPermissions;
+  final DateTime detectedAt;
+
+  const PluginPendingUpdate({
+    required this.version,
+    this.releaseTag,
+    this.commit,
+    required this.addedPermissions,
+    required this.detectedAt,
+  });
+
+  factory PluginPendingUpdate.fromJson(Map<String, dynamic> json) {
+    return PluginPendingUpdate(
+      version: json['version'] as String,
+      releaseTag: json['releaseTag'] as String?,
+      commit: json['commit'] as String?,
+      addedPermissions: ((json['addedPermissions'] as List?) ?? [])
+          .cast<String>(),
+      detectedAt: DateTime.parse(json['detectedAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'version': version,
+    'releaseTag': releaseTag,
+    'commit': commit,
+    'addedPermissions': addedPermissions,
+    'detectedAt': detectedAt.toIso8601String(),
+  };
+}
+
+class PluginSource {
+  final PluginSourceKind kind;
+  final String? repo;
+  final String? branch;
+  final String? commit;
+  final String? releaseTag;
+  final String? assetName;
+  final bool includePrerelease;
+  final DateTime installedAt;
+  final DateTime? lastChecked;
+  final String? lastError;
+  final PluginPendingUpdate? pendingUpdate;
+
+  const PluginSource({
+    required this.kind,
+    this.repo,
+    this.branch,
+    this.commit,
+    this.releaseTag,
+    this.assetName,
+    this.includePrerelease = false,
+    required this.installedAt,
+    this.lastChecked,
+    this.lastError,
+    this.pendingUpdate,
+  });
+
+  factory PluginSource.fromJson(Map<String, dynamic> json) {
+    final kind = PluginSourceKind.fromWireName(json['kind'] as String?);
+    if (kind == null) {
+      throw FormatException('Unknown plugin source kind: ${json['kind']}');
+    }
+    return PluginSource(
+      kind: kind,
+      repo: json['repo'] as String?,
+      branch: json['branch'] as String?,
+      commit: json['commit'] as String?,
+      releaseTag: json['releaseTag'] as String?,
+      assetName: json['assetName'] as String?,
+      includePrerelease: json['includePrerelease'] as bool? ?? false,
+      installedAt: DateTime.parse(json['installedAt'] as String),
+      lastChecked: json['lastChecked'] != null
+          ? DateTime.parse(json['lastChecked'] as String)
+          : null,
+      lastError: json['lastError'] as String?,
+      pendingUpdate: json['pendingUpdate'] != null
+          ? PluginPendingUpdate.fromJson(
+              json['pendingUpdate'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'kind': kind.wireName,
+    'repo': repo,
+    'branch': branch,
+    'commit': commit,
+    'releaseTag': releaseTag,
+    'assetName': assetName,
+    'includePrerelease': includePrerelease,
+    'installedAt': installedAt.toIso8601String(),
+    'lastChecked': lastChecked?.toIso8601String(),
+    'lastError': lastError,
+    'pendingUpdate': pendingUpdate?.toJson(),
+  };
+
+  PluginSource copyWith({
+    String? commit,
+    String? releaseTag,
+    DateTime? lastChecked,
+    String? lastError,
+    PluginPendingUpdate? pendingUpdate,
+    bool clearLastError = false,
+    bool clearPendingUpdate = false,
+  }) {
+    return PluginSource(
+      kind: kind,
+      repo: repo,
+      branch: branch,
+      commit: commit ?? this.commit,
+      releaseTag: releaseTag ?? this.releaseTag,
+      assetName: assetName,
+      includePrerelease: includePrerelease,
+      installedAt: installedAt,
+      lastChecked: lastChecked ?? this.lastChecked,
+      lastError: clearLastError ? null : (lastError ?? this.lastError),
+      pendingUpdate: clearPendingUpdate
+          ? null
+          : (pendingUpdate ?? this.pendingUpdate),
+    );
+  }
+}

--- a/lib/src/plugins/plugin_source_service.dart
+++ b/lib/src/plugins/plugin_source_service.dart
@@ -7,6 +7,7 @@ import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_package.dart';
 import 'package:reaprime/src/plugins/plugin_source.dart';
+import 'package:reaprime/src/plugins/plugin_version.dart';
 import 'package:reaprime/src/util/github_archive.dart';
 import 'package:reaprime/src/webui_support/webui_zip_support.dart';
 
@@ -145,13 +146,9 @@ class PluginSourceService {
 
   Future<PluginManifest> _install(
     PluginPackage package,
-    PluginSource source, {
-    bool allowDowngrade = false,
-  }) async {
-    final manifest = await _loader.installPluginPackage(
-      package.root,
-      allowDowngrade: allowDowngrade,
-    );
+    PluginSource source,
+  ) async {
+    final manifest = await _loader.installPluginPackage(package.root);
     _writeSource(manifest.id, source);
     return manifest;
   }
@@ -190,9 +187,21 @@ class PluginSourceService {
       final isBundledSource =
           existing.kind == PluginSourceKind.githubRelease &&
           existing.repo == repo;
-      if (!isBundledSource || existing.releaseTag == tag) continue;
+      if (!isBundledSource) continue;
 
-      _writeSource(pluginId, existing.copyWith(releaseTag: tag));
+      final pending = existing.pendingUpdate;
+      final pendingSatisfied =
+          pending != null &&
+          comparePluginVersions(manifest.version, pending.version) >= 0;
+      if (existing.releaseTag == tag && !pendingSatisfied) continue;
+
+      _writeSource(
+        pluginId,
+        existing.copyWith(
+          releaseTag: tag,
+          clearPendingUpdate: pendingSatisfied,
+        ),
+      );
       _log.info('Realigned bundled plugin source: $pluginId at $tag');
     }
   }
@@ -334,29 +343,133 @@ class PluginSourceService {
           installedAt: now,
           lastChecked: now,
         ),
-        allowDowngrade: true,
       );
     });
   }
 
   Future<PluginManifest> approvePendingUpdate(String pluginId) async {
     final source = sourceFor(pluginId);
-    if (source == null || source.pendingUpdate == null) {
+    final pending = source?.pendingUpdate;
+    final installed = _loader.getPluginManifest(pluginId);
+    if (source == null || pending == null || installed == null) {
       throw PluginApprovalRequiredException(
         'Plugin $pluginId has no update awaiting approval',
       );
     }
 
     if (source.kind == PluginSourceKind.githubRelease) {
-      return installFromGitHubRelease(
-        source.repo!,
-        assetName: source.assetName,
-        includePrerelease: source.includePrerelease,
+      final tag = pending.releaseTag;
+      if (tag == null) {
+        throw PluginApprovalRequiredException(
+          'Approved update of $pluginId records no release tag',
+        );
+      }
+
+      final release = await fetchGitHubReleaseByTag(source.repo!, tag);
+      final asset = _selectReleaseAsset(release, source.assetName);
+      final bytes = await downloadGitHubArchive(asset.downloadUrl);
+
+      return _withStaging((staging) async {
+        _extractArchive(bytes, staging);
+        final package = resolvePluginPackage(staging);
+        _requireSamePlugin(installed, package);
+        _requireTagMatchesManifest(release.tag, package.manifest.version);
+        _requireApprovedCandidate(
+          installed,
+          source,
+          pending,
+          package,
+          releaseTag: release.tag,
+        );
+
+        final now = DateTime.now();
+        return _install(
+          package,
+          PluginSource(
+            kind: PluginSourceKind.githubRelease,
+            repo: source.repo,
+            releaseTag: release.tag,
+            assetName: source.assetName,
+            includePrerelease: source.includePrerelease,
+            installedAt: now,
+            lastChecked: now,
+          ),
+        );
+      });
+    }
+
+    final commit = pending.commit;
+    if (commit == null) {
+      throw PluginApprovalRequiredException(
+        'Approved update of $pluginId records no commit',
       );
     }
-    return installFromGitHubBranch(
-      source.repo!,
-      branch: source.branch ?? 'main',
+
+    final bytes = await downloadGitHubArchive(
+      gitHubCommitArchiveUrl(source.repo!, commit),
+    );
+
+    return _withStaging((staging) async {
+      _extractArchive(bytes, staging);
+      final package = resolvePluginPackage(staging);
+      _requireSamePlugin(installed, package);
+      _requireApprovedCandidate(
+        installed,
+        source,
+        pending,
+        package,
+        commit: commit,
+      );
+
+      final now = DateTime.now();
+      return _install(
+        package,
+        PluginSource(
+          kind: PluginSourceKind.githubBranch,
+          repo: source.repo,
+          branch: source.branch ?? 'main',
+          commit: commit,
+          installedAt: now,
+          lastChecked: now,
+        ),
+      );
+    });
+  }
+
+  /// Rejects a candidate that is not the one whose permission delta the user
+  /// approved, and records the candidate as the new pending update so the
+  /// fresh delta is what gets reviewed next.
+  void _requireApprovedCandidate(
+    PluginManifest installed,
+    PluginSource source,
+    PluginPendingUpdate approved,
+    PluginPackage package, {
+    String? releaseTag,
+    String? commit,
+  }) {
+    final added = _addedPermissions(installed, package.manifest);
+    final unapproved = added
+        .where((p) => !approved.addedPermissions.contains(p))
+        .toList();
+    if (package.manifest.version == approved.version && unapproved.isEmpty) {
+      return;
+    }
+
+    _writeSource(
+      installed.id,
+      source.copyWith(
+        pendingUpdate: PluginPendingUpdate(
+          version: package.manifest.version,
+          releaseTag: releaseTag,
+          commit: commit,
+          addedPermissions: added,
+          detectedAt: DateTime.now(),
+        ),
+      ),
+    );
+    throw PluginApprovalRequiredException(
+      'Update of ${installed.id} changed since it was approved '
+      '(${approved.version} -> ${package.manifest.version}); approve again',
     );
   }
 

--- a/lib/src/plugins/plugin_source_service.dart
+++ b/lib/src/plugins/plugin_source_service.dart
@@ -20,6 +20,13 @@ class PluginApprovalRequiredException implements Exception {
 
 final _releaseTagPattern = RegExp(r'^v?\d+\.\d+\.\d+$');
 
+/// GitHub repositories the bundled plugins are published from. A bundled copy
+/// is the app-owned floor; this table lets an installed copy keep receiving
+/// releases from its canonical repo.
+const bundledPluginRepos = <String, String>{
+  'dye2.reaplugin': 'decentespresso/dye2',
+};
+
 class PluginSourceService {
   static const metadataFileName = '.rea_source.json';
 
@@ -149,8 +156,50 @@ class PluginSourceService {
     return manifest;
   }
 
+  /// Gives a bundled plugin the provenance of the repo it is published from,
+  /// so it takes part in update checks like any other release-backed plugin.
+  ///
+  /// Seeds a plugin that has no metadata yet - a fresh install, or an existing
+  /// one from before source tracking - and keeps the recorded tag in step with
+  /// the installed manifest version when the bundled copy has moved. Metadata
+  /// pointing somewhere else is left alone.
+  void seedBundledSources() {
+    for (final entry in bundledPluginRepos.entries) {
+      final pluginId = entry.key;
+      final repo = entry.value;
+      final manifest = _loader.getPluginManifest(pluginId);
+      if (manifest == null) continue;
+
+      final existing = sourceFor(pluginId);
+      final tag = 'v${manifest.version}';
+
+      if (existing == null) {
+        _writeSource(
+          pluginId,
+          PluginSource(
+            kind: PluginSourceKind.githubRelease,
+            repo: repo,
+            releaseTag: tag,
+            installedAt: DateTime.now(),
+          ),
+        );
+        _log.info('Seeded bundled plugin source: $pluginId from $repo');
+        continue;
+      }
+
+      final isBundledSource =
+          existing.kind == PluginSourceKind.githubRelease &&
+          existing.repo == repo;
+      if (!isBundledSource || existing.releaseTag == tag) continue;
+
+      _writeSource(pluginId, existing.copyWith(releaseTag: tag));
+      _log.info('Realigned bundled plugin source: $pluginId at $tag');
+    }
+  }
+
   Future<void> updateAllPlugins() async {
     _log.info('Starting update check for managed plugins');
+    seedBundledSources();
 
     for (final manifest in _loader.availablePlugins) {
       final source = sourceFor(manifest.id);
@@ -194,6 +243,7 @@ class PluginSourceService {
       await _withStaging((staging) async {
         _extractArchive(bytes, staging);
         final package = resolvePluginPackage(staging);
+        _requireSamePlugin(installed, package);
         _requireTagMatchesManifest(release.tag, package.manifest.version);
 
         final added = _addedPermissions(installed, package.manifest);
@@ -250,6 +300,7 @@ class PluginSourceService {
     await _withStaging((staging) async {
       _extractArchive(bytes, staging);
       final package = resolvePluginPackage(staging);
+      _requireSamePlugin(installed, package);
 
       final added = _addedPermissions(installed, package.manifest);
       if (added.isNotEmpty) {
@@ -306,6 +357,13 @@ class PluginSourceService {
     return installFromGitHubBranch(
       source.repo!,
       branch: source.branch ?? 'main',
+    );
+  }
+
+  void _requireSamePlugin(PluginManifest installed, PluginPackage package) {
+    if (package.manifest.id == installed.id) return;
+    throw PluginPackageException(
+      'Update for ${installed.id} carries plugin "${package.manifest.id}"',
     );
   }
 

--- a/lib/src/plugins/plugin_source_service.dart
+++ b/lib/src/plugins/plugin_source_service.dart
@@ -1,0 +1,383 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_package.dart';
+import 'package:reaprime/src/plugins/plugin_source.dart';
+import 'package:reaprime/src/util/github_archive.dart';
+import 'package:reaprime/src/webui_support/webui_zip_support.dart';
+
+class PluginApprovalRequiredException implements Exception {
+  final String message;
+  PluginApprovalRequiredException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+final _releaseTagPattern = RegExp(r'^v?\d+\.\d+\.\d+$');
+
+class PluginSourceService {
+  static const metadataFileName = '.rea_source.json';
+
+  final PluginLoaderService _loader;
+  final _log = Logger('PluginSourceService');
+
+  PluginSourceService(this._loader);
+
+  PluginSource? sourceFor(String pluginId) {
+    try {
+      final file = File(
+        '${_loader.getPluginDirectory(pluginId)}/$metadataFileName',
+      );
+      if (!file.existsSync()) return null;
+      return PluginSource.fromJson(
+        jsonDecode(file.readAsStringSync()) as Map<String, dynamic>,
+      );
+    } catch (e) {
+      _log.fine('No readable source metadata for $pluginId: $e');
+      return null;
+    }
+  }
+
+  void _writeSource(String pluginId, PluginSource source) {
+    File(
+      '${_loader.getPluginDirectory(pluginId)}/$metadataFileName',
+    ).writeAsStringSync(jsonEncode(source.toJson()));
+  }
+
+  Future<PluginManifest> installFromGitHubRelease(
+    String repo, {
+    String? assetName,
+    bool includePrerelease = false,
+  }) async {
+    final release = await fetchLatestGitHubRelease(
+      repo,
+      includePrerelease: includePrerelease,
+    );
+    final asset = _selectReleaseAsset(release, assetName);
+    final bytes = await downloadGitHubArchive(asset.downloadUrl);
+
+    return _withStaging((staging) async {
+      _extractArchive(bytes, staging);
+      final package = resolvePluginPackage(staging);
+      _requireTagMatchesManifest(release.tag, package.manifest.version);
+
+      final now = DateTime.now();
+      return _install(
+        package,
+        PluginSource(
+          kind: PluginSourceKind.githubRelease,
+          repo: repo,
+          releaseTag: release.tag,
+          assetName: assetName,
+          includePrerelease: includePrerelease,
+          installedAt: now,
+          lastChecked: now,
+        ),
+      );
+    });
+  }
+
+  Future<PluginManifest> installFromGitHubBranch(
+    String repo, {
+    String branch = 'main',
+  }) async {
+    final commit = await fetchGitHubBranchCommit(repo, branch);
+    final bytes = await downloadGitHubArchive(
+      gitHubBranchArchiveUrl(repo, branch),
+    );
+
+    return _withStaging((staging) async {
+      _extractArchive(bytes, staging);
+      final package = resolvePluginPackage(staging);
+
+      final now = DateTime.now();
+      return _install(
+        package,
+        PluginSource(
+          kind: PluginSourceKind.githubBranch,
+          repo: repo,
+          branch: branch,
+          commit: commit,
+          installedAt: now,
+          lastChecked: now,
+        ),
+      );
+    });
+  }
+
+  Future<PluginManifest> installFromZip(String zipPath) async {
+    final bytes = await File(zipPath).readAsBytes();
+    return _withStaging((staging) async {
+      _extractArchive(bytes, staging);
+      final package = resolvePluginPackage(staging);
+      return _install(
+        package,
+        PluginSource(
+          kind: PluginSourceKind.localZip,
+          installedAt: DateTime.now(),
+        ),
+      );
+    });
+  }
+
+  Future<PluginManifest> installFromFolder(String folderPath) async {
+    final package = resolvePluginPackage(Directory(folderPath));
+    return _install(
+      package,
+      PluginSource(
+        kind: PluginSourceKind.localFolder,
+        installedAt: DateTime.now(),
+      ),
+    );
+  }
+
+  Future<PluginManifest> _install(
+    PluginPackage package,
+    PluginSource source, {
+    bool allowDowngrade = false,
+  }) async {
+    final manifest = await _loader.installPluginPackage(
+      package.root,
+      allowDowngrade: allowDowngrade,
+    );
+    _writeSource(manifest.id, source);
+    return manifest;
+  }
+
+  Future<void> updateAllPlugins() async {
+    _log.info('Starting update check for managed plugins');
+
+    for (final manifest in _loader.availablePlugins) {
+      final source = sourceFor(manifest.id);
+      if (source == null || !source.kind.isManaged) continue;
+
+      try {
+        await _updatePlugin(manifest, source);
+      } catch (e, st) {
+        _log.warning('Failed to update plugin "${manifest.id}"', e, st);
+        _writeSource(
+          manifest.id,
+          source.copyWith(lastChecked: DateTime.now(), lastError: '$e'),
+        );
+      }
+    }
+
+    _log.info('Finished update check for managed plugins');
+  }
+
+  Future<void> _updatePlugin(
+    PluginManifest installed,
+    PluginSource source,
+  ) async {
+    final now = DateTime.now();
+
+    if (source.kind == PluginSourceKind.githubRelease) {
+      final release = await fetchLatestGitHubRelease(
+        source.repo!,
+        includePrerelease: source.includePrerelease,
+      );
+      if (release.tag == source.releaseTag) {
+        _writeSource(
+          installed.id,
+          source.copyWith(lastChecked: now, clearLastError: true),
+        );
+        return;
+      }
+
+      final asset = _selectReleaseAsset(release, source.assetName);
+      final bytes = await downloadGitHubArchive(asset.downloadUrl);
+      await _withStaging((staging) async {
+        _extractArchive(bytes, staging);
+        final package = resolvePluginPackage(staging);
+        _requireTagMatchesManifest(release.tag, package.manifest.version);
+
+        final added = _addedPermissions(installed, package.manifest);
+        if (added.isNotEmpty) {
+          _log.info(
+            'Update of ${installed.id} to ${release.tag} needs approval for: '
+            '${added.join(', ')}',
+          );
+          _writeSource(
+            installed.id,
+            source.copyWith(
+              lastChecked: now,
+              clearLastError: true,
+              pendingUpdate: PluginPendingUpdate(
+                version: package.manifest.version,
+                releaseTag: release.tag,
+                addedPermissions: added,
+                detectedAt: now,
+              ),
+            ),
+          );
+          return;
+        }
+
+        await _install(
+          package,
+          PluginSource(
+            kind: PluginSourceKind.githubRelease,
+            repo: source.repo,
+            releaseTag: release.tag,
+            assetName: source.assetName,
+            includePrerelease: source.includePrerelease,
+            installedAt: now,
+            lastChecked: now,
+          ),
+        );
+      });
+      return;
+    }
+
+    final branch = source.branch ?? 'main';
+    final commit = await fetchGitHubBranchCommit(source.repo!, branch);
+    if (commit == source.commit) {
+      _writeSource(
+        installed.id,
+        source.copyWith(lastChecked: now, clearLastError: true),
+      );
+      return;
+    }
+
+    final bytes = await downloadGitHubArchive(
+      gitHubBranchArchiveUrl(source.repo!, branch),
+    );
+    await _withStaging((staging) async {
+      _extractArchive(bytes, staging);
+      final package = resolvePluginPackage(staging);
+
+      final added = _addedPermissions(installed, package.manifest);
+      if (added.isNotEmpty) {
+        _log.info(
+          'Update of ${installed.id} to $commit needs approval for: '
+          '${added.join(', ')}',
+        );
+        _writeSource(
+          installed.id,
+          source.copyWith(
+            lastChecked: now,
+            clearLastError: true,
+            pendingUpdate: PluginPendingUpdate(
+              version: package.manifest.version,
+              commit: commit,
+              addedPermissions: added,
+              detectedAt: now,
+            ),
+          ),
+        );
+        return;
+      }
+
+      await _install(
+        package,
+        PluginSource(
+          kind: PluginSourceKind.githubBranch,
+          repo: source.repo,
+          branch: branch,
+          commit: commit,
+          installedAt: now,
+          lastChecked: now,
+        ),
+        allowDowngrade: true,
+      );
+    });
+  }
+
+  Future<PluginManifest> approvePendingUpdate(String pluginId) async {
+    final source = sourceFor(pluginId);
+    if (source == null || source.pendingUpdate == null) {
+      throw PluginApprovalRequiredException(
+        'Plugin $pluginId has no update awaiting approval',
+      );
+    }
+
+    if (source.kind == PluginSourceKind.githubRelease) {
+      return installFromGitHubRelease(
+        source.repo!,
+        assetName: source.assetName,
+        includePrerelease: source.includePrerelease,
+      );
+    }
+    return installFromGitHubBranch(
+      source.repo!,
+      branch: source.branch ?? 'main',
+    );
+  }
+
+  List<String> _addedPermissions(
+    PluginManifest installed,
+    PluginManifest candidate,
+  ) {
+    final added = candidate.permissions.difference(installed.permissions);
+    return added.map((p) => p.wireName).toList()..sort();
+  }
+
+  GitHubAsset _selectReleaseAsset(GitHubRelease release, String? assetName) {
+    if (assetName != null) {
+      final match = release.assets.where((a) => a.name == assetName);
+      if (match.isEmpty) {
+        throw PluginPackageException(
+          'Release ${release.tag} has no asset named "$assetName"',
+        );
+      }
+      return match.first;
+    }
+
+    final zips = release.zipAssets;
+    if (zips.isEmpty) {
+      throw PluginPackageException(
+        'Release ${release.tag} has no .zip asset to install',
+      );
+    }
+    if (zips.length > 1) {
+      throw PluginPackageException(
+        'Release ${release.tag} has ${zips.length} .zip assets '
+        '(${zips.map((a) => a.name).join(', ')}); name the one to install',
+      );
+    }
+    return zips.single;
+  }
+
+  void _requireTagMatchesManifest(String tag, String manifestVersion) {
+    if (!_releaseTagPattern.hasMatch(tag)) {
+      throw PluginPackageException('Release tag "$tag" is not X.Y.Z or vX.Y.Z');
+    }
+    final normalized = tag.startsWith('v') ? tag.substring(1) : tag;
+    if (normalized != manifestVersion) {
+      throw PluginPackageException(
+        'Release tag "$tag" does not match manifest version '
+        '"$manifestVersion"',
+      );
+    }
+  }
+
+  void _extractArchive(List<int> bytes, Directory destination) {
+    final archive = ZipDecoder().decodeBytes(bytes);
+    extractArchiveToDirectory(
+      archive,
+      destination,
+      sanitize: Platform.isWindows,
+      log: _log,
+    );
+  }
+
+  Future<T> _withStaging<T>(Future<T> Function(Directory staging) body) async {
+    final staging = await Directory.systemTemp.createTemp('decaid_plugin_');
+    try {
+      return await body(staging);
+    } finally {
+      if (staging.existsSync()) {
+        try {
+          staging.deleteSync(recursive: true);
+        } catch (e) {
+          _log.warning('Failed to clean plugin staging ${staging.path}', e);
+        }
+      }
+    }
+  }
+}

--- a/lib/src/plugins/plugin_source_service.dart
+++ b/lib/src/plugins/plugin_source_service.dart
@@ -96,7 +96,7 @@ class PluginSourceService {
   }) async {
     final commit = await fetchGitHubBranchCommit(repo, branch);
     final bytes = await downloadGitHubArchive(
-      gitHubBranchArchiveUrl(repo, branch),
+      gitHubCommitArchiveUrl(repo, commit),
     );
 
     return _withStaging((staging) async {
@@ -304,7 +304,7 @@ class PluginSourceService {
     }
 
     final bytes = await downloadGitHubArchive(
-      gitHubBranchArchiveUrl(source.repo!, branch),
+      gitHubCommitArchiveUrl(source.repo!, commit),
     );
     await _withStaging((staging) async {
       _extractArchive(bytes, staging);

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -7,6 +7,7 @@ import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/services/app_update_state.dart';
 import 'package:reaprime/src/settings/settings_service.dart';
+import 'package:reaprime/src/plugins/plugin_source_service.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 
 class UpdateCheckService {
@@ -14,6 +15,7 @@ class UpdateCheckService {
   final SettingsService _settingsService;
   final AndroidUpdater _updater;
   final WebUIStorage _webUIStorage;
+  final PluginSourceService? _pluginSourceService;
 
   final bool _isAndroid;
 
@@ -33,11 +35,13 @@ class UpdateCheckService {
     required SettingsService settingsService,
     AndroidUpdater? updater,
     required WebUIStorage webUIStorage,
+    PluginSourceService? pluginSourceService,
     bool? platformIsAndroid,
     bool? platformIsMacOS,
   }) : _settingsService = settingsService,
        _updater = updater ?? AndroidUpdater(owner: 'tadelv', repo: 'reaprime'),
        _webUIStorage = webUIStorage,
+       _pluginSourceService = pluginSourceService,
        _isAndroid = platformIsAndroid ?? Platform.isAndroid,
        _isMacOS = platformIsMacOS ?? Platform.isMacOS {
     _state = BehaviorSubject.seeded(_snapshot(AppUpdatePhase.idle));
@@ -140,13 +144,13 @@ class UpdateCheckService {
     );
 
     if (_isMacOS) {
-      await _updateSkins();
+      await _updateManagedContent();
     } else {
       final lastCheck = await _settingsService.lastUpdateCheckTime();
       if (lastCheck == null ||
           DateTime.now().difference(lastCheck) > _checkInterval) {
         await checkForUpdate();
-        await _updateSkins();
+        await _updateManagedContent();
       }
     }
 
@@ -155,7 +159,7 @@ class UpdateCheckService {
       if (!_isMacOS) {
         await checkForUpdate();
       }
-      await _updateSkins();
+      await _updateManagedContent();
     });
   }
 
@@ -165,13 +169,23 @@ class UpdateCheckService {
     _periodicTimer = null;
   }
 
-  Future<void> _updateSkins() async {
+  Future<void> _updateManagedContent() async {
     try {
       _log.info('Updating skins...');
       await _webUIStorage.updateAllSkins();
       _log.info('Skin update complete');
     } catch (e, st) {
       _log.warning('Error updating skins', e, st);
+    }
+
+    final pluginSourceService = _pluginSourceService;
+    if (pluginSourceService == null) return;
+    try {
+      _log.info('Updating plugins...');
+      await pluginSourceService.updateAllPlugins();
+      _log.info('Plugin update complete');
+    } catch (e, st) {
+      _log.warning('Error updating plugins', e, st);
     }
   }
 

--- a/lib/src/services/webserver/plugins_handler.dart
+++ b/lib/src/services/webserver/plugins_handler.dart
@@ -3,12 +3,19 @@ part of '../webserver_service.dart';
 final class PluginsHandler {
   final PluginManager pluginManager;
   final PluginLoaderService pluginService;
+  final PluginSourceService pluginSourceService;
 
   final Logger _log = Logger("PluginsHandler");
 
   final Random _random = Random();
 
-  PluginsHandler({required this.pluginManager, required this.pluginService});
+  PluginsHandler({
+    required this.pluginManager,
+    required PluginLoaderService pluginService,
+    PluginSourceService? pluginSourceService,
+  }) : pluginService = pluginService,
+       pluginSourceService =
+           pluginSourceService ?? PluginSourceService(pluginService);
 
   void addRoutes(RouterPlus app) {
     app.get('/api/v1/plugins', (Request req) async {
@@ -17,24 +24,40 @@ final class PluginsHandler {
         final json = manifest.toJson();
         json['loaded'] = pluginService.isPluginLoaded(manifest.id);
         json['autoLoad'] = await pluginService.shouldAutoLoad(manifest.id);
+        final source = pluginSourceService.sourceFor(manifest.id);
+        json['source'] = source == null ? null : _sourceJson(source);
+        json['pendingUpdate'] = source?.pendingUpdate?.toJson();
         list.add(json);
       }
       return jsonOk(list);
     });
 
     app.post('/api/v1/plugins/install', (Request request) async {
+      return jsonNotImplemented({
+        'error':
+            'Plugin install from an arbitrary URL is not supported. Use '
+            '/api/v1/plugins/install/github-release or '
+            '/api/v1/plugins/install/github-branch',
+      });
+    });
+
+    app.post(
+      '/api/v1/plugins/install/github-release',
+      _handleInstallFromGitHubRelease,
+    );
+
+    app.post(
+      '/api/v1/plugins/install/github-branch',
+      _handleInstallFromGitHubBranch,
+    );
+
+    app.post('/api/v1/plugins/update', (Request request) async {
       try {
-        final payload = await request.readAsString();
-        final json = jsonDecode(payload) as Map<String, dynamic>;
-        final url = json['url'] as String?;
-        if (url == null || url.isEmpty) {
-          return jsonBadRequest({'error': 'url is required'});
-        }
-        return jsonNotImplemented({
-          'error': 'Plugin install from URL not yet implemented',
-        });
+        await pluginSourceService.updateAllPlugins();
+        return jsonOk({'message': 'Plugin update check complete'});
       } catch (e) {
-        return jsonError({'error': 'Failed to install plugin: $e'});
+        _log.warning('Plugin update check failed', e);
+        return jsonError({'error': 'Failed to update plugins: $e'});
       }
     });
 
@@ -70,6 +93,31 @@ final class PluginsHandler {
       }
     });
 
+    app.post('/api/v1/plugins/<id>/update/approve', (
+      Request request,
+      String id,
+    ) async {
+      if (pluginService.getPluginManifest(id) == null) {
+        return jsonNotFound({'error': 'Plugin not found: $id'});
+      }
+      try {
+        final manifest = await pluginSourceService.approvePendingUpdate(id);
+        return jsonOk({
+          'message': 'Plugin updated',
+          'id': id,
+          'version': manifest.version,
+          'loaded': pluginService.isPluginLoaded(id),
+        });
+      } on PluginApprovalRequiredException catch (e) {
+        return jsonConflict({'error': e.message});
+      } on FormatException catch (e) {
+        return jsonBadRequest({'error': e.message});
+      } catch (e) {
+        _log.warning('Failed to approve update of plugin $id', e);
+        return jsonError({'error': 'Failed to approve update: $e'});
+      }
+    });
+
     app.delete('/api/v1/plugins/<id>', (Request request, String id) async {
       try {
         if (pluginService.getPluginManifest(id) == null) {
@@ -84,6 +132,86 @@ final class PluginsHandler {
 
     app.get('/ws/v1/plugins/<id>/<endpoint>', _handlePluginSocketEndpoint);
     app.all('/api/v1/plugins/<id>/<endpoint>', _handlePluginApiEndpoint);
+  }
+
+  Map<String, dynamic> _sourceJson(PluginSource source) {
+    final json = source.toJson();
+    json.remove('pendingUpdate');
+    return json;
+  }
+
+  Future<Response> _handleInstallFromGitHubRelease(Request request) async {
+    final Map<String, dynamic> json;
+    try {
+      json = jsonDecode(await request.readAsString()) as Map<String, dynamic>;
+    } catch (e) {
+      return jsonBadRequest({'error': 'Invalid JSON body: $e'});
+    }
+
+    final repo = json['repo'];
+    if (repo is! String || repo.isEmpty) {
+      return jsonBadRequest({'error': 'repo is required (owner/repo)'});
+    }
+    final assetName = json['assetName'];
+    if (assetName != null && assetName is! String) {
+      return jsonBadRequest({'error': 'assetName must be a string'});
+    }
+    final includePrerelease = json['includePrerelease'];
+    if (includePrerelease != null && includePrerelease is! bool) {
+      return jsonBadRequest({'error': 'includePrerelease must be a boolean'});
+    }
+
+    return _install(
+      () => pluginSourceService.installFromGitHubRelease(
+        repo,
+        assetName: assetName as String?,
+        includePrerelease: (includePrerelease as bool?) ?? false,
+      ),
+    );
+  }
+
+  Future<Response> _handleInstallFromGitHubBranch(Request request) async {
+    final Map<String, dynamic> json;
+    try {
+      json = jsonDecode(await request.readAsString()) as Map<String, dynamic>;
+    } catch (e) {
+      return jsonBadRequest({'error': 'Invalid JSON body: $e'});
+    }
+
+    final repo = json['repo'];
+    if (repo is! String || repo.isEmpty) {
+      return jsonBadRequest({'error': 'repo is required (owner/repo)'});
+    }
+    final branch = json['branch'];
+    if (branch != null && branch is! String) {
+      return jsonBadRequest({'error': 'branch must be a string'});
+    }
+
+    return _install(
+      () => pluginSourceService.installFromGitHubBranch(
+        repo,
+        branch: (branch as String?) ?? 'main',
+      ),
+    );
+  }
+
+  Future<Response> _install(Future<PluginManifest> Function() install) async {
+    try {
+      final manifest = await install();
+      return jsonOk({
+        'message': 'Plugin installed',
+        'id': manifest.id,
+        'version': manifest.version,
+        'loaded': pluginService.isPluginLoaded(manifest.id),
+      });
+    } on PluginDowngradeException catch (e) {
+      return jsonConflict({'error': e.message});
+    } on FormatException catch (e) {
+      return jsonBadRequest({'error': e.message});
+    } catch (e) {
+      _log.warning('Plugin installation failed', e);
+      return jsonError({'error': 'Failed to install plugin: $e'});
+    }
   }
 
   Future<Response> _handlePluginSourceWrite(Request request, String id) async {

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -24,6 +24,8 @@ import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/device/sensor.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_source.dart';
+import 'package:reaprime/src/plugins/plugin_source_service.dart';
 import 'package:reaprime/src/services/storage/hive_store_service.dart';
 import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:http/http.dart' as http;

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -7,6 +7,8 @@ import 'package:saf_util/saf_util.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_source.dart';
+import 'package:reaprime/src/plugins/plugin_source_service.dart';
 import 'package:reaprime/src/services/security_scoped_file.dart';
 
 const _maxPluginSafDepth = 32;
@@ -95,12 +97,14 @@ class PluginsSettingsView extends StatefulWidget {
   const PluginsSettingsView({
     super.key,
     required this.pluginLoaderService,
+    this.pluginSourceService,
     this.allowInstall = true,
   });
 
   static const routeName = '/plugins';
 
   final PluginLoaderService pluginLoaderService;
+  final PluginSourceService? pluginSourceService;
   final bool allowInstall;
 
   @override
@@ -109,7 +113,13 @@ class PluginsSettingsView extends StatefulWidget {
 
 class _PluginsSettingsViewState extends State<PluginsSettingsView> {
   List<PluginManifest> _plugins = [];
+  Map<String, PluginSource> _sources = {};
   bool _isLoading = true;
+  bool _isCheckingUpdates = false;
+
+  late final PluginSourceService _sourceService =
+      widget.pluginSourceService ??
+      PluginSourceService(widget.pluginLoaderService);
 
   @override
   void initState() {
@@ -123,9 +133,15 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
     });
 
     final plugins = widget.pluginLoaderService.availablePlugins;
+    final sources = <String, PluginSource>{};
+    for (final plugin in plugins) {
+      final source = _sourceService.sourceFor(plugin.id);
+      if (source != null) sources[plugin.id] = source;
+    }
 
     setState(() {
       _plugins = plugins;
+      _sources = sources;
       _isLoading = false;
     });
   }
@@ -145,11 +161,39 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
             onPressed: _refreshPlugins,
             tooltip: 'Refresh Plugins',
           ),
+          IconButton(
+            icon: _isCheckingUpdates
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(LucideIcons.cloudDownload),
+            onPressed: _isCheckingUpdates
+                ? null
+                : () => _checkForPluginUpdates(context),
+            tooltip: 'Check for updates',
+          ),
           if (widget.allowInstall)
-            IconButton(
+            PopupMenuButton<String>(
               icon: const Icon(LucideIcons.plus),
-              onPressed: () => _installPlugin(context),
               tooltip: 'Install Plugin',
+              onSelected: (value) => _handleInstallAction(context, value),
+              itemBuilder: (context) => const [
+                PopupMenuItem<String>(
+                  value: 'github-release',
+                  child: Text('GitHub Release'),
+                ),
+                PopupMenuItem<String>(
+                  value: 'github-branch',
+                  child: Text('GitHub Branch'),
+                ),
+                PopupMenuItem<String>(value: 'zip', child: Text('ZIP file')),
+                PopupMenuItem<String>(
+                  value: 'folder',
+                  child: Text('Folder snapshot'),
+                ),
+              ],
             ),
         ],
       ),
@@ -292,6 +336,8 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
                   ),
                 ],
               ),
+            _buildSourceLine(context, plugin),
+            _buildPendingUpdate(context, plugin),
             const SizedBox(height: 8),
             FutureBuilder<bool>(
               future: widget.pluginLoaderService.shouldAutoLoad(plugin.id),
@@ -429,6 +475,260 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
         final newDir = Directory(newPath);
         await _copyDirectoryRecursively(entry, newDir);
       }
+    }
+  }
+
+  Widget _buildSourceLine(BuildContext context, PluginManifest plugin) {
+    final source = _sources[plugin.id];
+    if (source == null) return const SizedBox.shrink();
+
+    final description = switch (source.kind) {
+      PluginSourceKind.githubRelease =>
+        'GitHub release ${source.repo} @ ${source.releaseTag}',
+      PluginSourceKind.githubBranch =>
+        'GitHub branch ${source.repo}@${source.branch} '
+            '(${_shortCommit(source.commit)})',
+      PluginSourceKind.localZip => 'Local ZIP snapshot',
+      PluginSourceKind.localFolder => 'Local folder snapshot',
+    };
+
+    final checked = source.lastChecked;
+    final suffix = source.kind.isManaged && checked != null
+        ? ' • checked ${checked.toLocal()}'
+        : '';
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '$description$suffix',
+            style: Theme.of(context).textTheme.labelSmall,
+          ),
+          if (source.lastError != null)
+            Text(
+              'Last update failed: ${source.lastError}',
+              style: Theme.of(
+                context,
+              ).textTheme.labelSmall?.copyWith(color: Colors.red),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _shortCommit(String? commit) {
+    if (commit == null || commit.isEmpty) return 'unknown';
+    return commit.length > 7 ? commit.substring(0, 7) : commit;
+  }
+
+  Widget _buildPendingUpdate(BuildContext context, PluginManifest plugin) {
+    final pending = _sources[plugin.id]?.pendingUpdate;
+    if (pending == null) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Update to ${pending.version} needs approval: adds '
+              '${pending.addedPermissions.join(', ')}',
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+          ),
+          const SizedBox(width: 8),
+          ShadButton.outline(
+            onPressed: () => _approvePendingUpdate(context, plugin, pending),
+            child: const Text('Review'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _approvePendingUpdate(
+    BuildContext context,
+    PluginManifest plugin,
+    PluginPendingUpdate pending,
+  ) async {
+    final approved = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Update ${plugin.name} to ${pending.version}?'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('This update requests new permissions:'),
+            const SizedBox(height: 8),
+            ...pending.addedPermissions.map((p) => Text('• $p')),
+            const SizedBox(height: 12),
+            Text(
+              'Current permissions: '
+              '${plugin.permissions.map((p) => p.wireName).join(', ')}',
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Approve and update'),
+          ),
+        ],
+      ),
+    );
+
+    if (approved != true || !mounted || !context.mounted) return;
+
+    await _runInstall(
+      context,
+      () => _sourceService.approvePendingUpdate(plugin.id),
+      successMessage: 'Plugin updated',
+    );
+  }
+
+  Future<void> _checkForPluginUpdates(BuildContext context) async {
+    setState(() => _isCheckingUpdates = true);
+    try {
+      await _sourceService.updateAllPlugins();
+      if (context.mounted) _showSnackBar(context, 'Plugin update check done');
+    } catch (e, st) {
+      Logger(
+        'PluginsSettingsView',
+      ).warning('Plugin update check failed', e, st);
+      if (context.mounted) {
+        _showSnackBar(context, 'Update check failed: $e', isError: true);
+      }
+    } finally {
+      if (mounted) setState(() => _isCheckingUpdates = false);
+      _refreshPlugins();
+    }
+  }
+
+  Future<void> _handleInstallAction(BuildContext context, String action) async {
+    switch (action) {
+      case 'github-release':
+        await _installFromGitHub(context, release: true);
+      case 'github-branch':
+        await _installFromGitHub(context, release: false);
+      case 'zip':
+        await _installFromZip(context);
+      case 'folder':
+        await _installPlugin(context);
+    }
+  }
+
+  Future<void> _installFromGitHub(
+    BuildContext context, {
+    required bool release,
+  }) async {
+    final repoController = TextEditingController();
+    final detailController = TextEditingController(text: release ? '' : 'main');
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(
+          release
+              ? 'Install from GitHub Release'
+              : 'Install from GitHub Branch',
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: repoController,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Repository',
+                hintText: 'owner/repo',
+              ),
+            ),
+            TextField(
+              controller: detailController,
+              decoration: InputDecoration(
+                labelText: release ? 'Asset name (optional)' : 'Branch',
+                hintText: release ? 'plugin.zip' : 'main',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Install'),
+          ),
+        ],
+      ),
+    );
+
+    final repo = repoController.text.trim();
+    final detail = detailController.text.trim();
+    repoController.dispose();
+    detailController.dispose();
+    if (confirmed != true || repo.isEmpty) return;
+    if (!context.mounted) return;
+
+    await _runInstall(
+      context,
+      () => release
+          ? _sourceService.installFromGitHubRelease(
+              repo,
+              assetName: detail.isEmpty ? null : detail,
+            )
+          : _sourceService.installFromGitHubBranch(
+              repo,
+              branch: detail.isEmpty ? 'main' : detail,
+            ),
+      successMessage: 'Plugin installed',
+    );
+  }
+
+  Future<void> _installFromZip(BuildContext context) async {
+    final picked = await FilePicker.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['zip'],
+    );
+    final path = picked?.files.firstOrNull?.path;
+    if (path == null || !mounted || !context.mounted) return;
+
+    await _runInstall(
+      context,
+      () => _sourceService.installFromZip(path),
+      successMessage: 'Plugin installed',
+    );
+  }
+
+  Future<void> _runInstall(
+    BuildContext context,
+    Future<PluginManifest> Function() install, {
+    required String successMessage,
+  }) async {
+    try {
+      final manifest = await install();
+      if (context.mounted) {
+        _showSnackBar(context, '$successMessage: ${manifest.name}');
+      }
+    } catch (e, st) {
+      Logger(
+        'PluginsSettingsView',
+      ).warning('Plugin installation failed', e, st);
+      if (context.mounted) {
+        _showSnackBar(context, 'Installation failed: $e', isError: true);
+      }
+    } finally {
+      _refreshPlugins();
     }
   }
 

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -133,6 +133,7 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
     });
 
     final plugins = widget.pluginLoaderService.availablePlugins;
+    _sourceService.seedBundledSources();
     final sources = <String, PluginSource>{};
     for (final plugin in plugins) {
       final source = _sourceService.sourceFor(plugin.id);

--- a/lib/src/settings/plugins_settings_view.dart
+++ b/lib/src/settings/plugins_settings_view.dart
@@ -773,7 +773,7 @@ class _PluginsSettingsViewState extends State<PluginsSettingsView> {
         }
       }
 
-      await widget.pluginLoaderService.addPlugin(tempDir.path);
+      await _sourceService.installFromFolder(tempDir.path);
 
       if (context.mounted) {
         _showSnackBar(context, 'Plugin installed successfully');

--- a/lib/src/util/github_archive.dart
+++ b/lib/src/util/github_archive.dart
@@ -104,9 +104,6 @@ Future<String> fetchGitHubBranchCommit(String repo, String branch) async {
   return commit;
 }
 
-String gitHubBranchArchiveUrl(String repo, String branch) =>
-    'https://github.com/$repo/archive/refs/heads/$branch.zip';
-
 String gitHubCommitArchiveUrl(String repo, String commit) =>
     'https://github.com/$repo/archive/$commit.zip';
 

--- a/lib/src/util/github_archive.dart
+++ b/lib/src/util/github_archive.dart
@@ -57,6 +57,24 @@ Future<GitHubRelease> fetchLatestGitHubRelease(
     release = decoded as Map<String, dynamic>;
   }
 
+  return _releaseFromJson(release);
+}
+
+Future<GitHubRelease> fetchGitHubReleaseByTag(String repo, String tag) async {
+  validateGitHubRepo(repo);
+  final response = await http.get(
+    Uri.parse('https://api.github.com/repos/$repo/releases/tags/$tag'),
+    headers: _headers,
+  );
+  if (response.statusCode != 200) {
+    throw Exception(
+      'Failed to fetch release "$tag" of $repo: ${response.statusCode}',
+    );
+  }
+  return _releaseFromJson(jsonDecode(response.body) as Map<String, dynamic>);
+}
+
+GitHubRelease _releaseFromJson(Map<String, dynamic> release) {
   final assets = ((release['assets'] as List?) ?? [])
       .cast<Map<String, dynamic>>()
       .map(
@@ -88,6 +106,9 @@ Future<String> fetchGitHubBranchCommit(String repo, String branch) async {
 
 String gitHubBranchArchiveUrl(String repo, String branch) =>
     'https://github.com/$repo/archive/refs/heads/$branch.zip';
+
+String gitHubCommitArchiveUrl(String repo, String commit) =>
+    'https://github.com/$repo/archive/$commit.zip';
 
 Future<List<int>> downloadGitHubArchive(String url) async {
   final response = await http.get(Uri.parse(url));

--- a/lib/src/util/github_archive.dart
+++ b/lib/src/util/github_archive.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class GitHubAsset {
+  final String name;
+  final String downloadUrl;
+
+  const GitHubAsset({required this.name, required this.downloadUrl});
+}
+
+class GitHubRelease {
+  final String tag;
+  final List<GitHubAsset> assets;
+
+  const GitHubRelease({required this.tag, required this.assets});
+
+  List<GitHubAsset> get zipAssets =>
+      assets.where((a) => a.name.toLowerCase().endsWith('.zip')).toList();
+}
+
+const _headers = {
+  'Accept': 'application/vnd.github.v3+json',
+  'User-Agent': 'Decaid',
+};
+
+void validateGitHubRepo(String repo) {
+  final parts = repo.split('/');
+  if (parts.length != 2 || parts.any((p) => p.isEmpty)) {
+    throw FormatException('Invalid GitHub repo "$repo". Use: owner/repo');
+  }
+}
+
+Future<GitHubRelease> fetchLatestGitHubRelease(
+  String repo, {
+  bool includePrerelease = false,
+}) async {
+  validateGitHubRepo(repo);
+  final url = includePrerelease
+      ? 'https://api.github.com/repos/$repo/releases'
+      : 'https://api.github.com/repos/$repo/releases/latest';
+
+  final response = await http.get(Uri.parse(url), headers: _headers);
+  if (response.statusCode != 200) {
+    throw Exception(
+      'Failed to fetch GitHub release for $repo: ${response.statusCode}',
+    );
+  }
+
+  final decoded = jsonDecode(response.body);
+  final Map<String, dynamic> release;
+  if (includePrerelease) {
+    final list = (decoded as List).cast<Map<String, dynamic>>();
+    if (list.isEmpty) throw Exception('No releases published for $repo');
+    release = list.first;
+  } else {
+    release = decoded as Map<String, dynamic>;
+  }
+
+  final assets = ((release['assets'] as List?) ?? [])
+      .cast<Map<String, dynamic>>()
+      .map(
+        (asset) => GitHubAsset(
+          name: asset['name'] as String,
+          downloadUrl: asset['browser_download_url'] as String,
+        ),
+      )
+      .toList();
+
+  return GitHubRelease(tag: release['tag_name'] as String, assets: assets);
+}
+
+Future<String> fetchGitHubBranchCommit(String repo, String branch) async {
+  validateGitHubRepo(repo);
+  final response = await http.get(
+    Uri.parse('https://api.github.com/repos/$repo/commits/$branch'),
+    headers: _headers,
+  );
+  if (response.statusCode != 200) {
+    throw Exception('Failed to resolve $repo@$branch: ${response.statusCode}');
+  }
+  final commit = (jsonDecode(response.body) as Map<String, dynamic>)['sha'];
+  if (commit is! String || commit.isEmpty) {
+    throw Exception('GitHub returned no commit for $repo@$branch');
+  }
+  return commit;
+}
+
+String gitHubBranchArchiveUrl(String repo, String branch) =>
+    'https://github.com/$repo/archive/refs/heads/$branch.zip';
+
+Future<List<int>> downloadGitHubArchive(String url) async {
+  final response = await http.get(Uri.parse(url));
+  if (response.statusCode != 200) {
+    throw Exception('Failed to download $url: ${response.statusCode}');
+  }
+  return response.bodyBytes;
+}

--- a/scripts/fetch_dye2_plugin.sh
+++ b/scripts/fetch_dye2_plugin.sh
@@ -5,7 +5,7 @@ pinned_version="v0.1.4"
 pinned_sha256="fd8e43afa7d953c48ad23ca74aa76cb5314fde5602d07149f954e8e3497b81a6"
 pinned_api_version="1"
 
-repo="${DYE2_REPO:-allofmeng/dye2}"
+repo="${DYE2_REPO:-decentespresso/dye2}"
 version="${DYE2_VERSION:-$pinned_version}"
 expected_sha256="${DYE2_SHA256:-$pinned_sha256}"
 expected_api_version="${DYE2_API_VERSION:-$pinned_api_version}"

--- a/test/plugins/plugin_package_test.dart
+++ b/test/plugins/plugin_package_test.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_package.dart';
+
+void main() {
+  late Directory tempDir;
+
+  Map<String, dynamic> manifestJson(String id, {String version = '1.0.0'}) => {
+    'id': id,
+    'author': 'Test',
+    'name': 'Test plugin',
+    'description': 'Test plugin',
+    'version': version,
+    'apiVersion': 1,
+    'permissions': <String>[],
+    'settings': <String, dynamic>{},
+    'api': <Object>[],
+  };
+
+  Directory writePlugin(
+    String path, {
+    String id = 'pkg.reaplugin',
+    Object? manifest,
+    bool withSource = true,
+  }) {
+    final dir = Directory(path)..createSync(recursive: true);
+    File(
+      '${dir.path}/manifest.json',
+    ).writeAsStringSync(jsonEncode(manifest ?? manifestJson(id)));
+    if (withSource) {
+      File('${dir.path}/plugin.js').writeAsStringSync('function f() {}');
+    }
+    return dir;
+  }
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('plugin_package');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('accepts a flat package root', () {
+    writePlugin('${tempDir.path}/staged');
+
+    final pkg = resolvePluginPackage(Directory('${tempDir.path}/staged'));
+
+    expect(pkg.manifest.id, 'pkg.reaplugin');
+    expect(pkg.root.path, '${tempDir.path}/staged');
+  });
+
+  test('accepts a single wrapper directory', () {
+    writePlugin('${tempDir.path}/staged/repo-1.0.0');
+
+    final pkg = resolvePluginPackage(Directory('${tempDir.path}/staged'));
+
+    expect(pkg.manifest.id, 'pkg.reaplugin');
+    expect(pkg.root.path, endsWith('repo-1.0.0'));
+  });
+
+  test('rejects several plugin roots as ambiguous', () {
+    writePlugin('${tempDir.path}/staged/one', id: 'one.reaplugin');
+    writePlugin('${tempDir.path}/staged/two', id: 'two.reaplugin');
+
+    expect(
+      () => resolvePluginPackage(Directory('${tempDir.path}/staged')),
+      throwsA(
+        isA<PluginPackageException>().having(
+          (e) => e.message,
+          'message',
+          contains('2 plugin roots'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects a package without a manifest', () {
+    Directory('${tempDir.path}/staged/assets').createSync(recursive: true);
+
+    expect(
+      () => resolvePluginPackage(Directory('${tempDir.path}/staged')),
+      throwsA(isA<PluginPackageException>()),
+    );
+  });
+
+  test('rejects a package without plugin.js', () {
+    writePlugin('${tempDir.path}/staged', withSource: false);
+
+    expect(
+      () => resolvePluginPackage(Directory('${tempDir.path}/staged')),
+      throwsA(
+        isA<PluginPackageException>().having(
+          (e) => e.message,
+          'message',
+          contains('plugin.js'),
+        ),
+      ),
+    );
+  });
+
+  test('rejects a malformed manifest', () {
+    final dir = Directory('${tempDir.path}/staged')
+      ..createSync(recursive: true);
+    File('${dir.path}/manifest.json').writeAsStringSync('{ not json');
+    File('${dir.path}/plugin.js').writeAsStringSync('function f() {}');
+
+    expect(
+      () => resolvePluginPackage(dir),
+      throwsA(isA<PluginPackageException>()),
+    );
+  });
+
+  test('rejects an unsafe plugin id', () {
+    writePlugin('${tempDir.path}/staged', id: '../escape');
+
+    expect(
+      () => resolvePluginPackage(Directory('${tempDir.path}/staged')),
+      throwsA(
+        isA<PluginPackageException>().having(
+          (e) => e.message,
+          'message',
+          contains('Unsafe plugin id'),
+        ),
+      ),
+    );
+  });
+}

--- a/test/plugins/plugin_source_service_test.dart
+++ b/test/plugins/plugin_source_service_test.dart
@@ -261,6 +261,55 @@ function createPlugin() {
       );
     });
 
+    test('a branch install downloads the commit it records', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('acme/plugin'),
+        () => MockClient((request) async {
+          final url = request.url.toString();
+          if (url.contains('/commits/')) {
+            return http.Response(jsonEncode({'sha': 'commit-1'}), 200);
+          }
+          if (url.endsWith('/archive/commit-1.zip')) {
+            return http.Response.bytes(pluginArchive(version: '1.0.0'), 200);
+          }
+          if (url.contains('/archive/refs/heads/')) {
+            return http.Response.bytes(pluginArchive(version: '2.0.0'), 200);
+          }
+          return http.Response('not found: $url', 404);
+        }),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.0.0');
+      expect(service.sourceFor(id)!.commit, 'commit-1');
+    });
+
+    test('a branch update downloads the commit it records', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('acme/plugin'),
+        () => gitHubClient(commit: 'commit-1'),
+      );
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => MockClient((request) async {
+          final url = request.url.toString();
+          if (url.contains('/commits/')) {
+            return http.Response(jsonEncode({'sha': 'commit-2'}), 200);
+          }
+          if (url.endsWith('/archive/commit-2.zip')) {
+            return http.Response.bytes(pluginArchive(version: '1.1.0'), 200);
+          }
+          if (url.contains('/archive/refs/heads/')) {
+            return http.Response.bytes(pluginArchive(version: '1.2.0'), 200);
+          }
+          return http.Response('not found: $url', 404);
+        }),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.1.0');
+      expect(service.sourceFor(id)!.commit, 'commit-2');
+    });
+
     test('an unchanged commit only moves lastChecked', () async {
       await http.runWithClient(
         () => service.installFromGitHubBranch('acme/plugin'),

--- a/test/plugins/plugin_source_service_test.dart
+++ b/test/plugins/plugin_source_service_test.dart
@@ -100,13 +100,16 @@ function createPlugin() {
             200,
           );
         }
+        if (url.contains('/releases/tags/')) {
+          return http.Response(releaseJson(url.split('/').last, assets), 200);
+        }
         if (url.contains('/commits/')) {
           return http.Response(jsonEncode({'sha': commit}), 200);
         }
         if (url.startsWith('https://example.test/assets/')) {
           return http.Response.bytes(releaseArchive ?? pluginArchive(), 200);
         }
-        if (url.contains('/archive/refs/heads/')) {
+        if (url.contains('/archive/')) {
           return http.Response.bytes(branchArchive ?? pluginArchive(), 200);
         }
         return http.Response('not found: $url', 404);
@@ -351,6 +354,178 @@ function createPlugin() {
       expect(service.sourceFor(id)?.pendingUpdate, isNull);
     });
 
+    test('approval installs the reviewed release, not a newer one', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        () => gitHubClient(releaseArchive: pluginArchive(permissions: ['log'])),
+      );
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          assets: ['plugin-1.1.0.zip'],
+          releaseArchive: pluginArchive(
+            version: '1.1.0',
+            permissions: ['log', 'proxy.decent_api'],
+          ),
+        ),
+      );
+      expect(service.sourceFor(id)!.pendingUpdate!.releaseTag, 'v1.1.0');
+
+      await http.runWithClient(
+        () => service.approvePendingUpdate(id),
+        () => MockClient((request) async {
+          final url = request.url.toString();
+          if (url.contains('/releases/latest')) {
+            return http.Response(
+              releaseJson('v1.2.0', ['plugin-1.2.0.zip']),
+              200,
+            );
+          }
+          if (url.endsWith('/releases/tags/v1.1.0')) {
+            return http.Response(
+              releaseJson('v1.1.0', ['plugin-1.1.0.zip']),
+              200,
+            );
+          }
+          if (url.endsWith('plugin-1.1.0.zip')) {
+            return http.Response.bytes(
+              pluginArchive(
+                version: '1.1.0',
+                permissions: ['log', 'proxy.decent_api'],
+              ),
+              200,
+            );
+          }
+          if (url.endsWith('plugin-1.2.0.zip')) {
+            return http.Response.bytes(
+              pluginArchive(
+                version: '1.2.0',
+                permissions: [
+                  'log',
+                  'proxy.decent_api',
+                  'proxy.decent_api.write',
+                ],
+              ),
+              200,
+            );
+          }
+          return http.Response('not found: $url', 404);
+        }),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.1.0');
+      expect(service.sourceFor(id)!.releaseTag, 'v1.1.0');
+      expect(service.sourceFor(id)!.pendingUpdate, isNull);
+    });
+
+    test('a release re-cut at the approved tag needs a new approval', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        () => gitHubClient(releaseArchive: pluginArchive(permissions: ['log'])),
+      );
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: pluginArchive(
+            version: '1.1.0',
+            permissions: ['log', 'proxy.decent_api'],
+          ),
+        ),
+      );
+
+      await expectLater(
+        http.runWithClient(
+          () => service.approvePendingUpdate(id),
+          () => gitHubClient(
+            tag: 'v1.1.0',
+            releaseArchive: pluginArchive(
+              version: '1.1.0',
+              permissions: [
+                'log',
+                'proxy.decent_api',
+                'proxy.decent_api.write',
+              ],
+            ),
+          ),
+        ),
+        throwsA(isA<PluginApprovalRequiredException>()),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.0.0');
+      expect(service.sourceFor(id)!.pendingUpdate!.addedPermissions, [
+        'proxy.decent_api',
+        'proxy.decent_api.write',
+      ]);
+    });
+
+    test('approval installs the reviewed commit, not the new head', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('acme/plugin'),
+        () => gitHubClient(commit: 'commit-1'),
+      );
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          commit: 'commit-2',
+          branchArchive: pluginArchive(version: '1.1.0', permissions: ['log']),
+        ),
+      );
+      expect(service.sourceFor(id)!.pendingUpdate!.commit, 'commit-2');
+
+      await http.runWithClient(
+        () => service.approvePendingUpdate(id),
+        () => MockClient((request) async {
+          final url = request.url.toString();
+          if (url.contains('/commits/')) {
+            return http.Response(jsonEncode({'sha': 'commit-3'}), 200);
+          }
+          if (url.endsWith('/archive/commit-2.zip')) {
+            return http.Response.bytes(
+              pluginArchive(version: '1.1.0', permissions: ['log']),
+              200,
+            );
+          }
+          if (url.contains('/archive/refs/heads/')) {
+            return http.Response.bytes(
+              pluginArchive(version: '2.0.0', permissions: ['log', 'emit']),
+              200,
+            );
+          }
+          return http.Response('not found: $url', 404);
+        }),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.1.0');
+      final source = service.sourceFor(id)!;
+      expect(source.commit, 'commit-2');
+      expect(source.pendingUpdate, isNull);
+    });
+
+    test('a branch commit that lowers the version is refused', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('acme/plugin'),
+        () => gitHubClient(
+          commit: 'commit-1',
+          branchArchive: pluginArchive(version: '2.0.0'),
+        ),
+      );
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          commit: 'commit-2',
+          branchArchive: pluginArchive(version: '1.0.0'),
+        ),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '2.0.0');
+      final source = service.sourceFor(id)!;
+      expect(source.commit, 'commit-1');
+      expect(source.lastError, isNotNull);
+    });
+
     test('approving without a pending update is an error', () async {
       await http.runWithClient(
         () => service.installFromGitHubRelease('acme/plugin'),
@@ -537,6 +712,12 @@ function createPlugin() {
     group('bundled plugin provenance', () {
       const dye2Id = 'dye2.reaplugin';
 
+      Future<void> bundledUpgrade(String version) => loader.updatePluginSource(
+        dye2Id,
+        manifestJson: manifestJson(dye2Id, version: version),
+        pluginJs: pluginJs(dye2Id),
+      );
+
       Future<void> installBundledCopy({String version = '0.1.4'}) async {
         final staging = Directory('${tempDir.path}/bundled_$version')
           ..createSync(recursive: true);
@@ -612,11 +793,67 @@ function createPlugin() {
         service.seedBundledSources();
         expect(service.sourceFor(dye2Id)?.releaseTag, 'v0.1.4');
 
-        await installBundledCopy(version: '0.1.5');
+        await bundledUpgrade('0.1.5');
         service.seedBundledSources();
 
         expect(service.sourceFor(dye2Id)?.releaseTag, 'v0.1.5');
       });
+
+      test(
+        'seeding clears a pending update the bundled copy satisfies',
+        () async {
+          await installBundledCopy();
+          service.seedBundledSources();
+
+          await http.runWithClient(
+            () => service.updateAllPlugins(),
+            () => gitHubClient(
+              tag: 'v0.2.0',
+              releaseArchive: pluginArchive(
+                pluginId: dye2Id,
+                version: '0.2.0',
+                permissions: ['log'],
+              ),
+            ),
+          );
+          expect(service.sourceFor(dye2Id)!.pendingUpdate!.version, '0.2.0');
+
+          await bundledUpgrade('0.2.0');
+          service.seedBundledSources();
+
+          final source = service.sourceFor(dye2Id)!;
+          expect(source.pendingUpdate, isNull);
+          expect(source.releaseTag, 'v0.2.0');
+        },
+      );
+
+      test(
+        'seeding keeps a pending update newer than the bundled copy',
+        () async {
+          await installBundledCopy();
+          service.seedBundledSources();
+
+          await http.runWithClient(
+            () => service.updateAllPlugins(),
+            () => gitHubClient(
+              tag: 'v0.3.0',
+              releaseArchive: pluginArchive(
+                pluginId: dye2Id,
+                version: '0.3.0',
+                permissions: ['log'],
+              ),
+            ),
+          );
+          expect(service.sourceFor(dye2Id)!.pendingUpdate!.version, '0.3.0');
+
+          await bundledUpgrade('0.2.0');
+          service.seedBundledSources();
+
+          final source = service.sourceFor(dye2Id)!;
+          expect(source.pendingUpdate!.version, '0.3.0');
+          expect(source.releaseTag, 'v0.2.0');
+        },
+      );
 
       test('seeding leaves a user-chosen source alone', () async {
         await http.runWithClient(

--- a/test/plugins/plugin_source_service_test.dart
+++ b/test/plugins/plugin_source_service_test.dart
@@ -1,0 +1,541 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/plugins/plugin_package.dart';
+import 'package:reaprime/src/plugins/plugin_source.dart';
+import 'package:reaprime/src/plugins/plugin_source_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'plugin_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PluginSourceService', () {
+    late Directory tempDir;
+    late PluginLoaderService loader;
+    late PluginSourceService service;
+
+    const id = 'managed.reaplugin';
+
+    Map<String, dynamic> manifestJson(
+      String pluginId, {
+      String version = '1.0.0',
+      List<String> permissions = const [],
+    }) => {
+      'id': pluginId,
+      'author': 'Test',
+      'name': 'Test plugin',
+      'description': 'Test plugin',
+      'version': version,
+      'apiVersion': 1,
+      'permissions': permissions,
+      'settings': <String, dynamic>{},
+      'api': <Object>[],
+    };
+
+    String pluginJs(String pluginId, {String marker = ''}) =>
+        '''
+// $marker
+function createPlugin() {
+  return { id: "$pluginId", onLoad() {} };
+}
+''';
+
+    List<int> makeArchive(
+      Map<String, String> files, {
+      String prefix = 'repo-main/',
+    }) {
+      final archive = Archive();
+      files.forEach((path, content) {
+        archive.addFile(ArchiveFile.string('$prefix$path', content));
+      });
+      return ZipEncoder().encode(archive);
+    }
+
+    List<int> pluginArchive({
+      String pluginId = id,
+      String version = '1.0.0',
+      List<String> permissions = const [],
+      String marker = '',
+      String prefix = 'repo-main/',
+    }) => makeArchive({
+      'manifest.json': jsonEncode(
+        manifestJson(pluginId, version: version, permissions: permissions),
+      ),
+      'plugin.js': pluginJs(pluginId, marker: marker),
+    }, prefix: prefix);
+
+    String releaseJson(String tag, List<String> assetNames) => jsonEncode({
+      'tag_name': tag,
+      'name': tag,
+      'assets': [
+        for (final name in assetNames)
+          {
+            'name': name,
+            'browser_download_url': 'https://example.test/assets/$name',
+          },
+      ],
+    });
+
+    MockClient gitHubClient({
+      String tag = 'v1.0.0',
+      List<String> assets = const ['plugin.zip'],
+      List<int>? releaseArchive,
+      String commit = 'commit-1',
+      List<int>? branchArchive,
+    }) {
+      return MockClient((request) async {
+        final url = request.url.toString();
+        if (url.contains('/releases/latest') || url.endsWith('/releases')) {
+          final body = releaseJson(tag, assets);
+          return http.Response(
+            url.endsWith('/releases') ? '[$body]' : body,
+            200,
+          );
+        }
+        if (url.contains('/commits/')) {
+          return http.Response(jsonEncode({'sha': commit}), 200);
+        }
+        if (url.startsWith('https://example.test/assets/')) {
+          return http.Response.bytes(releaseArchive ?? pluginArchive(), 200);
+        }
+        if (url.contains('/archive/refs/heads/')) {
+          return http.Response.bytes(branchArchive ?? pluginArchive(), 200);
+        }
+        return http.Response('not found: $url', 404);
+      });
+    }
+
+    File sourceFile(String pluginId) =>
+        File('${tempDir.path}/plugins/$pluginId/.rea_source.json');
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      tempDir = Directory.systemTemp.createTempSync('plugin_source_service');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (_) async => tempDir.path,
+          );
+      loader = PluginLoaderService(kvStore: FakeKeyValueStoreService());
+      await loader.initialize();
+      service = PluginSourceService(loader);
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            null,
+          );
+      await loader.dispose();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('installs from a GitHub release and records provenance', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        gitHubClient,
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.0.0');
+      final source = service.sourceFor(id)!;
+      expect(source.kind, PluginSourceKind.githubRelease);
+      expect(source.repo, 'acme/plugin');
+      expect(source.releaseTag, 'v1.0.0');
+      expect(source.installedAt, isNotNull);
+      expect(source.lastChecked, isNotNull);
+    });
+
+    test('rejects a release tag that is not X.Y.Z or vX.Y.Z', () async {
+      await expectLater(
+        http.runWithClient(
+          () => service.installFromGitHubRelease('acme/plugin'),
+          () => gitHubClient(tag: 'release-2026'),
+        ),
+        throwsA(
+          isA<PluginPackageException>().having(
+            (e) => e.message,
+            'message',
+            contains('X.Y.Z'),
+          ),
+        ),
+      );
+      expect(loader.getPluginManifest(id), isNull);
+    });
+
+    test('rejects a release tag that disagrees with the manifest', () async {
+      await expectLater(
+        http.runWithClient(
+          () => service.installFromGitHubRelease('acme/plugin'),
+          () => gitHubClient(tag: 'v2.0.0'),
+        ),
+        throwsA(
+          isA<PluginPackageException>().having(
+            (e) => e.message,
+            'message',
+            contains('does not match manifest version'),
+          ),
+        ),
+      );
+    });
+
+    test('accepts a tag without the v prefix', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        () => gitHubClient(tag: '1.0.0'),
+      );
+
+      expect(service.sourceFor(id)?.releaseTag, '1.0.0');
+    });
+
+    test(
+      'requires an explicit asset when a release has several zips',
+      () async {
+        await expectLater(
+          http.runWithClient(
+            () => service.installFromGitHubRelease('acme/plugin'),
+            () => gitHubClient(assets: ['one.zip', 'two.zip']),
+          ),
+          throwsA(
+            isA<PluginPackageException>().having(
+              (e) => e.message,
+              'message',
+              contains('name the one to install'),
+            ),
+          ),
+        );
+
+        await http.runWithClient(
+          () => service.installFromGitHubRelease(
+            'acme/plugin',
+            assetName: 'two.zip',
+          ),
+          () => gitHubClient(assets: ['one.zip', 'two.zip']),
+        );
+        expect(service.sourceFor(id)?.assetName, 'two.zip');
+      },
+    );
+
+    test('installs from a GitHub branch and records the commit', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('acme/plugin', branch: 'dev'),
+        () => gitHubClient(commit: 'abc123'),
+      );
+
+      final source = service.sourceFor(id)!;
+      expect(source.kind, PluginSourceKind.githubBranch);
+      expect(source.branch, 'dev');
+      expect(source.commit, 'abc123');
+    });
+
+    test('branch update follows the commit, not the version', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('acme/plugin'),
+        () => gitHubClient(commit: 'first'),
+      );
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          commit: 'second',
+          branchArchive: pluginArchive(marker: 'v2 content'),
+        ),
+      );
+
+      expect(service.sourceFor(id)?.commit, 'second');
+      expect(loader.getPluginManifest(id)?.version, '1.0.0');
+      expect(
+        File('${tempDir.path}/plugins/$id/plugin.js').readAsStringSync(),
+        contains('v2 content'),
+      );
+    });
+
+    test('an unchanged commit only moves lastChecked', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('acme/plugin'),
+        () => gitHubClient(commit: 'same'),
+      );
+      final before = service.sourceFor(id)!.lastChecked!;
+
+      await Future.delayed(const Duration(milliseconds: 5));
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(commit: 'same'),
+      );
+
+      final after = service.sourceFor(id)!;
+      expect(after.commit, 'same');
+      expect(after.lastChecked!.isAfter(before), isTrue);
+    });
+
+    test('a release update with reduced permissions installs', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        () => gitHubClient(
+          releaseArchive: pluginArchive(permissions: ['log', 'api']),
+        ),
+      );
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: pluginArchive(version: '1.1.0', permissions: ['log']),
+        ),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.1.0');
+      expect(service.sourceFor(id)?.pendingUpdate, isNull);
+    });
+
+    test('an added permission blocks the automatic update', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        () => gitHubClient(releaseArchive: pluginArchive(permissions: ['log'])),
+      );
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: pluginArchive(
+            version: '1.1.0',
+            permissions: ['log', 'proxy.decent_api'],
+          ),
+        ),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.0.0');
+      final pending = service.sourceFor(id)!.pendingUpdate!;
+      expect(pending.version, '1.1.0');
+      expect(pending.releaseTag, 'v1.1.0');
+      expect(pending.addedPermissions, ['proxy.decent_api']);
+    });
+
+    test('approving a pending update installs it', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        () => gitHubClient(releaseArchive: pluginArchive(permissions: ['log'])),
+      );
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: pluginArchive(
+            version: '1.1.0',
+            permissions: ['log', 'proxy.decent_api'],
+          ),
+        ),
+      );
+
+      await http.runWithClient(
+        () => service.approvePendingUpdate(id),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: pluginArchive(
+            version: '1.1.0',
+            permissions: ['log', 'proxy.decent_api'],
+          ),
+        ),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.1.0');
+      expect(service.sourceFor(id)?.pendingUpdate, isNull);
+    });
+
+    test('approving without a pending update is an error', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        gitHubClient,
+      );
+
+      await expectLater(
+        service.approvePendingUpdate(id),
+        throwsA(isA<PluginApprovalRequiredException>()),
+      );
+    });
+
+    test('a running plugin is restarted on the new version', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        gitHubClient,
+      );
+      await loader.enablePlugin(id);
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: pluginArchive(version: '1.1.0'),
+        ),
+      );
+
+      expect(loader.isPluginLoaded(id), isTrue);
+      expect(await loader.shouldAutoLoad(id), isTrue);
+      expect(loader.getPluginManifest(id)?.version, '1.1.0');
+    });
+
+    test('a disabled plugin stays unloaded across an update', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        gitHubClient,
+      );
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: pluginArchive(version: '1.1.0'),
+        ),
+      );
+
+      expect(loader.isPluginLoaded(id), isFalse);
+      expect(await loader.shouldAutoLoad(id), isFalse);
+    });
+
+    test('settings survive an update', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        () => gitHubClient(
+          releaseArchive: makeArchive({
+            'manifest.json': jsonEncode({
+              ...manifestJson(id),
+              'settings': {
+                'Token': {'type': 'string'},
+              },
+            }),
+            'plugin.js': pluginJs(id),
+          }),
+        ),
+      );
+      await loader.savePluginSettings(id, {'Token': 'abc'});
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: makeArchive({
+            'manifest.json': jsonEncode({
+              ...manifestJson(id, version: '1.1.0'),
+              'settings': {
+                'Token': {'type': 'string'},
+              },
+            }),
+            'plugin.js': pluginJs(id),
+          }),
+        ),
+      );
+
+      expect(loader.getPluginManifest(id)?.version, '1.1.0');
+      expect(await loader.pluginSettings(id), containsPair('Token', 'abc'));
+    });
+
+    test('one plugin failing does not stop the others', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('broken/plugin'),
+        () => gitHubClient(commit: 'first'),
+      );
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('good/plugin'),
+        () => gitHubClient(
+          commit: 'first',
+          branchArchive: pluginArchive(pluginId: 'other.reaplugin'),
+        ),
+      );
+
+      await http.runWithClient(() => service.updateAllPlugins(), () {
+        return MockClient((request) async {
+          final url = request.url.toString();
+          if (url.contains('broken/plugin')) {
+            return http.Response('boom', 500);
+          }
+          if (url.contains('/commits/')) {
+            return http.Response(jsonEncode({'sha': 'second'}), 200);
+          }
+          return http.Response.bytes(
+            pluginArchive(pluginId: 'other.reaplugin', marker: 'fresh'),
+            200,
+          );
+        });
+      });
+
+      expect(service.sourceFor(id)!.lastError, isNotNull);
+      expect(service.sourceFor(id)!.commit, 'first');
+      expect(service.sourceFor('other.reaplugin')!.commit, 'second');
+      expect(service.sourceFor('other.reaplugin')!.lastError, isNull);
+    });
+
+    test('a local zip install is a snapshot that never auto-updates', () async {
+      final zip = File('${tempDir.path}/plugin.zip')
+        ..writeAsBytesSync(pluginArchive(prefix: 'wrapper/'));
+
+      await service.installFromZip(zip.path);
+
+      final source = service.sourceFor(id)!;
+      expect(source.kind, PluginSourceKind.localZip);
+      expect(source.kind.isManaged, isFalse);
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => MockClient(
+          (_) async => throw StateError('managed update must not run'),
+        ),
+      );
+      expect(loader.getPluginManifest(id)?.version, '1.0.0');
+    });
+
+    test('a flat local zip installs too', () async {
+      final zip = File('${tempDir.path}/flat.zip')
+        ..writeAsBytesSync(pluginArchive(prefix: ''));
+
+      await service.installFromZip(zip.path);
+
+      expect(loader.getPluginManifest(id)?.version, '1.0.0');
+    });
+
+    test('removing a plugin clears its source metadata', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        gitHubClient,
+      );
+      expect(sourceFile(id).existsSync(), isTrue);
+
+      await loader.removePlugin(id);
+
+      expect(sourceFile(id).existsSync(), isFalse);
+      expect(loader.getPluginManifest(id), isNull);
+    });
+
+    test('a failed install leaves the previous version running', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubRelease('acme/plugin'),
+        gitHubClient,
+      );
+      await loader.enablePlugin(id);
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          releaseArchive: makeArchive({
+            'manifest.json': jsonEncode(manifestJson(id, version: '1.1.0')),
+            'plugin.js': 'function createPlugin() { throw new Error("boom"); }',
+          }),
+        ),
+      );
+
+      expect(loader.isPluginLoaded(id), isTrue);
+      expect(loader.getPluginManifest(id)?.version, '1.0.0');
+      expect(service.sourceFor(id)!.releaseTag, 'v1.0.0');
+      expect(service.sourceFor(id)!.lastError, isNotNull);
+    });
+  });
+}

--- a/test/plugins/plugin_source_service_test.dart
+++ b/test/plugins/plugin_source_service_test.dart
@@ -514,6 +514,128 @@ function createPlugin() {
       expect(loader.getPluginManifest(id), isNull);
     });
 
+    test('an update carrying a different plugin is rejected', () async {
+      await http.runWithClient(
+        () => service.installFromGitHubBranch('acme/plugin'),
+        () => gitHubClient(commit: 'first'),
+      );
+
+      await http.runWithClient(
+        () => service.updateAllPlugins(),
+        () => gitHubClient(
+          commit: 'second',
+          branchArchive: pluginArchive(pluginId: 'someone-else.reaplugin'),
+        ),
+      );
+
+      expect(loader.getPluginManifest('someone-else.reaplugin'), isNull);
+      final source = service.sourceFor(id)!;
+      expect(source.commit, 'first');
+      expect(source.lastError, contains('someone-else.reaplugin'));
+    });
+
+    group('bundled plugin provenance', () {
+      const dye2Id = 'dye2.reaplugin';
+
+      Future<void> installBundledCopy({String version = '0.1.4'}) async {
+        final staging = Directory('${tempDir.path}/bundled_$version')
+          ..createSync(recursive: true);
+        File(
+          '${staging.path}/manifest.json',
+        ).writeAsStringSync(jsonEncode(manifestJson(dye2Id, version: version)));
+        File('${staging.path}/plugin.js').writeAsStringSync(pluginJs(dye2Id));
+        await loader.installPluginPackage(staging);
+      }
+
+      test('a freshly installed bundled DYE2 gets its repo', () async {
+        await installBundledCopy();
+        expect(sourceFile(dye2Id).existsSync(), isFalse);
+
+        service.seedBundledSources();
+
+        final source = service.sourceFor(dye2Id)!;
+        expect(source.kind, PluginSourceKind.githubRelease);
+        expect(source.repo, 'decentespresso/dye2');
+        expect(source.releaseTag, 'v0.1.4');
+        expect(source.includePrerelease, isFalse);
+        expect(source.assetName, isNull);
+      });
+
+      test('an existing DYE2 without metadata is migrated', () async {
+        await installBundledCopy();
+        expect(service.sourceFor(dye2Id), isNull);
+
+        await http.runWithClient(
+          () => service.updateAllPlugins(),
+          () => gitHubClient(
+            tag: 'v0.1.4',
+            releaseArchive: pluginArchive(pluginId: dye2Id),
+          ),
+        );
+
+        expect(service.sourceFor(dye2Id)?.repo, 'decentespresso/dye2');
+      });
+
+      test('the update checker then queries decentespresso/dye2', () async {
+        await installBundledCopy();
+
+        final requested = <String>[];
+        await http.runWithClient(() => service.updateAllPlugins(), () {
+          return MockClient((request) async {
+            requested.add(request.url.toString());
+            final url = request.url.toString();
+            if (url.contains('/releases/latest')) {
+              return http.Response(
+                releaseJson('v0.2.0', ['dye2.reaplugin-0.2.0.zip']),
+                200,
+              );
+            }
+            return http.Response.bytes(
+              pluginArchive(pluginId: dye2Id, version: '0.2.0'),
+              200,
+            );
+          });
+        });
+
+        expect(
+          requested,
+          contains(
+            'https://api.github.com/repos/decentespresso/dye2/releases/latest',
+          ),
+        );
+        expect(loader.getPluginManifest(dye2Id)?.version, '0.2.0');
+        expect(service.sourceFor(dye2Id)?.releaseTag, 'v0.2.0');
+      });
+
+      test('seeding realigns the tag after a newer bundled copy', () async {
+        await installBundledCopy();
+        service.seedBundledSources();
+        expect(service.sourceFor(dye2Id)?.releaseTag, 'v0.1.4');
+
+        await installBundledCopy(version: '0.1.5');
+        service.seedBundledSources();
+
+        expect(service.sourceFor(dye2Id)?.releaseTag, 'v0.1.5');
+      });
+
+      test('seeding leaves a user-chosen source alone', () async {
+        await http.runWithClient(
+          () => service.installFromGitHubBranch('someone/dye2-fork'),
+          () => gitHubClient(
+            commit: 'fork-commit',
+            branchArchive: pluginArchive(pluginId: dye2Id),
+          ),
+        );
+
+        service.seedBundledSources();
+
+        final source = service.sourceFor(dye2Id)!;
+        expect(source.kind, PluginSourceKind.githubBranch);
+        expect(source.repo, 'someone/dye2-fork');
+        expect(source.commit, 'fork-commit');
+      });
+    });
+
     test('a failed install leaves the previous version running', () async {
       await http.runWithClient(
         () => service.installFromGitHubRelease('acme/plugin'),

--- a/test/plugins/plugins_settings_view_sources_test.dart
+++ b/test/plugins/plugins_settings_view_sources_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_source.dart';
+import 'package:reaprime/src/plugins/plugin_source_service.dart';
+import 'package:reaprime/src/settings/plugins_settings_view.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class _FakeLoader extends Fake implements PluginLoaderService {
+  _FakeLoader(this.plugins);
+
+  final List<PluginManifest> plugins;
+
+  @override
+  List<PluginManifest> get availablePlugins => plugins;
+
+  @override
+  bool isPluginLoaded(String pluginId) => false;
+
+  @override
+  Future<bool> shouldAutoLoad(String pluginId) async => false;
+
+  @override
+  PluginManifest? getPluginManifest(String pluginId) {
+    for (final plugin in plugins) {
+      if (plugin.id == pluginId) return plugin;
+    }
+    return null;
+  }
+}
+
+class _FakeSourceService extends PluginSourceService {
+  _FakeSourceService(super.loader, {this.source});
+
+  final PluginSource? source;
+  int updateCalls = 0;
+  int approvals = 0;
+
+  @override
+  PluginSource? sourceFor(String pluginId) => source;
+
+  @override
+  Future<void> updateAllPlugins() async {
+    updateCalls++;
+  }
+
+  @override
+  Future<PluginManifest> approvePendingUpdate(String pluginId) async {
+    approvals++;
+    return PluginManifest(
+      id: pluginId,
+      name: 'Test plugin',
+      author: 'Test',
+      description: '',
+      version: '1.1.0',
+      apiVersion: 1,
+      permissions: const {},
+      settings: const {},
+      api: null,
+    );
+  }
+}
+
+PluginManifest manifest({Set<PluginPermissions> permissions = const {}}) =>
+    PluginManifest(
+      id: 'source.reaplugin',
+      name: 'Sourced plugin',
+      author: 'Test',
+      description: 'A plugin with provenance',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: permissions,
+      settings: const {},
+      api: null,
+    );
+
+void main() {
+  Future<void> pumpView(
+    WidgetTester tester, {
+    required _FakeSourceService sourceService,
+    List<PluginManifest> plugins = const [],
+  }) async {
+    await tester.pumpWidget(
+      ShadApp(
+        home: ScaffoldMessenger(
+          child: PluginsSettingsView(
+            pluginLoaderService: _FakeLoader(plugins),
+            pluginSourceService: sourceService,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('the install menu offers every source', (tester) async {
+    final sourceService = _FakeSourceService(_FakeLoader(const []));
+    await pumpView(tester, sourceService: sourceService);
+
+    await tester.tap(find.byTooltip('Install Plugin'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('GitHub Release'), findsOneWidget);
+    expect(find.text('GitHub Branch'), findsOneWidget);
+    expect(find.text('ZIP file'), findsOneWidget);
+    expect(find.text('Folder snapshot'), findsOneWidget);
+  });
+
+  testWidgets('check for updates runs the managed update', (tester) async {
+    final sourceService = _FakeSourceService(_FakeLoader(const []));
+    await pumpView(tester, sourceService: sourceService);
+
+    await tester.tap(find.byTooltip('Check for updates'));
+    await tester.pumpAndSettle();
+
+    expect(sourceService.updateCalls, 1);
+  });
+
+  testWidgets('a GitHub-backed plugin shows its provenance', (tester) async {
+    final sourceService = _FakeSourceService(
+      _FakeLoader(const []),
+      source: PluginSource(
+        kind: PluginSourceKind.githubRelease,
+        repo: 'acme/plugin',
+        releaseTag: 'v1.0.0',
+        installedAt: DateTime(2026, 1, 1),
+      ),
+    );
+
+    await pumpView(tester, sourceService: sourceService, plugins: [manifest()]);
+
+    expect(
+      find.textContaining('GitHub release acme/plugin @ v1.0.0'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a permission escalation is confirmed before it installs', (
+    tester,
+  ) async {
+    final sourceService = _FakeSourceService(
+      _FakeLoader(const []),
+      source: PluginSource(
+        kind: PluginSourceKind.githubRelease,
+        repo: 'acme/plugin',
+        releaseTag: 'v1.0.0',
+        installedAt: DateTime(2026, 1, 1),
+        pendingUpdate: PluginPendingUpdate(
+          version: '1.1.0',
+          releaseTag: 'v1.1.0',
+          addedPermissions: const ['proxy.decent_api'],
+          detectedAt: DateTime(2026, 1, 2),
+        ),
+      ),
+    );
+
+    await pumpView(
+      tester,
+      sourceService: sourceService,
+      plugins: [
+        manifest(permissions: {PluginPermissions.log}),
+      ],
+    );
+
+    expect(
+      find.textContaining('needs approval: adds proxy.decent_api'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('requests new permissions'), findsOneWidget);
+    expect(find.text('• proxy.decent_api'), findsOneWidget);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(sourceService.approvals, 0);
+
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Approve and update'));
+    await tester.pumpAndSettle();
+
+    expect(sourceService.approvals, 1);
+  });
+}

--- a/test/update_check_service_test.dart
+++ b/test/update_check_service_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/plugins/plugin_source_service.dart';
 import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/services/app_update_state.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
@@ -9,6 +11,19 @@ import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/webui_support/webui_storage.dart';
 
 import 'helpers/mock_settings_service.dart';
+
+class _FakeLoader extends Fake implements PluginLoaderService {}
+
+class _RecordingPluginSourceService extends PluginSourceService {
+  _RecordingPluginSourceService() : super(_FakeLoader());
+
+  int updateCalls = 0;
+
+  @override
+  Future<void> updateAllPlugins() async {
+    updateCalls++;
+  }
+}
 
 class _FakeUpdater extends AndroidUpdater {
   _FakeUpdater() : super(owner: 'tadelv', repo: 'reaprime');
@@ -74,15 +89,18 @@ void main() {
   late _FakeUpdater updater;
   late MockSettingsService settingsService;
   late WebUIStorage webUIStorage;
+  late _RecordingPluginSourceService pluginSourceService;
 
   UpdateCheckService build({bool isAndroid = true, bool isMacOS = false}) {
     updater = _FakeUpdater();
     settingsService = MockSettingsService();
     final settingsController = SettingsController(settingsService);
     webUIStorage = WebUIStorage(settingsController);
+    pluginSourceService = _RecordingPluginSourceService();
     return UpdateCheckService(
       settingsService: settingsService,
       webUIStorage: webUIStorage,
+      pluginSourceService: pluginSourceService,
       updater: updater,
       platformIsAndroid: isAndroid,
       platformIsMacOS: isMacOS,
@@ -322,6 +340,26 @@ void main() {
       await svc.initialize();
 
       expect(updater.checkCalls, 0);
+      svc.dispose();
+    });
+  });
+
+  group('managed content', () {
+    test('enabling automatic checks also updates managed plugins', () async {
+      final svc = build();
+
+      await svc.enableAutomaticChecks();
+
+      expect(pluginSourceService.updateCalls, 1);
+      svc.dispose();
+    });
+
+    test('macOS still updates managed plugins', () async {
+      final svc = build(isMacOS: true);
+
+      await svc.enableAutomaticChecks();
+
+      expect(pluginSourceService.updateCalls, 1);
       svc.dispose();
     });
   });

--- a/test/webserver/plugins_handler_install_test.dart
+++ b/test/webserver/plugins_handler_install_test.dart
@@ -67,7 +67,8 @@ void main() {
     }) {
       return MockClient((request) async {
         final url = request.url.toString();
-        if (url.contains('/releases/latest')) {
+        if (url.contains('/releases/latest') ||
+            url.contains('/releases/tags/')) {
           return http.Response(
             jsonEncode({
               'tag_name': tag,

--- a/test/webserver/plugins_handler_install_test.dart
+++ b/test/webserver/plugins_handler_install_test.dart
@@ -1,0 +1,279 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:reaprime/src/plugins/plugin_loader_service.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+import '../plugins/plugin_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('plugin installation API', () {
+    late Directory tempDir;
+    late PluginLoaderService service;
+    late Handler handler;
+
+    const id = 'installed.reaplugin';
+
+    Map<String, dynamic> manifestJson({
+      String version = '1.0.0',
+      List<String> permissions = const [],
+    }) => {
+      'id': id,
+      'author': 'Test',
+      'name': 'Test plugin',
+      'description': 'Test plugin',
+      'version': version,
+      'apiVersion': 1,
+      'permissions': permissions,
+      'settings': <String, dynamic>{},
+      'api': <Object>[],
+    };
+
+    List<int> pluginArchive({
+      String version = '1.0.0',
+      List<String> permissions = const [],
+    }) {
+      final archive = Archive()
+        ..addFile(
+          ArchiveFile.string(
+            'repo-main/manifest.json',
+            jsonEncode(
+              manifestJson(version: version, permissions: permissions),
+            ),
+          ),
+        )
+        ..addFile(
+          ArchiveFile.string(
+            'repo-main/plugin.js',
+            'function createPlugin() { return { id: "$id", onLoad() {} }; }',
+          ),
+        );
+      return ZipEncoder().encode(archive);
+    }
+
+    MockClient gitHubClient({
+      String tag = 'v1.0.0',
+      String commit = 'commit-1',
+      List<int>? archive,
+    }) {
+      return MockClient((request) async {
+        final url = request.url.toString();
+        if (url.contains('/releases/latest')) {
+          return http.Response(
+            jsonEncode({
+              'tag_name': tag,
+              'assets': [
+                {
+                  'name': 'plugin.zip',
+                  'browser_download_url': 'https://example.test/plugin.zip',
+                },
+              ],
+            }),
+            200,
+          );
+        }
+        if (url.contains('/commits/')) {
+          return http.Response(jsonEncode({'sha': commit}), 200);
+        }
+        return http.Response.bytes(archive ?? pluginArchive(), 200);
+      });
+    }
+
+    Future<Response> post(String path, [Object? body]) async => handler(
+      Request(
+        'POST',
+        Uri.parse('http://localhost$path'),
+        body: body == null ? null : jsonEncode(body),
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+
+    Future<Map<String, dynamic>> listedPlugin() async {
+      final res = await handler(
+        Request('GET', Uri.parse('http://localhost/api/v1/plugins')),
+      );
+      final list = jsonDecode(await res.readAsString()) as List<dynamic>;
+      return list.cast<Map<String, dynamic>>().firstWhere(
+        (plugin) => plugin['id'] == id,
+      );
+    }
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      tempDir = Directory.systemTemp.createTempSync('plugins_handler_install');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (_) async => tempDir.path,
+          );
+      service = PluginLoaderService(kvStore: FakeKeyValueStoreService());
+      await service.initialize();
+      final app = Router().plus;
+      PluginsHandler(
+        pluginManager: service.pluginManager,
+        pluginService: service,
+      ).addRoutes(app);
+      handler = app.call;
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            null,
+          );
+      await service.dispose();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('installs from a GitHub release and lists the source', () async {
+      final res = await http.runWithClient(
+        () => post('/api/v1/plugins/install/github-release', {
+          'repo': 'acme/plugin',
+        }),
+        gitHubClient,
+      );
+
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body, containsPair('id', id));
+      expect(body, containsPair('version', '1.0.0'));
+
+      final listed = await listedPlugin();
+      expect(listed['source']['kind'], 'github_release');
+      expect(listed['source']['repo'], 'acme/plugin');
+      expect(listed['source']['releaseTag'], 'v1.0.0');
+      expect(listed['pendingUpdate'], isNull);
+    });
+
+    test('installs from a GitHub branch', () async {
+      final res = await http.runWithClient(
+        () => post('/api/v1/plugins/install/github-branch', {
+          'repo': 'acme/plugin',
+          'branch': 'dev',
+        }),
+        () => gitHubClient(commit: 'abcdef'),
+      );
+
+      expect(res.statusCode, 200);
+      final listed = await listedPlugin();
+      expect(listed['source']['kind'], 'github_branch');
+      expect(listed['source']['branch'], 'dev');
+      expect(listed['source']['commit'], 'abcdef');
+    });
+
+    test('rejects a missing repo with 400', () async {
+      final res = await post('/api/v1/plugins/install/github-release', {});
+      expect(res.statusCode, 400);
+    });
+
+    test('rejects a tag that disagrees with the manifest with 400', () async {
+      final res = await http.runWithClient(
+        () => post('/api/v1/plugins/install/github-release', {
+          'repo': 'acme/plugin',
+        }),
+        () => gitHubClient(tag: 'v9.9.9'),
+      );
+
+      expect(res.statusCode, 400);
+      expect(await res.readAsString(), contains('does not match'));
+    });
+
+    test(
+      'the URL installer stays unimplemented and points elsewhere',
+      () async {
+        final res = await post('/api/v1/plugins/install', {
+          'url': 'https://example.test/plugin.zip',
+        });
+
+        expect(res.statusCode, 501);
+        expect(await res.readAsString(), contains('github-release'));
+      },
+    );
+
+    test('update-all reports success', () async {
+      await http.runWithClient(
+        () => post('/api/v1/plugins/install/github-branch', {
+          'repo': 'acme/plugin',
+        }),
+        () => gitHubClient(commit: 'first'),
+      );
+
+      final res = await http.runWithClient(
+        () => post('/api/v1/plugins/update'),
+        () => gitHubClient(commit: 'second'),
+      );
+
+      expect(res.statusCode, 200);
+      final listed = await listedPlugin();
+      expect(listed['source']['commit'], 'second');
+    });
+
+    test('a permission-escalating update is listed as pending', () async {
+      await http.runWithClient(
+        () => post('/api/v1/plugins/install/github-release', {
+          'repo': 'acme/plugin',
+        }),
+        () => gitHubClient(archive: pluginArchive(permissions: ['log'])),
+      );
+
+      await http.runWithClient(
+        () => post('/api/v1/plugins/update'),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          archive: pluginArchive(
+            version: '1.1.0',
+            permissions: ['log', 'proxy.decent_api'],
+          ),
+        ),
+      );
+
+      final listed = await listedPlugin();
+      expect(listed['version'], '1.0.0');
+      expect(listed['pendingUpdate']['version'], '1.1.0');
+      expect(listed['pendingUpdate']['addedPermissions'], ['proxy.decent_api']);
+
+      final approved = await http.runWithClient(
+        () => post('/api/v1/plugins/$id/update/approve'),
+        () => gitHubClient(
+          tag: 'v1.1.0',
+          archive: pluginArchive(
+            version: '1.1.0',
+            permissions: ['log', 'proxy.decent_api'],
+          ),
+        ),
+      );
+
+      expect(approved.statusCode, 200);
+      final after = await listedPlugin();
+      expect(after['version'], '1.1.0');
+      expect(after['pendingUpdate'], isNull);
+    });
+
+    test('approving without a pending update is a conflict', () async {
+      await http.runWithClient(
+        () => post('/api/v1/plugins/install/github-release', {
+          'repo': 'acme/plugin',
+        }),
+        gitHubClient,
+      );
+
+      final res = await post('/api/v1/plugins/$id/update/approve');
+      expect(res.statusCode, 409);
+    });
+
+    test('approving an unknown plugin is a 404', () async {
+      final res = await post('/api/v1/plugins/nope.reaplugin/update/approve');
+      expect(res.statusCode, 404);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Brings plugin installation and updates to parity with WebUI skins: install from a GitHub release, a GitHub branch, a local ZIP or a local folder, with provenance and automatic update checks for the GitHub-backed sources.

- **One validation path** (`lib/src/plugins/plugin_package.dart`). Any staged directory resolves to a single plugin root - flat, or one wrapper directory as GitHub archives and release ZIPs produce - and must carry a parseable `manifest.json`, a `plugin.js` and a safe id. Several candidate roots are rejected rather than guessed. Nothing installed is touched until validation passes.
- **Transactional install** (`PluginLoaderService.installPluginPackage`). Under the existing per-plugin mutation lock: rename the installed directory aside, copy the candidate in, reload if it was running; on any failure restore the previous files, manifest cache and runtime. `addPlugin` delegates to it, so the folder picker path is unchanged.
- **Provenance and updates** (`PluginSourceService`). Release installs require a `X.Y.Z`/`vX.Y.Z` tag equal to the manifest version and exactly one `.zip` asset unless the caller names one. Branch installs record the resolved commit, so a moved branch is an update even when the manifest version does not change. Local ZIP/folder installs are untracked snapshots and never auto-update.
- **Metadata storage.** A Decaid-owned `.rea_source.json` inside the plugin directory (the same shape of decision as WebUI's `.rea_metadata.json`). Removal deletes the directory, so removal clears the metadata with no extra wiring; the partial `PUT /source` write leaves it alone.
- **Permission escalation.** An automatic update installs only when the candidate keeps the same permissions or fewer. Anything added is recorded as a `pendingUpdate` carrying the candidate version and the permission delta, surfaced in the UI and the API, and installed only after explicit approval.
- **Update cadence.** `updateAllPlugins()` runs beside `WebUIStorage.updateAllSkins()` in `UpdateCheckService` - no new timer. One plugin's failure is recorded in `lastError` and never stops the others.
- **REST.** `POST /api/v1/plugins/install/github-release`, `/install/github-branch`, `/update`, `/{id}/update/approve`; `GET /api/v1/plugins` now reports `source` and `pendingUpdate`. The old URL installer stub still returns 501 but names the endpoints to use; arbitrary remote ZIP URLs stay out of scope per the issue.
- **Native UI.** The install button becomes a four-source menu, plus a "Check for updates" action, a per-plugin provenance line, and a permission-delta dialog before an escalating update installs.

## Linked Issue

Refs #626

## Verification

- `flutter analyze`: `No issues found!`
- `flutter test`: 3151 passing. The 4 failures in `test/webui_support/webui_token_injection_test.dart` are environmental on this machine, not from this branch - a running Decaid instance holds port 3000 (`SocketException: Address already in use, port = 3000`); stashing the branch and re-running that file reproduces them identically.
- New tests:
  - `test/plugins/plugin_package_test.dart` (7): flat root, single wrapper, several roots rejected, missing manifest, missing `plugin.js`, malformed manifest, unsafe id.
  - `test/plugins/plugin_source_service_test.dart` (20): release install + provenance, non-semver tag rejected, tag/manifest mismatch rejected, `v`-less tag accepted, several zip assets require explicit selection, branch install + commit, branch update with unchanged manifest version, unchanged commit only moves `lastChecked`, reduced permissions auto-update, added permission blocks and records approval-required, approval installs, running plugin restarted, disabled stays disabled, settings survive, one failure does not stop others, local zip (flat and wrapped) not auto-updated, removal clears metadata, failed install leaves the previous version running.
  - `test/webserver/plugins_handler_install_test.dart` (9): both install endpoints, listed source fields, 400 on missing repo and on tag mismatch, 501 URL stub, update-all, pending update listed then approved, 409 without a pending update, 404 for unknown plugin.
  - `test/plugins/plugins_settings_view_sources_test.dart` (4): install menu, manual update check, provenance line, permission-delta confirmation (cancel installs nothing, approve installs).
  - `test/update_check_service_test.dart` (+2): managed plugins updated on the normal cadence, including macOS.

## Impact

- API: four new endpoints; two new fields on `GET /api/v1/plugins`. `assets/api/rest_v1.yml` updated in the same commit (`PluginSource`, `PluginPendingUpdate`, `PluginInstallResult` schemas), `doc/Api.md` table updated.
- Docs: `doc/Plugins.md` gains a Distribution and Updates section - the four sources, the release packaging contract (tag == manifest version, one zip asset), update rules, and the permission-escalation rule.
- Behavior: `addPlugin` is now transactional and reloads a plugin that was running; previously it deleted the directory first and left a running plugin unloaded.
- Security: automatic updates can no longer widen a plugin's permissions. Plugin routes remain outside the account-proxy bearer token, unchanged by this PR and already documented.
- Not included, per the issue: arbitrary remote ZIP URL installation; bundled plugins keep the app-owned startup copy path.
- Design rationale archived at `doc/plans/archive/plugin-distribution/plugin-distribution-parity.md`.

Note: the GitHub release/branch helpers are new (`lib/src/util/github_archive.dart`) and used by plugins only. `WebUIStorage` still has its own inline HTTP/release parsing - rewiring skins onto the shared helper is worth doing but risks skin regressions, so I left it for a follow-up rather than bundling it here.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
