### PR TITLE
fix(de1): bound transport operations

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -358,6 +358,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MachineStateError"
+        "503":
+          description: DE1 write queue is full for non-idle state changes
   /api/v1/machine/profile:
     post:
       summary: Set Machine Profile
@@ -375,7 +377,7 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
   /api/v1/machine/shotSettings:
@@ -395,7 +397,7 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
   /api/v1/machine/capabilities:
@@ -464,7 +466,7 @@ paths:
         "404":
           description: Machine connected but does not support cup warmer (not a Bengle)
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
   /api/v1/machine/cupWarmer/preheat:
@@ -512,7 +514,7 @@ paths:
         "404":
           description: Machine connected but does not support pre-warm
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
   /api/v1/machine/ledStrip:
@@ -564,7 +566,7 @@ paths:
         "404":
           description: Machine connected but does not support LED strip
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
 
@@ -590,7 +592,7 @@ paths:
         "404":
           description: Machine connected but does not support LED strip
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
 
@@ -621,7 +623,7 @@ paths:
         "404":
           description: Machine connected but does not support LED strip
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait, or firmware read failed
+          description: DE1 write queue is full, or firmware read failed
         "500":
           description: No machine was ever connected
   /api/v1/machine/scaleCalibration:
@@ -684,7 +686,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ScaleCalibrationRejected"
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
   /api/v1/machine/settings:
@@ -715,7 +717,7 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
 
@@ -747,7 +749,7 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
 
@@ -763,7 +765,7 @@ paths:
         "202":
           description: Reset accepted (one grouped serialized device write)
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No DE1 connected
 
@@ -801,7 +803,7 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
 
@@ -878,7 +880,7 @@ paths:
         "400":
           description: Malformed JSON body, unknown target, or invalid values
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "504":
           description: Machine did not acknowledge the calibration write within the response timeout
         "500":
@@ -900,7 +902,7 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: Machine disconnected mid-write and no replacement appeared within the bounded wait
+          description: DE1 write queue is full
         "500":
           description: No machine was ever connected
 
@@ -1338,6 +1340,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "409":
+          description: A pending DE1 settings write was superseded by a newer value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "413":
           description: Request body exceeds the 1 MiB workflow payload limit
           content:
@@ -1359,9 +1367,9 @@ paths:
         "503":
           description: >
             The request waited more than 30 seconds for its turn and was
-            skipped, or the machine disconnected mid-write and no replacement
-            machine appeared within the bounded wait (10 seconds). In both
-            cases the controller workflow is unchanged.
+            skipped, the DE1 write queue was full, or a replaceable setting
+            could not reconnect to the same machine within the bounded wait.
+            In each case the controller workflow is unchanged.
           content:
             application/json:
               schema:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -926,7 +926,8 @@ paths:
       description: |
         Send a raw firmware file to the machine. Returns an NDJSON progress
         stream. Rejects an empty body with 400. Returns 409 if an update is
-        already in progress. Returns 503 if no machine is connected.
+        already in progress. Returns 503 if no machine is connected or the
+        DE1 write queue is full.
 
         A successful stream emits `erasing`, zero or more `uploading` events,
         then `done`. A failed stream emits `erasing`, zero or more `uploading`
@@ -956,7 +957,7 @@ paths:
         "409":
           description: Firmware update already in progress
         "503":
-          description: No machine connected
+          description: No machine connected or DE1 write queue full
     delete:
       summary: Cancel an in-progress firmware update
       description: |
@@ -1011,7 +1012,7 @@ paths:
         "422":
           description: Artifact validation, compatibility, or version-policy failure
         "503":
-          description: No machine connected
+          description: No machine connected or DE1 write queue full
 
   # Scale API
   /api/v1/scale/tare:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -359,7 +359,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/MachineStateError"
         "503":
-          description: DE1 write queue is full for non-idle state changes
+          description: Machine write queue is full for non-idle state changes
   /api/v1/machine/profile:
     post:
       summary: Set Machine Profile
@@ -377,9 +377,9 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
   /api/v1/machine/shotSettings:
     post:
       summary: Update Shot Settings
@@ -397,9 +397,9 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
   /api/v1/machine/capabilities:
     get:
       summary: List machine capabilities
@@ -466,9 +466,9 @@ paths:
         "404":
           description: Machine connected but does not support cup warmer (not a Bengle)
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
   /api/v1/machine/cupWarmer/preheat:
     get:
       summary: Get scheduled pre-warm state
@@ -514,9 +514,9 @@ paths:
         "404":
           description: Machine connected but does not support pre-warm
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
   /api/v1/machine/ledStrip:
     get:
       summary: Get LED strip configuration
@@ -566,9 +566,9 @@ paths:
         "404":
           description: Machine connected but does not support LED strip
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
 
   /api/v1/machine/ledStrip/commit:
     post:
@@ -592,9 +592,9 @@ paths:
         "404":
           description: Machine connected but does not support LED strip
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
 
   /api/v1/machine/ledStrip/reset:
     post:
@@ -623,9 +623,9 @@ paths:
         "404":
           description: Machine connected but does not support LED strip
         "503":
-          description: DE1 write queue is full, or firmware read failed
+          description: Machine write queue is full, or firmware read failed
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
   /api/v1/machine/scaleCalibration:
     get:
       summary: Get scale-calibration state
@@ -686,9 +686,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ScaleCalibrationRejected"
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
   /api/v1/machine/settings:
     get:
       summary: Get machine settings
@@ -717,9 +717,9 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
 
   /api/v1/machine/settings/advanced:
     get:
@@ -749,9 +749,9 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
 
   /api/v1/machine/settings/reset:
     delete:
@@ -765,9 +765,9 @@ paths:
         "202":
           description: Reset accepted (one grouped serialized device write)
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No DE1 connected
+          description: No machine was connected, the machine changed during the write, or the write failed
 
   /api/v1/machine/calibration:
     get:
@@ -803,9 +803,9 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
 
   /api/v1/machine/calibration/{target}:
     get:
@@ -880,11 +880,11 @@ paths:
         "400":
           description: Malformed JSON body, unknown target, or invalid values
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "504":
           description: Machine did not acknowledge the calibration write within the response timeout
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
 
   /api/v1/machine/waterLevels:
     post:
@@ -902,9 +902,9 @@ paths:
         "400":
           description: Malformed JSON body
         "503":
-          description: DE1 write queue is full
+          description: Machine write queue is full
         "500":
-          description: No machine was ever connected
+          description: No machine was connected, the machine changed during the write, or the write failed
 
   /api/v1/machine/firmware:
     get:
@@ -927,7 +927,7 @@ paths:
         Send a raw firmware file to the machine. Returns an NDJSON progress
         stream. Rejects an empty body with 400. Returns 409 if an update is
         already in progress. Returns 503 if no machine is connected or the
-        DE1 write queue is full.
+        machine write queue is full.
 
         A successful stream emits `erasing`, zero or more `uploading` events,
         then `done`. A failed stream emits `erasing`, zero or more `uploading`
@@ -957,7 +957,7 @@ paths:
         "409":
           description: Firmware update already in progress
         "503":
-          description: No machine connected or DE1 write queue full
+          description: No machine connected or machine write queue full
     delete:
       summary: Cancel an in-progress firmware update
       description: |
@@ -1012,7 +1012,7 @@ paths:
         "422":
           description: Artifact validation, compatibility, or version-policy failure
         "503":
-          description: No machine connected or DE1 write queue full
+          description: No machine connected or machine write queue full
 
   # Scale API
   /api/v1/scale/tare:
@@ -1368,7 +1368,7 @@ paths:
         "503":
           description: >
             The request waited more than 30 seconds for its turn and was
-            skipped, the DE1 write queue was full, or a replaceable setting
+            skipped, the machine write queue was full, or a replaceable setting
             could not reconnect to the same machine within the bounded wait.
             In each case the controller workflow is unchanged.
           content:

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -202,15 +202,14 @@ of records and one JSON record, never with backup size. Rationale and traps:
 ## Workflow PUT Queue
 
 `PUT /api/v1/workflow` operations are serialized through one queue owned by
-`WorkflowHandler`. One HTTP request is exactly one queue entry. Separate requests
-must not be coalesced without a future explicit client or session contract. The
-handler reads the workflow base when a queue entry reaches execution, then applies
-only that request's deep merge. Machine side effects from workflow PUTs, profile
-sync, and Bengle workflow bridges share the `De1Controller` device-write queue.
-Each entry captures one machine and connection generation; workflow setting writes
-retry once on a replacement machine after that generation's startup initialization
-settles. Startup defaults finish before the generation barrier releases. A failure
-must not poison the queue tail.
+`WorkflowHandler`. One HTTP request is exactly one handler queue entry. The handler
+reads the workflow base when that entry reaches execution, then applies only that
+request's deep merge. Machine side effects from workflow PUTs, profile sync, Bengle
+workflow bridges, and other callers share the `De1Controller` governor: one active
+DE1 operation plus at most 32 pending operations. Pending rinse, steam, and hot-water
+workflow setting writes coalesce by setting group; the displaced caller receives
+`409 Conflict`, while unrelated and imperative writes remain FIFO. A failure must
+not poison either queue tail.
 Request bodies are read with a 30-second timeout before their queued operation
 executes; body-read failures are observed immediately and do not poison the queue.
 The body stream subscription is cancelled on completion, error, size rejection, or
@@ -228,29 +227,31 @@ remains the owner of asynchronous profile upload after controller changes.
 
 ### Device-Write Retry and Machine Replacement
 
-`De1Controller.runDeviceWrite()` is the single serialization point for all REST
-machine writes (workflow PUTs, profile, shot settings, machine settings). The write
-callback receives the machine acquired inside the retry loop, so a disconnected
-interval (controller holding no machine) is handled by waiting — bounded by
-`ConnectionTimings.machineReplacementTimeout` (10 s) — for a non-null replacement and
-that generation's startup initialization to settle, then re-running the complete
-grouped write once on the replacement. The old machine is never acquired for a new
-write after the generation changes (an already-running write may still finish on it,
-see below). If no replacement appears within the bound, the handler returns
-`503 Machine unavailable`; if there was never a machine at all, the first attempt
-fails fast with `500` (unchanged behavior). The first attempt never waits: the bounded
-wait only applies to retries after a mid-write disconnect.
+`De1Controller.runDeviceWrite()` is the single serialized boundary for imperative
+DE1 operations. It captures the connection generation and physical-machine identity
+when admitted. Imperative operations never replay: a generation change before or
+during execution fails the operation after any in-flight native write settles.
 
-A machine generation change cannot cancel an in-flight native write: the old machine
-may receive a partial or complete attempt. Only after that attempt finishes does the
-post-write generation check reject it, and the retry then re-runs the complete grouped
-operation from the start on the replacement.
+Only `runReplaceableDeviceWrite()` operations for rinse, steam, and hot-water
+workflow settings may reconcile once after a disconnect. Reconciliation waits up to
+`ConnectionTimings.machineReplacementTimeout` (10 s), then requires the replacement
+to have the same physical identity and its startup initialization to settle. Identity
+uses the machine serial number when available and otherwise the device ID. A different
+machine is rejected rather than receiving stale work. If the same machine does not
+return within the bound, the handler returns `503 Machine unavailable`.
+
+Caller cancellation or timeout does not release an active physical operation. The
+governor advances only after that operation actually settles. Firmware upload uses
+the same serialized boundary for its full duration; firmware cancellation remains a
+direct command.
 
 ### REST Route Serialization Audit
 
-All mutating machine routes in `de1handler.dart` route their physical writes through
-`runDeviceWrite` (one HTTP request = one queue entry, parse-then-write, controller
-streams published only after the grouped write succeeds):
+Mutating machine routes in `de1handler.dart` route physical writes through the DE1
+governor. Ordinary REST machine mutations enter as imperative operations; workflow
+updates use replaceable setting groups. Bodies are parsed before admission and
+controller streams are published only after the grouped write succeeds. The idle
+safety path is the exception documented below:
 
 - `PUT /api/v1/workflow` (workflow handler, device writes via `updateWorkflowSettings`)
 - `POST /api/v1/machine/profile`
@@ -263,19 +264,19 @@ streams published only after the grouped write succeeds):
 - `PUT /api/v1/machine/cupWarmer`, `PUT /api/v1/machine/ledStrip`,
   `POST /api/v1/machine/ledStrip/commit`, `POST /api/v1/machine/ledStrip/reset`
 
-Every endpoint above can return `503` when the machine disconnects mid-write and no
-replacement appears within the bounded wait, and `400` for malformed JSON bodies
+Every endpoint above can return `503` when the 32-entry pending queue is full and
+`400` for malformed JSON bodies
 (machine settings, advanced, calibration, waterLevels, cupWarmer, ledStrip,
 profile, and shot settings parse their complete body before reserving a queue entry).
 Machine-write failures otherwise map to `500`.
 
 Documented bypasses:
 
-- `PUT /api/v1/machine/state/<newState>`: latency-sensitive machine commands (a stop
-  request must not queue behind a settings or profile write) that target the state
-  characteristic, not the settings/MMR registers the queue serializes.
+- `PUT /api/v1/machine/state/<newState>` routes non-idle requests through the governor.
+  Only `idle` bypasses it so stop remains serviceable behind saturated or stalled work.
 - Raw low-level MMR commands via `/ws/v1/machine/raw`: intentionally unqueued (see
   the machine WebSocket re-bind section); a delayed raw read/write could be stale.
+- Diagnostic UI commands remain intentionally unqueued.
 
 ### Machine Disconnect Simulation (debug only)
 
@@ -293,7 +294,8 @@ behavior is documented.
 | 200 | Workflow updated and committed |
 | 400 | Malformed or invalid JSON |
 | 408 | Client did not finish sending the body within the timeout |
+| 409 | A pending replaceable workflow setting write was superseded by a newer value |
 | 413 | Body exceeds 1 MiB limit |
 | 429 | Admission capacity full (8 active or queued requests) |
 | 500 | A required direct machine write failed, or no machine was ever connected |
-| 503 | Mutation timed out waiting for its execution turn, or no replacement machine appeared within the bounded wait |
+| 503 | Mutation timed out waiting for its execution turn, the 32-entry DE1 pending queue is full, or the same machine did not return within the bounded wait for a replaceable workflow write |

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -76,9 +76,9 @@ The catalog endpoint is available offline and without a connected machine. It re
 
 Managed apply accepts `{"artifactId":"de1-1352","force":false}`. The complete image is checked against its manifest, SHA-256 digest, canonical DE1 header, and connected model before erase. `force` permits reinstall or downgrade, including when the installed build is unknown, but never bypasses integrity or model checks. The raw endpoint retains its developer/recovery role and accepts `application/octet-stream`.
 
-Raw and managed updates return `application/x-ndjson`. Events are ordered `erasing`, zero or more `uploading`, then `done`; failures after streaming starts terminate with `error`. Upload progress is emitted in approximately one-percent increments. The stream remains open during final machine verification, and `done` is sent only after the DE1 reports `FF FF FD`. Client disconnect and `DELETE` request cancellation through the shared machine operation.
+Raw and managed updates return `application/x-ndjson`. Events are ordered `erasing`, zero or more `uploading`, then `done`; failures after streaming starts terminate with `error`. Upload progress is emitted in approximately one-percent increments. The stream remains open during final machine verification, and `done` is sent only after the DE1 reports `FF FF FD`. Client disconnect and `DELETE` cancel a pending update before it starts or forward cancellation to an active update.
 
-Pre-stream responses are `400` for malformed input, `404` for an unknown artifact, `409` for an active update, `422` for validation or policy rejection, and `503` when apply requires a machine. Idempotent cancellation returns `202` with `{"operation":{"state":"idle"}}` when no update remains active.
+Pre-stream responses are `400` for malformed input, `404` for an unknown artifact, `409` for an active update, `422` for validation or policy rejection, and `503` when apply requires a machine or the DE1 write queue is full. Idempotent cancellation returns `202` with `{"operation":{"state":"idle"}}` when no update remains active.
 
 ### Scale
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -213,11 +213,14 @@ than 30 seconds for execution return `503` without being applied. Machine-write 
 return an error before the controller workflow is committed. Multi-step machine writes may
 be partially applied, and retrying the same request re-attempts the requested settings.
 Request bodies have a 30-second read timeout; body-read failures return `408`
