### PR TITLE
fix(de1): publish flush temp and timeout after a settings write

### DIFF
--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -617,7 +617,13 @@ class De1Controller {
         await device.setSteamPurgeMode(steamPurgeMode);
       }
     }, retryOnReplacement: true);
-    if (flushFlow != null) _publishFlushFlow(flushFlow);
+    if (flushTemp != null || flushFlow != null || flushTimeout != null) {
+      _publishRinseSettings(
+        targetTemperature: flushTemp,
+        flow: flushFlow,
+        duration: flushTimeout,
+      );
+    }
     if (hotWaterFlow != null) _publishHotWaterFlow(hotWaterFlow);
     if (steamFlow != null) _publishSteamFlow(steamFlow);
   }
@@ -650,13 +656,22 @@ class De1Controller {
   }
 
   void _publishFlushFlow(double newFlow) {
+    _publishRinseSettings(flow: newFlow);
+  }
+
+  void _publishRinseSettings({
+    double? targetTemperature,
+    double? duration,
+    double? flow,
+  }) {
     final current = _rinseStream.valueOrNull;
     if (current != null) {
       _rinseStream.add(
         RinseData(
-          targetTemperature: current.targetTemperature,
-          duration: current.duration,
-          flow: newFlow,
+          targetTemperature:
+              targetTemperature?.toInt() ?? current.targetTemperature,
+          duration: duration?.toInt() ?? current.duration,
+          flow: flow ?? current.flow,
         ),
       );
     }

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -1589,6 +1589,34 @@ void main() {
     );
 
     test(
+      'a successful settings request publishes flush temp and timeout once',
+      () async {
+        await _settleHandler(spy);
+        final initial = workflowController.currentWorkflow;
+        final flushTemp = initial.rinseData.targetTemperature + 1;
+        final flushTimeout = initial.rinseData.duration + 1;
+
+        final rinseEmits = <(int, int)>[];
+        final rinseSub = de1Controller.rinseData
+            .map((e) => (e.targetTemperature, e.duration))
+            .listen(rinseEmits.add);
+
+        final response = await postSettings({
+          'flushTemp': flushTemp,
+          'flushTimeout': flushTimeout,
+        });
+        expect(response.statusCode, 202);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(
+          rinseEmits.where((e) => e == (flushTemp, flushTimeout)).length,
+          1,
+        );
+        await rinseSub.cancel();
+      },
+    );
+
+    test(
       'no flow publication occurs before a replacement retry succeeds',
       () async {
         await _settleHandler(spy);


### PR DESCRIPTION
## Summary

What changed, and why?

- `De1Controller.updateMachineSettings` wrote `flushTemp` and `flushTimeout` to the machine but republished only the three flow values (`_publishFlushFlow` / `_publishHotWaterFlow` / `_publishSteamFlow`). `flushTemp` and `flushTimeout` are the `targetTemperature` and `duration` halves of the same `RinseData` that `_rinseStream` carries, so after a successful write the controller's `rinseData` stream still reported the previous values.
- `_publishFlushFlow` now delegates to a new `_publishRinseSettings({targetTemperature, duration, flow})` that rebuilds `RinseData` from the current stream value with only the changed fields replaced, mirroring how the existing publishers work. `updateMachineSettings` calls it once per request, so a request that changes several flush fields still emits exactly one rinse update.

## Linked Issue

Fixes # N/A — found by code inspection while reading the settings write path; no existing issue or branch covers it (checked open/closed issues and all remote branches).

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- New regression test in `test/webserver/workflow_handler_test.dart`: `a successful settings request publishes flush temp and timeout once`, alongside the existing "publishes each changed flow exactly once" test. It fails on `main` (`Expected: <1> Actual: <0>`) and passes with the fix.
- `dart format lib test`, `flutter analyze` on the touched files (no issues), `flutter test` full suite: `+3184 ~1: All tests passed!`.
- No hardware testing.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Behavior: `De1Controller.rinseData` now reflects a `flushTemp` / `flushTimeout` change immediately instead of staying stale until the next shot-settings notification triggered the MMR re-read in `_processShotSettingsUpdate`. Before this, `GET /api/v1/machine/settings` (live MMR read) and the controller stream disagreed in that window.
- No REST/WS surface change, no spec or doc change: `doc/AI_API_NOTES.md` only states that controller streams are published after the grouped write succeeds, which still holds.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)