### PR TITLE
test(hardening): cover pressure regressions

### DIFF
--- a/.agents/skills/decent-app/SKILL.md
+++ b/.agents/skills/decent-app/SKILL.md
@@ -49,6 +49,7 @@ Pick the scenario that matches the task, run it verbatim, and finish before call
 | Account-proxy write forwarding + write-scope gate | `scenarios/account-proxy-write.md` |
 | Account-proxy native consent gate | `scenarios/account-proxy-consent.md` |
 | Plugin Decent-account proxy bridge (host.decentProxy) | `scenarios/plugin-decent-proxy.md` |
+| API pressure hardening | `scenarios/api-pressure-hardening.md` |
 
 ## Authoritative sources
 

--- a/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
+++ b/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
@@ -80,6 +80,7 @@ test "$WS_BASELINE" -gt 0
   done
   wait
 )
+kill -0 "$WS_PID"
 test "$(wc -l < /tmp/decaid-pressure-snapshot.jsonl)" -gt "$WS_BASELINE"
 ```
 

--- a/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
+++ b/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
@@ -14,7 +14,7 @@ WS=ws://localhost:8080
 Confirm the simulated machine is connected:
 
 ```bash
-curl -sf "$BASE/api/v1/devices" \
+curl -sf --max-time 2 "$BASE/api/v1/devices" \
   | jq -e '.[] | select(.name == "MockDe1" and .state == "connected")'
 ```
 
@@ -46,7 +46,7 @@ test "$WS_BASELINE" -gt 0
     esac
 
     (
-      code=$(curl -s -o /dev/null -w '%{http_code}' \
+      code=$(curl -s --max-time 35 -o /dev/null -w '%{http_code}' \
         -X PUT "$BASE/api/v1/workflow" \
         -H 'content-type: application/json' \
         -d "{\"$field\":{\"$key\":$value}}")
@@ -105,7 +105,7 @@ admission rejection, then prove all three fields reached the workflow.
 ```bash
 final_ok=false
 for attempt in $(seq 1 20); do
-  if curl -sf -X PUT "$BASE/api/v1/workflow" \
+  if curl -sf --max-time 35 -X PUT "$BASE/api/v1/workflow" \
     -H 'content-type: application/json' \
     -d '{"steamSettings":{"duration":47},"hotWaterData":{"volume":121},"rinseData":{"flow":3.25}}' \
     >/dev/null; then
@@ -116,12 +116,12 @@ for attempt in $(seq 1 20); do
 done
 test "$final_ok" = true
 
-curl -sf "$BASE/api/v1/workflow" | jq -e '
+curl -sf --max-time 2 "$BASE/api/v1/workflow" | jq -e '
   .steamSettings.duration == 47 and
   .hotWaterData.volume == 121 and
   .rinseData.flow == 3.25'
-curl -sf "$BASE/api/v1/machine/state" | jq -e '.state.state == "idle"'
-curl -sf "$BASE/api/v1/devices" \
+curl -sf --max-time 2 "$BASE/api/v1/machine/state" | jq -e '.state.state == "idle"'
+curl -sf --max-time 2 "$BASE/api/v1/devices" \
   | jq -e '.[] | select(.name == "MockDe1" and .state == "connected")'
 ```
 

--- a/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
+++ b/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
@@ -25,10 +25,17 @@ at most 64 concurrent clients. The idle request is made during the burst and
 retried only when generic API admission rejects it.
 
 ```bash
-rm -f /tmp/decaid-pressure-status /tmp/decaid-pressure-snapshot.jsonl
+rm -f /tmp/decaid-pressure-status /tmp/decaid-pressure-probes \
+  /tmp/decaid-pressure-snapshot.jsonl
 websocat "$WS/ws/v1/machine/snapshot" \
   > /tmp/decaid-pressure-snapshot.jsonl &
 WS_PID=$!
+for attempt in $(seq 1 20); do
+  test -s /tmp/decaid-pressure-snapshot.jsonl && break
+  sleep 0.1
+done
+WS_BASELINE=$(wc -l < /tmp/decaid-pressure-snapshot.jsonl)
+test "$WS_BASELINE" -gt 0
 
 (
   for i in $(seq 1 500); do
@@ -46,7 +53,10 @@ WS_PID=$!
       printf '%s %s %s %s\n' "$i" "$field" "$value" "$code" \
         >> /tmp/decaid-pressure-status
       if ((i % 25 == 0)); then
-        curl -sf "$BASE/api/v1/machine/state" >/dev/null || true
+        probe_code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' \
+          "$BASE/api/v1/machine/state")
+        printf '%s %s\n' "$i" "$probe_code" \
+          >> /tmp/decaid-pressure-probes
       fi
     ) &
 
@@ -57,17 +67,20 @@ WS_PID=$!
     if ((i == 100)); then
       idle_ok=false
       for attempt in $(seq 1 20); do
-        if curl -sf -X PUT "$BASE/api/v1/machine/state/idle" >/dev/null; then
-          idle_ok=true
-          break
-        fi
-        sleep 1
+        code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' \
+          -X PUT "$BASE/api/v1/machine/state/idle")
+        case "$code" in
+          200) idle_ok=true; break ;;
+          429|503) sleep 1 ;;
+          *) printf 'unexpected idle status: %s\n' "$code" >&2; exit 1 ;;
+        esac
       done
       test "$idle_ok" = true
     fi
   done
   wait
 )
+test "$(wc -l < /tmp/decaid-pressure-snapshot.jsonl)" -gt "$WS_BASELINE"
 ```
 
 The run is finite. Successful and rejected requests must account for all 500
@@ -78,6 +91,10 @@ awk '$4 == 200 {ok++} $4 == 429 {limited++} $4 == 503 {busy++}
      END {print "ok=" ok+0, "429=" limited+0, "503=" busy+0;
           exit (ok+limited+busy == 500 ? 0 : 1)}' \
   /tmp/decaid-pressure-status
+awk '$2 == 200 || $2 == 429 || $2 == 503 {valid++}
+     END {print "responsive probes=" valid+0;
+          exit (valid == 20 ? 0 : 1)}' \
+  /tmp/decaid-pressure-probes
 ```
 
 ## Final admitted state
@@ -106,7 +123,6 @@ curl -sf "$BASE/api/v1/workflow" | jq -e '
 curl -sf "$BASE/api/v1/machine/state" | jq -e '.state.state == "idle"'
 curl -sf "$BASE/api/v1/devices" \
   | jq -e '.[] | select(.name == "MockDe1" and .state == "connected")'