-without poisoning later queued mutations. If the machine disconnects while a
-workflow device write is in flight, the write is retried once on the replacement
-machine (waiting up to 10 seconds for one to appear); if no replacement arrives the
-request returns `503` and the workflow is not committed. A `stopAtTemperature`-only
-workflow change never touches the DE1 directly — the Bengle bridge applies it
+without poisoning later queued mutations. DE1 writes allow one active operation and
+32 pending operations; a full device queue returns `503`. Pending rinse, steam, and
+hot-water settings coalesce by component, and a superseded workflow request returns
+`409`. A replaceable setting may reconcile after reconnect only when the machine
+identity matches; failure to reconnect within the bounded wait returns `503`.
+Imperative writes are not replayed after a disconnect. In each failure case, the
+workflow is not committed. A `stopAtTemperature`-only workflow change never touches
+the DE1 directly — the Bengle bridge applies it
 asynchronously — so it commits even while no machine is connected.
 
 ### Beans

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -345,7 +345,10 @@ class _MyAppState extends State<MyApp> {
                         (e) => e.deviceId == deviceId,
                       );
                       if (device is De1Interface) {
-                        return De1DebugView(machine: device);
+                        return De1DebugView(
+                          machine: device,
+                          de1Controller: widget.de1Controller,
+                        );
                       }
                       if (device is Scale) {
                         return ScaleDebugView(scale: device);
@@ -363,6 +366,7 @@ class _MyAppState extends State<MyApp> {
                     case DebugItemListView.routeName:
                       return DebugItemListView(
                         controller: widget.deviceController,
+                        de1Controller: widget.de1Controller,
                       );
                     case RealtimeShotFeature.routeName:
                       final args = routeSettings.arguments;

--- a/lib/src/controllers/battery_controller.dart
+++ b/lib/src/controllers/battery_controller.dart
@@ -46,8 +46,7 @@ class BatteryController {
         _log.fine('Skipping USB charger mode update during BLE scan');
         return;
       }
-      final de1 = _de1Controller.connectedDe1OrNull;
-      if (de1 == null) {
+      if (_de1Controller.connectedDe1OrNull == null) {
         _log.fine('No machine connected, skipping USB charger mode update');
         _lastAppliedCharge = null;
         return;
@@ -92,7 +91,9 @@ class BatteryController {
         reassertInterval: _dischargeReassertInterval,
       )) {
         try {
-          await de1.setUsbChargerMode(decision.shouldCharge);
+          await _de1Controller.runDeviceWrite(
+            (device) => device.setUsbChargerMode(decision.shouldCharge),
+          );
           _lastAppliedCharge = decision.shouldCharge;
           _lastChargeWrite = now;
         } catch (e) {

--- a/lib/src/controllers/bengle_saw_bridge.dart
+++ b/lib/src/controllers/bengle_saw_bridge.dart
@@ -26,6 +26,7 @@ class BengleSawBridge {
 
   StreamSubscription<De1Interface?>? _de1Sub;
   Timer? _debounceTimer;
+  Timer? _retryTimer;
   double? _lastPushed;
   int? _lastPushedGeneration;
   double? _desired;
@@ -111,6 +112,14 @@ class BengleSawBridge {
             _desiredGeneration = null;
           }
           _log.info('SAW target written: ${grams}g');
+        } on De1WriteQueueFullException catch (e, st) {
+          _log.warning('SAW write queue full', e, st);
+          if (_isCurrent(machine, generation) &&
+              _desired == grams &&
+              _desiredGeneration == generation) {
+            _scheduleRetry(grams, generation);
+          }
+          return;
         } on DeviceNotConnectedException {
           _log.fine('SAW write aborted — machine disconnected mid-call');
           if (!_isCurrent(machine, generation) ||
@@ -144,11 +153,26 @@ class BengleSawBridge {
     }
   }
 
+  void _scheduleRetry(double grams, int generation) {
+    if (_retryTimer != null) return;
+    _retryTimer = Timer(debounce, () {
+      _retryTimer = null;
+      if (!_disposed &&
+          _desired == grams &&
+          _desiredGeneration == generation &&
+          _de1.connectedDe1OrNull is BengleInterface) {
+        unawaited(_drain());
+      }
+    });
+  }
+
   Future<void> dispose() async {
     _disposed = true;
     _workflow.removeListener(_onWorkflowChange);
     _debounceTimer?.cancel();
     _debounceTimer = null;
+    _retryTimer?.cancel();
+    _retryTimer = null;
     _desired = null;
     _desiredGeneration = null;
     _restartAfterDrain = false;

--- a/lib/src/controllers/bengle_saw_bridge.dart
+++ b/lib/src/controllers/bengle_saw_bridge.dart
@@ -65,6 +65,8 @@ class BengleSawBridge {
       if (_pushing) _restartAfterDrain = true;
       return;
     }
+    _retryTimer?.cancel();
+    _retryTimer = null;
     _debounceTimer?.cancel();
     _debounceTimer = null;
     _desired = _currentTargetYield();

--- a/lib/src/controllers/bengle_steam_stop_bridge.dart
+++ b/lib/src/controllers/bengle_steam_stop_bridge.dart
@@ -26,6 +26,7 @@ class BengleSteamStopBridge {
 
   StreamSubscription<De1Interface?>? _de1Sub;
   Timer? _debounceTimer;
+  Timer? _retryTimer;
   double? _lastPushed;
   int? _lastPushedGeneration;
   double? _desired;
@@ -113,6 +114,14 @@ class BengleSteamStopBridge {
             _desiredGeneration = null;
           }
           _log.info('Stop-at-temperature target written: $celsius°C');
+        } on De1WriteQueueFullException catch (e, st) {
+          _log.warning('Steam-stop write queue full', e, st);
+          if (_isCurrent(machine, generation) &&
+              _desired == celsius &&
+              _desiredGeneration == generation) {
+            _scheduleRetry(celsius, generation);
+          }
+          return;
         } on DeviceNotConnectedException {
           _log.fine('Steam-stop write aborted — machine disconnected mid-call');
           if (!_isCurrent(machine, generation) ||
@@ -146,11 +155,26 @@ class BengleSteamStopBridge {
     }
   }
 
+  void _scheduleRetry(double celsius, int generation) {
+    if (_retryTimer != null) return;
+    _retryTimer = Timer(debounce, () {
+      _retryTimer = null;
+      if (!_disposed &&
+          _desired == celsius &&
+          _desiredGeneration == generation &&
+          _de1.connectedDe1OrNull is BengleInterface) {
+        unawaited(_drain());
+      }
+    });
+  }
+
   Future<void> dispose() async {
     _disposed = true;
     _workflow.removeListener(_onWorkflowChange);
     _debounceTimer?.cancel();
     _debounceTimer = null;
+    _retryTimer?.cancel();
+    _retryTimer = null;
     _desired = null;
     _desiredGeneration = null;
     _restartAfterDrain = false;

--- a/lib/src/controllers/bengle_steam_stop_bridge.dart
+++ b/lib/src/controllers/bengle_steam_stop_bridge.dart
@@ -65,6 +65,8 @@ class BengleSteamStopBridge {
       if (_pushing) _restartAfterDrain = true;
       return;
     }
+    _retryTimer?.cancel();
+    _retryTimer = null;
     _debounceTimer?.cancel();
     _debounceTimer = null;
     _desired = _currentTarget();

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:collection';
+import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
 import 'package:logging/logging.dart';
@@ -10,10 +12,13 @@ import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/firmware_update_state.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/subjects.dart';
 
 part 'de1_controller.defaults.dart';
+part 'de1_controller.governor.dart';
 
 class De1Controller {
   final DeviceController _deviceController;
@@ -97,7 +102,9 @@ class De1Controller {
   final List<StreamSubscription<dynamic>> _subscriptions = [];
   bool _dataInitialized = false;
   Timer? _shotSettingsDebounce;
-  Future<void> _deviceWriteQueue = Future<void>.value();
+  final Queue<_PendingDe1Write<dynamic>> _pendingDeviceWrites = Queue();
+  _PendingDe1Write<dynamic>? _activeDeviceWrite;
+  bool _firmwareUpdatePending = false;
 
   int _connectionGeneration = 0;
 
@@ -110,12 +117,15 @@ class De1Controller {
   int get connectionGeneration => _connectionGeneration;
 
   final Duration machineReplacementTimeout;
+  final int maxPendingDeviceWrites;
 
   De1Controller({
     required DeviceController controller,
     this.machineReplacementTimeout =
         ConnectionTimings.machineReplacementTimeout,
-  }) : _deviceController = controller {
+    this.maxPendingDeviceWrites = 32,
+  }) : assert(maxPendingDeviceWrites >= 0),
+       _deviceController = controller {
     _log.info("checking ${_deviceController.devices}");
   }
 
@@ -377,86 +387,24 @@ class De1Controller {
 
   De1Interface? get connectedDe1OrNull => _de1;
 
+  int get pendingDeviceWriteCount => _pendingDeviceWrites.length;
+
   Future<T> runDeviceWrite<T>(
     Future<T> Function(De1Interface device) write, {
-    bool retryOnReplacement = false,
+    De1ReplayPolicy replayPolicy = De1ReplayPolicy.never,
   }) {
-    final operation = _deviceWriteQueue.then(
-      (_) => _runDeviceWrite(write, retryOnReplacement),
+    return _enqueueDeviceWrite(write, replayPolicy: replayPolicy);
+  }
+
+  Future<void> runReplaceableDeviceWrite(
+    String key,
+    Future<void> Function(De1Interface device) write,
+  ) {
+    return _enqueueDeviceWrite(
+      write,
+      replayPolicy: De1ReplayPolicy.sameMachine,
+      coalescingKey: key,
     );
-    _deviceWriteQueue = operation.then<void>(
-      (_) {},
-      onError: (Object error, StackTrace stackTrace) {},
-    );
-    return operation;
-  }
-
-  Future<T> _runDeviceWrite<T>(
-    Future<T> Function(De1Interface device) write,
-    bool retryOnReplacement,
-  ) async {
-    final attempts = retryOnReplacement ? 2 : 1;
-    for (var attempt = 0; attempt < attempts; attempt++) {
-      De1Interface device;
-      try {
-        device = connectedDe1();
-      } on DeviceNotConnectedException {
-        if (!retryOnReplacement || attempt == 0) rethrow;
-        final replacement = await _waitForMachineReplacement(
-          machineReplacementTimeout,
-        );
-        if (replacement == null) {
-          throw MachineReplacementTimeoutException(machineReplacementTimeout);
-        }
-        device = replacement;
-      }
-      final generation = _connectionGeneration;
-      try {
-        await _waitForInitialization(device, generation);
-        if (generation != _connectionGeneration ||
-            !identical(device, connectedDe1OrNull)) {
-          if (attempt + 1 < attempts) continue;
-          break;
-        }
-        final result = await write(device);
-        if (generation == _connectionGeneration &&
-            identical(device, connectedDe1OrNull)) {
-          return result;
-        }
-      } catch (_) {
-        if (attempt + 1 == attempts ||
-            (generation == _connectionGeneration &&
-                identical(device, connectedDe1OrNull))) {
-          rethrow;
-        }
-      }
-    }
-    throw StateError('Machine changed during device write');
-  }
-
-  Future<De1Interface?> _waitForMachineReplacement(Duration timeout) async {
-    try {
-      return await _de1Controller.stream
-          .firstWhere((de1) => de1 != null)
-          .timeout(timeout);
-    } on TimeoutException {
-      return null;
-    }
-  }
-
-  Future<void> _waitForInitialization(
-    De1Interface device,
-    int generation,
-  ) async {
-    if (_initSettledSubject.valueOrNull == generation) return;
-    await _initSettledSubject.stream
-        .firstWhere(
-          (settled) =>
-              settled == generation ||
-              generation != _connectionGeneration ||
-              !identical(device, connectedDe1OrNull),
-        )
-        .timeout(ConnectionTimings.initialShotSettingsTimeout);
   }
 
   Future<De1ShotSettings> _readShotSettings(De1Interface device) async {
@@ -485,9 +433,9 @@ class De1Controller {
   }
 
   Future<void> updateSteamSettings(SteamFormSettings settings) async {
-    await runDeviceWrite(
+    await runReplaceableDeviceWrite(
+      'workflow.steam',
       (device) => _writeSteamSettings(device, settings),
-      retryOnReplacement: true,
     );
     _publishSteamSettings(settings);
   }
@@ -531,9 +479,9 @@ class De1Controller {
   }
 
   Future<void> updateHotWaterSettings(HotWaterFormSettings settings) async {
-    await runDeviceWrite(
+    await runReplaceableDeviceWrite(
+      'workflow.hotWater',
       (device) => _writeHotWaterSettings(device, settings),
-      retryOnReplacement: true,
     );
     _publishHotWaterSettings(settings);
   }
@@ -565,9 +513,9 @@ class De1Controller {
   }
 
   Future<void> updateFlushSettings(RinseData settings) async {
-    await runDeviceWrite(
+    await runReplaceableDeviceWrite(
+      'workflow.rinse',
       (device) => _writeFlushSettings(device, settings),
-      retryOnReplacement: true,
     );
     _rinseStream.add(settings);
   }
@@ -606,43 +554,25 @@ class De1Controller {
       volume: updated.hotWaterData.volume,
       duration: updated.hotWaterData.duration,
     );
-    await runDeviceWrite((device) async {
-      if (rinseChanged) {
-        await _writeFlushSettings(device, updated.rinseData);
-      }
-      if (steamChanged) {
-        await _writeSteamSettings(device, steam);
-      }
-      if (hotWaterChanged) {
-        await _writeHotWaterSettings(device, hotWater);
-      }
-    }, retryOnReplacement: true);
-    if (rinseChanged) _rinseStream.add(updated.rinseData);
-    if (steamChanged) _publishSteamSettings(steam);
-    if (hotWaterChanged) _publishHotWaterSettings(hotWater);
+    await Future.wait([
+      if (rinseChanged) updateFlushSettings(updated.rinseData),
+      if (steamChanged) updateSteamSettings(steam),
+      if (hotWaterChanged) updateHotWaterSettings(hotWater),
+    ]);
   }
 
   Future<void> setSteamFlow(double newFlow) async {
-    await runDeviceWrite(
-      (device) => device.setSteamFlow(newFlow),
-      retryOnReplacement: true,
-    );
+    await runDeviceWrite((device) => device.setSteamFlow(newFlow));
     _publishSteamFlow(newFlow);
   }
 
   Future<void> setHotWaterFlow(double newFlow) async {
-    await runDeviceWrite(
-      (device) => device.setHotWaterFlow(newFlow),
-      retryOnReplacement: true,
-    );
+    await runDeviceWrite((device) => device.setHotWaterFlow(newFlow));
     _publishHotWaterFlow(newFlow);
   }
 
   Future<void> setFlushFlow(double newFlow) async {
-    await runDeviceWrite(
-      (device) => device.setFlushFlow(newFlow),
-      retryOnReplacement: true,
-    );
+    await runDeviceWrite((device) => device.setFlushFlow(newFlow));
     _publishFlushFlow(newFlow);
   }
 
@@ -669,7 +599,7 @@ class De1Controller {
       if (steamPurgeMode != null) {
         await device.setSteamPurgeMode(steamPurgeMode);
       }
-    }, retryOnReplacement: true);
+    });
     if (flushTemp != null || flushFlow != null || flushTimeout != null) {
       _publishRinseSettings(
         targetTemperature: flushTemp,
@@ -728,6 +658,44 @@ class De1Controller {
         ),
       );
     }
+  }
+
+  Future<void> requestMachineState(MachineState state) {
+    if (state == MachineState.idle) {
+      return connectedDe1().requestState(state);
+    }
+    return runDeviceWrite((device) => device.requestState(state));
+  }
+
+  Future<void> updateFirmware(
+    Uint8List image, {
+    required void Function(double progress) onProgress,
+    void Function()? onStart,
+  }) {
+    if (_firmwareUpdatePending ||
+        connectedDe1().firmwareUpdateState != FirmwareUpdateState.idle) {
+      throw FirmwareUpdateInProgressException();
+    }
+    _firmwareUpdatePending = true;
+    final Future<void> operation;
+    try {
+      operation = runDeviceWrite((device) {
+        onStart?.call();
+        return device.updateFirmware(image, onProgress: onProgress);
+      });
+    } catch (_) {
+      _firmwareUpdatePending = false;
+      rethrow;
+    }
+    operation.then(
+      (_) => _firmwareUpdatePending = false,
+      onError: (Object _, StackTrace _) => _firmwareUpdatePending = false,
+    );
+    return operation;
+  }
+
+  Future<void> cancelFirmwareUpload() {
+    return connectedDe1().cancelFirmwareUpload();
   }
 
   Future<void> dispose() async {

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -105,6 +105,8 @@ class De1Controller {
   final Queue<_PendingDe1Write<dynamic>> _pendingDeviceWrites = Queue();
   _PendingDe1Write<dynamic>? _activeDeviceWrite;
   bool _firmwareUpdatePending = false;
+  bool _firmwareUpdateStarted = false;
+  bool _firmwareCancellationRequested = false;
   _PendingDe1Write<dynamic>? _pendingFirmwareWrite;
 
   int _connectionGeneration = 0;
@@ -682,32 +684,50 @@ class De1Controller {
       throw De1WriteQueueFullException(maxPendingDeviceWrites);
     }
     _firmwareUpdatePending = true;
+    _firmwareUpdateStarted = false;
+    _firmwareCancellationRequested = false;
     final queued = _activeDeviceWrite != null;
     final Future<void> operation;
     try {
       operation = runDeviceWrite((device) {
         _pendingFirmwareWrite = null;
+        if (_firmwareCancellationRequested) {
+          throw const FirmwareUpdateCancelledException();
+        }
+        _firmwareUpdateStarted = true;
         onStart?.call();
         return device.updateFirmware(image, onProgress: onProgress);
       });
       if (queued) _pendingFirmwareWrite = _pendingDeviceWrites.last;
     } catch (_) {
       _firmwareUpdatePending = false;
+      _firmwareUpdateStarted = false;
+      _firmwareCancellationRequested = false;
       rethrow;
     }
+    void clearState() {
+      _firmwareUpdatePending = false;
+      _firmwareUpdateStarted = false;
+      _firmwareCancellationRequested = false;
+    }
+
     operation.then(
-      (_) => _firmwareUpdatePending = false,
-      onError: (Object _, StackTrace _) => _firmwareUpdatePending = false,
+      (_) => clearState(),
+      onError: (Object _, StackTrace _) => clearState(),
     );
     return operation;
   }
 
   Future<void> cancelFirmwareUpload() {
-    final pending = _pendingFirmwareWrite;
-    _pendingFirmwareWrite = null;
-    if (pending != null && _pendingDeviceWrites.remove(pending)) {
-      _firmwareUpdatePending = false;
-      pending.completer.completeError(const FirmwareUpdateCancelledException());
+    if (_firmwareUpdatePending && !_firmwareUpdateStarted) {
+      _firmwareCancellationRequested = true;
+      final pending = _pendingFirmwareWrite;
+      _pendingFirmwareWrite = null;
+      if (pending != null && _pendingDeviceWrites.remove(pending)) {
+        pending.completer.completeError(
+          const FirmwareUpdateCancelledException(),
+        );
+      }
       return Future.value();
     }
     return connectedDe1().cancelFirmwareUpload();

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -569,6 +569,17 @@ class De1Controller {
     _publishSteamFlow(newFlow);
   }
 
+  Future<int> extendSteamDuration(int seconds) {
+    return runDeviceWrite((device) async {
+      final settings = await _readShotSettings(device);
+      final duration = settings.targetSteamDuration + seconds;
+      await device.updateShotSettings(
+        settings.copyWith(targetSteamDuration: duration),
+      );
+      return duration;
+    });
+  }
+
   Future<void> setHotWaterFlow(double newFlow) async {
     await runDeviceWrite((device) => device.setHotWaterFlow(newFlow));
     _publishHotWaterFlow(newFlow);
@@ -668,6 +679,14 @@ class De1Controller {
       return connectedDe1().requestState(state);
     }
     return runDeviceWrite((device) => device.requestState(state));
+  }
+
+  Future<bool> requestShotStepSkip(bool Function() stillApplicable) {
+    return runDeviceWrite((device) async {
+      if (!stillApplicable()) return false;
+      await device.requestState(MachineState.skipStep);
+      return true;
+    });
   }
 
   Future<void> updateFirmware(

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -105,6 +105,7 @@ class De1Controller {
   final Queue<_PendingDe1Write<dynamic>> _pendingDeviceWrites = Queue();
   _PendingDe1Write<dynamic>? _activeDeviceWrite;
   bool _firmwareUpdatePending = false;
+  _PendingDe1Write<dynamic>? _pendingFirmwareWrite;
 
   int _connectionGeneration = 0;
 
@@ -676,13 +677,20 @@ class De1Controller {
         connectedDe1().firmwareUpdateState != FirmwareUpdateState.idle) {
       throw FirmwareUpdateInProgressException();
     }
+    if (_activeDeviceWrite != null &&
+        _pendingDeviceWrites.length >= maxPendingDeviceWrites) {
+      throw De1WriteQueueFullException(maxPendingDeviceWrites);
+    }
     _firmwareUpdatePending = true;
+    final queued = _activeDeviceWrite != null;
     final Future<void> operation;
     try {
       operation = runDeviceWrite((device) {
+        _pendingFirmwareWrite = null;
         onStart?.call();
         return device.updateFirmware(image, onProgress: onProgress);
       });
+      if (queued) _pendingFirmwareWrite = _pendingDeviceWrites.last;
     } catch (_) {
       _firmwareUpdatePending = false;
       rethrow;
@@ -695,6 +703,13 @@ class De1Controller {
   }
 
   Future<void> cancelFirmwareUpload() {
+    final pending = _pendingFirmwareWrite;
+    _pendingFirmwareWrite = null;
+    if (pending != null && _pendingDeviceWrites.remove(pending)) {
+      _firmwareUpdatePending = false;
+      pending.completer.completeError(const FirmwareUpdateCancelledException());
+      return Future.value();
+    }
     return connectedDe1().cancelFirmwareUpload();
   }
 

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -557,6 +557,11 @@ class De1Controller {
       volume: updated.hotWaterData.volume,
       duration: updated.hotWaterData.duration,
     );
+    _ensureReplaceableDeviceWriteCapacity([
+      if (rinseChanged) 'workflow.rinse',
+      if (steamChanged) 'workflow.steam',
+      if (hotWaterChanged) 'workflow.hotWater',
+    ]);
     await Future.wait([
       if (rinseChanged) updateFlushSettings(updated.rinseData),
       if (steamChanged) updateSteamSettings(steam),
@@ -681,12 +686,23 @@ class De1Controller {
     return runDeviceWrite((device) => device.requestState(state));
   }
 
-  Future<bool> requestShotStepSkip(bool Function() stillApplicable) {
+  Future<bool> requestMachineStateIf(
+    MachineState state,
+    bool Function() stillApplicable,
+  ) {
     return runDeviceWrite((device) async {
       if (!stillApplicable()) return false;
-      await device.requestState(MachineState.skipStep);
+      await device.requestState(state);
       return true;
     });
+  }
+
+  Future<void> sendUserPresent() {
+    return runDeviceWrite((device) => device.sendUserPresent());
+  }
+
+  Future<bool> requestShotStepSkip(bool Function() stillApplicable) {
+    return requestMachineStateIf(MachineState.skipStep, stillApplicable);
   }
 
   Future<void> updateFirmware(

--- a/lib/src/controllers/de1_controller.governor.dart
+++ b/lib/src/controllers/de1_controller.governor.dart
@@ -1,0 +1,183 @@
+part of 'de1_controller.dart';
+
+enum De1ReplayPolicy { never, sameMachine }
+
+final class _PendingDe1Write<T> {
+  const _PendingDe1Write({
+    required this.call,
+    required this.completer,
+    required this.targetMachineIdentity,
+    required this.connectionGeneration,
+    required this.replayPolicy,
+    this.coalescingKey,
+  });
+
+  final Future<T> Function(De1Interface device) call;
+  final Completer<T> completer;
+  final String targetMachineIdentity;
+  final int connectionGeneration;
+  final De1ReplayPolicy replayPolicy;
+  final String? coalescingKey;
+}
+
+extension De1Governor on De1Controller {
+  Future<T> _enqueueDeviceWrite<T>(
+    Future<T> Function(De1Interface device) write, {
+    required De1ReplayPolicy replayPolicy,
+    String? coalescingKey,
+  }) {
+    final device = connectedDe1();
+    final completer = Completer<T>();
+    final operation = _PendingDe1Write<T>(
+      call: write,
+      completer: completer,
+      targetMachineIdentity: _machineIdentity(device),
+      connectionGeneration: _connectionGeneration,
+      replayPolicy: replayPolicy,
+      coalescingKey: coalescingKey,
+    );
+
+    if (coalescingKey != null) {
+      _PendingDe1Write<dynamic>? replaced;
+      final updated = _pendingDeviceWrites
+          .map((pending) {
+            if (replaced == null && pending.coalescingKey == coalescingKey) {
+              replaced = pending;
+              return operation;
+            }
+            return pending;
+          })
+          .toList(growable: false);
+      if (replaced != null) {
+        _pendingDeviceWrites
+          ..clear()
+          ..addAll(updated);
+        replaced!.completer.completeError(
+          De1WriteSupersededException(coalescingKey),
+        );
+        return completer.future;
+      }
+    }
+
+    if (_activeDeviceWrite != null &&
+        _pendingDeviceWrites.length >= maxPendingDeviceWrites) {
+      completer.completeError(
+        De1WriteQueueFullException(maxPendingDeviceWrites),
+      );
+      return completer.future;
+    }
+
+    if (_activeDeviceWrite == null) {
+      _activeDeviceWrite = operation;
+      unawaited(_executeActiveDeviceWrite());
+    } else {
+      _pendingDeviceWrites.addLast(operation);
+    }
+    return completer.future;
+  }
+
+  Future<void> _executeActiveDeviceWrite() async {
+    final operation = _activeDeviceWrite;
+    if (operation == null) return;
+    try {
+      operation.completer.complete(await _runDeviceWrite(operation));
+    } catch (error, stackTrace) {
+      operation.completer.completeError(error, stackTrace);
+    } finally {
+      _activeDeviceWrite = _pendingDeviceWrites.isEmpty
+          ? null
+          : _pendingDeviceWrites.removeFirst();
+      if (_activeDeviceWrite != null) {
+        unawaited(_executeActiveDeviceWrite());
+      }
+    }
+  }
+
+  Future<dynamic> _runDeviceWrite(_PendingDe1Write<dynamic> operation) async {
+    final attempts = operation.replayPolicy == De1ReplayPolicy.sameMachine
+        ? 2
+        : 1;
+    for (var attempt = 0; attempt < attempts; attempt++) {
+      final device = await _resolveDeviceFor(operation);
+      final generation = _connectionGeneration;
+      try {
+        await _waitForInitialization(device, generation);
+        if (generation != _connectionGeneration ||
+            !identical(device, connectedDe1OrNull)) {
+          if (attempt + 1 < attempts) continue;
+          break;
+        }
+        final result = await operation.call(device);
+        if (generation == _connectionGeneration &&
+            identical(device, connectedDe1OrNull)) {
+          return result;
+        }
+      } catch (_) {
+        if (operation.replayPolicy == De1ReplayPolicy.never ||
+            attempt + 1 == attempts ||
+            (generation == _connectionGeneration &&
+                identical(device, connectedDe1OrNull))) {
+          rethrow;
+        }
+      }
+    }
+    throw StateError('Machine changed during device write');
+  }
+
+  Future<De1Interface> _resolveDeviceFor(
+    _PendingDe1Write<dynamic> operation,
+  ) async {
+    if (operation.replayPolicy == De1ReplayPolicy.never &&
+        operation.connectionGeneration != _connectionGeneration) {
+      throw StateError('Machine changed before device write');
+    }
+
+    var device = connectedDe1OrNull;
+    if (device == null) {
+      if (operation.replayPolicy == De1ReplayPolicy.never) {
+        throw const DeviceNotConnectedException.machine();
+      }
+      device = await _waitForMachineReplacement(machineReplacementTimeout);
+      if (device == null) {
+        throw MachineReplacementTimeoutException(machineReplacementTimeout);
+      }
+    }
+    if (_machineIdentity(device) != operation.targetMachineIdentity) {
+      throw StateError('Machine changed before device write');
+    }
+    return device;
+  }
+
+  String _machineIdentity(De1Interface device) {
+    try {
+      final serial = device.machineInfo.serialNumber.trim();
+      if (serial.isNotEmpty && serial != '0') return 'serial:$serial';
+    } catch (_) {}
+    return 'device:${device.deviceId}';
+  }
+
+  Future<De1Interface?> _waitForMachineReplacement(Duration timeout) async {
+    try {
+      return await _de1Controller.stream
+          .firstWhere((de1) => de1 != null)
+          .timeout(timeout);
+    } on TimeoutException {
+      return null;
+    }
+  }
+
+  Future<void> _waitForInitialization(
+    De1Interface device,
+    int generation,
+  ) async {
+    if (_initSettledSubject.valueOrNull == generation) return;
+    await _initSettledSubject.stream
+        .firstWhere(
+          (settled) =>
+              settled == generation ||
+              generation != _connectionGeneration ||
+              !identical(device, connectedDe1OrNull),
+        )
+        .timeout(ConnectionTimings.initialShotSettingsTimeout);
+  }
+}

--- a/lib/src/controllers/de1_controller.governor.dart
+++ b/lib/src/controllers/de1_controller.governor.dart
@@ -21,6 +21,21 @@ final class _PendingDe1Write<T> {
 }
 
 extension De1Governor on De1Controller {
+  void _ensureReplaceableDeviceWriteCapacity(Iterable<String> keys) {
+    final pendingKeys = _pendingDeviceWrites
+        .map((pending) => pending.coalescingKey)
+        .whereType<String>()
+        .toSet();
+    final requiredSlots = keys.toSet().difference(pendingKeys).length;
+    final availableSlots =
+        maxPendingDeviceWrites -
+        _pendingDeviceWrites.length +
+        (_activeDeviceWrite == null ? 1 : 0);
+    if (requiredSlots > availableSlots) {
+      throw De1WriteQueueFullException(maxPendingDeviceWrites);
+    }
+  }
+
   Future<T> _enqueueDeviceWrite<T>(
     Future<T> Function(De1Interface device) write, {
     required De1ReplayPolicy replayPolicy,

--- a/lib/src/controllers/hot_water_sequencer.dart
+++ b/lib/src/controllers/hot_water_sequencer.dart
@@ -160,10 +160,9 @@ class HotWaterSequencer {
         '(weight ${decision.weight.toStringAsFixed(1)} g, '
         'projected ${decision.projectedWeight.toStringAsFixed(1)} g) — stopping',
       );
-      final machine = _machine;
-      if (machine != null) {
-        machine
-            .requestState(MachineState.idle)
+      if (_machine != null) {
+        _de1
+            .requestMachineState(MachineState.idle)
             .catchError(
               (e) => _log.warning('Failed to stop hot water at weight', e),
             );

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -33,6 +33,7 @@ class PresenceController {
   Timer? _pendingUserPresentTimer;
 
   Timer? _sleepTimer;
+  int _activityGeneration = 0;
 
   Timer? _scheduleTimer;
   Timer? _scheduleRetryTimer;
@@ -104,6 +105,7 @@ class PresenceController {
       return -1;
     }
 
+    _activityGeneration++;
     _sendPresenceThrottled();
 
     _resetSleepTimer();
@@ -121,6 +123,7 @@ class PresenceController {
     _scheduleRetryTimer?.cancel();
     _scheduleRetryTimer = null;
     _currentMachineState = null;
+    _activityGeneration++;
     _lastPresenceSent = null;
 
     _pendingUserPresent = false;
@@ -144,6 +147,10 @@ class PresenceController {
   void _onSnapshot(MachineSnapshot snapshot) {
     final newState = snapshot.state.state;
 
+    if (_isActiveState(newState) && newState != _currentMachineState) {
+      _activityGeneration++;
+    }
+
     if (_currentMachineState == MachineState.sleeping &&
         (newState == MachineState.idle || newState == MachineState.schedIdle)) {
       if (_pendingUserPresent) {
@@ -151,9 +158,7 @@ class PresenceController {
         _pendingUserPresentTimer?.cancel();
         _pendingUserPresentTimer = null;
         _lastPresenceSent = null;
-        _de1?.sendUserPresent().catchError((Object e) {
-          _log.warning('Failed to send deferred user present on wake', e);
-        });
+        unawaited(_sendUserPresent());
         _lastPresenceSent = _clock();
       }
     }
@@ -232,9 +237,17 @@ class PresenceController {
       return;
     }
 
-    _de1?.sendUserPresent().catchError((Object e) {
-      _log.warning('Failed to send user present', e);
-    });
+    unawaited(_sendUserPresent());
+  }
+
+  Future<void> _sendUserPresent() async {
+    try {
+      await _de1Controller.sendUserPresent();
+    } on De1WriteQueueFullException catch (e, st) {
+      _log.warning('User-present write dropped because queue is full', e, st);
+    } catch (e, st) {
+      _log.warning('Failed to send user present', e, st);
+    }
   }
 
   void _resetSleepTimer() {
@@ -278,8 +291,17 @@ class PresenceController {
 
   Future<void> _requestSleep() async {
     final de1 = _de1;
+    final activityGeneration = _activityGeneration;
     try {
-      await _de1Controller.requestMachineState(MachineState.sleeping);
+      await _de1Controller.requestMachineStateIf(MachineState.sleeping, () {
+        final state = _currentMachineState;
+        return identical(de1, _de1) &&
+            activityGeneration == _activityGeneration &&
+            _settingsController.userPresenceEnabled &&
+            state != null &&
+            _canSleepFromState(state) &&
+            _activeKeepAwakeOccurrence == null;
+      });
     } catch (e, st) {
       _log.warning('Failed to request sleep', e, st);
       final state = _currentMachineState;
@@ -471,8 +493,14 @@ class PresenceController {
   }
 
   Future<void> _requestScheduledWake(String scheduleId) async {
+    final de1 = _de1;
     try {
-      await _de1Controller.requestMachineState(MachineState.schedIdle);
+      await _de1Controller.requestMachineStateIf(
+        MachineState.schedIdle,
+        () =>
+            identical(de1, _de1) &&
+            _currentMachineState == MachineState.sleeping,
+      );
     } on De1WriteQueueFullException catch (e, st) {
       _log.warning('Failed to request schedIdle', e, st);
       _firedScheduleIds.remove(scheduleId);

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -266,7 +266,9 @@ class PresenceController {
     final state = _currentMachineState;
     if (state != null && _canSleepFromState(state)) {
       _log.info('Sleep timeout fired, putting machine to sleep');
-      _de1!.requestState(MachineState.sleeping).catchError((Object e) {
+      _de1Controller.requestMachineState(MachineState.sleeping).catchError((
+        Object e,
+      ) {
         _log.warning('Failed to request sleep', e);
       });
     }
@@ -437,9 +439,11 @@ class PresenceController {
             'Schedule ${schedule.id} matched at ${now.hour}:${now.minute}, waking machine',
           );
           _firedScheduleIds.add(schedule.id);
-          _de1!.requestState(MachineState.schedIdle).catchError((Object e) {
-            _log.warning('Failed to request schedIdle', e);
-          });
+          _de1Controller.requestMachineState(MachineState.schedIdle).catchError(
+            (Object e) {
+              _log.warning('Failed to request schedIdle', e);
+            },
+          );
           break;
         }
       }

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -495,12 +495,15 @@ class PresenceController {
   Future<void> _requestScheduledWake(String scheduleId) async {
     final de1 = _de1;
     try {
-      await _de1Controller.requestMachineStateIf(
-        MachineState.schedIdle,
-        () =>
-            identical(de1, _de1) &&
-            _currentMachineState == MachineState.sleeping,
-      );
+      await _de1Controller.requestMachineStateIf(MachineState.schedIdle, () {
+        final now = _clock();
+        return identical(de1, _de1) &&
+            _currentMachineState == MachineState.sleeping &&
+            _wakeSchedules.any(
+              (schedule) =>
+                  schedule.id == scheduleId && schedule.matchesTime(now),
+            );
+      });
     } on De1WriteQueueFullException catch (e, st) {
       _log.warning('Failed to request schedIdle', e, st);
       _firedScheduleIds.remove(scheduleId);

--- a/lib/src/controllers/presence_controller.dart
+++ b/lib/src/controllers/presence_controller.dart
@@ -6,6 +6,7 @@ import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/firmware_wake_window.dart';
 import 'package:reaprime/src/models/keep_awake_occurrence.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
@@ -34,6 +35,7 @@ class PresenceController {
   Timer? _sleepTimer;
 
   Timer? _scheduleTimer;
+  Timer? _scheduleRetryTimer;
 
   final Set<String> _firedScheduleIds = {};
   int? _lastCheckedMinute;
@@ -88,6 +90,8 @@ class PresenceController {
     _sleepTimer = null;
     _scheduleTimer?.cancel();
     _scheduleTimer = null;
+    _scheduleRetryTimer?.cancel();
+    _scheduleRetryTimer = null;
     _pendingUserPresent = false;
     _pendingUserPresentTimer?.cancel();
     _pendingUserPresentTimer = null;
@@ -114,6 +118,8 @@ class PresenceController {
     _snapshotSubscription = null;
     _sleepTimer?.cancel();
     _sleepTimer = null;
+    _scheduleRetryTimer?.cancel();
+    _scheduleRetryTimer = null;
     _currentMachineState = null;
     _lastPresenceSent = null;
 
@@ -266,11 +272,23 @@ class PresenceController {
     final state = _currentMachineState;
     if (state != null && _canSleepFromState(state)) {
       _log.info('Sleep timeout fired, putting machine to sleep');
-      _de1Controller.requestMachineState(MachineState.sleeping).catchError((
-        Object e,
-      ) {
-        _log.warning('Failed to request sleep', e);
-      });
+      unawaited(_requestSleep());
+    }
+  }
+
+  Future<void> _requestSleep() async {
+    final de1 = _de1;
+    try {
+      await _de1Controller.requestMachineState(MachineState.sleeping);
+    } catch (e, st) {
+      _log.warning('Failed to request sleep', e, st);
+      final state = _currentMachineState;
+      if (identical(de1, _de1) &&
+          _settingsController.userPresenceEnabled &&
+          state != null &&
+          _canSleepFromState(state)) {
+        _resetSleepTimer();
+      }
     }
   }
 
@@ -345,13 +363,17 @@ class PresenceController {
     final windows = enabled
         ? translateWakeSchedules(keepAwakeSchedulesFromJson(schedulesJson))
         : const <FirmwareWakeWindow>[];
-    final secondsSinceSunday = localSecondsSinceSunday(_clock());
-    await de1.setInactivitySleepTimeout(timeout);
-    await de1.pushFirmwareWakeSchedule(
-      secondsSinceSundayLocal: secondsSinceSunday,
-      windows: windows,
-    );
-    if (_de1 == de1) {
+    var pushed = false;
+    await _de1Controller.runDeviceWrite((device) async {
+      if (!identical(device, de1)) return;
+      await de1.setInactivitySleepTimeout(timeout);
+      await de1.pushFirmwareWakeSchedule(
+        secondsSinceSundayLocal: localSecondsSinceSunday(_clock()),
+        windows: windows,
+      );
+      pushed = true;
+    });
+    if (pushed && _de1 == de1) {
       _lastPushedDevice = de1;
       _lastPushedMasterEnabled = enabled;
       _lastPushedSleepTimeout = timeout;
@@ -439,16 +461,27 @@ class PresenceController {
             'Schedule ${schedule.id} matched at ${now.hour}:${now.minute}, waking machine',
           );
           _firedScheduleIds.add(schedule.id);
-          _de1Controller.requestMachineState(MachineState.schedIdle).catchError(
-            (Object e) {
-              _log.warning('Failed to request schedIdle', e);
-            },
-          );
+          unawaited(_requestScheduledWake(schedule.id));
           break;
         }
       }
     } catch (e) {
       _log.warning('Failed to parse wake schedules', e);
+    }
+  }
+
+  Future<void> _requestScheduledWake(String scheduleId) async {
+    try {
+      await _de1Controller.requestMachineState(MachineState.schedIdle);
+    } on De1WriteQueueFullException catch (e, st) {
+      _log.warning('Failed to request schedIdle', e, st);
+      _firedScheduleIds.remove(scheduleId);
+      _scheduleRetryTimer ??= Timer(_firmwareSyncRetryDelay, () {
+        _scheduleRetryTimer = null;
+        _checkSchedules();
+      });
+    } catch (e, st) {
+      _log.warning('Failed to request schedIdle', e, st);
     }
   }
 }

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -33,6 +33,7 @@ class ShotSequencer {
   final bool _machineHasAutonomousSAW;
 
   List<int> skippedSteps = [];
+  final Set<int> _pendingSkipSteps = {};
   final StepExitArbiter _stepExitArbiter = StepExitArbiter();
   int _lastProfileFrame = -1;
 
@@ -362,6 +363,7 @@ class ShotSequencer {
           _settleSamples = 0;
           _prevStoppingFlow = null;
           skippedSteps.clear();
+          _pendingSkipSteps.clear();
           _stepExitArbiter.reset();
           _lastProfileFrame = -1;
           _maxFrameSeen = -1;
@@ -578,7 +580,8 @@ class ShotSequencer {
       return;
     }
 
-    if (skippedSteps.contains(profileFrame)) {
+    if (skippedSteps.contains(profileFrame) ||
+        _pendingSkipSteps.contains(profileFrame)) {
       return;
     }
 
@@ -598,20 +601,35 @@ class ShotSequencer {
       }
     }
 
-    _emitDecision(
-      ShotDecisionKind.advance,
-      ShotDecisionReason.profileSkip,
-      details:
-          'Step weight ${stepExitWeight}g reached '
-          '(projected: $projectedWeight), skipping frame $profileFrame',
-      data: {
-        'frame': profileFrame,
-        'stepExitWeight': stepExitWeight,
-        'projectedWeight': projectedWeight,
-      },
-    );
-    skippedSteps.add(profileFrame);
-    de1controller.requestMachineState(MachineState.skipStep);
+    _pendingSkipSteps.add(profileFrame);
+    de1controller
+        .requestMachineState(MachineState.skipStep)
+        .then(
+          (_) {
+            _pendingSkipSteps.remove(profileFrame);
+            skippedSteps.add(profileFrame);
+            _emitDecision(
+              ShotDecisionKind.advance,
+              ShotDecisionReason.profileSkip,
+              details:
+                  'Step weight ${stepExitWeight}g reached '
+                  '(projected: $projectedWeight), skipping frame $profileFrame',
+              data: {
+                'frame': profileFrame,
+                'stepExitWeight': stepExitWeight,
+                'projectedWeight': projectedWeight,
+              },
+            );
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            _pendingSkipSteps.remove(profileFrame);
+            _log.warning(
+              'Failed to skip frame $profileFrame',
+              error,
+              stackTrace,
+            );
+          },
+        );
   }
 
   void _enterStopping(WeightSnapshot? scale) {

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -91,8 +91,7 @@ class ShotSequencer {
         details: 'No scale connected, blocking shot',
       );
       de1controller
-          .connectedDe1()
-          .requestState(MachineState.idle)
+          .requestMachineState(MachineState.idle)
           .catchError(
             (error) =>
                 _log.warning("Failed to abort shot for blockOnNoScale: $error"),
@@ -448,7 +447,7 @@ class ShotSequencer {
                 'projectedWeight': projectedWeight,
               },
             );
-            de1controller.connectedDe1().requestState(MachineState.idle);
+            de1controller.requestMachineState(MachineState.idle);
             _enterStopping(scale);
             break;
           }
@@ -472,7 +471,7 @@ class ShotSequencer {
                 'projectedVolume': projectedVolume,
               },
             );
-            de1controller.connectedDe1().requestState(MachineState.idle);
+            de1controller.requestMachineState(MachineState.idle);
             _enterStopping(scale);
             break;
           }
@@ -612,7 +611,7 @@ class ShotSequencer {
       },
     );
     skippedSteps.add(profileFrame);
-    de1controller.connectedDe1().requestState(MachineState.skipStep);
+    de1controller.requestMachineState(MachineState.skipStep);
   }
 
   void _enterStopping(WeightSnapshot? scale) {

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -603,10 +603,14 @@ class ShotSequencer {
 
     _pendingSkipSteps.add(profileFrame);
     de1controller
-        .requestMachineState(MachineState.skipStep)
+        .requestShotStepSkip(
+          () =>
+              _state == ShotState.pouring && _lastProfileFrame == profileFrame,
+        )
         .then(
-          (_) {
+          (skipped) {
             _pendingSkipSteps.remove(profileFrame);
+            if (!skipped) return;
             skippedSteps.add(profileFrame);
             _emitDecision(
               ShotDecisionKind.advance,

--- a/lib/src/controllers/steam_sequencer.dart
+++ b/lib/src/controllers/steam_sequencer.dart
@@ -146,10 +146,9 @@ class SteamSequencer {
     if (temp < target) return;
     _appSideStopRequested = true;
     _log.info('App-side stop: probe $temp°C ≥ target $target°C');
-    final machine = _machine;
-    if (machine != null) {
+    if (_machine != null) {
       // ignore: discarded_futures
-      machine.requestState(MachineState.idle);
+      _de1.requestMachineState(MachineState.idle);
     }
   }
 

--- a/lib/src/debug_feature/calibration_debug_card.dart
+++ b/lib/src/debug_feature/calibration_debug_card.dart
@@ -3,9 +3,14 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 class CalibrationDebugCard extends StatefulWidget {
-  const CalibrationDebugCard({super.key, required this.machine});
+  const CalibrationDebugCard({
+    super.key,
+    required this.machine,
+    required this.writeCalibration,
+  });
 
   final De1Interface machine;
+  final Future<void> Function(De1Calibration calibration) writeCalibration;
 
   @override
   State<CalibrationDebugCard> createState() => _CalibrationDebugCardState();
@@ -204,7 +209,7 @@ class _CalibrationDebugCardState extends State<CalibrationDebugCard>
     }
     setState(() => _writing = {target});
     try {
-      await widget.machine.writeCalibration(
+      await widget.writeCalibration(
         De1Calibration(
           target: target,
           de1ReportedValue: reported,

--- a/lib/src/debug_feature/debug_item_details_view.dart
+++ b/lib/src/debug_feature/debug_item_details_view.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/debug_feature/calibration_debug_card.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
@@ -14,11 +15,16 @@ String debugViewTitle(De1Interface machine) =>
     machine is BengleInterface ? 'Bengle Details' : 'DE1 Details';
 
 class De1DebugView extends StatefulWidget {
-  const De1DebugView({super.key, required this.machine});
+  const De1DebugView({
+    super.key,
+    required this.machine,
+    required this.de1Controller,
+  });
 
   static const routeName = '/debug_details';
 
   final De1Interface machine;
+  final De1Controller? de1Controller;
 
   @override
   State<De1DebugView> createState() => _De1DebugViewState();
@@ -27,6 +33,11 @@ class De1DebugView extends StatefulWidget {
 class _De1DebugViewState extends State<De1DebugView> {
   var _lastDate = DateTime.now();
   late final Future<void> _connection;
+
+  De1Controller? get _machineController =>
+      identical(widget.de1Controller?.connectedDe1OrNull, widget.machine)
+      ? widget.de1Controller
+      : null;
 
   @override
   void initState() {
@@ -69,7 +80,12 @@ class _De1DebugViewState extends State<De1DebugView> {
       selectedOptionBuilder: (context, state) => Text(state.name),
       onChanged: (state) {
         if (state != null) {
-          widget.machine.requestState(state);
+          final controller = _machineController;
+          if (controller == null) {
+            widget.machine.requestState(state);
+          } else {
+            controller.requestMachineState(state);
+          }
         }
       },
       options: MachineState.values
@@ -150,7 +166,10 @@ class _De1DebugViewState extends State<De1DebugView> {
             child: Text('Machine connection failed'),
           );
         }
-        return CalibrationDebugCard(machine: widget.machine);
+        return CalibrationDebugCard(
+          machine: widget.machine,
+          writeCalibration: _writeCalibration,
+        );
       },
     );
   }
@@ -322,7 +341,12 @@ class _De1DebugViewState extends State<De1DebugView> {
           onPopInvokedWithResult: (didPop, _) {
             if (didPop) {
               cancelled = true;
-              widget.machine.cancelFirmwareUpload();
+              final controller = _machineController;
+              if (controller == null) {
+                widget.machine.cancelFirmwareUpload();
+              } else {
+                controller.cancelFirmwareUpload();
+              }
             }
           },
           child: ValueListenableBuilder<double>(
@@ -362,10 +386,18 @@ class _De1DebugViewState extends State<De1DebugView> {
     );
 
     try {
-      await widget.machine.updateFirmware(
-        data,
-        onProgress: (p) => progressNotifier.value = p,
-      );
+      final controller = _machineController;
+      if (controller == null) {
+        await widget.machine.updateFirmware(
+          data,
+          onProgress: (p) => progressNotifier.value = p,
+        );
+      } else {
+        await controller.updateFirmware(
+          data,
+          onProgress: (p) => progressNotifier.value = p,
+        );
+      }
     } on FirmwareUpdateInProgressException {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -401,6 +433,14 @@ class _De1DebugViewState extends State<De1DebugView> {
     if (mounted) {
       Navigator.of(context).pop();
     }
+  }
+
+  Future<void> _writeCalibration(De1Calibration calibration) {
+    final controller = _machineController;
+    if (controller == null) return widget.machine.writeCalibration(calibration);
+    return controller.runDeviceWrite(
+      (machine) => machine.writeCalibration(calibration),
+    );
   }
 
   final TextEditingController _serialPayloadController =

--- a/lib/src/debug_feature/debug_item_list_view.dart
+++ b/lib/src/debug_feature/debug_item_list_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart' as dev;
@@ -8,11 +9,16 @@ import 'package:reaprime/src/debug_feature/scale_debug_view.dart';
 import 'package:shadcn_ui/shadcn_ui.dart' hide Scale;
 
 class DebugItemListView extends StatelessWidget {
-  const DebugItemListView({super.key, required this.controller});
+  const DebugItemListView({
+    super.key,
+    required this.controller,
+    required this.de1Controller,
+  });
 
   static const routeName = '/debug';
 
   final DeviceController controller;
+  final De1Controller de1Controller;
 
   @override
   Widget build(BuildContext context) {
@@ -227,7 +233,10 @@ class DebugItemListView extends StatelessWidget {
     if (device is De1Interface) {
       Navigator.push(
         context,
-        MaterialPageRoute(builder: (_) => De1DebugView(machine: device)),
+        MaterialPageRoute(
+          builder: (_) =>
+              De1DebugView(machine: device, de1Controller: de1Controller),
+        ),
       );
     } else if (device is Scale) {
       Navigator.push(

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -96,6 +96,25 @@ class MachineReplacementTimeoutException implements Exception {
       'within $timeout';
 }
 
+class De1WriteQueueFullException implements Exception {
+  final int maxPendingWrites;
+
+  const De1WriteQueueFullException(this.maxPendingWrites);
+
+  @override
+  String toString() =>
+      'De1WriteQueueFullException: maximum $maxPendingWrites pending writes';
+}
+
+class De1WriteSupersededException implements Exception {
+  final String key;
+
+  const De1WriteSupersededException(this.key);
+
+  @override
+  String toString() => 'De1WriteSupersededException: $key was superseded';
+}
+
 class FirmwareUpdateInProgressException implements Exception {
   @override
   String toString() =>

--- a/lib/src/realtime_shot_feature/realtime_shot_feature.dart
+++ b/lib/src/realtime_shot_feature/realtime_shot_feature.dart
@@ -214,7 +214,7 @@ class _RealtimeShotFeatureState extends State<RealtimeShotFeature> {
             widget.shotSequencer.de1controller.recordStopIntent(
               ShotDecisionReason.appStop,
             );
-            widget.shotSequencer.de1controller.connectedDe1().requestState(
+            widget.shotSequencer.de1controller.requestMachineState(
               MachineState.idle,
             );
           },
@@ -223,7 +223,7 @@ class _RealtimeShotFeatureState extends State<RealtimeShotFeature> {
         ShadButton.secondary(
           enabled: !backEnabled,
           onPressed: () {
-            widget.shotSequencer.de1controller.connectedDe1().requestState(
+            widget.shotSequencer.de1controller.requestMachineState(
               MachineState.skipStep,
             );
           },

--- a/lib/src/realtime_shot_feature/realtime_shot_feature.dart
+++ b/lib/src/realtime_shot_feature/realtime_shot_feature.dart
@@ -29,6 +29,19 @@ class RealtimeShotFeature extends StatefulWidget {
 }
 
 class _RealtimeShotFeatureState extends State<RealtimeShotFeature> {
+  Future<void> _skipStep() async {
+    try {
+      await widget.shotSequencer.de1controller.requestMachineState(
+        MachineState.skipStep,
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Unable to skip step: $error')));
+    }
+  }
+
   late ShotSequencer _shotSequencer;
   final List<ShotSnapshot> _shotSnapshots = [];
   late StreamSubscription<ShotSnapshot> _shotSubscription;
@@ -222,11 +235,7 @@ class _RealtimeShotFeatureState extends State<RealtimeShotFeature> {
         ),
         ShadButton.secondary(
           enabled: !backEnabled,
-          onPressed: () {
-            widget.shotSequencer.de1controller.requestMachineState(
-              MachineState.skipStep,
-            );
-          },
+          onPressed: _skipStep,
           trailing: Icon(LucideIcons.fastForward),
           child: Text('Skip Step'),
         ),

--- a/lib/src/realtime_steam_feature/realtime_steam_feature.dart
+++ b/lib/src/realtime_steam_feature/realtime_steam_feature.dart
@@ -111,20 +111,17 @@ class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
     }
   }
 
-  void _extendSteam() async {
-    if (_steamActive) {
-      setState(() {
-        _steamDuration += 10;
-      });
-
-      final currentSettings = await _de1Controller
-          .connectedDe1()
-          .shotSettings
-          .first;
-      await _de1Controller.runDeviceWrite(
-        (device) => device.updateShotSettings(
-          currentSettings.copyWith(targetSteamDuration: _steamDuration),
-        ),
+  Future<void> _extendSteam() async {
+    if (!_steamActive) return;
+    try {
+      final duration = await _de1Controller.extendSteamDuration(10);
+      if (!mounted) return;
+      setState(() => _steamDuration = duration);
+    } catch (e, st) {
+      _log.warning('Failed to extend steam duration', e, st);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to extend steam duration')),
       );
     }
   }

--- a/lib/src/realtime_steam_feature/realtime_steam_feature.dart
+++ b/lib/src/realtime_steam_feature/realtime_steam_feature.dart
@@ -105,7 +105,7 @@ class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
         _remainingTime = 0;
       });
 
-      _de1Controller.connectedDe1().requestState(MachineState.idle);
+      _de1Controller.requestMachineState(MachineState.idle);
 
       _stopSteamTimer();
     }
@@ -121,8 +121,10 @@ class _RealtimeSteamFeatureState extends State<RealtimeSteamFeature> {
           .connectedDe1()
           .shotSettings
           .first;
-      await _de1Controller.connectedDe1().updateShotSettings(
-        currentSettings.copyWith(targetSteamDuration: _steamDuration),
+      await _de1Controller.runDeviceWrite(
+        (device) => device.updateShotSettings(
+          currentSettings.copyWith(targetSteamDuration: _steamDuration),
+        ),
       );
     }
   }

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -114,7 +114,7 @@ class De1Handler {
           await bengle.setCupWarmerEnabled(true);
         }
         return jsonOk({'status': 'accepted'});
-      }, retryOnReplacement: true);
+      });
     });
 
     app.get('/api/v1/machine/cupWarmer/preheat', (Request _) async {
@@ -168,7 +168,7 @@ class De1Handler {
           leadMinutes: lead ?? current.leadMinutes,
         );
         return jsonOk({'status': 'accepted'});
-      }, retryOnReplacement: true);
+      });
     });
 
     app.get('/ws/v1/machine/snapshot', sws.webSocketHandler(_handleSnapshot));
@@ -215,7 +215,7 @@ class De1Handler {
         if (gate != null) return gate;
         await (de1 as BengleInterface).setLedStrip(state);
         return jsonOk({'status': 'accepted'});
-      }, retryOnReplacement: true);
+      });
     });
 
     app.post('/api/v1/machine/ledStrip/commit', (Request _) async {
@@ -224,7 +224,7 @@ class De1Handler {
         if (gate != null) return gate;
         await (de1 as BengleInterface).commitLedStrip();
         return jsonAccepted();
-      }, retryOnReplacement: true);
+      });
     });
 
     app.post('/api/v1/machine/ledStrip/reset', (Request _) async {
@@ -238,7 +238,7 @@ class De1Handler {
           });
         }
         return jsonOk(state.toJson());
-      }, retryOnReplacement: true);
+      });
     });
 
     app.get('/api/v1/machine/scaleCalibration', (Request _) async {
@@ -303,7 +303,7 @@ class De1Handler {
           'reason': 'machine busy or shot in progress',
           'state': state.toJson(),
         });
-      }, retryOnReplacement: true);
+      });
     });
 
     app.post('/api/v1/machine/waterLevels', (Request r) async {
@@ -324,7 +324,7 @@ class De1Handler {
           await de1.setRefillLevel(refillLevel);
         }
         return jsonAccepted();
-      }, retryOnReplacement: true);
+      });
     });
 
     app.post('/api/v1/machine/settings', (Request r) async {
@@ -445,7 +445,7 @@ class De1Handler {
           await de1.setRefillKitSettings(refillKitSetting);
         }
         return jsonAccepted();
-      }, retryOnReplacement: true);
+      });
     });
 
     app.get('/api/v1/machine/settings/advanced', () async {
@@ -487,7 +487,7 @@ class De1Handler {
           await de1.setFlowEstimation(flowMultiplier);
         }
         return jsonAccepted();
-      }, retryOnReplacement: true);
+      });
     });
 
     app.get('/api/v1/machine/calibration/<target>', (
@@ -575,14 +575,13 @@ class De1Handler {
           return jsonBadRequest({'error': e.toString()});
         }
         return jsonAccepted();
-      }, retryOnReplacement: true);
+      });
     });
 
     app.delete('/api/v1/machine/settings/reset', (Request r) async {
       return _mapDe1WriteErrors(() async {
         await _controller.runDeviceWrite(
           (device) => _controller.applySettingsDefaults(device),
-          retryOnReplacement: true,
         );
         return jsonAccepted();
       });
@@ -592,27 +591,26 @@ class De1Handler {
   De1CalibrationTarget? _parseCalibrationTarget(String target) =>
       De1CalibrationTarget.values.where((t) => t.name == target).firstOrNull;
 
-  Future<Response> withDe1(Future<Response> Function(De1Interface) call) async {
-    try {
-      var de1 = _controller.connectedDe1();
-      return await call(de1);
-    } on MachineReplacementTimeoutException catch (e) {
-      return jsonServiceUnavailable({
-        'error': 'Machine unavailable',
-        'message': '$e',
-      });
-    } on EndpointUnavailableException catch (e) {
-      return jsonGatewayTimeout({'error': e.toString()});
-    } on BleTimeoutException catch (e) {
-      return jsonGatewayTimeout({'error': e.toString()});
-    } catch (e, st) {
-      return jsonError({'error': e.toString(), 'st': st.toString()});
-    }
+  Future<Response> withDe1(Future<Response> Function(De1Interface) call) {
+    return _mapDe1WriteErrors(() async {
+      final de1 = _controller.connectedDe1();
+      return call(de1);
+    });
   }
 
   Future<Response> _mapDe1WriteErrors(Future<Response> Function() call) async {
     try {
       return await call();
+    } on De1WriteQueueFullException catch (e) {
+      return jsonServiceUnavailable({
+        'error': 'Machine write queue is full',
+        'message': '$e',
+      });
+    } on De1WriteSupersededException catch (e) {
+      return jsonConflict({
+        'error': 'Machine write was superseded',
+        'message': '$e',
+      });
     } on MachineReplacementTimeoutException catch (e) {
       return jsonServiceUnavailable({
         'error': 'Machine unavailable',
@@ -637,15 +635,9 @@ class De1Handler {
   }
 
   Future<Response> withQueuedDe1(
-    Future<Response> Function(De1Interface device) call, {
-    bool retryOnReplacement = false,
-  }) {
-    return _mapDe1WriteErrors(
-      () => _controller.runDeviceWrite(
-        call,
-        retryOnReplacement: retryOnReplacement,
-      ),
-    );
+    Future<Response> Function(De1Interface device) call,
+  ) {
+    return _mapDe1WriteErrors(() => _controller.runDeviceWrite(call));
   }
 
   void _withDe1Ws(
@@ -766,7 +758,7 @@ class De1Handler {
       final stoppingActiveShot =
           requestState == MachineState.idle &&
           _controller.currentShotState.state != ShotState.idle;
-      await de1.requestState(requestState);
+      await _controller.requestMachineState(requestState);
       if (stoppingActiveShot) {
         _controller.recordStopIntent(ShotDecisionReason.apiStop);
       }
@@ -785,10 +777,7 @@ class De1Handler {
         return jsonBadRequest({'error': 'Invalid JSON body'});
       }
       Profile profile = Profile.fromJson(json);
-      await _controller.runDeviceWrite(
-        (device) => device.setProfile(profile),
-        retryOnReplacement: true,
-      );
+      await _controller.runDeviceWrite((device) => device.setProfile(profile));
       return jsonOk(null);
     });
   }
@@ -806,7 +795,6 @@ class De1Handler {
       De1ShotSettings settings = De1ShotSettings.fromJson(json);
       await _controller.runDeviceWrite(
         (device) => device.updateShotSettings(settings),
-        retryOnReplacement: true,
       );
       return jsonOk(null);
     });

--- a/lib/src/services/webserver/firmware_handler.dart
+++ b/lib/src/services/webserver/firmware_handler.dart
@@ -211,9 +211,8 @@ class FirmwareHandler {
   Future<Response> _cancelUpdate(Request _) async {
     FirmwareUpdateState state = FirmwareUpdateState.idle;
     try {
-      final de1 = _controller.connectedDe1();
-      await de1.cancelFirmwareUpload();
-      state = de1.firmwareUpdateState;
+      await _controller.cancelFirmwareUpload();
+      state = _resolveOperationState();
     } catch (_) {}
     return Response(
       202,
@@ -287,11 +286,22 @@ class FirmwareHandler {
             progressController.close();
           });
     } on FirmwareUpdateInProgressException {
+      unawaited(progressController.close());
       return Response(
         409,
         body: jsonEncode({
           'error': 'firmware_update_in_progress',
           'message': 'A firmware update is already in progress',
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } on De1WriteQueueFullException catch (e) {
+      unawaited(progressController.close());
+      return Response(
+        503,
+        body: jsonEncode({
+          'error': 'Machine write queue is full',
+          'message': '$e',
         }),
         headers: {'Content-Type': 'application/json'},
       );

--- a/lib/src/services/webserver/firmware_handler.dart
+++ b/lib/src/services/webserver/firmware_handler.dart
@@ -119,7 +119,7 @@ class FirmwareHandler {
     final de1 = _resolveDe1();
     if (de1 == null) return _machineUnavailable();
 
-    return _streamFirmwareUpload(de1, fwImage);
+    return _streamFirmwareUpload(fwImage);
   }
 
   Future<Response> _applyManaged(Request request) async {
@@ -205,7 +205,7 @@ class FirmwareHandler {
       );
     }
 
-    return _streamFirmwareUpload(de1, image);
+    return _streamFirmwareUpload(image);
   }
 
   Future<Response> _cancelUpdate(Request _) async {
@@ -250,7 +250,7 @@ class FirmwareHandler {
     );
   }
 
-  Response _streamFirmwareUpload(De1Interface de1, Uint8List image) {
+  Response _streamFirmwareUpload(Uint8List image) {
     final progressController = StreamController<List<int>>();
 
     void emit(Map<String, dynamic> event) {
@@ -261,14 +261,15 @@ class FirmwareHandler {
 
     progressController.onCancel = () async {
       _log.warning('firmware upload: client disconnected, cancelling');
-      await de1.cancelFirmwareUpload();
+      await _controller.cancelFirmwareUpload();
     };
 
     var lastProgress = -1.0;
     try {
-      de1
+      _controller
           .updateFirmware(
             image,
+            onStart: () => emit({'status': 'erasing', 'progress': 0.0}),
             onProgress: (progress) {
               if (progress - lastProgress < 0.01) return;
               lastProgress = progress;
@@ -295,8 +296,6 @@ class FirmwareHandler {
         headers: {'Content-Type': 'application/json'},
       );
     }
-
-    emit({'status': 'erasing', 'progress': 0.0});
 
     return Response.ok(
       progressController.stream,

--- a/lib/src/services/webserver/firmware_handler.dart
+++ b/lib/src/services/webserver/firmware_handler.dart
@@ -143,8 +143,7 @@ class FirmwareHandler {
     }
     final force = forceValue as bool? ?? false;
 
-    final de1 = _resolveDe1();
-    if (de1 == null) return _machineUnavailable();
+    if (_resolveDe1() == null) return _machineUnavailable();
 
     final manifest = await _catalog.loadManifest();
     FirmwareManifestEntry? entry;
@@ -179,6 +178,8 @@ class FirmwareHandler {
       );
     }
 
+    final de1 = _resolveDe1();
+    if (de1 == null) return _machineUnavailable();
     final info = de1.machineInfo;
     final eligibility = _validator.evaluateEligibility(
       entry.artifact,

--- a/lib/src/services/webserver/workflow_handler.dart
+++ b/lib/src/services/webserver/workflow_handler.dart
@@ -184,6 +184,16 @@ class WorkflowHandler {
           return jsonOk(updatedWorkflow.toJson());
         }
       }
+    } on De1WriteQueueFullException catch (e) {
+      return jsonServiceUnavailable({
+        'error': 'Machine write queue is full',
+        'message': '$e',
+      });
+    } on De1WriteSupersededException catch (e) {
+      return jsonConflict({
+        'error': 'Workflow update was superseded',
+        'message': '$e',
+      });
     } on MachineReplacementTimeoutException catch (e) {
       return jsonServiceUnavailable({
         'error': 'Machine unavailable',

--- a/test/controllers/bengle_saw_bridge_test.dart
+++ b/test/controllers/bengle_saw_bridge_test.dart
@@ -339,4 +339,41 @@ void main() {
     expect(bengle.sawWrites, [0.0]);
     await bridge.dispose();
   });
+
+  test('queue saturation retries the current target', () async {
+    await de1Controller.dispose();
+    de1Controller = De1Controller(
+      controller: deviceController,
+      maxPendingDeviceWrites: 0,
+    );
+    final bengle = _RecordingBengle();
+    await connectBengle(bengle);
+    final bridge = BengleSawBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    bengle.sawWrites.clear();
+
+    final started = Completer<void>();
+    final release = Completer<void>();
+    final active = de1Controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    final context = workflow.currentWorkflow.context ?? const WorkflowContext();
+    workflow.updateWorkflow(context: context.copyWith(targetYield: 42.0));
+    await pumpDebounce();
+    expect(bengle.sawWrites, isEmpty);
+
+    release.complete();
+    await active;
+    await pumpDebounce();
+
+    expect(bengle.sawWrites, [42.0]);
+    await bridge.dispose();
+  });
 }

--- a/test/controllers/bengle_saw_bridge_test.dart
+++ b/test/controllers/bengle_saw_bridge_test.dart
@@ -376,4 +376,46 @@ void main() {
     expect(bengle.sawWrites, [42.0]);
     await bridge.dispose();
   });
+
+  test(
+    'reconnect replaces a saturated retry with the new generation',
+    () async {
+      await de1Controller.dispose();
+      de1Controller = De1Controller(
+        controller: deviceController,
+        maxPendingDeviceWrites: 0,
+      );
+      final first = _RecordingBengle();
+      await connectBengle(first);
+      final bridge = BengleSawBridge(
+        workflowController: workflow,
+        de1Controller: de1Controller,
+        debounce: _debounce,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final started = Completer<void>();
+      final release = Completer<void>();
+      final active = de1Controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      final activeResult = expectLater(active, throwsA(isA<StateError>()));
+      await started.future;
+      final context =
+          workflow.currentWorkflow.context ?? const WorkflowContext();
+      workflow.updateWorkflow(context: context.copyWith(targetYield: 42.0));
+      await pumpDebounce();
+
+      final replacement = _RecordingBengle();
+      await connectBengle(replacement);
+      await pumpDebounce();
+      release.complete();
+      await activeResult;
+      await pumpDebounce();
+
+      expect(replacement.sawWrites, [42.0]);
+      await bridge.dispose();
+    },
+  );
 }

--- a/test/controllers/bengle_steam_stop_bridge_test.dart
+++ b/test/controllers/bengle_steam_stop_bridge_test.dart
@@ -351,4 +351,44 @@ void main() {
     expect(bengle.stopAtTempWrites, [72.0]);
     await bridge.dispose();
   });
+
+  test(
+    'reconnect replaces a saturated retry with the new generation',
+    () async {
+      await de1Controller.dispose();
+      de1Controller = De1Controller(
+        controller: deviceController,
+        maxPendingDeviceWrites: 0,
+      );
+      final first = _RecordingBengle();
+      await connectBengle(first);
+      final bridge = BengleSteamStopBridge(
+        workflowController: workflow,
+        de1Controller: de1Controller,
+        debounce: _debounce,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final started = Completer<void>();
+      final release = Completer<void>();
+      final active = de1Controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      final activeResult = expectLater(active, throwsA(isA<StateError>()));
+      await started.future;
+      setStopAtTemp(72.0);
+      await pumpDebounce();
+
+      final replacement = _RecordingBengle();
+      await connectBengle(replacement);
+      await pumpDebounce();
+      release.complete();
+      await activeResult;
+      await pumpDebounce();
+
+      expect(replacement.stopAtTempWrites, [72.0]);
+      await bridge.dispose();
+    },
+  );
 }

--- a/test/controllers/bengle_steam_stop_bridge_test.dart
+++ b/test/controllers/bengle_steam_stop_bridge_test.dart
@@ -315,4 +315,40 @@ void main() {
 
     expect(bengle.stopAtTempWrites, isEmpty);
   });
+
+  test('queue saturation retries the current target', () async {
+    await de1Controller.dispose();
+    de1Controller = De1Controller(
+      controller: deviceController,
+      maxPendingDeviceWrites: 0,
+    );
+    final bengle = _RecordingBengle();
+    await connectBengle(bengle);
+    final bridge = BengleSteamStopBridge(
+      workflowController: workflow,
+      de1Controller: de1Controller,
+      debounce: _debounce,
+    );
+    await Future<void>.delayed(Duration.zero);
+    bengle.stopAtTempWrites.clear();
+
+    final started = Completer<void>();
+    final release = Completer<void>();
+    final active = de1Controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    setStopAtTemp(72.0);
+    await pumpDebounce();
+    expect(bengle.stopAtTempWrites, isEmpty);
+
+    release.complete();
+    await active;
+    await pumpDebounce();
+
+    expect(bengle.stopAtTempWrites, [72.0]);
+    await bridge.dispose();
+  });
 }

--- a/test/controllers/de1_controller_governor_test.dart
+++ b/test/controllers/de1_controller_governor_test.dart
@@ -24,6 +24,7 @@ final class _GovernorTestDe1 extends TestDe1 {
   Completer<void>? firmwareStarted;
   Completer<void>? firmwareRelease;
   var firmwareCancelCalls = 0;
+  var userPresentCalls = 0;
 
   @override
   Future<void> setFlushFlow(double newFlow) async {
@@ -59,6 +60,11 @@ final class _GovernorTestDe1 extends TestDe1 {
   Future<void> cancelFirmwareUpload() async {
     firmwareCancelCalls++;
     firmwareRelease?.complete();
+  }
+
+  @override
+  Future<void> sendUserPresent() async {
+    userPresentCalls++;
   }
 }
 
@@ -142,6 +148,24 @@ void main() {
 
     expect(calls, ['active', 'next']);
     expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('user-present writes wait behind the active machine write', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    final presence = controller.sendUserPresent();
+    await Future<void>.delayed(Duration.zero);
+    expect(machine.userPresentCalls, 0);
+
+    release.complete();
+    await Future.wait([active, presence]);
+    expect(machine.userPresentCalls, 1);
   });
 
   test(

--- a/test/controllers/de1_controller_governor_test.dart
+++ b/test/controllers/de1_controller_governor_test.dart
@@ -559,6 +559,36 @@ void main() {
     expect(machine.firmwareStarted!.isCompleted, isFalse);
   });
 
+  test(
+    'active firmware can be cancelled before initialization settles',
+    () async {
+      await controller.dispose();
+      controller = De1Controller(
+        controller: devices,
+        maxPendingDeviceWrites: 2,
+      );
+      machine = _GovernorTestDe1();
+      await controller.connectToDe1(machine);
+      machine.firmwareStarted = Completer<void>();
+
+      final firmware = controller.updateFirmware(
+        Uint8List(1),
+        onProgress: (_) {},
+      );
+      expect(controller.pendingDeviceWriteCount, 0);
+
+      await controller.cancelFirmwareUpload();
+      machine.emitShotSettings(_shotSettings());
+
+      await expectLater(
+        firmware,
+        throwsA(isA<FirmwareUpdateCancelledException>()),
+      );
+      expect(machine.firmwareStarted!.isCompleted, isFalse);
+      expect(machine.firmwareCancelCalls, 0);
+    },
+  );
+
   test('cancelling queued firmware preserves the following write', () async {
     final ordinaryRelease = Completer<void>();
     final ordinaryStarted = Completer<void>();

--- a/test/controllers/de1_controller_governor_test.dart
+++ b/test/controllers/de1_controller_governor_test.dart
@@ -22,6 +22,7 @@ final class _GovernorTestDe1 extends TestDe1 {
   final List<String> events = [];
   Completer<void>? firmwareStarted;
   Completer<void>? firmwareRelease;
+  var firmwareCancelCalls = 0;
 
   @override
   Future<void> setFlushFlow(double newFlow) async {
@@ -46,6 +47,12 @@ final class _GovernorTestDe1 extends TestDe1 {
   }) async {
     firmwareStarted?.complete();
     await firmwareRelease?.future;
+  }
+
+  @override
+  Future<void> cancelFirmwareUpload() async {
+    firmwareCancelCalls++;
+    firmwareRelease?.complete();
   }
 }
 
@@ -354,5 +361,48 @@ void main() {
     machine.firmwareRelease!.complete();
     await Future.wait([firmware, later]);
     expect(laterStarted, isTrue);
+  });
+
+  test('pending firmware can be cancelled before it starts', () async {
+    final ordinaryRelease = Completer<void>();
+    final ordinaryStarted = Completer<void>();
+    final ordinary = controller.runDeviceWrite((_) async {
+      ordinaryStarted.complete();
+      await ordinaryRelease.future;
+    });
+    await ordinaryStarted.future;
+
+    machine.firmwareStarted = Completer<void>();
+    final firmware = controller.updateFirmware(
+      Uint8List(1),
+      onProgress: (_) {},
+    );
+
+    await controller.cancelFirmwareUpload();
+    await expectLater(
+      firmware,
+      throwsA(isA<FirmwareUpdateCancelledException>()),
+    );
+    expect(controller.pendingDeviceWriteCount, 0);
+    expect(machine.firmwareCancelCalls, 0);
+
+    ordinaryRelease.complete();
+    await ordinary;
+    expect(machine.firmwareStarted!.isCompleted, isFalse);
+  });
+
+  test('active firmware cancellation reaches the machine', () async {
+    machine.firmwareStarted = Completer<void>();
+    machine.firmwareRelease = Completer<void>();
+    final firmware = controller.updateFirmware(
+      Uint8List(1),
+      onProgress: (_) {},
+    );
+    await machine.firmwareStarted!.future;
+
+    await controller.cancelFirmwareUpload();
+    await firmware;
+
+    expect(machine.firmwareCancelCalls, 1);
   });
 }

--- a/test/controllers/de1_controller_governor_test.dart
+++ b/test/controllers/de1_controller_governor_test.dart
@@ -1,0 +1,358 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/home_feature/forms/steam_form.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/errors.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/test_de1.dart';
+
+final class _GovernorTestDe1 extends TestDe1 {
+  _GovernorTestDe1({super.serialNumber});
+
+  final List<double> flushFlows = [];
+  final List<double> steamFlows = [];
+  final List<String> events = [];
+  Completer<void>? firmwareStarted;
+  Completer<void>? firmwareRelease;
+
+  @override
+  Future<void> setFlushFlow(double newFlow) async {
+    flushFlows.add(newFlow);
+  }
+
+  @override
+  Future<void> setSteamFlow(double newFlow) async {
+    steamFlows.add(newFlow);
+  }
+
+  @override
+  Future<void> requestState(MachineState newState) async {
+    events.add(newState.name);
+    await super.requestState(newState);
+  }
+
+  @override
+  Future<void> updateFirmware(
+    Uint8List fwImage, {
+    required void Function(double progress) onProgress,
+  }) async {
+    firmwareStarted?.complete();
+    await firmwareRelease?.future;
+  }
+}
+
+De1ShotSettings _shotSettings() => De1ShotSettings(
+  steamSetting: 0,
+  targetSteamTemp: 150,
+  targetSteamDuration: 30,
+  targetHotWaterTemp: 75,
+  targetHotWaterVolume: 50,
+  targetHotWaterDuration: 30,
+  targetShotVolume: 36,
+  groupTemp: 94,
+);
+
+Future<void> _connect(
+  De1Controller controller,
+  _GovernorTestDe1 machine,
+) async {
+  await controller.connectToDe1(machine);
+  machine.emitShotSettings(_shotSettings());
+  await controller.initSettled.firstWhere((generation) => generation != null);
+}
+
+void main() {
+  late DeviceController devices;
+  late De1Controller controller;
+  late _GovernorTestDe1 machine;
+
+  setUp(() async {
+    devices = DeviceController([MockDeviceDiscoveryService()]);
+    await devices.initialize();
+    controller = De1Controller(controller: devices, maxPendingDeviceWrites: 2);
+    machine = _GovernorTestDe1();
+    await _connect(controller, machine);
+  });
+
+  tearDown(() async {
+    await controller.dispose();
+  });
+
+  test('bounds pending writes and preserves FIFO order', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final calls = <String>[];
+    final active = controller.runDeviceWrite((_) async {
+      calls.add('active');
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    final first = controller.runDeviceWrite((_) async => calls.add('first'));
+    final second = controller.runDeviceWrite((_) async => calls.add('second'));
+    final rejected = controller.runDeviceWrite((_) async => calls.add('third'));
+
+    expect(controller.pendingDeviceWriteCount, 2);
+    await expectLater(rejected, throwsA(isA<De1WriteQueueFullException>()));
+    release.complete();
+    await Future.wait([active, first, second]);
+
+    expect(calls, ['active', 'first', 'second']);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test(
+    'coalesces pending rinse writes and applies only the final value',
+    () async {
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+
+      Future<void>? latest;
+      final superseded = <Future<void>>[];
+      for (var i = 0; i < 100; i++) {
+        final previous = latest;
+        latest = controller.updateFlushSettings(
+          RinseData(targetTemperature: 90, duration: 5, flow: i.toDouble()),
+        );
+        if (previous != null) {
+          superseded.add(
+            expectLater(previous, throwsA(isA<De1WriteSupersededException>())),
+          );
+        }
+      }
+
+      expect(controller.pendingDeviceWriteCount, 1);
+      release.complete();
+      await active;
+      await latest;
+      await Future.wait(superseded);
+
+      expect(machine.flushFlows, [99]);
+      expect(controller.pendingDeviceWriteCount, 0);
+    },
+  );
+
+  test('coalesces rinse and steam independently', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    final rinse1 = controller.updateFlushSettings(
+      RinseData(targetTemperature: 90, duration: 5, flow: 1),
+    );
+    final steam1 = controller.updateSteamSettings(
+      SteamFormSettings(
+        steamEnabled: true,
+        targetTemp: 150,
+        targetDuration: 20,
+        targetFlow: 1,
+      ),
+    );
+    final rinse1Result = expectLater(
+      rinse1,
+      throwsA(isA<De1WriteSupersededException>()),
+    );
+    final steam1Result = expectLater(
+      steam1,
+      throwsA(isA<De1WriteSupersededException>()),
+    );
+    final rinse2 = controller.updateFlushSettings(
+      RinseData(targetTemperature: 91, duration: 6, flow: 2),
+    );
+    final steam2 = controller.updateSteamSettings(
+      SteamFormSettings(
+        steamEnabled: true,
+        targetTemp: 151,
+        targetDuration: 21,
+        targetFlow: 2,
+      ),
+    );
+
+    expect(controller.pendingDeviceWriteCount, 2);
+    release.complete();
+    await Future.wait([active, rinse2, steam2, rinse1Result, steam1Result]);
+
+    expect(machine.flushFlows, [2]);
+    expect(machine.steamFlows, [2]);
+  });
+
+  test('caller timeout does not release the active write', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    var secondStarted = false;
+    final second = controller.runDeviceWrite((_) async {
+      secondStarted = true;
+    });
+    await expectLater(
+      active.timeout(const Duration(milliseconds: 10)),
+      throwsA(isA<TimeoutException>()),
+    );
+    expect(secondStarted, isFalse);
+
+    release.complete();
+    await Future.wait([active, second]);
+    expect(secondStarted, isTrue);
+  });
+
+  test(
+    'pending imperative write does not move to a different machine',
+    () async {
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+      final activeResult = expectLater(active, throwsA(isA<StateError>()));
+
+      var replacementWrites = 0;
+      final pending = controller.runDeviceWrite((device) async {
+        if (!identical(device, machine)) replacementWrites++;
+      });
+      final pendingResult = expectLater(pending, throwsA(isA<StateError>()));
+      machine.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(Duration.zero);
+      final replacement = _GovernorTestDe1(serialNumber: '2');
+      await _connect(controller, replacement);
+
+      release.complete();
+      await Future.wait([activeResult, pendingResult]);
+      expect(replacementWrites, 0);
+      await machine.dispose();
+      machine = replacement;
+    },
+  );
+
+  test(
+    'replaceable write may reconcile on the same machine identity',
+    () async {
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+      final activeResult = expectLater(active, throwsA(isA<StateError>()));
+
+      _GovernorTestDe1? writtenDevice;
+      final pending = controller.runReplaceableDeviceWrite(
+        'workflow.rinse',
+        (device) async => writtenDevice = device as _GovernorTestDe1,
+      );
+      machine.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(Duration.zero);
+      final replacement = _GovernorTestDe1(serialNumber: machine.serialNumber);
+      await _connect(controller, replacement);
+
+      release.complete();
+      await Future.wait([activeResult, pending]);
+      expect(writtenDevice, same(replacement));
+      await machine.dispose();
+      machine = replacement;
+    },
+  );
+
+  test(
+    'imperative write does not replay on the same machine identity',
+    () async {
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+      final activeResult = expectLater(active, throwsA(isA<StateError>()));
+
+      var replacementWrites = 0;
+      final pending = controller.runDeviceWrite((device) async {
+        if (!identical(device, machine)) replacementWrites++;
+      });
+      final pendingResult = expectLater(pending, throwsA(isA<StateError>()));
+      machine.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(Duration.zero);
+      final replacement = _GovernorTestDe1(serialNumber: machine.serialNumber);
+      await _connect(controller, replacement);
+
+      release.complete();
+      await Future.wait([activeResult, pendingResult]);
+      expect(replacementWrites, 0);
+      await machine.dispose();
+      machine = replacement;
+    },
+  );
+
+  test('idle bypasses an active ordinary write', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      machine.events.add('ordinary');
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    await controller.requestMachineState(MachineState.idle);
+    expect(machine.events, ['ordinary', 'idle']);
+
+    release.complete();
+    await active;
+  });
+
+  test('firmware excludes earlier and later ordinary writes', () async {
+    final ordinaryRelease = Completer<void>();
+    final ordinaryStarted = Completer<void>();
+    final ordinary = controller.runDeviceWrite((_) async {
+      ordinaryStarted.complete();
+      await ordinaryRelease.future;
+    });
+    await ordinaryStarted.future;
+
+    machine.firmwareStarted = Completer<void>();
+    machine.firmwareRelease = Completer<void>();
+    final firmware = controller.updateFirmware(
+      Uint8List(1),
+      onProgress: (_) {},
+    );
+    var laterStarted = false;
+    final later = controller.runDeviceWrite((_) async {
+      laterStarted = true;
+    });
+    expect(machine.firmwareStarted!.isCompleted, isFalse);
+
+    ordinaryRelease.complete();
+    await ordinary;
+    await machine.firmwareStarted!.future;
+    expect(laterStarted, isFalse);
+
+    machine.firmwareRelease!.complete();
+    await Future.wait([firmware, later]);
+    expect(laterStarted, isTrue);
+  });
+}

--- a/test/controllers/de1_controller_governor_test.dart
+++ b/test/controllers/de1_controller_governor_test.dart
@@ -15,7 +15,7 @@ import '../helpers/mock_device_discovery_service.dart';
 import '../helpers/test_de1.dart';
 
 final class _GovernorTestDe1 extends TestDe1 {
-  _GovernorTestDe1({super.serialNumber});
+  _GovernorTestDe1({super.deviceId, super.serialNumber});
 
   final List<double> flushFlows = [];
   final List<double> steamFlows = [];
@@ -117,6 +117,27 @@ void main() {
     expect(controller.pendingDeviceWriteCount, 0);
   });
 
+  test('failed active write does not stall the next write', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final calls = <String>[];
+    final active = controller.runDeviceWrite((_) async {
+      calls.add('active');
+      started.complete();
+      await release.future;
+      throw StateError('failed');
+    });
+    await started.future;
+    final activeResult = expectLater(active, throwsA(isA<StateError>()));
+    final next = controller.runDeviceWrite((_) async => calls.add('next'));
+
+    release.complete();
+    await Future.wait([activeResult, next]);
+
+    expect(calls, ['active', 'next']);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
   test(
     'coalesces pending rinse writes and applies only the final value',
     () async {
@@ -199,6 +220,68 @@ void main() {
 
     expect(machine.flushFlows, [2]);
     expect(machine.steamFlows, [2]);
+  });
+
+  test('coalescing preserves the pending queue position', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final calls = <String>[];
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    final first = controller.runReplaceableDeviceWrite(
+      'workflow.rinse',
+      (_) async => calls.add('first rinse'),
+    );
+    final firstResult = expectLater(
+      first,
+      throwsA(isA<De1WriteSupersededException>()),
+    );
+    final imperative = controller.runDeviceWrite(
+      (_) async => calls.add('imperative'),
+    );
+    final replacement = controller.runReplaceableDeviceWrite(
+      'workflow.rinse',
+      (_) async => calls.add('replacement rinse'),
+    );
+
+    release.complete();
+    await Future.wait([active, firstResult, imperative, replacement]);
+
+    expect(calls, ['replacement rinse', 'imperative']);
+  });
+
+  test('coalescing succeeds while the pending queue is full', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    final first = controller.runReplaceableDeviceWrite(
+      'workflow.rinse',
+      (_) async {},
+    );
+    final firstResult = expectLater(
+      first,
+      throwsA(isA<De1WriteSupersededException>()),
+    );
+    final imperative = controller.runDeviceWrite((_) async {});
+    expect(controller.pendingDeviceWriteCount, 2);
+
+    final replacement = controller.runReplaceableDeviceWrite(
+      'workflow.rinse',
+      (_) async {},
+    );
+    expect(controller.pendingDeviceWriteCount, 2);
+
+    release.complete();
+    await Future.wait([active, firstResult, imperative, replacement]);
   });
 
   test('caller timeout does not release the active write', () async {
@@ -285,6 +368,69 @@ void main() {
     },
   );
 
+  test('replaceable write does not move to a different machine', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+    final activeResult = expectLater(active, throwsA(isA<StateError>()));
+
+    var replacementWrites = 0;
+    final pending = controller.runReplaceableDeviceWrite(
+      'workflow.rinse',
+      (_) async => replacementWrites++,
+    );
+    final pendingResult = expectLater(pending, throwsA(isA<StateError>()));
+    machine.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+    final replacement = _GovernorTestDe1(serialNumber: '2');
+    await _connect(controller, replacement);
+
+    release.complete();
+    await Future.wait([activeResult, pendingResult]);
+    expect(replacementWrites, 0);
+    await machine.dispose();
+    machine = replacement;
+  });
+
+  test('machine identity falls back to device ID', () async {
+    await controller.dispose();
+    machine = _GovernorTestDe1(deviceId: 'fallback-id', serialNumber: '0');
+    controller = De1Controller(controller: devices, maxPendingDeviceWrites: 2);
+    await _connect(controller, machine);
+
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+    final activeResult = expectLater(active, throwsA(isA<StateError>()));
+
+    _GovernorTestDe1? writtenDevice;
+    final pending = controller.runReplaceableDeviceWrite(
+      'workflow.rinse',
+      (device) async => writtenDevice = device as _GovernorTestDe1,
+    );
+    machine.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+    final replacement = _GovernorTestDe1(
+      deviceId: 'fallback-id',
+      serialNumber: '',
+    );
+    await _connect(controller, replacement);
+
+    release.complete();
+    await Future.wait([activeResult, pending]);
+    expect(writtenDevice, same(replacement));
+    await machine.dispose();
+    machine = replacement;
+  });
+
   test(
     'imperative write does not replay on the same machine identity',
     () async {
@@ -330,6 +476,28 @@ void main() {
 
     release.complete();
     await active;
+  });
+
+  test('idle bypasses a full pending queue', () async {
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      machine.events.add('ordinary');
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+    final pending = List.generate(
+      controller.maxPendingDeviceWrites,
+      (_) => controller.runDeviceWrite((_) async {}),
+    );
+    expect(controller.pendingDeviceWriteCount, 2);
+
+    await controller.requestMachineState(MachineState.idle);
+    expect(machine.events, ['ordinary', 'idle']);
+
+    release.complete();
+    await Future.wait([active, ...pending]);
   });
 
   test('firmware excludes earlier and later ordinary writes', () async {
@@ -389,6 +557,35 @@ void main() {
     ordinaryRelease.complete();
     await ordinary;
     expect(machine.firmwareStarted!.isCompleted, isFalse);
+  });
+
+  test('cancelling queued firmware preserves the following write', () async {
+    final ordinaryRelease = Completer<void>();
+    final ordinaryStarted = Completer<void>();
+    final events = <String>[];
+    final ordinary = controller.runDeviceWrite((_) async {
+      ordinaryStarted.complete();
+      await ordinaryRelease.future;
+    });
+    await ordinaryStarted.future;
+
+    machine.firmwareStarted = Completer<void>();
+    final firmware = controller.updateFirmware(
+      Uint8List(1),
+      onProgress: (_) {},
+    );
+    final firmwareResult = expectLater(
+      firmware,
+      throwsA(isA<FirmwareUpdateCancelledException>()),
+    );
+    final later = controller.runDeviceWrite((_) async => events.add('later'));
+
+    await controller.cancelFirmwareUpload();
+    ordinaryRelease.complete();
+    await Future.wait([ordinary, firmwareResult, later]);
+
+    expect(machine.firmwareStarted!.isCompleted, isFalse);
+    expect(events, ['later']);
   });
 
   test('active firmware cancellation reaches the machine', () async {

--- a/test/controllers/de1_controller_governor_test.dart
+++ b/test/controllers/de1_controller_governor_test.dart
@@ -20,6 +20,7 @@ final class _GovernorTestDe1 extends TestDe1 {
   final List<double> flushFlows = [];
   final List<double> steamFlows = [];
   final List<String> events = [];
+  De1ShotSettings? writtenShotSettings;
   Completer<void>? firmwareStarted;
   Completer<void>? firmwareRelease;
   var firmwareCancelCalls = 0;
@@ -38,6 +39,11 @@ final class _GovernorTestDe1 extends TestDe1 {
   Future<void> requestState(MachineState newState) async {
     events.add(newState.name);
     await super.requestState(newState);
+  }
+
+  @override
+  Future<void> updateShotSettings(De1ShotSettings newSettings) async {
+    writtenShotSettings = newSettings;
   }
 
   @override
@@ -137,6 +143,35 @@ void main() {
     expect(calls, ['active', 'next']);
     expect(controller.pendingDeviceWriteCount, 0);
   });
+
+  test(
+    'steam extension reads and writes settings inside its queue turn',
+    () async {
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+
+      final extension = controller.extendSteamDuration(10);
+      machine.emitShotSettings(
+        _shotSettings().copyWith(
+          targetSteamTemp: 160,
+          targetSteamDuration: 40,
+          targetHotWaterTemp: 82,
+        ),
+      );
+      release.complete();
+      await active;
+
+      expect(await extension, 50);
+      expect(machine.writtenShotSettings?.targetSteamDuration, 50);
+      expect(machine.writtenShotSettings?.targetSteamTemp, 160);
+      expect(machine.writtenShotSettings?.targetHotWaterTemp, 82);
+    },
+  );
 
   test(
     'coalesces pending rinse writes and applies only the final value',

--- a/test/controllers/hot_water_sequencer_test.dart
+++ b/test/controllers/hot_water_sequencer_test.dart
@@ -48,6 +48,10 @@ class _StubDe1Controller extends De1Controller {
   Stream<De1Interface?> get de1 => _de1subj.stream;
   @override
   Stream<HotWaterData> get hotWaterData => _hw.stream;
+  @override
+  Future<void> requestMachineState(MachineState state) {
+    return _de1subj.value!.requestState(state);
+  }
 
   void emitMachine(De1Interface? d) => _de1subj.add(d);
   void setHotWater(HotWaterData hw) => _hw.add(hw);

--- a/test/controllers/presence_controller_bengle_sync_test.dart
+++ b/test/controllers/presence_controller_bengle_sync_test.dart
@@ -13,8 +13,10 @@ import 'package:reaprime/src/models/firmware_wake_window.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/models/device/led_strip.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/scale_calibration.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:rxdart/subjects.dart';
@@ -146,6 +148,13 @@ class _TestDe1Controller extends De1Controller {
 
   void setDe1(De1Interface? de1) {
     _de1Subject.add(de1);
+  }
+
+  @override
+  Future<void> requestMachineState(MachineState state) {
+    final de1 = _de1Subject.valueOrNull;
+    if (de1 == null) throw const DeviceNotConnectedException.machine();
+    return de1.requestState(state);
   }
 }
 

--- a/test/controllers/presence_controller_bengle_sync_test.dart
+++ b/test/controllers/presence_controller_bengle_sync_test.dart
@@ -143,11 +143,26 @@ class _TestDe1Controller extends De1Controller {
 
   _TestDe1Controller({required super.controller});
 
+  int deviceWriteCalls = 0;
+  Future<void> Function()? beforeDeviceWrite;
+
   @override
   Stream<De1Interface?> get de1 => _de1Subject.stream;
 
   void setDe1(De1Interface? de1) {
     _de1Subject.add(de1);
+  }
+
+  @override
+  Future<T> runDeviceWrite<T>(
+    Future<T> Function(De1Interface device) write, {
+    De1ReplayPolicy replayPolicy = De1ReplayPolicy.never,
+  }) async {
+    deviceWriteCalls++;
+    await beforeDeviceWrite?.call();
+    final de1 = _de1Subject.valueOrNull;
+    if (de1 == null) throw const DeviceNotConnectedException.machine();
+    return write(de1);
   }
 
   @override
@@ -205,6 +220,29 @@ void main() {
         const FirmwareWakeWindow(dow: 0, startMin: 450, endMin: 495),
       ]);
 
+      controller.dispose();
+    });
+  });
+
+  test('firmware sync is one governed write and computes clock when run', () {
+    fakeAsync((async) {
+      var now = DateTime(2026, 1, 15, 6);
+      de1Controller.beforeDeviceWrite = () async {
+        now = DateTime(2026, 1, 15, 7);
+      };
+      final controller = PresenceController(
+        de1Controller: de1Controller,
+        settingsController: settingsController,
+        clock: () => now,
+      );
+      controller.initialize();
+      de1Controller.setDe1(bengle);
+      async.flushMicrotasks();
+
+      expect(de1Controller.deviceWriteCalls, 1);
+      expect(bengle.pushedClockSeconds, [
+        localSecondsSinceSunday(DateTime(2026, 1, 15, 7)),
+      ]);
       controller.dispose();
     });
   });

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -235,6 +235,8 @@ class _TestDe1Controller extends De1Controller {
 
   int failNextStateRequests = 0;
   int stateRequestAttempts = 0;
+  Completer<void>? stateRequestEntered;
+  Completer<void>? stateRequestRelease;
 
   @override
   Stream<De1Interface?> get de1 => _de1Subject.stream;
@@ -253,6 +255,32 @@ class _TestDe1Controller extends De1Controller {
     final de1 = _de1Subject.valueOrNull;
     if (de1 == null) throw const DeviceNotConnectedException.machine();
     return de1.requestState(state);
+  }
+
+  @override
+  Future<bool> requestMachineStateIf(
+    MachineState state,
+    bool Function() stillApplicable,
+  ) async {
+    stateRequestAttempts++;
+    if (failNextStateRequests > 0) {
+      failNextStateRequests--;
+      throw const De1WriteQueueFullException(0);
+    }
+    stateRequestEntered?.complete();
+    await stateRequestRelease?.future;
+    if (!stillApplicable()) return false;
+    final de1 = _de1Subject.valueOrNull;
+    if (de1 == null) throw const DeviceNotConnectedException.machine();
+    await de1.requestState(state);
+    return true;
+  }
+
+  @override
+  Future<void> sendUserPresent() async {
+    final de1 = _de1Subject.valueOrNull;
+    if (de1 == null) throw const DeviceNotConnectedException.machine();
+    await de1.sendUserPresent();
   }
 }
 
@@ -321,6 +349,36 @@ void main() {
   });
 
   group('sleep timeout', () {
+    test('heartbeat cancels an admitted sleep request', () {
+      fakeAsync((async) {
+        settingsController.setSleepTimeoutMinutes(5);
+        async.flushMicrotasks();
+        de1Controller.stateRequestEntered = Completer<void>();
+        de1Controller.stateRequestRelease = Completer<void>();
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => clock.now(),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+        testDe1.emitState(MachineState.idle);
+        controller.heartbeat();
+
+        async.elapse(const Duration(minutes: 5, seconds: 1));
+        async.flushMicrotasks();
+        expect(de1Controller.stateRequestEntered!.isCompleted, isTrue);
+
+        controller.heartbeat();
+        de1Controller.stateRequestRelease!.complete();
+        async.flushMicrotasks();
+
+        expect(testDe1.requestedStates, isEmpty);
+        controller.dispose();
+      });
+    });
+
     test('queue saturation re-arms the sleep timer', () {
       fakeAsync((async) {
         settingsController.setSleepTimeoutMinutes(5);

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -17,6 +17,7 @@ import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/wake_schedule.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:rxdart/subjects.dart';
@@ -237,6 +238,13 @@ class _TestDe1Controller extends De1Controller {
 
   void setDe1(De1Interface? de1) {
     _de1Subject.add(de1);
+  }
+
+  @override
+  Future<void> requestMachineState(MachineState state) {
+    final de1 = _de1Subject.valueOrNull;
+    if (de1 == null) throw const DeviceNotConnectedException.machine();
+    return de1.requestState(state);
   }
 }
 

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -233,6 +233,9 @@ class _TestDe1Controller extends De1Controller {
 
   _TestDe1Controller({required super.controller});
 
+  int failNextStateRequests = 0;
+  int stateRequestAttempts = 0;
+
   @override
   Stream<De1Interface?> get de1 => _de1Subject.stream;
 
@@ -242,6 +245,11 @@ class _TestDe1Controller extends De1Controller {
 
   @override
   Future<void> requestMachineState(MachineState state) {
+    stateRequestAttempts++;
+    if (failNextStateRequests > 0) {
+      failNextStateRequests--;
+      return Future.error(const De1WriteQueueFullException(0));
+    }
     final de1 = _de1Subject.valueOrNull;
     if (de1 == null) throw const DeviceNotConnectedException.machine();
     return de1.requestState(state);
@@ -313,6 +321,36 @@ void main() {
   });
 
   group('sleep timeout', () {
+    test('queue saturation re-arms the sleep timer', () {
+      fakeAsync((async) {
+        settingsController.setSleepTimeoutMinutes(5);
+        async.flushMicrotasks();
+        de1Controller.failNextStateRequests = 1;
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => clock.now(),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+        testDe1.emitState(MachineState.idle);
+        async.flushMicrotasks();
+
+        controller.heartbeat();
+        async.elapse(const Duration(minutes: 5, seconds: 1));
+        async.flushMicrotasks();
+        expect(testDe1.requestedStates, isEmpty);
+
+        async.elapse(const Duration(minutes: 5, seconds: 1));
+        async.flushMicrotasks();
+        expect(testDe1.requestedStates, [MachineState.sleeping]);
+        expect(de1Controller.stateRequestAttempts, 2);
+        controller.dispose();
+      });
+    });
+
     test(
       'heartbeat resets sleep timer - no sleep if heartbeat before timeout',
       () {
@@ -592,6 +630,45 @@ void main() {
   });
 
   group('scheduled wake', () {
+    test('queue saturation retries within the matching minute', () {
+      fakeAsync((async) {
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([
+            const WakeSchedule(
+              id: 'retry',
+              hour: 7,
+              minute: 0,
+              daysOfWeek: {},
+              enabled: true,
+            ),
+          ]),
+        );
+        async.flushMicrotasks();
+        de1Controller.failNextStateRequests = 1;
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => DateTime(2026, 1, 15, 7),
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+        testDe1.emitState(MachineState.sleeping);
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 31));
+        async.flushMicrotasks();
+        expect(testDe1.requestedStates, isEmpty);
+
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+        expect(testDe1.requestedStates, [MachineState.schedIdle]);
+        expect(de1Controller.stateRequestAttempts, 2);
+        controller.dispose();
+      });
+    });
+
     test('wakes sleeping machine at matching schedule time', () {
       fakeAsync((async) {
         final schedule = WakeSchedule(

--- a/test/controllers/presence_controller_test.dart
+++ b/test/controllers/presence_controller_test.dart
@@ -688,6 +688,48 @@ void main() {
   });
 
   group('scheduled wake', () {
+    test('queued wake expires when the matching minute ends', () {
+      fakeAsync((async) {
+        var now = DateTime(2026, 1, 15, 7);
+        settingsController.setWakeSchedules(
+          WakeSchedule.serializeList([
+            const WakeSchedule(
+              id: 'expires',
+              hour: 7,
+              minute: 0,
+              daysOfWeek: {},
+              enabled: true,
+            ),
+          ]),
+        );
+        async.flushMicrotasks();
+        de1Controller.stateRequestEntered = Completer<void>();
+        de1Controller.stateRequestRelease = Completer<void>();
+
+        final controller = PresenceController(
+          de1Controller: de1Controller,
+          settingsController: settingsController,
+          clock: () => now,
+        );
+        controller.initialize();
+        de1Controller.setDe1(testDe1);
+        async.flushMicrotasks();
+        testDe1.emitState(MachineState.sleeping);
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 31));
+        async.flushMicrotasks();
+        expect(de1Controller.stateRequestEntered!.isCompleted, isTrue);
+
+        now = DateTime(2026, 1, 15, 7, 1);
+        de1Controller.stateRequestRelease!.complete();
+        async.flushMicrotasks();
+
+        expect(testDe1.requestedStates, isEmpty);
+        controller.dispose();
+      });
+    });
+
     test('queue saturation retries within the matching minute', () {
       fakeAsync((async) {
         settingsController.setWakeSchedules(

--- a/test/controllers/shot_sequencer_bengle_bypass_test.dart
+++ b/test/controllers/shot_sequencer_bengle_bypass_test.dart
@@ -133,6 +133,11 @@ class _BengleDe1Controller extends De1Controller {
 
   @override
   Stream<De1Interface?> get de1 => BehaviorSubject.seeded(bengle).stream;
+
+  @override
+  Future<void> requestMachineState(MachineState state) {
+    return bengle.requestState(state);
+  }
 }
 
 class _TestScaleController extends ScaleController {

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -50,6 +50,13 @@ class _TestDe1Controller extends De1Controller {
   Future<void> requestMachineState(MachineState state) {
     return testDe1.requestState(state);
   }
+
+  @override
+  Future<bool> requestShotStepSkip(bool Function() stillApplicable) async {
+    if (!stillApplicable()) return false;
+    await testDe1.requestState(MachineState.skipStep);
+    return true;
+  }
 }
 
 class _TestScaleController extends ScaleController {
@@ -365,6 +372,104 @@ void main() {
 
     expect(testDe1.requestedStates, contains(MachineState.skipStep));
     expect(sequencer.skippedSteps, [0]);
+  });
+
+  test('admitted step skip is dropped after the frame advances', () async {
+    final testDe1 = TestDe1();
+    final devices = DeviceController([_FakeDiscoveryService()]);
+    await devices.initialize();
+    final de1Controller = De1Controller(
+      controller: devices,
+      maxPendingDeviceWrites: 1,
+    );
+    await de1Controller.connectToDe1(testDe1);
+    testDe1.emitShotSettings(
+      De1ShotSettings(
+        steamSetting: 0,
+        targetSteamTemp: 150,
+        targetSteamDuration: 30,
+        targetHotWaterTemp: 75,
+        targetHotWaterVolume: 50,
+        targetHotWaterDuration: 30,
+        targetShotVolume: 36,
+        groupTemp: 94,
+      ),
+    );
+    await de1Controller.initSettled.firstWhere(
+      (generation) => generation != null,
+    );
+    addTearDown(de1Controller.dispose);
+
+    final testScale = TestScale();
+    final scaleController = _TestScaleController(testScale);
+    addTearDown(() {
+      scaleController.dispose();
+      testScale.dispose();
+    });
+    final persistenceController = PersistenceController(
+      storageService: _NullStorageService(),
+    );
+    addTearDown(persistenceController.dispose);
+    scaleController.emitWeight(0);
+    final sequencer = ShotSequencer(
+      scaleController: scaleController,
+      de1controller: de1Controller,
+      persistenceController: persistenceController,
+      targetProfile: _profileWithSteps([
+        _pressureStep(name: 'first', weight: 10),
+        _pressureStep(name: 'second', weight: 20),
+      ]),
+      targetYield: 200,
+      bypassSAW: false,
+      blockOnNoScale: false,
+      weightFlowMultiplier: 0,
+      volumeFlowMultiplier: 0,
+      stepExitArbiterEnabled: true,
+    );
+    addTearDown(sequencer.dispose);
+    final decisions = <ShotDecision>[];
+    final decisionSubscription = sequencer.decisions.listen(decisions.add);
+    addTearDown(decisionSubscription.cancel);
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.preparingForShot,
+    );
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.pouring,
+    );
+
+    final activeStarted = Completer<void>();
+    final activeRelease = Completer<void>();
+    final active = de1Controller.runDeviceWrite((_) async {
+      activeStarted.complete();
+      await activeRelease.future;
+    });
+    await activeStarted.future;
+
+    scaleController.emitWeight(12);
+    testDe1.emitSnapshot(
+      testDe1.snapshotSubject.value.copyWith(profileFrame: 0),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(de1Controller.pendingDeviceWriteCount, 1);
+
+    testDe1.emitSnapshot(
+      testDe1.snapshotSubject.value.copyWith(profileFrame: 1),
+    );
+    await Future<void>.delayed(Duration.zero);
+    activeRelease.complete();
+    await active;
+    await Future<void>.delayed(Duration.zero);
+
+    expect(testDe1.requestedStates, isNot(contains(MachineState.skipStep)));
+    expect(sequencer.skippedSteps, isEmpty);
+    expect(
+      decisions.where(
+        (decision) => decision.reason == ShotDecisionReason.profileSkip,
+      ),
+      isEmpty,
+    );
   });
 
   group('ShotSequencer — scale disconnect during shot', () {

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -45,6 +45,11 @@ class _TestDe1Controller extends De1Controller {
 
   @override
   Stream<De1Interface?> get de1 => BehaviorSubject.seeded(testDe1).stream;
+
+  @override
+  Future<void> requestMachineState(MachineState state) {
+    return testDe1.requestState(state);
+  }
 }
 
 class _TestScaleController extends ScaleController {

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -275,6 +275,98 @@ ProfileStepFlow _flowStep({
 }
 
 void main() {
+  test('step weight exit retries after governor saturation clears', () async {
+    final testDe1 = TestDe1();
+    final devices = DeviceController([_FakeDiscoveryService()]);
+    await devices.initialize();
+    final de1Controller = De1Controller(
+      controller: devices,
+      maxPendingDeviceWrites: 0,
+    );
+    await de1Controller.connectToDe1(testDe1);
+    testDe1.emitShotSettings(
+      De1ShotSettings(
+        steamSetting: 0,
+        targetSteamTemp: 150,
+        targetSteamDuration: 30,
+        targetHotWaterTemp: 75,
+        targetHotWaterVolume: 50,
+        targetHotWaterDuration: 30,
+        targetShotVolume: 36,
+        groupTemp: 94,
+      ),
+    );
+    await de1Controller.initSettled.firstWhere(
+      (generation) => generation != null,
+    );
+    addTearDown(de1Controller.dispose);
+
+    final testScale = TestScale();
+    final scaleController = _TestScaleController(testScale);
+    addTearDown(() {
+      scaleController.dispose();
+      testScale.dispose();
+    });
+    final persistenceController = PersistenceController(
+      storageService: _NullStorageService(),
+    );
+    addTearDown(persistenceController.dispose);
+    final profile = _profileWithSteps([
+      _pressureStep(name: 'retry', weight: 10),
+    ]);
+    scaleController.emitWeight(0);
+    final sequencer = ShotSequencer(
+      scaleController: scaleController,
+      de1controller: de1Controller,
+      persistenceController: persistenceController,
+      targetProfile: profile,
+      targetYield: 200,
+      bypassSAW: false,
+      blockOnNoScale: false,
+      weightFlowMultiplier: 0,
+      volumeFlowMultiplier: 0,
+      stepExitArbiterEnabled: true,
+    );
+    addTearDown(sequencer.dispose);
+
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.preparingForShot,
+    );
+    testDe1.emitStateAndSubstate(
+      MachineState.espresso,
+      MachineSubstate.pouring,
+    );
+
+    final activeStarted = Completer<void>();
+    final activeRelease = Completer<void>();
+    final active = de1Controller.runDeviceWrite((_) async {
+      activeStarted.complete();
+      await activeRelease.future;
+    });
+    await activeStarted.future;
+
+    scaleController.emitWeight(12);
+    testDe1.emitSnapshot(
+      testDe1.snapshotSubject.value.copyWith(profileFrame: 0),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(testDe1.requestedStates, isNot(contains(MachineState.skipStep)));
+
+    activeRelease.complete();
+    await active;
+    final skipped = sequencer.decisions.firstWhere(
+      (decision) => decision.reason == ShotDecisionReason.profileSkip,
+    );
+    testDe1.emitSnapshot(
+      testDe1.snapshotSubject.value.copyWith(profileFrame: 0),
+    );
+    await skipped;
+
+    expect(testDe1.requestedStates, contains(MachineState.skipStep));
+    expect(sequencer.skippedSteps, [0]);
+  });
+
   group('ShotSequencer — scale disconnect during shot', () {
     late TestDe1 testDe1;
     late TestScale testScale;

--- a/test/controllers/steam_sequencer_test.dart
+++ b/test/controllers/steam_sequencer_test.dart
@@ -39,6 +39,10 @@ class _StubDe1Controller extends De1Controller {
 
   @override
   Stream<De1Interface?> get de1 => _subj.stream;
+  @override
+  Future<void> requestMachineState(MachineState state) {
+    return _subj.value!.requestState(state);
+  }
 
   void emit(De1Interface? device) => _subj.add(device);
 }

--- a/test/debug_feature/debug_item_details_view_test.dart
+++ b/test/debug_feature/debug_item_details_view_test.dart
@@ -2,17 +2,22 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
 import 'package:reaprime/src/debug_feature/debug_item_details_view.dart';
+import 'package:rxdart/subjects.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
+import '../helpers/mock_device_discovery_service.dart';
 import '../helpers/test_de1.dart';
 
 class _CalibrationDe1 extends TestDe1 {
   var reads = <(De1CalibrationTarget, De1CalibrationSource)>[];
   var writes = <De1Calibration>[];
+  Completer<void>? writeRecorded;
   var failReads = false;
   var failWrites = false;
 
@@ -59,6 +64,7 @@ class _CalibrationDe1 extends TestDe1 {
   Future<void> writeCalibration(De1Calibration calibration) async {
     if (failWrites) throw Exception('write failed');
     writes = [...writes, calibration];
+    writeRecorded?.complete();
     final previous = current[calibration.target]!.measuredValue;
     final measuredValue = calibration.target == De1CalibrationTarget.temperature
         ? previous + (calibration.measuredValue - calibration.de1ReportedValue)
@@ -73,6 +79,30 @@ class _CalibrationDe1 extends TestDe1 {
         measuredValue: measuredValue,
       ),
     };
+  }
+}
+
+class _GovernedCalibrationDe1 extends _CalibrationDe1 {
+  final _settings = BehaviorSubject.seeded(
+    De1ShotSettings(
+      steamSetting: 0,
+      targetSteamTemp: 150,
+      targetSteamDuration: 30,
+      targetHotWaterTemp: 75,
+      targetHotWaterVolume: 50,
+      targetHotWaterDuration: 30,
+      targetShotVolume: 36,
+      groupTemp: 94,
+    ),
+  );
+
+  @override
+  Stream<De1ShotSettings> get shotSettings => _settings.stream;
+
+  @override
+  Future<void> dispose() async {
+    await _settings.close();
+    await super.dispose();
   }
 }
 
@@ -114,11 +144,16 @@ void main() {
       WidgetTester tester,
       _CalibrationDe1 machine, {
       bool scrollToCalibration = true,
+      De1Controller? de1Controller,
     }) async {
       await tester.pumpWidget(
         ScaffoldMessenger(
           child: ShadApp(
-            home: De1DebugView(key: ValueKey(machine), machine: machine),
+            home: De1DebugView(
+              key: ValueKey(machine),
+              machine: machine,
+              de1Controller: de1Controller,
+            ),
           ),
         ),
       );
@@ -132,6 +167,55 @@ void main() {
         await tester.pumpAndSettle();
       }
     }
+
+    testWidgets('queues calibration writes with connected machine work', (
+      tester,
+    ) async {
+      late final DeviceController devices;
+      late final De1Controller controller;
+      late final _CalibrationDe1 machine;
+      late final Completer<void> release;
+      late final Future<void> active;
+      await tester.runAsync(() async {
+        devices = DeviceController([MockDeviceDiscoveryService()]);
+        await devices.initialize();
+        controller = De1Controller(controller: devices);
+        machine = _GovernedCalibrationDe1();
+        machine.writeRecorded = Completer<void>();
+        await controller.connectToDe1(machine);
+        await controller.initSettled.firstWhere(
+          (generation) => generation != null,
+        );
+
+        final started = Completer<void>();
+        release = Completer<void>();
+        active = controller.runDeviceWrite((_) async {
+          started.complete();
+          await release.future;
+        });
+        await started.future;
+      });
+      addTearDown(controller.dispose);
+      addTearDown(devices.dispose);
+
+      await pumpView(tester, machine, de1Controller: controller);
+      final write = find.byKey(const Key('calibration-write-flow'));
+      await tester.ensureVisible(write);
+      await tester.tap(write);
+      await tester.pump();
+
+      expect(machine.writes, isEmpty);
+      expect(controller.pendingDeviceWriteCount, 1);
+
+      await tester.runAsync(() async {
+        release.complete();
+        await active;
+        await machine.writeRecorded!.future;
+      });
+      await tester.pump();
+      expect(machine.writes, hasLength(1));
+      expect(controller.pendingDeviceWriteCount, 0);
+    });
 
     testWidgets('reads current and factory values for every target', (
       tester,
@@ -167,7 +251,9 @@ void main() {
 
       await tester.pumpWidget(
         ScaffoldMessenger(
-          child: ShadApp(home: De1DebugView(machine: machine)),
+          child: ShadApp(
+            home: De1DebugView(machine: machine, de1Controller: null),
+          ),
         ),
       );
       await tester.pump();

--- a/test/integration/steam_sequencer_integration_test.dart
+++ b/test/integration/steam_sequencer_integration_test.dart
@@ -36,6 +36,10 @@ class _StubDe1Controller extends De1Controller {
 
   @override
   Stream<De1Interface?> get de1 => _subj.stream;
+  @override
+  Future<void> requestMachineState(MachineState state) {
+    return _subj.value!.requestState(state);
+  }
 
   void emit(De1Interface? device) => _subj.add(device);
 }

--- a/test/services/webserver/de1handler_no_scale_test.dart
+++ b/test/services/webserver/de1handler_no_scale_test.dart
@@ -5,9 +5,7 @@ import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/profile.dart';
-import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
-import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
 import 'package:shelf_plus/shelf_plus.dart';
@@ -17,21 +15,13 @@ import '../../helpers/mock_settings_service.dart';
 import '../../helpers/test_scale.dart';
 import '../../helpers/test_scale_controller.dart';
 
-class _FixedDe1Controller extends De1Controller {
-  _FixedDe1Controller({required super.controller, this.device});
-
-  De1Interface? device;
-
-  @override
-  De1Interface connectedDe1() {
-    final d = device;
-    if (d == null) throw const DeviceNotConnectedException.machine();
-    return d;
-  }
-}
-
 void main() {
   late Handler handler;
+  late De1Controller controller;
+
+  tearDown(() async {
+    await controller.dispose();
+  });
 
   Future<void> wire({
     required bool blockOnNoScale,
@@ -40,10 +30,9 @@ void main() {
   }) async {
     final deviceController = DeviceController([MockDeviceDiscoveryService()]);
     await deviceController.initialize();
-    final controller = _FixedDe1Controller(
-      controller: deviceController,
-      device: MockDe1(),
-    );
+    controller = De1Controller(controller: deviceController);
+    controller.adoptDevice(MockDe1());
+    await controller.initSettled.firstWhere((generation) => generation != null);
 
     final mockSettings = MockSettingsService();
     await mockSettings.setBlockOnNoScale(blockOnNoScale);

--- a/test/services/webserver/de1handler_no_scale_test.dart
+++ b/test/services/webserver/de1handler_no_scale_test.dart
@@ -6,6 +6,7 @@ import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
 import 'package:shelf_plus/shelf_plus.dart';
@@ -15,9 +16,20 @@ import '../../helpers/mock_settings_service.dart';
 import '../../helpers/test_scale.dart';
 import '../../helpers/test_scale_controller.dart';
 
+final class _RecordingMockDe1 extends MockDe1 {
+  final List<MachineState> requestedStates = [];
+
+  @override
+  Future<void> requestState(MachineState newState) async {
+    requestedStates.add(newState);
+    await super.requestState(newState);
+  }
+}
+
 void main() {
   late Handler handler;
   late De1Controller controller;
+  late _RecordingMockDe1 machine;
 
   tearDown(() async {
     await controller.dispose();
@@ -31,7 +43,8 @@ void main() {
     final deviceController = DeviceController([MockDeviceDiscoveryService()]);
     await deviceController.initialize();
     controller = De1Controller(controller: deviceController);
-    controller.adoptDevice(MockDe1());
+    machine = _RecordingMockDe1();
+    controller.adoptDevice(machine);
     await controller.initSettled.firstWhere((generation) => generation != null);
 
     final mockSettings = MockSettingsService();
@@ -77,6 +90,7 @@ void main() {
       expect(res.statusCode, 400);
       final body = jsonDecode(await res.readAsString());
       expect(body['type'], 'block_no_scale');
+      expect(machine.requestedStates, isEmpty);
     });
 
     test(
@@ -89,6 +103,7 @@ void main() {
         );
         final res = await requestEspresso();
         expect(res.statusCode, 200);
+        expect(machine.requestedStates, [MachineState.espresso]);
       },
     );
   });

--- a/test/webserver/firmware_handler_test.dart
+++ b/test/webserver/firmware_handler_test.dart
@@ -26,6 +26,14 @@ final class _FixedController extends De1Controller {
   De1Interface connectedDe1() {
     return machine ?? (throw const DeviceNotConnectedException.machine());
   }
+
+  @override
+  Future<T> runDeviceWrite<T>(
+    Future<T> Function(De1Interface device) write, {
+    De1ReplayPolicy replayPolicy = De1ReplayPolicy.never,
+  }) {
+    return write(connectedDe1());
+  }
 }
 
 final class _FirmwareDe1 extends MockDe1 {

--- a/test/webserver/firmware_handler_test.dart
+++ b/test/webserver/firmware_handler_test.dart
@@ -42,6 +42,9 @@ final class _FirmwareDe1 extends MockDe1 {
   final String version;
   final String model;
   var updateCalls = 0;
+  var cancelCalls = 0;
+  Completer<void>? firmwareStarted;
+  Completer<void>? firmwareRelease;
 
   @override
   MachineInfo get machineInfo => MachineInfo(
@@ -58,8 +61,18 @@ final class _FirmwareDe1 extends MockDe1 {
     required void Function(double progress) onProgress,
   }) async {
     updateCalls++;
+    firmwareStarted?.complete();
+    if (firmwareRelease != null) await firmwareRelease!.future;
     await Future<void>.delayed(Duration.zero);
     onProgress(1);
+  }
+
+  @override
+  Future<void> cancelFirmwareUpload() async {
+    cancelCalls++;
+    if (firmwareRelease case final release? when !release.isCompleted) {
+      release.complete();
+    }
   }
 }
 
@@ -104,6 +117,108 @@ void main() {
     final subscription = first.read().listen((_) {});
     await subscription.cancel();
   });
+
+  test(
+    'raw upload returns 503 before streaming when the DE1 queue is full',
+    () async {
+      final harness = await _governedHandler(maxPendingDeviceWrites: 0);
+      addTearDown(harness.controller.dispose);
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = harness.controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+
+      final rejected = await _raw(harness.handler, const [1]);
+      expect(rejected.statusCode, 503);
+      expect(harness.machine.updateCalls, 0);
+
+      release.complete();
+      await active;
+      final accepted = await _raw(harness.handler, const [1]);
+      expect(accepted.statusCode, 200);
+      await _readEvents(accepted);
+      expect(harness.machine.updateCalls, 1);
+    },
+  );
+
+  test('DELETE cancels firmware while pending', () async {
+    final harness = await _governedHandler();
+    addTearDown(harness.controller.dispose);
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = harness.controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    await _raw(harness.handler, const [1]);
+    final cancellation = await _delete(harness.handler);
+    expect(cancellation.statusCode, 202);
+    expect(harness.controller.pendingDeviceWriteCount, 0);
+
+    release.complete();
+    await active;
+    expect(harness.machine.updateCalls, 0);
+    expect(harness.machine.cancelCalls, 0);
+  });
+
+  test('response cancellation cancels firmware while pending', () async {
+    final harness = await _governedHandler();
+    addTearDown(harness.controller.dispose);
+    final release = Completer<void>();
+    final started = Completer<void>();
+    final active = harness.controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+
+    final response = await _raw(harness.handler, const [1]);
+    final subscription = response.read().listen((_) {});
+    await subscription.cancel();
+    expect(harness.controller.pendingDeviceWriteCount, 0);
+
+    release.complete();
+    await active;
+    expect(harness.machine.updateCalls, 0);
+    expect(harness.machine.cancelCalls, 0);
+  });
+
+  test('DELETE forwards cancellation after firmware starts', () async {
+    final harness = await _governedHandler();
+    addTearDown(harness.controller.dispose);
+    harness.machine.firmwareStarted = Completer<void>();
+    harness.machine.firmwareRelease = Completer<void>();
+
+    final response = await _raw(harness.handler, const [1]);
+    await harness.machine.firmwareStarted!.future;
+    final cancellation = await _delete(harness.handler);
+
+    expect(cancellation.statusCode, 202);
+    expect(harness.machine.cancelCalls, 1);
+    await _readEvents(response);
+  });
+
+  test(
+    'response cancellation forwards cancellation after firmware starts',
+    () async {
+      final harness = await _governedHandler();
+      addTearDown(harness.controller.dispose);
+      harness.machine.firmwareStarted = Completer<void>();
+      harness.machine.firmwareRelease = Completer<void>();
+
+      final response = await _raw(harness.handler, const [1]);
+      await harness.machine.firmwareStarted!.future;
+      final subscription = response.read().listen((_) {});
+      await subscription.cancel();
+
+      expect(harness.machine.cancelCalls, 1);
+    },
+  );
 
   test('NDJSON stays open until successful verification', () async {
     final transport = FakeBleTransport();
@@ -289,6 +404,30 @@ Future<Response> _apply(Handler handler, String body) async {
       body: body,
     ),
   );
+}
+
+Future<Response> _delete(Handler handler) async {
+  return await handler(
+    Request('DELETE', Uri.parse('http://localhost/api/v1/machine/firmware')),
+  );
+}
+
+Future<({Handler handler, De1Controller controller, _FirmwareDe1 machine})>
+_governedHandler({int maxPendingDeviceWrites = 2}) async {
+  final devices = DeviceController([MockDeviceDiscoveryService()]);
+  await devices.initialize();
+  final controller = De1Controller(
+    controller: devices,
+    maxPendingDeviceWrites: maxPendingDeviceWrites,
+  );
+  final machine = _FirmwareDe1(version: '1358');
+  await controller.connectToDe1(machine);
+  final app = Router().plus;
+  FirmwareHandler(
+    controller: controller,
+    catalog: BundledFirmwareCatalog(bundle: rootBundle),
+  ).addRoutes(app);
+  return (handler: app.call, controller: controller, machine: machine);
 }
 
 Future<List<Map<String, dynamic>>> _readEvents(Response response) async {

--- a/test/webserver/firmware_handler_test.dart
+++ b/test/webserver/firmware_handler_test.dart
@@ -76,6 +76,25 @@ final class _FirmwareDe1 extends MockDe1 {
   }
 }
 
+final class _BlockingFirmwareBundle extends CachingAssetBundle {
+  final Completer<void> imageLoadStarted = Completer<void>();
+  final Completer<void> imageLoadRelease = Completer<void>();
+
+  @override
+  Future<ByteData> load(String key) async {
+    if (key != 'assets/firmware/manifest.json') {
+      imageLoadStarted.complete();
+      await imageLoadRelease.future;
+    }
+    return rootBundle.load(key);
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) {
+    return rootBundle.loadString(key, cache: cache);
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -320,6 +339,32 @@ void main() {
     expect(bengle.updateCalls, 0);
   });
 
+  test(
+    'managed apply revalidates after the connected machine changes',
+    () async {
+      final bundle = _BlockingFirmwareBundle();
+      final harness = await _governedHandler(bundle: bundle);
+      addTearDown(harness.controller.dispose);
+
+      final applying = _apply(
+        harness.handler,
+        jsonEncode({'artifactId': 'de1-1352', 'force': true}),
+      );
+      await bundle.imageLoadStarted.future;
+
+      harness.machine.simulateDisconnect();
+      await Future<void>.delayed(Duration.zero);
+      final replacement = _FirmwareDe1(version: '1351', model: 'Bengle');
+      await harness.controller.connectToDe1(replacement);
+      bundle.imageLoadRelease.complete();
+
+      final response = await applying;
+      expect(response.statusCode, 422);
+      expect(harness.machine.updateCalls, 0);
+      expect(replacement.updateCalls, 0);
+    },
+  );
+
   test('verification failure emits error and closes without done', () async {
     final transport = FakeBleTransport();
     addTearDown(transport.dispose);
@@ -413,7 +458,7 @@ Future<Response> _delete(Handler handler) async {
 }
 
 Future<({Handler handler, De1Controller controller, _FirmwareDe1 machine})>
-_governedHandler({int maxPendingDeviceWrites = 2}) async {
+_governedHandler({int maxPendingDeviceWrites = 2, AssetBundle? bundle}) async {
   final devices = DeviceController([MockDeviceDiscoveryService()]);
   await devices.initialize();
   final controller = De1Controller(
@@ -425,7 +470,7 @@ _governedHandler({int maxPendingDeviceWrites = 2}) async {
   final app = Router().plus;
   FirmwareHandler(
     controller: controller,
-    catalog: BundledFirmwareCatalog(bundle: rootBundle),
+    catalog: BundledFirmwareCatalog(bundle: bundle ?? rootBundle),
   ).addRoutes(app);
   return (handler: app.call, controller: controller, machine: machine);
 }

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -400,6 +400,59 @@ void main() {
     );
   }
 
+  group('PUT /api/v1/workflow — DE1 governor errors', () {
+    test('returns 503 when the DE1 write queue is full', () async {
+      await _settleHandler(spy);
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = de1Controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+      final pending = List.generate(
+        de1Controller.maxPendingDeviceWrites,
+        (_) => de1Controller.runDeviceWrite((_) async {}),
+      );
+
+      final response = await put({
+        'rinseData': {'flow': 5.5},
+      });
+      expect(response.statusCode, 503);
+
+      release.complete();
+      await Future.wait([active, ...pending]);
+    });
+
+    test('returns 409 when a pending DE1 setting is superseded', () async {
+      await _settleHandler(spy);
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = de1Controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+
+      final responseFuture = put({
+        'rinseData': {'flow': 5.5},
+      });
+      while (de1Controller.pendingDeviceWriteCount == 0) {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+      final replacement = de1Controller.runReplaceableDeviceWrite(
+        'workflow.rinse',
+        (_) async {},
+      );
+
+      final response = await responseFuture;
+      expect(response.statusCode, 409);
+
+      release.complete();
+      await Future.wait([active, replacement]);
+    });
+  });
+
   group('PUT /api/v1/workflow — redundant writes', () {
     test('steam-only PUT does not trigger hot-water or flush writes', () async {
       await _settleHandler(spy);
@@ -1489,65 +1542,42 @@ void main() {
       },
     );
 
-    test(
-      'machine replacement cannot split one settings request across old and new machines',
-      () async {
-        await _settleHandler(spy);
-        final initial = workflowController.currentWorkflow;
-        final steamFlow = initial.steamSettings.flow + 1;
-        final hotWaterFlow = initial.hotWaterData.flow + 1;
-        final flushTemp = initial.rinseData.targetTemperature + 1;
-        final entered = Completer<void>();
-        final release = Completer<void>();
-        spy.blockedSteamFlow = steamFlow;
-        spy.failSteamFlow = steamFlow;
-        spy.steamFlowEntered = entered;
-        spy.steamFlowRelease = release;
-        spy.writeOrder.clear();
+    test('machine replacement does not replay a settings request', () async {
+      await _settleHandler(spy);
+      final initial = workflowController.currentWorkflow;
+      final steamFlow = initial.steamSettings.flow + 1;
+      final hotWaterFlow = initial.hotWaterData.flow + 1;
+      final flushTemp = initial.rinseData.targetTemperature + 1;
+      final entered = Completer<void>();
+      final release = Completer<void>();
+      spy.blockedSteamFlow = steamFlow;
+      spy.failSteamFlow = steamFlow;
+      spy.steamFlowEntered = entered;
+      spy.steamFlowRelease = release;
+      spy.writeOrder.clear();
 
-        final settingsFuture = postSettings({
-          'flushTemp': flushTemp,
-          'steamFlow': steamFlow,
-          'hotWaterFlow': hotWaterFlow,
-        });
-        await entered.future.timeout(const Duration(seconds: 2));
-        expect(spy.setFlushTemperatureCalls, [flushTemp]);
-        expect(spy.setHotWaterFlowCalls, [hotWaterFlow]);
-        expect(spy.setSteamFlowCalls, [steamFlow]);
+      final settingsFuture = postSettings({
+        'flushTemp': flushTemp,
+        'steamFlow': steamFlow,
+        'hotWaterFlow': hotWaterFlow,
+      });
+      await entered.future.timeout(const Duration(seconds: 2));
+      expect(spy.setFlushTemperatureCalls, [flushTemp]);
+      expect(spy.setHotWaterFlowCalls, [hotWaterFlow]);
+      expect(spy.setSteamFlowCalls, [steamFlow]);
 
-        spy.setConnectionState(ConnectionState.disconnected);
-        await Future<void>.delayed(Duration.zero);
-        expect(de1Controller.connectedDe1OrNull, isNull);
-        release.complete();
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        var completed = false;
-        unawaited(settingsFuture.then((_) => completed = true));
-        expect(completed, isFalse);
-
-        final replacement = SpyDe1(readyState: false);
-        await de1Controller.connectToDe1(replacement);
-        expect(completed, isFalse);
-        replacement.setReady(true);
-        replacement.writeOrder.clear();
-
-        final response = await settingsFuture.timeout(
-          const Duration(seconds: 3),
-        );
-        expect(response.statusCode, 202);
-        expect(replacement.writeOrder.sublist(1), [
-          'flushTemp:${flushTemp.toDouble()}',
-          'hotWater:$hotWaterFlow',
-          'steam:$steamFlow',
-        ]);
-        expect(spy.writeOrder, [
-          'flushTemp:${flushTemp.toDouble()}',
-          'hotWater:$hotWaterFlow',
-          'steam:$steamFlow',
-        ]);
-        await replacement.dispose();
-      },
-    );
+      spy.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(Duration.zero);
+      expect(de1Controller.connectedDe1OrNull, isNull);
+      release.complete();
+      final response = await settingsFuture.timeout(const Duration(seconds: 3));
+      expect(response.statusCode, 500);
+      expect(spy.writeOrder, [
+        'flushTemp:${flushTemp.toDouble()}',
+        'hotWater:$hotWaterFlow',
+        'steam:$steamFlow',
+      ]);
+    });
 
     test(
       'a successful settings request publishes each changed flow exactly once',
@@ -1617,7 +1647,7 @@ void main() {
     );
 
     test(
-      'no flow publication occurs before a replacement retry succeeds',
+      'no flow publication occurs after a disconnected imperative write',
       () async {
         await _settleHandler(spy);
         final initial = workflowController.currentWorkflow;
@@ -1638,80 +1668,16 @@ void main() {
 
         spy.setConnectionState(ConnectionState.disconnected);
         release.complete();
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-        expect(steamEmits.where((f) => f == steamFlow), isEmpty);
-
-        final replacement = SpyDe1(readyState: false);
-        await de1Controller.connectToDe1(replacement);
-        replacement.setReady(true);
         final response = await settingsFuture.timeout(
           const Duration(seconds: 3),
         );
-        expect(response.statusCode, 202);
+        expect(response.statusCode, 500);
 
         await Future<void>.delayed(const Duration(milliseconds: 50));
-        expect(steamEmits.where((f) => f == steamFlow).length, 1);
+        expect(steamEmits.where((f) => f == steamFlow), isEmpty);
         await steamSub.cancel();
-        await replacement.dispose();
       },
     );
-
-    test('no flow publication occurs when replacement waiting fails', () async {
-      final shortSpy = SpyDe1();
-      final shortController = De1Controller(
-        controller: deviceController,
-        machineReplacementTimeout: const Duration(milliseconds: 100),
-      );
-      await shortController.connectToDe1(shortSpy);
-      await Future<void>.delayed(Duration.zero);
-      final mockSettings = MockSettingsService();
-      final settingsController = SettingsController(mockSettings);
-      await settingsController.loadSettings();
-      final shortDe1Handler = De1Handler(
-        controller: shortController,
-        settingsController: settingsController,
-        scaleController: TestScaleController(TestScale()),
-        workflowController: WorkflowController(),
-      );
-      final shortApp = Router().plus;
-      shortDe1Handler.addRoutes(shortApp);
-      final shortCall = shortApp.call;
-
-      final initial = WorkflowController().currentWorkflow;
-      final steamFlow = initial.steamSettings.flow + 2;
-      final entered = Completer<void>();
-      final release = Completer<void>();
-      shortSpy.blockedSteamFlow = steamFlow;
-      shortSpy.steamFlowEntered = entered;
-      shortSpy.steamFlowRelease = release;
-
-      final steamEmits = <double>[];
-      final steamSub = shortController.steamData
-          .map((e) => e.flow)
-          .listen(steamEmits.add);
-
-      final settingsFuture = () async {
-        return await shortCall(
-          Request(
-            'POST',
-            Uri.parse('http://localhost/api/v1/machine/settings'),
-            body: jsonEncode({'steamFlow': steamFlow}),
-            headers: {'content-type': 'application/json'},
-          ),
-        );
-      }();
-      await entered.future.timeout(const Duration(seconds: 2));
-
-      shortSpy.setConnectionState(ConnectionState.disconnected);
-      release.complete();
-
-      final response = await settingsFuture.timeout(const Duration(seconds: 5));
-      expect(response.statusCode, 503);
-      expect(steamEmits.where((f) => f == steamFlow), isEmpty);
-      await steamSub.cancel();
-      await shortController.dispose();
-      await shortSpy.dispose();
-    });
 
     test('malformed JSON in a settings request returns 400', () async {
       final response = await settingsHandler(
@@ -1800,59 +1766,34 @@ void main() {
       },
     );
 
-    test(
-      'machine replacement cannot split a reset across old and new machines',
-      () async {
-        await _settleHandler(spy);
-        final entered = Completer<void>();
-        final release = Completer<void>();
-        spy.blockedHeaterPhase2Flow = 4.0;
-        spy.failHeaterPhase2Flow = 4.0;
-        spy.heaterPhase2FlowEntered = entered;
-        spy.heaterPhase2FlowRelease = release;
-        spy.writeOrder.clear();
+    test('machine replacement does not replay a settings reset', () async {
+      await _settleHandler(spy);
+      final entered = Completer<void>();
+      final release = Completer<void>();
+      spy.blockedHeaterPhase2Flow = 4.0;
+      spy.failHeaterPhase2Flow = 4.0;
+      spy.heaterPhase2FlowEntered = entered;
+      spy.heaterPhase2FlowRelease = release;
+      spy.writeOrder.clear();
 
-        final resetFuture = deleteReset();
-        await entered.future.timeout(const Duration(seconds: 2));
-        expect(spy.setFanThreshholdCalls, [55, 55]);
-        expect(spy.setHeaterIdleTempCalls, [95]);
-        expect(spy.setHeaterPhase1FlowCalls, [2.0]);
+      final resetFuture = deleteReset();
+      await entered.future.timeout(const Duration(seconds: 2));
+      expect(spy.setFanThreshholdCalls, [55, 55]);
+      expect(spy.setHeaterIdleTempCalls, [95]);
+      expect(spy.setHeaterPhase1FlowCalls, [2.0]);
 
-        spy.setConnectionState(ConnectionState.disconnected);
-        await Future<void>.delayed(Duration.zero);
-        expect(de1Controller.connectedDe1OrNull, isNull);
-        release.complete();
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        var completed = false;
-        unawaited(resetFuture.then((_) => completed = true));
-        expect(completed, isFalse);
-
-        final replacement = SpyDe1(readyState: false);
-        await de1Controller.connectToDe1(replacement);
-        replacement.setReady(true);
-        replacement.writeOrder.clear();
-
-        final response = await resetFuture.timeout(const Duration(seconds: 3));
-        expect(response.statusCode, 202);
-        expect(replacement.writeOrder.sublist(1), [
-          'fan:55',
-          'heaterIdleTemp:95.0',
-          'heaterPh1:2.0',
-          'heaterPh2:4.0',
-          'heaterPh2Timeout:4.0',
-          'refillKit:De1RefillKitSettings.auto',
-          'flowEstimation:1.0',
-          'steamPurgeMode:0',
-        ]);
-        expect(spy.writeOrder, [
-          'fan:55',
-          'heaterIdleTemp:95.0',
-          'heaterPh1:2.0',
-          'heaterPh2:4.0',
-        ]);
-        await replacement.dispose();
-      },
-    );
+      spy.setConnectionState(ConnectionState.disconnected);
+      await Future<void>.delayed(Duration.zero);
+      expect(de1Controller.connectedDe1OrNull, isNull);
+      release.complete();
+      final response = await resetFuture.timeout(const Duration(seconds: 3));
+      expect(response.statusCode, 500);
+      expect(spy.writeOrder, [
+        'fan:55',
+        'heaterIdleTemp:95.0',
+        'heaterPh1:2.0',
+        'heaterPh2:4.0',
+      ]);
+    });
   });
 }

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -424,6 +424,36 @@ void main() {
       await Future.wait([active, ...pending]);
     });
 
+    test('rejects a multi-group update before admitting any writes', () async {
+      await _settleHandler(spy);
+      spy.setSteamFlowCalls.clear();
+      spy.setFlushFlowCalls.clear();
+      final release = Completer<void>();
+      final started = Completer<void>();
+      final active = de1Controller.runDeviceWrite((_) async {
+        started.complete();
+        await release.future;
+      });
+      await started.future;
+      final pending = List.generate(
+        de1Controller.maxPendingDeviceWrites - 1,
+        (_) => de1Controller.runDeviceWrite((_) async {}),
+      );
+
+      final response = await put({
+        'rinseData': {'flow': 5.5},
+        'steamSettings': {'flow': 3.5},
+      });
+
+      expect(response.statusCode, 503);
+      expect(spy.setFlushFlowCalls, isEmpty);
+      expect(spy.setSteamFlowCalls, isEmpty);
+      release.complete();
+      await Future.wait([active, ...pending]);
+      expect(spy.setFlushFlowCalls, isEmpty);
+      expect(spy.setSteamFlowCalls, isEmpty);
+    });
+
     test('returns 409 when a pending DE1 setting is superseded', () async {
       await _settleHandler(spy);
       final release = Completer<void>();


### PR DESCRIPTION
## Summary

What changed, and why?

- Replace the unbounded DE1 write chain with one active operation and at most 32 pending operations.
- Coalesce pending rinse, steam, and hot-water settings while preserving final values and explicit supersession results.
- Make pending firmware updates cancellable and reject a full machine queue before committing an HTTP 200 response.
- Prevent replay onto a different machine, keep idle direct, and serialize firmware without coupling scale operations.

## Linked Issue

Fixes #687

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- Focused controller, sequencer, firmware, workflow, and no-scale handler tests passed.
- Pending and active firmware cancellation are covered through both DELETE and response-stream cancellation.
- Firmware queue saturation is covered at the HTTP boundary and returns 503 before streaming.
- The no-scale handler fixture now connects through the real controller state required by the governor and asserts the physical espresso request.
- Deterministic boundary tests cover failure recovery, coalescing position at capacity, identity fallback, saturated idle bypass, and queued firmware cancellation.
- Managed firmware eligibility is re-evaluated against the machine connected after catalog/image loading.
- Firmware cancellation covers the active-but-not-started initialization window.
- Automatic skip-step retries after queue rejection; manual rejection is surfaced in the UI.
- Multi-group workflow updates preflight all coalescing slots and reject atomically before any machine write is admitted.
- Queued sleep and scheduled-wake commands revalidate device and state at execution; heartbeats invalidate stale sleep work.
- User-present MMR writes now use the machine governor, and both Bengle bridges replace stale-generation retry timers.
- OpenAPI YAML parses successfully and documents machine-change/write failures for imperative mutations.
- Latest review regression suite: 152 passed (governor, shot sequencer, presence, both Bengle bridges, and workflow handler).
- `flutter analyze` completed with no issues.
- Full Windows `flutter test`: 3169 passed, 1 skipped, 220 failed in existing platform-dependent tests (CRLF-sensitive schema assertions and unavailable native QuickJS/runtime dependencies); the affected regression suite is green.
- Live smoke attempted with `sb-dev`; the helper is POSIX-only on Windows, and its documented direct-`flutter run` fallback is blocked on this host by the existing VS2019/universal_ble linker incompatibility before app startup.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Bounds pending machine transport work and rejects overflow instead of allowing unbounded growth.
- Adds documented 409 supersession and 503 queue-full responses for affected workflow/API paths.
- Firmware canceled while pending no longer starts later.
- Idle remains serviceable under ordinary write saturation; scale transport remains independent.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
