### PR TITLE
ci: publish stable aliases for release artifacts

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -179,6 +179,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Test release aliases
+        run: scripts/test_release_aliases.sh
+
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -773,6 +773,19 @@ jobs:
           cd ..
           cat "decaid-${VERSION}-SHA256SUMS.txt"
 
+      - name: Create stable aliases for every artifact
+        env:
+          VERSION: ${{ needs.release-metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd release-artifacts
+          while IFS= read -r f; do
+            cp "$f" "${f/-${VERSION}/-latest}"
+          done < <(find . -type f -name "*-${VERSION}.*" | sort)
+          find . -type f -name "*-latest.*" -print0 | sort -z | xargs -0 sha256sum \
+            | sed 's| \./[^/]*/| |' > "../decaid-latest-SHA256SUMS.txt"
+          cat "../decaid-latest-SHA256SUMS.txt"
+
       - name: Generate release notes
         run: |
           gh api --method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
@@ -798,6 +811,8 @@ jobs:
           - **Linux portable archives** — \`decaid-linux-x64-${VERSION}.tar.gz\` and \`decaid-linux-arm64-${VERSION}.tar.gz\`.
           - **Android** — \`decaid-android-${VERSION}.apk\`. **iOS** — unsigned \`decaid-ios-unsigned-${VERSION}.ipa\`.
 
+          **Stable URLs** — every file above also ships as a \`-latest\` alias, so \`https://github.com/decentespresso/decaid/releases/latest/download/decaid-android-latest.apk\` (and \`decaid-macos-latest.dmg\`, \`decaid-linux-x86_64-latest.AppImage\`, ...) always points at the newest release. The aliases are covered by \`decaid-latest-SHA256SUMS.txt\`.
+
           See \`doc/RELEASE.md\` for install and verification instructions.
 
           EOF
@@ -815,6 +830,7 @@ jobs:
             release-artifacts/windows-app/*
             release-artifacts/ios-ipa-unsigned/*
             decaid-${{ needs.release-metadata.outputs.version }}-SHA256SUMS.txt
+            decaid-latest-SHA256SUMS.txt
           tag_name: ${{ needs.release-metadata.outputs.tag }}
           name: Decaid ${{ needs.release-metadata.outputs.version }}
           draft: false
@@ -841,6 +857,7 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           # Match the prerelease detection in create-release: any beta/alpha/rc
           # tag publishes to the Sparkle beta channel.
           if [[ "$VERSION" == *beta* || "$VERSION" == *alpha* || "$VERSION" == *rc* ]]; then
@@ -878,7 +895,7 @@ jobs:
       - name: Download the release ZIP asset
         run: |
           gh release download "${{ steps.version.outputs.tag }}" \
-            --pattern 'decaid-macos-*.zip' \
+            --pattern "decaid-macos-${{ steps.version.outputs.version }}.zip" \
             --dir "$RUNNER_TEMP/appcast-staging"
           ls -la "$RUNNER_TEMP/appcast-staging"
         env:
@@ -917,7 +934,7 @@ jobs:
             echo "  gh secret set SPARKLE_ED_PRIVATE_KEY < private-key-file"
             exit 1
           fi
-          ZIP="$(ls "$RUNNER_TEMP/appcast-staging"/decaid-macos-*.zip | head -1)"
+          ZIP="$RUNNER_TEMP/appcast-staging/decaid-macos-${{ steps.version.outputs.version }}.zip"
           mkdir -p "$RUNNER_TEMP/pages"
           PREV=""
           if [ -f "$RUNNER_TEMP/previous-appcast.xml" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -776,15 +776,7 @@ jobs:
       - name: Create stable aliases for every artifact
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
-        run: |
-          set -euo pipefail
-          cd release-artifacts
-          while IFS= read -r f; do
-            cp "$f" "${f/-${VERSION}/-latest}"
-          done < <(find . -type f -name "*-${VERSION}.*" | sort)
-          find . -type f -name "*-latest.*" -print0 | sort -z | xargs -0 sha256sum \
-            | sed 's| \./[^/]*/| |' > "../decaid-latest-SHA256SUMS.txt"
-          cat "../decaid-latest-SHA256SUMS.txt"
+        run: scripts/create_release_aliases.sh release-artifacts "$VERSION"
 
       - name: Generate release notes
         run: |
@@ -811,7 +803,7 @@ jobs:
           - **Linux portable archives** — \`decaid-linux-x64-${VERSION}.tar.gz\` and \`decaid-linux-arm64-${VERSION}.tar.gz\`.
           - **Android** — \`decaid-android-${VERSION}.apk\`. **iOS** — unsigned \`decaid-ios-unsigned-${VERSION}.ipa\`.
 
-          **Stable URLs** — every file above also ships as a \`-latest\` alias, so \`https://github.com/decentespresso/decaid/releases/latest/download/decaid-android-latest.apk\` (and \`decaid-macos-latest.dmg\`, \`decaid-linux-x86_64-latest.AppImage\`, ...) always points at the newest release. The aliases are covered by \`decaid-latest-SHA256SUMS.txt\`.
+          **Stable URLs** — every file above also ships as a \`-latest\` alias, so \`https://github.com/decentespresso/decaid/releases/latest/download/decaid-android-latest.apk\` (and \`decaid-macos-latest.dmg\`, \`decaid-linux-x86_64-latest.AppImage\`, ...) always points at the newest stable release. The aliases are covered by \`decaid-latest-SHA256SUMS.txt\`.
 
           See \`doc/RELEASE.md\` for install and verification instructions.
 

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -26,6 +26,8 @@ Each tagged release attaches these desktop files (plus the Android APK and unsig
 
 All files are covered by `decaid-<version>-SHA256SUMS.txt` in the release.
 
+Every file also ships as a `-latest` alias (`decaid-android-latest.apk`, `decaid-macos-latest.dmg`, `decaid-linux-x86_64-latest.AppImage`, ...), so `https://github.com/decentespresso/decaid/releases/latest/download/decaid-android-latest.apk` always points at the newest release. The aliases are covered by `decaid-latest-SHA256SUMS.txt`.
+
 ### Verifying checksums
 
 ```bash

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -26,7 +26,7 @@ Each tagged release attaches these desktop files (plus the Android APK and unsig
 
 All files are covered by `decaid-<version>-SHA256SUMS.txt` in the release.
 
-Every file also ships as a `-latest` alias (`decaid-android-latest.apk`, `decaid-macos-latest.dmg`, `decaid-linux-x86_64-latest.AppImage`, ...), so `https://github.com/decentespresso/decaid/releases/latest/download/decaid-android-latest.apk` always points at the newest release. The aliases are covered by `decaid-latest-SHA256SUMS.txt`.
+Every file also ships as a `-latest` alias (`decaid-android-latest.apk`, `decaid-macos-latest.dmg`, `decaid-linux-x86_64-latest.AppImage`, ...), so `https://github.com/decentespresso/decaid/releases/latest/download/decaid-android-latest.apk` always points at the newest stable release. The aliases are covered by `decaid-latest-SHA256SUMS.txt`.
 
 ### Verifying checksums
 

--- a/scripts/create_release_aliases.sh
+++ b/scripts/create_release_aliases.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <artifact-directory> <version>" >&2
+  exit 1
+fi
+
+ARTIFACTS_DIR="$1"
+VERSION="$2"
+[ -d "$ARTIFACTS_DIR" ] || { echo "FAIL: missing $ARTIFACTS_DIR" >&2; exit 1; }
+
+ARTIFACTS_DIR="$(cd "$ARTIFACTS_DIR" && pwd)"
+MANIFEST="$(dirname "$ARTIFACTS_DIR")/decaid-latest-SHA256SUMS.txt"
+cd "$ARTIFACTS_DIR"
+
+SOURCES=()
+while IFS= read -r -d '' source; do
+  SOURCES+=("$source")
+done < <(find . -type f -name "*-${VERSION}.*" -print0 | sort -z)
+
+[ "${#SOURCES[@]}" -gt 0 ] || {
+  echo "FAIL: no versioned release artifacts found for $VERSION" >&2
+  exit 1
+}
+
+ALIASES=()
+for source in "${SOURCES[@]}"; do
+  alias="${source/-${VERSION}/-latest}"
+  cp "$source" "$alias"
+  cmp -s "$source" "$alias" || { echo "FAIL: $alias differs from $source" >&2; exit 1; }
+  ALIASES+=("$alias")
+done
+
+{
+  for alias in "${ALIASES[@]}"; do
+    sha256sum "$alias"
+  done
+} | sed 's| \./[^/]*/| |' > "$MANIFEST"
+cat "$MANIFEST"

--- a/scripts/test_release_aliases.sh
+++ b/scripts/test_release_aliases.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+VERSION=1.2.3
+ARTIFACTS="$TMP/release-artifacts"
+MANIFEST="$TMP/decaid-latest-SHA256SUMS.txt"
+SOURCE_PATHS=(
+  "android-apk/decaid-android-${VERSION}.apk"
+  "macos-app/decaid-macos-${VERSION}.zip"
+  "macos-app/decaid-macos-${VERSION}.dmg"
+  "linux-app/decaid-linux-x64-${VERSION}.tar.gz"
+  "linux-app/decaid-linux-x86_64-${VERSION}.AppImage"
+  "raspberrypi-linux-arm64-app/decaid-linux-arm64-${VERSION}.tar.gz"
+  "raspberrypi-linux-arm64-app/decaid-linux-aarch64-${VERSION}.AppImage"
+  "windows-app/decaid-windows-x64-${VERSION}.zip"
+  "ios-ipa-unsigned/decaid-ios-unsigned-${VERSION}.ipa"
+)
+ALIAS_PATHS=(
+  "android-apk/decaid-android-latest.apk"
+  "macos-app/decaid-macos-latest.zip"
+  "macos-app/decaid-macos-latest.dmg"
+  "linux-app/decaid-linux-x64-latest.tar.gz"
+  "linux-app/decaid-linux-x86_64-latest.AppImage"
+  "raspberrypi-linux-arm64-app/decaid-linux-arm64-latest.tar.gz"
+  "raspberrypi-linux-arm64-app/decaid-linux-aarch64-latest.AppImage"
+  "windows-app/decaid-windows-x64-latest.zip"
+  "ios-ipa-unsigned/decaid-ios-unsigned-latest.ipa"
+)
+
+for i in "${!SOURCE_PATHS[@]}"; do
+  source="$ARTIFACTS/${SOURCE_PATHS[$i]}"
+  mkdir -p "$(dirname "$source")"
+  printf '%s\n' "${SOURCE_PATHS[$i]}" > "$source"
+done
+
+scripts/create_release_aliases.sh "$ARTIFACTS" "$VERSION" >/dev/null
+
+[ -f "$MANIFEST" ] || { echo "FAIL: missing $MANIFEST"; exit 1; }
+for i in "${!SOURCE_PATHS[@]}"; do
+  source="$ARTIFACTS/${SOURCE_PATHS[$i]}"
+  alias="$ARTIFACTS/${ALIAS_PATHS[$i]}"
+  [ -f "$alias" ] || { echo "FAIL: missing $alias"; exit 1; }
+  cmp -s "$source" "$alias" || { echo "FAIL: $alias differs from $source"; exit 1; }
+done
+
+EXPECTED_NAMES="$TMP/expected-names.txt"
+ACTUAL_NAMES="$TMP/actual-names.txt"
+for alias in "${ALIAS_PATHS[@]}"; do
+  basename "$alias"
+done | sort > "$EXPECTED_NAMES"
+awk '{print $2}' "$MANIFEST" | sort > "$ACTUAL_NAMES"
+diff -u "$EXPECTED_NAMES" "$ACTUAL_NAMES"
+
+DOWNLOAD="$TMP/download"
+mkdir "$DOWNLOAD"
+for alias in "${ALIAS_PATHS[@]}"; do
+  cp "$ARTIFACTS/$alias" "$DOWNLOAD/"
+done
+(cd "$DOWNLOAD" && sha256sum -c "$MANIFEST" >/dev/null)
+
+EMPTY="$TMP/empty/release-artifacts"
+mkdir -p "$EMPTY"
+if scripts/create_release_aliases.sh "$EMPTY" "$VERSION" >/dev/null 2>&1; then
+  echo "FAIL: empty artifact set was accepted"
+  exit 1
+fi
+
+echo "All release alias tests passed"


### PR DESCRIPTION
## Summary

What changed, and why?

- Publish every versioned release artifact under a matching `-latest` alias for permanent `releases/latest/download/...` URLs.
- Generate `decaid-latest-SHA256SUMS.txt` and keep Sparkle appcast publication pinned to the exact versioned macOS ZIP.
- Add a tested release-alias script to PR checks and document that these URLs follow the newest stable release.

## Linked Issue

Related #606

Keep the issue open until the first post-merge stable release confirms the permanent URLs return 200.

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `scripts/test_release_aliases.sh` — passed; verifies all nine aliases, flattened checksum manifest, and empty-input rejection.
- `scripts/test_appcast_helpers.sh` — passed.
- `shellcheck scripts/create_release_aliases.sh scripts/test_release_aliases.sh` — clean.
- `actionlint -shellcheck='' .github/workflows/release.yml .github/workflows/pr-checks.yml` — clean; embedded ShellCheck was validated separately for changed scripts because `main` has three pre-existing informational findings in the Linux smoke step.
- `flutter analyze` — no issues.
- `flutter test` — 3,212 passed, 1 skipped.
- `git diff --check main...HEAD` — clean.

## Impact

- Future stable GitHub releases gain `-latest` copies of every platform artifact and a matching checksum manifest; versioned artifacts remain unchanged for archival and Sparkle.
- Documentation updated in `doc/RELEASE.md`.
- No API, data migration, or security impact.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