-test "$(wc -l < /tmp/decaid-pressure-snapshot.jsonl)" -gt 0
 ```
 
 ## Postconditions

--- a/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
+++ b/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
@@ -106,14 +106,15 @@ admission rejection, then prove all three fields reached the workflow.
 ```bash
 final_ok=false
 for attempt in $(seq 1 20); do
-  if curl -sf --max-time 35 -X PUT "$BASE/api/v1/workflow" \
+  code=$(curl -s --max-time 35 -o /dev/null -w '%{http_code}' \
+    -X PUT "$BASE/api/v1/workflow" \
     -H 'content-type: application/json' \
-    -d '{"steamSettings":{"duration":47},"hotWaterData":{"volume":121},"rinseData":{"flow":3.25}}' \
-    >/dev/null; then
-    final_ok=true
-    break
-  fi
-  sleep 1
+    -d '{"steamSettings":{"duration":47},"hotWaterData":{"volume":121},"rinseData":{"flow":3.25}}')
+  case "$code" in
+    200) final_ok=true; break ;;
+    429|503) sleep 1 ;;
+    *) printf 'unexpected final mutation status: %s\n' "$code" >&2; exit 1 ;;
+  esac
 done
 test "$final_ok" = true
 

--- a/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
+++ b/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
@@ -30,42 +30,44 @@ websocat "$WS/ws/v1/machine/snapshot" \
   > /tmp/decaid-pressure-snapshot.jsonl &
 WS_PID=$!
 
-for i in $(seq 1 500); do
-  case $((i % 3)) in
-    0) field=steamSettings; key=duration; value=$((10 + i % 40)) ;;
-    1) field=hotWaterData; key=volume; value=$((50 + i % 150)) ;;
-    2) field=rinseData; key=flow; value=$((2 + i % 8)) ;;
-  esac
+(
+  for i in $(seq 1 500); do
+    case $((i % 3)) in
+      0) field=steamSettings; key=duration; value=$((10 + i % 40)) ;;
+      1) field=hotWaterData; key=volume; value=$((50 + i % 150)) ;;
+      2) field=rinseData; key=flow; value=$((2 + i % 8)) ;;
+    esac
 
-  (
-    code=$(curl -s -o /dev/null -w '%{http_code}' \
-      -X PUT "$BASE/api/v1/workflow" \
-      -H 'content-type: application/json' \
-      -d "{\"$field\":{\"$key\":$value}}")
-    printf '%s %s %s %s\n' "$i" "$field" "$value" "$code" \
-      >> /tmp/decaid-pressure-status
-    if ((i % 25 == 0)); then
-      curl -sf "$BASE/api/v1/machine/state" >/dev/null || true
-    fi
-  ) &
-
-  while (( $(jobs -rp | wc -l) >= 64 )); do
-    wait -n || true
-  done
-
-  if ((i == 100)); then
-    idle_ok=false
-    for attempt in $(seq 1 20); do
-      if curl -sf -X PUT "$BASE/api/v1/machine/state/idle" >/dev/null; then
-        idle_ok=true
-        break
+    (
+      code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -X PUT "$BASE/api/v1/workflow" \
+        -H 'content-type: application/json' \
+        -d "{\"$field\":{\"$key\":$value}}")
+      printf '%s %s %s %s\n' "$i" "$field" "$value" "$code" \
+        >> /tmp/decaid-pressure-status
+      if ((i % 25 == 0)); then
+        curl -sf "$BASE/api/v1/machine/state" >/dev/null || true
       fi
-      sleep 1
+    ) &
+
+    while (( $(jobs -rp | wc -l) >= 64 )); do
+      wait -n || true
     done
