### PR TITLE
fix(scales): log why a BLE scale connect failed

### DIFF
--- a/lib/src/models/device/impl/atomheart/atomheart_scale.dart
+++ b/lib/src/models/device/impl/atomheart/atomheart_scale.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -12,6 +13,8 @@ import 'package:reaprime/src/models/errors.dart';
 import '../../scale.dart';
 
 class AtomheartScale implements Scale {
+  final Logger _log = Logger('AtomheartScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.long('b905eaea-6c7e-4f73-b43d-2cdfcab29570');
   static final BleServiceIdentifier dataCharacteristic =
@@ -82,6 +85,7 @@ class AtomheartScale implements Scale {
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/blackcoffee/blackcoffee_scale.dart
+++ b/lib/src/models/device/impl/blackcoffee/blackcoffee_scale.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -11,6 +12,8 @@ import 'package:reaprime/src/models/device/device.dart';
 import '../../scale.dart';
 
 class BlackCoffeeScale implements Scale {
+  final Logger _log = Logger('BlackCoffeeScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.short('ffb0');
   static final BleServiceIdentifier dataCharacteristic =
@@ -81,6 +84,7 @@ class BlackCoffeeScale implements Scale {
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/bookoo/miniscale.dart
+++ b/lib/src/models/device/impl/bookoo/miniscale.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -12,6 +13,8 @@ import 'package:reaprime/src/models/device/device.dart';
 import '../../scale.dart';
 
 class BookooScale implements Scale {
+  final Logger _log = Logger('BookooScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.short('0ffe');
   static final BleServiceIdentifier dataCharacteristic =
@@ -77,6 +80,7 @@ class BookooScale implements Scale {
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/difluid/difluid_scale.dart
+++ b/lib/src/models/device/impl/difluid/difluid_scale.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -11,6 +12,8 @@ import 'package:reaprime/src/models/device/device.dart';
 import '../../scale.dart';
 
 class DifluidScale implements Scale {
+  final Logger _log = Logger('DifluidScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.short('00ee');
   static final BleServiceIdentifier dataCharacteristic =
@@ -98,6 +101,7 @@ class DifluidScale implements Scale {
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/eureka/eureka_scale.dart
+++ b/lib/src/models/device/impl/eureka/eureka_scale.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -12,6 +13,8 @@ import 'package:reaprime/src/models/errors.dart';
 import '../../scale.dart';
 
 class EurekaScale implements Scale {
+  final Logger _log = Logger('EurekaScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.short('fff0');
   static final BleServiceIdentifier dataCharacteristic =
@@ -89,6 +92,7 @@ class EurekaScale implements Scale {
       _readBattery();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/felicita/arc.dart
+++ b/lib/src/models/device/impl/felicita/arc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:logging/logging.dart';
 import 'package:collection/collection.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
@@ -13,6 +14,8 @@ import 'package:reaprime/src/models/errors.dart';
 import '../../scale.dart';
 
 class FelicitaArc implements Scale {
+  final Logger _log = Logger('FelicitaArc');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.short('ffe0');
   static final BleServiceIdentifier dataCharacteristic =
@@ -81,6 +84,7 @@ class FelicitaArc implements Scale {
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/hiroia/hiroia_scale.dart
+++ b/lib/src/models/device/impl/hiroia/hiroia_scale.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -12,6 +13,8 @@ import 'package:reaprime/src/models/errors.dart';
 import '../../scale.dart';
 
 class HiroiaScale implements Scale {
+  final Logger _log = Logger('HiroiaScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.long('06c31822-8682-4744-9211-febc93e3bece');
   static final BleServiceIdentifier dataCharacteristic =
@@ -81,6 +84,7 @@ class HiroiaScale implements Scale {
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/skale/skale2_scale.dart
+++ b/lib/src/models/device/impl/skale/skale2_scale.dart
@@ -107,6 +107,7 @@ class Skale2Scale implements Scale {
       await _initScale();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/smartchef/smartchef_scale.dart
+++ b/lib/src/models/device/impl/smartchef/smartchef_scale.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -10,6 +11,8 @@ import 'package:reaprime/src/models/device/device.dart';
 import '../../scale.dart';
 
 class SmartChefScale implements Scale {
+  final Logger _log = Logger('SmartChefScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.short('fff0');
   static final BleServiceIdentifier dataCharacteristic =
@@ -80,6 +83,7 @@ class SmartChefScale implements Scale {
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/varia/varia_aku_scale.dart
+++ b/lib/src/models/device/impl/varia/varia_aku_scale.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
@@ -12,6 +13,8 @@ import 'package:reaprime/src/models/errors.dart';
 import '../../scale.dart';
 
 class VariaAkuScale implements Scale {
+  final Logger _log = Logger('VariaAkuScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.short('fff0');
   static final BleServiceIdentifier dataCharacteristic =
@@ -83,6 +86,7 @@ class VariaAkuScale implements Scale {
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
     } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/lib/src/models/device/impl/weighmaster/weighmaster_scale.dart
+++ b/lib/src/models/device/impl/weighmaster/weighmaster_scale.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/ble_service_identifier.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
@@ -12,6 +13,8 @@ import 'package:rxdart/subjects.dart';
 import '../../scale.dart';
 
 class WeighMasterScale implements Scale {
+  final Logger _log = Logger('WeighMasterScale');
+
   static final BleServiceIdentifier serviceIdentifier =
       BleServiceIdentifier.short('fff0');
   static final BleServiceIdentifier dataCharacteristic =
@@ -93,7 +96,8 @@ class WeighMasterScale implements Scale {
       }
       await _registerNotifications();
       _connectionStateController.add(ConnectionState.connected);
-    } catch (_) {
+    } catch (e) {
+      _log.warning('Connect failed: $e');
       disconnectSub?.cancel();
       _connectionStateController.add(ConnectionState.disconnected);
       try {

--- a/test/unit/models/atomheart_scale_connect_failure_test.dart
+++ b/test/unit/models/atomheart_scale_connect_failure_test.dart
@@ -1,0 +1,127 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/impl/atomheart/atomheart_scale.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _AtomheartTransport extends BLETransport {
+  final BehaviorSubject<ConnectionState> states = BehaviorSubject.seeded(
+    ConnectionState.discovered,
+  );
+  Object? connectError;
+  List<String> services = [AtomheartScale.serviceIdentifier.long];
+
+  @override
+  String get id => 'atomheart-test';
+
+  @override
+  String get name => 'Atomheart Eclair';
+
+  @override
+  Stream<ConnectionState> get connectionState => states.stream;
+
+  @override
+  Future<ConnectionState> getConnectionState() async => states.value;
+
+  @override
+  Future<void> connect() async {
+    final error = connectError;
+    if (error != null) throw error;
+    states.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async => states.add(ConnectionState.disconnected);
+
+  @override
+  Future<List<String>> discoverServices() async => services;
+
+  @override
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) async => Uint8List(0);
+
+  @override
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {}
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {}
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+void main() {
+  late List<LogRecord> records;
+  late Level previousLevel;
+
+  setUp(() {
+    records = [];
+    previousLevel = Logger.root.level;
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen(records.add);
+  });
+
+  tearDown(() {
+    Logger.root.level = previousLevel;
+    Logger.root.clearListeners();
+  });
+
+  test('logs the reason when the transport connect fails', () async {
+    final transport = _AtomheartTransport()
+      ..connectError = TimeoutException('connect timed out');
+    final scale = AtomheartScale(transport: transport);
+
+    await scale.onConnect();
+
+    expect(await scale.connectionState.first, ConnectionState.disconnected);
+    expect(
+      records.where(
+        (r) =>
+            r.level >= Level.WARNING && r.message.contains('connect timed out'),
+      ),
+      isNotEmpty,
+    );
+  });
+
+  test('logs the reason when the expected service is missing', () async {
+    final transport = _AtomheartTransport()..services = ['0000180a-0000'];
+    final scale = AtomheartScale(transport: transport);
+
+    await scale.onConnect();
+
+    expect(await scale.connectionState.first, ConnectionState.disconnected);
+    expect(
+      records.where(
+        (r) =>
+            r.level >= Level.WARNING && r.message.contains('Expected service'),
+      ),
+      isNotEmpty,
+    );
+  });
+}
+
+class TimeoutException implements Exception {
+  final String message;
+  TimeoutException(this.message);
+  @override
+  String toString() => message;
+}


### PR DESCRIPTION
## Summary

What changed, and why?

- Every BLE scale's `onConnect` swallowed its connect exception with a bare `catch`, so a failed connect surfaced only as `WARNING ScaleController - Scale failed to connect (state: disconnected)` with the cause discarded. Transport-level detail is logged at `FINE`, which end users never run at, so a failing scale leaves no diagnosable trace at all.
- Log the exception at `WARNING` before reporting the disconnected state, in the 11 scale implementations that were silent (Atomheart, BlackCoffee, Bookoo, Difluid, Eureka, Felicita, Hiroia, Skale2, SmartChef, Varia, WeighMaster). Acaia, DecentScale and DecentTemp already logged theirs.
- Behavior is otherwise unchanged: the catch still swallows and still reports `disconnected`.

This is the missing instrumentation for #629, not a fix for it. Log analysis for that issue: the Atomheart Eclair is discovered by name and keeps advertising throughout, while each connect attempt dies at a consistent ~20.4s — matching `UniversalBle.connect(timeout: 20s)` in `universal_ble_transport.dart` plus the 300ms Android pre-connect settle. Whether that is the GATT connect timing out, service discovery failing, or the subscribe call throwing cannot be told apart from the submitted log, because of the bug this PR fixes. Next step is a repro log at `FINE`.

## Linked Issue

Refs #629 (adds the diagnostics needed to root-cause it; does not close it)

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- New `test/unit/models/atomheart_scale_connect_failure_test.dart`: two cases (transport `connect()` throws; expected service missing from discovery) assert the state goes to `disconnected` *and* a `WARNING` record carrying the reason is emitted. Written first, confirmed red before the change, green after.
- `flutter analyze` → `No issues found!`
- `flutter test` → `+3111 ~1 -4`. The 4 failures are all in `test/webui_support/webui_token_injection_test.dart` with `SocketException: Failed to create server socket (OS Error: Address already in use, errno = 48), address = 0.0.0.0, port = 3000` — a locally running Decaid instance holding port 3000 (`lsof -nP -iTCP:3000` confirms), unrelated to this change and untouched by it.
- No hardware testing: the reporter's Eclair is the only known unit and it is not on hand.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- No behavior change. One additional `WARNING` log line per failed scale connect, which also means failed scale connects now reach the Crashlytics log buffer (`main.dart` forwards records at `>= WARNING`). Device IDs in those records go through the existing `Anonymization.scrubString`.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