-    test "$idle_ok" = true
-  fi
-done
-wait
+
+    if ((i == 100)); then
+      idle_ok=false
+      for attempt in $(seq 1 20); do
+        if curl -sf -X PUT "$BASE/api/v1/machine/state/idle" >/dev/null; then
+          idle_ok=true
+          break
+        fi
+        sleep 1
+      done
+      test "$idle_ok" = true
+    fi
+  done
+  wait
+)
 ```
 
 The run is finite. Successful and rejected requests must account for all 500

--- a/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
+++ b/.agents/skills/decent-app/scenarios/api-pressure-hardening.md
@@ -1,0 +1,119 @@
+# Scenario: API pressure hardening
+
+Finite simulate-mode check for chatty workflow clients, admission rejection,
+machine telemetry, and the direct idle path.
+
+## Preconditions
+
+```bash
+scripts/sb-dev.sh start --connect-machine MockDe1
+BASE=http://localhost:8080
+WS=ws://localhost:8080
+```
+
+Confirm the simulated machine is connected:
+
+```bash
+curl -sf "$BASE/api/v1/devices" \
+  | jq -e '.[] | select(.name == "MockDe1" and .state == "connected")'
+```
+
+## Finite pressure burst
+
+Keep the machine snapshot stream open while 500 workflow mutations run with
+at most 64 concurrent clients. The idle request is made during the burst and
+retried only when generic API admission rejects it.
+
+```bash
+rm -f /tmp/decaid-pressure-status /tmp/decaid-pressure-snapshot.jsonl
+websocat "$WS/ws/v1/machine/snapshot" \
+  > /tmp/decaid-pressure-snapshot.jsonl &
+WS_PID=$!
+
+for i in $(seq 1 500); do
+  case $((i % 3)) in
+    0) field=steamSettings; key=duration; value=$((10 + i % 40)) ;;
+    1) field=hotWaterData; key=volume; value=$((50 + i % 150)) ;;
+    2) field=rinseData; key=flow; value=$((2 + i % 8)) ;;
+  esac
+
+  (
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+      -X PUT "$BASE/api/v1/workflow" \
+      -H 'content-type: application/json' \
+      -d "{\"$field\":{\"$key\":$value}}")
+    printf '%s %s %s %s\n' "$i" "$field" "$value" "$code" \
+      >> /tmp/decaid-pressure-status
+    if ((i % 25 == 0)); then
+      curl -sf "$BASE/api/v1/machine/state" >/dev/null || true
+    fi
+  ) &
+
+  while (( $(jobs -rp | wc -l) >= 64 )); do
+    wait -n || true
+  done
+
+  if ((i == 100)); then
+    idle_ok=false
+    for attempt in $(seq 1 20); do
+      if curl -sf -X PUT "$BASE/api/v1/machine/state/idle" >/dev/null; then
+        idle_ok=true
+        break
+      fi
+      sleep 1
+    done
+    test "$idle_ok" = true
+  fi
+done
+wait
+```
+
+The run is finite. Successful and rejected requests must account for all 500
+attempts; overload may return `429` or `503`.
+
+```bash
+awk '$4 == 200 {ok++} $4 == 429 {limited++} $4 == 503 {busy++}
+     END {print "ok=" ok+0, "429=" limited+0, "503=" busy+0;
+          exit (ok+limited+busy == 500 ? 0 : 1)}' \
+  /tmp/decaid-pressure-status
+```
+
+## Final admitted state
+
+Send one deterministic final mutation after pressure has drained. Retry on
+admission rejection, then prove all three fields reached the workflow.
+
+```bash
+final_ok=false
+for attempt in $(seq 1 20); do
+  if curl -sf -X PUT "$BASE/api/v1/workflow" \
+    -H 'content-type: application/json' \
+    -d '{"steamSettings":{"duration":47},"hotWaterData":{"volume":121},"rinseData":{"flow":3.25}}' \
+    >/dev/null; then
+    final_ok=true
+    break
+  fi
+  sleep 1
+done
+test "$final_ok" = true
+
+curl -sf "$BASE/api/v1/workflow" | jq -e '
+  .steamSettings.duration == 47 and
+  .hotWaterData.volume == 121 and
+  .rinseData.flow == 3.25'
+curl -sf "$BASE/api/v1/machine/state" | jq -e '.state.state == "idle"'
+curl -sf "$BASE/api/v1/devices" \
+  | jq -e '.[] | select(.name == "MockDe1" and .state == "connected")'
+test "$(wc -l < /tmp/decaid-pressure-snapshot.jsonl)" -gt 0
+```
+
+## Postconditions
+
+```bash
+kill "$WS_PID" 2>/dev/null || true
+scripts/sb-dev.sh logs --filter error -n 50
+scripts/sb-dev.sh stop
+```
+
+For an optional longer manual run, raise the finite loop count while keeping
+the concurrency cap. Do not turn it into an endless soak or a normal CI job.

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -462,7 +462,22 @@ Handler _init(
     debugHandler.addRoutes(app);
   }
 
-  final handler = const Pipeline()
+  return buildWebServerHandler(
+    app.call,
+    proxyTokenService: proxyTokenService,
+    accountProxyAllowedOrigins: accountProxyAllowedOrigins,
+  );
+}
+
+Set<String> _noAccountProxyOrigins() => const {};
+
+Handler buildWebServerHandler(
+  Handler routes, {
+  ProxyTokenService? proxyTokenService,
+  Set<String> Function() accountProxyAllowedOrigins = _noAccountProxyOrigins,
+  AdmissionGate? admissionGate,
+}) {
+  return const Pipeline()
       .addMiddleware(accountProxyCorsMiddleware(accountProxyAllowedOrigins))
       .addMiddleware(logRequestsWithClientIp())
       .addMiddleware(
@@ -482,10 +497,8 @@ Handler _init(
             : proxyAuthMiddleware(proxyTokenService),
       )
       .addMiddleware(requestBodyReadMiddleware())
-      .addMiddleware(apiAdmissionMiddleware(_apiAdmissionGate))
-      .addHandler(app.call);
-
-  return handler;
+      .addMiddleware(apiAdmissionMiddleware(admissionGate ?? _apiAdmissionGate))
+      .addHandler(routes);
 }
 
 const _shelfConnectionInfoKey = 'shelf.io.connection_info';

--- a/test/controllers/de1_controller_governor_pressure_test.dart
+++ b/test/controllers/de1_controller_governor_pressure_test.dart
@@ -1,0 +1,461 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/home_feature/forms/hot_water_form.dart';
+import 'package:reaprime/src/home_feature/forms/steam_form.dart';
+import 'package:reaprime/src/models/data/workflow.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/errors.dart';
+
+import '../helpers/mock_device_discovery_service.dart';
+import '../helpers/test_de1.dart';
+import '../helpers/test_scale.dart';
+
+final class _PressureDe1 extends TestDe1 {
+  _PressureDe1({super.serialNumber});
+
+  final List<double> flushFlows = [];
+  final List<double> steamFlows = [];
+  final List<double> hotWaterFlows = [];
+  final List<De1ShotSettings> shotSettingsWrites = [];
+  final List<String> events = [];
+  Completer<void>? blockedFlushStarted;
+  Completer<void>? blockedFlushRelease;
+  double? blockedFlushFlow;
+  Completer<void>? firmwareStarted;
+  Completer<void>? firmwareRelease;
+  int firmwareWrites = 0;
+  bool _disposed = false;
+  late De1ShotSettings currentSettings;
+
+  @override
+  void emitShotSettings(De1ShotSettings settings) {
+    currentSettings = settings;
+    super.emitShotSettings(settings);
+  }
+
+  @override
+  Future<void> setFlushFlow(double newFlow) async {
+    flushFlows.add(newFlow);
+    if (newFlow == blockedFlushFlow) {
+      blockedFlushStarted?.complete();
+      await blockedFlushRelease?.future;
+    }
+  }
+
+  @override
+  Future<void> setSteamFlow(double newFlow) async {
+    steamFlows.add(newFlow);
+  }
+
+  @override
+  Future<void> setHotWaterFlow(double newFlow) async {
+    hotWaterFlows.add(newFlow);
+  }
+
+  @override
+  Future<void> updateShotSettings(De1ShotSettings newSettings) async {
+    shotSettingsWrites.add(newSettings);
+    emitShotSettings(newSettings);
+  }
+
+  @override
+  Future<void> requestState(MachineState newState) async {
+    events.add(newState.name);
+    await super.requestState(newState);
+  }
+
+  @override
+  Future<void> updateFirmware(
+    Uint8List fwImage, {
+    required void Function(double progress) onProgress,
+  }) async {
+    firmwareWrites++;
+    firmwareStarted?.complete();
+    await firmwareRelease?.future;
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await super.dispose();
+  }
+}
+
+final class _BlockingScale extends TestScale {
+  final Completer<void> tareStarted = Completer<void>();
+  final Completer<void> tareRelease = Completer<void>();
+
+  @override
+  Future<void> tare() async {
+    tareCallCount++;
+    if (!tareStarted.isCompleted) tareStarted.complete();
+    await tareRelease.future;
+  }
+}
+
+De1ShotSettings _shotSettings() => De1ShotSettings(
+  steamSetting: 0,
+  targetSteamTemp: 150,
+  targetSteamDuration: 30,
+  targetHotWaterTemp: 75,
+  targetHotWaterVolume: 50,
+  targetHotWaterDuration: 30,
+  targetShotVolume: 36,
+  groupTemp: 94,
+);
+
+Future<void> _connect(De1Controller controller, _PressureDe1 machine) async {
+  await controller.connectToDe1(machine);
+  machine.emitShotSettings(_shotSettings());
+  await controller.initSettled.firstWhere((generation) => generation != null);
+}
+
+Future<void> _settleErrors(Iterable<Future<void>> futures) {
+  return Future.wait(futures.map((future) => future.catchError((_) {})));
+}
+
+void main() {
+  late DeviceController devices;
+  late De1Controller controller;
+  late _PressureDe1 machine;
+  late List<_PressureDe1> machines;
+
+  setUp(() async {
+    devices = DeviceController([MockDeviceDiscoveryService()]);
+    await devices.initialize();
+    controller = De1Controller(controller: devices, maxPendingDeviceWrites: 4);
+    machine = _PressureDe1();
+    machines = [machine];
+    await _connect(controller, machine);
+  });
+
+  tearDown(() async {
+    await controller.dispose();
+    for (final connected in machines) {
+      await connected.dispose();
+    }
+  });
+
+  Future<_PressureDe1> replace({required String serialNumber}) async {
+    final replacement = _PressureDe1(serialNumber: serialNumber);
+    machines.add(replacement);
+    await _connect(controller, replacement);
+    machine = replacement;
+    return replacement;
+  }
+
+  test('1000 rinse updates retain one pending final value', () async {
+    final activeStarted = Completer<void>();
+    final activeRelease = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      activeStarted.complete();
+      await activeRelease.future;
+    });
+    await activeStarted.future;
+
+    var superseded = 0;
+    final outcomes = <Future<void>>[];
+    Future<void>? latest;
+    for (var i = 0; i < 1000; i++) {
+      final previous = latest;
+      latest = controller.updateFlushSettings(
+        RinseData(targetTemperature: 90, duration: 5, flow: i.toDouble()),
+      );
+      if (previous != null) {
+        outcomes.add(
+          previous.then(
+            (_) => fail('superseded rinse write completed successfully'),
+            onError: (Object error) {
+              expect(error, isA<De1WriteSupersededException>());
+              superseded++;
+            },
+          ),
+        );
+      }
+    }
+
+    expect(controller.pendingDeviceWriteCount, 1);
+    expect(controller.pendingDeviceWriteCount, lessThanOrEqualTo(4));
+    expect(machine.flushFlows, isEmpty);
+    activeRelease.complete();
+    await Future.wait([active, latest!, ...outcomes]);
+
+    expect(superseded, 999);
+    expect(machine.flushFlows, [999]);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('three replaceable keys coalesce independently', () async {
+    final activeStarted = Completer<void>();
+    final activeRelease = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      activeStarted.complete();
+      await activeRelease.future;
+    });
+    await activeStarted.future;
+
+    final superseded = <Future<void>>[];
+    Future<void>? rinse;
+    Future<void>? steam;
+    Future<void>? hotWater;
+    for (var i = 0; i < 100; i++) {
+      if (rinse != null) superseded.add(rinse.catchError((_) {}));
+      if (steam != null) superseded.add(steam.catchError((_) {}));
+      if (hotWater != null) superseded.add(hotWater.catchError((_) {}));
+      rinse = controller.updateFlushSettings(
+        RinseData(targetTemperature: 91, duration: 6, flow: i.toDouble()),
+      );
+      steam = controller.updateSteamSettings(
+        SteamFormSettings(
+          steamEnabled: true,
+          targetTemp: 151,
+          targetDuration: i,
+          targetFlow: i.toDouble(),
+        ),
+      );
+      hotWater = controller.updateHotWaterSettings(
+        HotWaterFormSettings(
+          targetTemperature: 76,
+          flow: i.toDouble(),
+          volume: i,
+          duration: i,
+        ),
+      );
+    }
+
+    expect(controller.pendingDeviceWriteCount, 3);
+    activeRelease.complete();
+    await Future.wait([active, rinse!, steam!, hotWater!, ...superseded]);
+
+    expect(machine.flushFlows, [99]);
+    expect(machine.steamFlows, [99]);
+    expect(machine.hotWaterFlows, [99]);
+    expect(machine.currentSettings.targetSteamDuration, 99);
+    expect(machine.currentSettings.targetHotWaterVolume, 99);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('caller timeout leaves physical serialization occupied', () async {
+    final events = <String>[];
+    final started = Completer<void>();
+    final release = Completer<void>();
+    final first = controller.runDeviceWrite((_) async {
+      events.add('first-start');
+      started.complete();
+      await release.future;
+      events.add('first-end');
+    });
+    await started.future;
+    final second = controller.runDeviceWrite((_) async {
+      events.add('second');
+    });
+
+    await expectLater(
+      first.timeout(const Duration(milliseconds: 10)),
+      throwsA(isA<TimeoutException>()),
+    );
+    expect(events, ['first-start']);
+    release.complete();
+    await Future.wait([first, second]);
+    expect(events, ['first-start', 'first-end', 'second']);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('same-machine reconnect reconciles only the pending setting', () async {
+    final original = machine;
+    final started = Completer<void>();
+    final release = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+    final activeResult = active.catchError((_) {});
+    final pending = controller.updateFlushSettings(
+      RinseData(targetTemperature: 92, duration: 7, flow: 4.5),
+    );
+
+    original.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+    final replacement = await replace(serialNumber: original.serialNumber);
+    release.complete();
+    await Future.wait([activeResult, pending]);
+
+    expect(original.flushFlows, isEmpty);
+    expect(replacement.flushFlows, [4.5]);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('different-machine replacement receives no queued work', () async {
+    final original = machine;
+    final started = Completer<void>();
+    final release = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+    final activeResult = active.catchError((_) {});
+    final imperative = controller.setFlushFlow(7).catchError((_) {});
+    final replaceable = controller
+        .updateFlushSettings(
+          RinseData(targetTemperature: 92, duration: 7, flow: 8),
+        )
+        .catchError((_) {});
+
+    original.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+    final replacement = await replace(serialNumber: 'different');
+    release.complete();
+    await Future.wait([activeResult, imperative, replaceable]);
+
+    expect(replacement.flushFlows, isEmpty);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('stale completion cannot publish into a new generation', () async {
+    final original = machine;
+    original.blockedFlushFlow = 6;
+    original.blockedFlushStarted = Completer<void>();
+    original.blockedFlushRelease = Completer<void>();
+    final stale = controller.setFlushFlow(6).catchError((_) {});
+    await original.blockedFlushStarted!.future;
+
+    original.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+    final replacement = await replace(serialNumber: original.serialNumber);
+    original.blockedFlushRelease!.complete();
+    await stale;
+
+    expect(replacement.flushFlows, isEmpty);
+    expect((await controller.rinseData.first).flow, isNot(6));
+    await controller.setFlushFlow(7);
+    expect(replacement.flushFlows, [7]);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('deterministic connection flapping terminates every future', () async {
+    final first = machine;
+    final started = Completer<void>();
+    final release = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+    final futures = <Future<void>>[
+      active,
+      controller.setFlushFlow(1),
+      controller.updateFlushSettings(
+        RinseData(targetTemperature: 90, duration: 5, flow: 2),
+      ),
+      controller.updateSteamSettings(
+        SteamFormSettings(
+          steamEnabled: true,
+          targetTemp: 150,
+          targetDuration: 20,
+          targetFlow: 3,
+        ),
+      ),
+    ];
+
+    first.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+    final second = await replace(serialNumber: first.serialNumber);
+    second.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+    await replace(serialNumber: first.serialNumber);
+    release.complete();
+    await _settleErrors(futures).timeout(const Duration(seconds: 2));
+
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('idle bypasses a saturated ordinary queue', () async {
+    final started = Completer<void>();
+    final release = Completer<void>();
+    final active = controller.runDeviceWrite((_) async {
+      machine.events.add('ordinary-start');
+      started.complete();
+      await release.future;
+    });
+    await started.future;
+    final pending = List.generate(
+      controller.maxPendingDeviceWrites,
+      (_) => controller.runDeviceWrite((_) async {}),
+    );
+    expect(controller.pendingDeviceWriteCount, 4);
+
+    await controller.requestMachineState(MachineState.idle);
+    expect(machine.events, ['ordinary-start', 'idle']);
+    release.complete();
+    await Future.wait([active, ...pending]);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('firmware is exclusive and never replays after disconnect', () async {
+    machine.firmwareStarted = Completer<void>();
+    machine.firmwareRelease = Completer<void>();
+    final firmware = controller
+        .updateFirmware(Uint8List(1), onProgress: (_) {})
+        .catchError((_) {});
+    await machine.firmwareStarted!.future;
+    var ordinaryStarted = false;
+    final ordinary = controller.runDeviceWrite((_) async {
+      ordinaryStarted = true;
+    });
+    expect(ordinaryStarted, isFalse);
+
+    final original = machine;
+    original.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+    final replacement = await replace(serialNumber: original.serialNumber);
+    original.firmwareRelease!.complete();
+    await firmware;
+    await ordinary.catchError((_) {});
+
+    expect(replacement.firmwareWrites, 0);
+    expect(ordinaryStarted, isFalse);
+    await controller.setFlushFlow(9);
+    expect(replacement.flushFlows, [9]);
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+
+  test('DE1 and scale operations remain independent', () async {
+    final scale = _BlockingScale();
+    final scaleController = ScaleController();
+    await scaleController.connectToScale(scale);
+    addTearDown(() {
+      scaleController.dispose();
+      scale.dispose();
+    });
+
+    final stalledScale = scaleController.tare();
+    await scale.tareStarted.future;
+    await controller.setFlushFlow(10);
+    expect(machine.flushFlows, [10]);
+    scale.tareRelease.complete();
+    await stalledScale;
+
+    final de1Started = Completer<void>();
+    final de1Release = Completer<void>();
+    final stalledDe1 = controller.runDeviceWrite((_) async {
+      de1Started.complete();
+      await de1Release.future;
+    });
+    await de1Started.future;
+    await scaleController.tare();
+    expect(scale.tareCallCount, 2);
+    de1Release.complete();
+    await stalledDe1;
+    expect(controller.pendingDeviceWriteCount, 0);
+  });
+}

--- a/test/controllers/de1_controller_governor_pressure_test.dart
+++ b/test/controllers/de1_controller_governor_pressure_test.dart
@@ -304,18 +304,24 @@ void main() {
     });
     await started.future;
     final activeResult = active.catchError((_) {});
-    final imperative = controller.setFlushFlow(7).catchError((_) {});
-    final replaceable = controller
-        .updateFlushSettings(
-          RinseData(targetTemperature: 92, duration: 7, flow: 8),
-        )
-        .catchError((_) {});
+    final imperative = controller.setFlushFlow(7);
+    final replaceable = controller.updateFlushSettings(
+      RinseData(targetTemperature: 92, duration: 7, flow: 8),
+    );
+    final imperativeResult = expectLater(
+      imperative,
+      throwsA(isA<StateError>()),
+    );
+    final replaceableResult = expectLater(
+      replaceable,
+      throwsA(isA<StateError>()),
+    );
 
     original.setConnectionState(ConnectionState.disconnected);
     await Future<void>.delayed(Duration.zero);
     final replacement = await replace(serialNumber: 'different');
     release.complete();
-    await Future.wait([activeResult, imperative, replaceable]);
+    await Future.wait([activeResult, imperativeResult, replaceableResult]);
 
     expect(replacement.flushFlows, isEmpty);
     expect(controller.pendingDeviceWriteCount, 0);

--- a/test/services/webserver/admission_control_pressure_test.dart
+++ b/test/services/webserver/admission_control_pressure_test.dart
@@ -102,6 +102,22 @@ void main() {
     expect(gate.activeCount, 0);
   });
 
+  test('global accepted-request budget resets independently', () {
+    var now = 0;
+    final gate = _gate(globalRate: 2, perClientRate: 10, nowMs: () => now);
+
+    expect(gate.acquire('a'), AdmissionDecision.accepted);
+    gate.release('a');
+    expect(gate.acquire('b'), AdmissionDecision.accepted);
+    gate.release('b');
+    expect(gate.acquire('c'), AdmissionDecision.globalLimit);
+
+    now = 1000;
+    expect(gate.acquire('c'), AdmissionDecision.accepted);
+    gate.release('c');
+    expect(gate.activeCount, 0);
+  });
+
   test('WebSocket connection and handshake limits are exact', () async {
     var now = 0;
     final gate = _gate(
@@ -167,10 +183,21 @@ void main() {
       nowMs: () => now,
     );
     final rateConnected = StreamController<WebSocketChannel>.broadcast();
-    final rateHandler = admittedWebSocketHandler((channel, _) {
+    final rateAdmitted = admittedWebSocketHandler((channel, _) {
       channel.stream.listen((_) {});
       rateConnected.add(channel);
     }, gate: rateGate);
+    FutureOr<Response> rateHandler(Request request) {
+      final client = request.requestedUri.queryParameters['client'] ?? '1';
+      return rateAdmitted(
+        request.change(
+          context: {
+            'shelf.io.connection_info': _ConnectionInfo('10.0.1.$client'),
+          },
+        ),
+      );
+    }
+
     final rateServer = await shelf_io.serve(rateHandler, 'localhost', 0);
     addTearDown(() async {
       await rateConnected.close();
@@ -178,20 +205,29 @@ void main() {
     });
     final rateBase = 'ws://localhost:${rateServer.port}';
 
-    Future<(WebSocket, WebSocketChannel)> openRate() async {
+    Future<(WebSocket, WebSocketChannel)> openRate(String client) async {
       final serverSide = rateConnected.stream.first;
-      final socket = await WebSocket.connect(rateBase);
+      final socket = await WebSocket.connect('$rateBase?client=$client');
       return (socket, await serverSide);
     }
 
-    final rate1 = await openRate();
+    final rate1 = await openRate('1');
     await close(rate1);
-    final rate2 = await openRate();
+    final rate2 = await openRate('1');
     await close(rate2);
-    await _expectWebSocketRejection(rateBase, 429);
+    await _expectWebSocketRejection('$rateBase?client=1', 429);
     now = 1000;
-    final reset = await openRate();
+    final reset = await openRate('1');
     await close(reset);
+
+    final global2 = await openRate('2');
+    await close(global2);
+    final global3 = await openRate('3');
+    await close(global3);
+    await _expectWebSocketRejection('$rateBase?client=4', 503);
+    now = 2000;
+    final globalReset = await openRate('4');
+    await close(globalReset);
     expect(rateGate.activeCount, 0);
   });
 }

--- a/test/services/webserver/admission_control_pressure_test.dart
+++ b/test/services/webserver/admission_control_pressure_test.dart
@@ -69,7 +69,7 @@ void main() {
 
   test('client tracking stays bounded and expires exactly at the window', () {
     var now = 0;
-    final gate = _gate(nowMs: () => now);
+    final gate = _gate(globalRate: 1000, perClientRate: 1000, nowMs: () => now);
 
     for (var i = 0; i < 100; i++) {
       final key = 'client-$i';

--- a/test/services/webserver/admission_control_pressure_test.dart
+++ b/test/services/webserver/admission_control_pressure_test.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_plus/shelf_plus.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+final class _ConnectionInfo implements HttpConnectionInfo {
+  _ConnectionInfo(String address) : _address = InternetAddress(address);
+
+  final InternetAddress _address;
+
+  @override
+  InternetAddress get remoteAddress => _address;
+
+  @override
+  int get remotePort => 0;
+
+  @override
+  int get localPort => 0;
+}
+
+void main() {
+  test('100-request burst is bounded without an admission queue', () {
+    final gate = _gate();
+    var peakActive = 0;
+    var accepted = 0;
+    var rejected = 0;
+
+    for (var i = 0; i < 100; i++) {
+      final decision = gate.acquire('noisy');
+      if (decision == AdmissionDecision.accepted) {
+        accepted++;
+        peakActive = gate.activeCount > peakActive
+            ? gate.activeCount
+            : peakActive;
+      } else {
+        expect(decision, AdmissionDecision.perClientLimit);
+        rejected++;
+      }
+    }
+
+    expect(accepted, 2);
+    expect(rejected, 98);
+    expect(peakActive, 2);
+    expect(peakActive, lessThanOrEqualTo(4));
+    for (var i = 0; i < accepted; i++) {
+      gate.release('noisy');
+    }
+    expect(gate.activeCount, 0);
+  });
+
+  test('one client cannot consume another client capacity', () {
+    final gate = _gate();
+
+    expect(gate.acquire('a'), AdmissionDecision.accepted);
+    expect(gate.acquire('a'), AdmissionDecision.accepted);
+    expect(gate.acquire('a'), AdmissionDecision.perClientLimit);
+    expect(gate.acquire('b'), AdmissionDecision.accepted);
+    expect(gate.activeCount, 3);
+
+    gate.release('a');
+    gate.release('a');
+    gate.release('b');
+    expect(gate.activeCount, 0);
+  });
+
+  test('client tracking stays bounded and expires exactly at the window', () {
+    var now = 0;
+    final gate = _gate(nowMs: () => now);
+
+    for (var i = 0; i < 100; i++) {
+      final key = 'client-$i';
+      final decision = gate.acquire(key);
+      expect(gate.trackedClientCount, lessThanOrEqualTo(8));
+      if (decision == AdmissionDecision.accepted) gate.release(key);
+    }
+    expect(gate.trackedClientCount, 8);
+
+    now = 1000;
+    expect(gate.acquire('fresh'), AdmissionDecision.accepted);
+    expect(gate.trackedClientCount, 1);
+    gate.release('fresh');
+    expect(gate.activeCount, 0);
+  });
+
+  test('accepted-request budget resets without wall-clock delay', () {
+    var now = 0;
+    final gate = _gate(nowMs: () => now);
+
+    for (var i = 0; i < 4; i++) {
+      expect(gate.acquire('a'), AdmissionDecision.accepted);
+      gate.release('a');
+    }
+    expect(gate.acquire('a'), AdmissionDecision.perClientLimit);
+
+    now = 1000;
+    expect(gate.acquire('a'), AdmissionDecision.accepted);
+    gate.release('a');
+    expect(gate.activeCount, 0);
+  });
+
+  test('WebSocket connection and handshake limits are exact', () async {
+    var now = 0;
+    final gate = _gate(
+      globalConcurrent: 3,
+      perClientConcurrent: 2,
+      globalRate: 20,
+      perClientRate: 10,
+      nowMs: () => now,
+    );
+    final connected = StreamController<WebSocketChannel>.broadcast();
+    final admitted = admittedWebSocketHandler((channel, _) {
+      channel.stream.listen((_) {});
+      connected.add(channel);
+    }, gate: gate);
+    FutureOr<Response> handler(Request request) {
+      final client = request.requestedUri.queryParameters['client'] ?? 'a';
+      return admitted(
+        request.change(
+          context: {
+            'shelf.io.connection_info': _ConnectionInfo('10.0.0.$client'),
+          },
+        ),
+      );
+    }
+
+    final server = await shelf_io.serve(handler, 'localhost', 0);
+    addTearDown(() async {
+      await connected.close();
+      await server.close(force: true);
+    });
+    final base = 'ws://localhost:${server.port}';
+
+    Future<(WebSocket, WebSocketChannel)> open(String client) async {
+      final serverSide = connected.stream.first;
+      final socket = await WebSocket.connect('$base?client=$client');
+      return (socket, await serverSide);
+    }
+
+    Future<void> close((WebSocket, WebSocketChannel) pair) async {
+      await pair.$1.close();
+      await pair.$2.sink.done;
+    }
+
+    final a1 = await open('1');
+    final a2 = await open('1');
+    await _expectWebSocketRejection('$base?client=1', 429);
+    final b1 = await open('2');
+    await _expectWebSocketRejection('$base?client=2', 503);
+    expect(gate.activeCount, 3);
+
+    await close(a1);
+    final b2 = await open('2');
+    await close(a2);
+    await close(b1);
+    await close(b2);
+    expect(gate.activeCount, 0);
+
+    final rateGate = _gate(
+      globalConcurrent: 3,
+      perClientConcurrent: 3,
+      globalRate: 3,
+      perClientRate: 2,
+      nowMs: () => now,
+    );
+    final rateConnected = StreamController<WebSocketChannel>.broadcast();
+    final rateHandler = admittedWebSocketHandler((channel, _) {
+      channel.stream.listen((_) {});
+      rateConnected.add(channel);
+    }, gate: rateGate);
+    final rateServer = await shelf_io.serve(rateHandler, 'localhost', 0);
+    addTearDown(() async {
+      await rateConnected.close();
+      await rateServer.close(force: true);
+    });
+    final rateBase = 'ws://localhost:${rateServer.port}';
+
+    Future<(WebSocket, WebSocketChannel)> openRate() async {
+      final serverSide = rateConnected.stream.first;
+      final socket = await WebSocket.connect(rateBase);
+      return (socket, await serverSide);
+    }
+
+    final rate1 = await openRate();
+    await close(rate1);
+    final rate2 = await openRate();
+    await close(rate2);
+    await _expectWebSocketRejection(rateBase, 429);
+    now = 1000;
+    final reset = await openRate();
+    await close(reset);
+    expect(rateGate.activeCount, 0);
+  });
+}
+
+AdmissionGate _gate({
+  int globalConcurrent = 4,
+  int perClientConcurrent = 2,
+  int globalRate = 8,
+  int perClientRate = 4,
+  int maxTrackedClients = 8,
+  int Function()? nowMs,
+}) {
+  return AdmissionGate(
+    globalConcurrent: globalConcurrent,
+    perClientConcurrent: perClientConcurrent,
+    globalRate: globalRate,
+    perClientRate: perClientRate,
+    maxTrackedClients: maxTrackedClients,
+    nowMs: nowMs,
+  );
+}
+
+Future<void> _expectWebSocketRejection(String uri, int status) {
+  return expectLater(
+    WebSocket.connect(uri),
+    throwsA(
+      isA<WebSocketException>().having(
+        (error) => error.toString(),
+        'status',
+        contains('$status'),
+      ),
+    ),
+  );
+}

--- a/test/services/webserver/pressure_integration_test.dart
+++ b/test/services/webserver/pressure_integration_test.dart
@@ -85,6 +85,7 @@ void main() {
       release.complete();
       await activeWrite;
       expect((await mutation).statusCode, 200);
+      expect(de1Controller.pendingDeviceWriteCount, 0);
       final admitted = await handler(_request('GET', '/api/v1/info'));
       expect(admitted.statusCode, 200);
       expect(gate.activeCount, 0);

--- a/test/services/webserver/pressure_integration_test.dart
+++ b/test/services/webserver/pressure_integration_test.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_cors_headers/shelf_cors_headers.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+final class _ConnectionInfo implements HttpConnectionInfo {
+  _ConnectionInfo(String address) : _address = InternetAddress(address);
+
+  final InternetAddress _address;
+
+  @override
+  InternetAddress get remoteAddress => _address;
+
+  @override
+  int get remotePort => 0;
+
+  @override
+  int get localPort => 0;
+}
+
+void main() {
+  test(
+    'real API middleware rejects a burst and recovers after release',
+    () async {
+      final gate = AdmissionGate(
+        globalConcurrent: 2,
+        perClientConcurrent: 1,
+        globalRate: 10,
+        perClientRate: 10,
+        maxTrackedClients: 4,
+      );
+      final entered = Completer<void>();
+      final release = Completer<void>();
+      final router = Router().plus
+        ..get('/api/v1/info', (_) async {
+          entered.complete();
+          await release.future;
+          return Response.ok('info');
+        })
+        ..put('/api/v1/workflow', (Request request) async {
+          return Response.ok(await request.readAsString());
+        });
+      final handler = const Pipeline()
+          .addMiddleware(corsHeaders())
+          .addMiddleware(apiAdmissionMiddleware(gate))
+          .addHandler(router.call);
+      final get = handler(_request('GET', '/api/v1/info'));
+      await entered.future;
+
+      final rejected = await handler(
+        _request(
+          'PUT',
+          '/api/v1/workflow',
+          body: jsonEncode({
+            'rinseData': {'flow': 3.0},
+          }),
+        ),
+      );
+      expect(rejected.statusCode, 429);
+      expect(rejected.headers['retry-after'], '1');
+      expect(
+        rejected.headers['access-control-allow-origin'],
+        'http://localhost',
+      );
+
+      release.complete();
+      expect((await get).statusCode, 200);
+      final admitted = await handler(
+        _request(
+          'PUT',
+          '/api/v1/workflow',
+          body: jsonEncode({
+            'rinseData': {'flow': 3.0},
+          }),
+        ),
+      );
+      expect(admitted.statusCode, 200);
+      expect(gate.activeCount, 0);
+    },
+  );
+}
+
+Request _request(String method, String path, {Object? body}) {
+  return Request(
+    method,
+    Uri.parse('http://localhost$path'),
+    body: body,
+    headers: {'origin': 'http://localhost', 'content-type': 'application/json'},
+    context: {'shelf.io.connection_info': _ConnectionInfo('10.0.0.1')},
+  );
+}

--- a/test/services/webserver/pressure_integration_test.dart
+++ b/test/services/webserver/pressure_integration_test.dart
@@ -3,9 +3,16 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/services/webserver/info_handler.dart';
+import 'package:reaprime/src/services/webserver/workflow_handler.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
-import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 import 'package:shelf_plus/shelf_plus.dart';
+
+import '../../helpers/mock_device_discovery_service.dart';
 
 final class _ConnectionInfo implements HttpConnectionInfo {
   _ConnectionInfo(String address) : _address = InternetAddress(address);
@@ -35,23 +42,29 @@ void main() {
       );
       final entered = Completer<void>();
       final release = Completer<void>();
-      final router = Router().plus
-        ..get('/api/v1/info', (_) async {
-          entered.complete();
-          await release.future;
-          return Response.ok('info');
-        })
-        ..put('/api/v1/workflow', (Request request) async {
-          return Response.ok(await request.readAsString());
-        });
-      final handler = const Pipeline()
-          .addMiddleware(corsHeaders())
-          .addMiddleware(apiAdmissionMiddleware(gate))
-          .addHandler(router.call);
-      final get = handler(_request('GET', '/api/v1/info'));
-      await entered.future;
+      final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+      await deviceController.initialize();
+      addTearDown(deviceController.dispose);
+      final de1Controller = De1Controller(controller: deviceController);
+      addTearDown(de1Controller.dispose);
+      await de1Controller.connectToDe1(MockDe1());
+      await de1Controller.initSettled.firstWhere(
+        (generation) => generation != null,
+      );
 
-      final rejected = await handler(
+      final router = Router().plus;
+      InfoHandler().addRoutes(router);
+      WorkflowHandler(
+        controller: WorkflowController(),
+        de1controller: de1Controller,
+      ).addRoutes(router);
+      final handler = buildWebServerHandler(router.call, admissionGate: gate);
+      final activeWrite = de1Controller.runDeviceWrite((_) async {
+        entered.complete();
+        await release.future;
+      });
+      await entered.future;
+      final mutation = handler(
         _request(
           'PUT',
           '/api/v1/workflow',
@@ -60,6 +73,8 @@ void main() {
           }),
         ),
       );
+
+      final rejected = await handler(_request('GET', '/api/v1/info'));
       expect(rejected.statusCode, 429);
       expect(rejected.headers['retry-after'], '1');
       expect(
@@ -68,16 +83,9 @@ void main() {
       );
 
       release.complete();
-      expect((await get).statusCode, 200);
-      final admitted = await handler(
-        _request(
-          'PUT',
-          '/api/v1/workflow',
-          body: jsonEncode({
-            'rinseData': {'flow': 3.0},
-          }),
-        ),
-      );
+      await activeWrite;
+      expect((await mutation).statusCode, 200);
+      final admitted = await handler(_request('GET', '/api/v1/info'));
       expect(admitted.statusCode, 200);
       expect(gate.activeCount, 0);
     },

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -609,6 +609,40 @@ void main() {
       );
     });
 
+    test('interleaved partial patches preserve every final field', () async {
+      await _settleHandler(spy);
+      spy.updateShotSettingsCalls.clear();
+      spy.setSteamFlowCalls.clear();
+      spy.setHotWaterFlowCalls.clear();
+      spy.setFlushFlowCalls.clear();
+
+      for (final patch in [
+        {
+          'steamSettings': {'duration': 12},
+        },
+        {
+          'rinseData': {'flow': 3.0},
+        },
+        {
+          'steamSettings': {'duration': 16},
+        },
+        {
+          'hotWaterData': {'volume': 120},
+        },
+      ]) {
+        expect((await put(patch)).statusCode, 200);
+      }
+
+      final workflow = workflowController.currentWorkflow;
+      expect(workflow.steamSettings.duration, 16);
+      expect(workflow.rinseData.flow, 3.0);
+      expect(workflow.hotWaterData.volume, 120);
+      expect(spy.setFlushFlowCalls.last, 3.0);
+      expect(spy.updateShotSettingsCalls.last.targetSteamDuration, 16);
+      expect(spy.updateShotSettingsCalls.last.targetHotWaterVolume, 120);
+      expect(de1Controller.pendingDeviceWriteCount, 0);
+    });
+
     test('no-op PUT (same values) issues no DE1 writes', () async {
       await _settleHandler(spy);
       final snapshot = workflowController.currentWorkflow;

--- a/test/webserver/workflow_handler_test.dart
+++ b/test/webserver/workflow_handler_test.dart
@@ -616,10 +616,15 @@ void main() {
       spy.setHotWaterFlowCalls.clear();
       spy.setFlushFlowCalls.clear();
 
-      for (final patch in [
-        {
-          'steamSettings': {'duration': 12},
-        },
+      spy.blockedSteamFlow = 1.5;
+      spy.steamFlowEntered = Completer<void>();
+      spy.steamFlowRelease = Completer<void>();
+      final first = put({
+        'steamSettings': {'flow': 1.5},
+      });
+      await spy.steamFlowEntered!.future;
+      workflowController.updateWorkflow(description: 'concurrent revision');
+      final pending = [
         {
           'rinseData': {'flow': 3.0},
         },
@@ -629,14 +634,21 @@ void main() {
         {
           'hotWaterData': {'volume': 120},
         },
-      ]) {
-        expect((await put(patch)).statusCode, 200);
-      }
+      ].map(put).toList();
+      spy.steamFlowRelease!.complete();
+      final responses = await Future.wait([first, ...pending]);
+      expect(
+        responses.map((response) => response.statusCode),
+        everyElement(200),
+      );
 
       final workflow = workflowController.currentWorkflow;
+      expect(workflow.description, 'concurrent revision');
+      expect(workflow.steamSettings.flow, 1.5);
       expect(workflow.steamSettings.duration, 16);
       expect(workflow.rinseData.flow, 3.0);
       expect(workflow.hotWaterData.volume, 120);
+      expect(spy.setSteamFlowCalls.last, 1.5);
       expect(spy.setFlushFlowCalls.last, 3.0);
       expect(spy.updateShotSettingsCalls.last.targetSteamDuration, 16);
       expect(spy.updateShotSettingsCalls.last.targetHotWaterVolume, 120);


### PR DESCRIPTION
## Summary

What changed, and why?

- Add deterministic pressure coverage for exact API, WebSocket, client-map, and DE1 queue bounds.
- Cover 1000-write coalescing, timeout serialization, reconnect identity, stale completions, idle, firmware exclusivity, and DE1/scale independence.
- Exercise API pressure through the production middleware composition and real info/workflow route registration.
- Exercise overlapping workflow mutations while the first physical write is blocked and the workflow revision changes.
- Add a finite simulator pressure scenario for the chatty-client behavior reported in #678.
- Bound every scenario network call, require the WebSocket process to remain alive, and require telemetry to advance during the burst.
- Retry idle and final recovery only for documented admission responses; fail immediately on other statuses.
- Prove process-global and per-client API/WebSocket rate windows reset independently.
- Assert pressure tests drain admission and DE1 resources before completion.

This draft is stacked on #686 and #687 because it verifies the concrete contracts introduced by both implementation changes.

## Linked Issue

Fixes #688

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- Focused governor, MockDe1 pressure, admission, bounded-body, and production middleware run: 64 tests passed.
- All Bash blocks in the pressure scenario pass `bash -n` using Git Bash.
- `flutter analyze --no-pub` completed with no issues.
- Current USB-tablet simulator run: 500/500 requests accounted for, all 20 control probes remained responsive, telemetry grew from 28 to 222 snapshots while the socket stayed alive, final workflow values matched, idle succeeded, and MockDe1 remained connected.
- Full Windows suite reached 3199 passing and 1 skipped; 220 unrelated checkout/environment failures remain, dominated by the unavailable `quickjs_c_bridge.dll` and CRLF-sensitive fixtures.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Adds a testable entry point for the existing production middleware composition while preserving auth, body-error, admission, logging, and CORS ordering.
- No dependency or migration is added.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->