### PR TITLE
fix(account): block proxy traffic when stored credentials are known-invalid

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -446,6 +446,7 @@ void main(List<String> args) async {
       requireConsent: gate.requireConsent,
       baseUrl: decentBaseUrl,
       onAuthFailure: () => decentAccountService!.reportAuthenticationFailure(),
+      isAuthKnownInvalid: decentAccountService!.isAuthKnownInvalid,
     );
     accountTokensController = AccountTokensController(
       tokenService: proxyTokenService,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -446,7 +446,7 @@ void main(List<String> args) async {
       requireConsent: gate.requireConsent,
       baseUrl: decentBaseUrl,
       onAuthFailure: () => decentAccountService!.reportAuthenticationFailure(),
-      isAuthKnownInvalid: decentAccountService!.isAuthKnownInvalid,
+      isAuthKnownInvalid: decentAccountService.isAuthKnownInvalid,
     );
     accountTokensController = AccountTokensController(
       tokenService: proxyTokenService,

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
 
 List<String> parseSerialNumbers(String body) {
   return const LineSplitter()
@@ -29,6 +30,7 @@ class DecentAccountService {
   final CredentialStore _store;
   final String baseUrl;
   final Duration retryInterval;
+  final Logger _log = Logger('DecentAccount');
 
   bool? _authenticated;
   Future<bool>? _validationFuture;
@@ -55,8 +57,10 @@ class DecentAccountService {
       await _store.write(key: 'password', value: response.body.trim());
       _authGeneration++;
       _authenticated = true;
+      _log.info('login -> accepted');
       return true;
     }
+    _log.warning('login -> rejected');
     return false;
   }
 
@@ -98,6 +102,7 @@ class DecentAccountService {
     final email = await _store.read(key: 'email');
     final password = await _store.read(key: 'password');
     if (email == null || password == null) {
+      _log.info('validation -> indeterminate');
       _setAuthenticated(generation, false);
       return false;
     }
@@ -105,14 +110,24 @@ class DecentAccountService {
     try {
       response = await _authedGet(email, password, '/support/api/login_test');
     } catch (_) {
+      _log.info('validation -> indeterminate');
       return _authenticated ?? false;
     }
     final valid = response.statusCode == 200 && response.body.trim() != '0';
     final rejected =
         response.statusCode == 401 ||
         (response.statusCode == 200 && response.body.trim() == '0');
-    if (!valid && !rejected) return _authenticated ?? false;
-    _setAuthenticated(generation, valid);
+    if (!valid && !rejected) {
+      _log.info('validation -> indeterminate');
+      return _authenticated ?? false;
+    }
+    if (valid) {
+      _log.info('validation -> accepted');
+      _setAuthenticated(generation, valid);
+      return _authenticated ?? false;
+    }
+    _log.info('validation -> rejected');
+    _setAuthenticated(generation, false);
     return _authenticated ?? false;
   }
 
@@ -124,6 +139,8 @@ class DecentAccountService {
     _authGeneration++;
     _authenticated = false;
   }
+
+  Future<bool> isAuthKnownInvalid() async => _authenticated == false;
 
   Future<String?> getEmail() async => _store.read(key: 'email');
 

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -102,7 +102,7 @@ class DecentAccountService {
     final email = await _store.read(key: 'email');
     final password = await _store.read(key: 'password');
     if (email == null || password == null) {
-      _log.info('validation -> indeterminate');
+      _log.info('validation -> no stored credentials (account not linked)');
       _setAuthenticated(generation, false);
       return false;
     }

--- a/lib/src/services/account/decent_proxy_service.dart
+++ b/lib/src/services/account/decent_proxy_service.dart
@@ -12,6 +12,12 @@ class DecentAccountNotLinkedException implements Exception {
   String toString() => 'DecentAccountNotLinkedException: no account linked';
 }
 
+class DecentAccountAuthInvalidException implements Exception {
+  @override
+  String toString() =>
+      'DecentAccountAuthInvalidException: stored credentials are known-invalid';
+}
+
 class DecentProxyForbiddenPathException implements Exception {
   final String path;
   DecentProxyForbiddenPathException(this.path);
@@ -47,6 +53,7 @@ class DecentProxyService {
   final RequireAccountConsent _requireConsent;
   final String baseUrl;
   final void Function()? onAuthFailure;
+  final Future<bool> Function()? isAuthKnownInvalid;
 
   final Set<String> allowedPrefixes;
 
@@ -71,6 +78,7 @@ class DecentProxyService {
     this.baseUrl = 'https://decentespresso.com',
     this.allowedPrefixes = const {'support/api/'},
     this.onAuthFailure,
+    this.isAuthKnownInvalid,
   }) : _httpClient = httpClient,
        _store = credentialStore,
        _requireConsent = requireConsent;
@@ -102,6 +110,13 @@ class DecentProxyService {
 
     if (await _credentials() == null) {
       throw DecentAccountNotLinkedException();
+    }
+
+    if (await isAuthKnownInvalid?.call() ?? false) {
+      _log.warning(
+        'caller=$callerId $normalizedMethod /$normalizedPath -> blocked, credentials known-invalid',
+      );
+      throw DecentAccountAuthInvalidException();
     }
 
     if (!await _requireConsent(callerId)) {

--- a/lib/src/services/webserver/account_proxy_handler.dart
+++ b/lib/src/services/webserver/account_proxy_handler.dart
@@ -34,6 +34,10 @@ class AccountProxyHandler {
       );
     } on DecentAccountNotLinkedException {
       return jsonUnauthorized({'error': 'Decent account not linked'});
+    } on DecentAccountAuthInvalidException {
+      return jsonUnauthorized({
+        'error': 'Decent account credentials are invalid',
+      });
     } on DecentProxyForbiddenPathException {
       return jsonForbidden({'error': 'Path not allowed'});
     } on DecentProxyConsentDeniedException {
@@ -77,6 +81,10 @@ class AccountProxyHandler {
       );
     } on DecentAccountNotLinkedException {
       return jsonUnauthorized({'error': 'Decent account not linked'});
+    } on DecentAccountAuthInvalidException {
+      return jsonUnauthorized({
+        'error': 'Decent account credentials are invalid',
+      });
     } on DecentProxyForbiddenPathException {
       return jsonForbidden({'error': 'Path not allowed'});
     } on DecentProxyConsentDeniedException {

--- a/test/services/account/decent_proxy_service_test.dart
+++ b/test/services/account/decent_proxy_service_test.dart
@@ -543,12 +543,27 @@ void main() {
   );
 
   test('successful login restores proxy access after a block', () async {
-    await linkAccount();
-    var authInvalid = true;
+    await store.write(key: 'email', value: 'old@example.com');
+    await store.write(key: 'password', value: 'stale_cryptpw');
+    final oldAuth = base64Encode(utf8.encode('old@example.com:stale_cryptpw'));
+    final accountService = DecentAccountService(
+      httpClient: http_testing.MockClient((request) async {
+        if (request.headers['authorization'] == 'Basic $oldAuth') {
+          return http.Response('0\n', 200); // rejected
+        }
+        return http.Response('newcryptpw\n', 200); // accepted
+      }),
+      credentialStore: store,
+    );
+
+    // Stale stored credentials are rejected by validation: auth is
+    // known-invalid and the proxy blocks locally.
+    expect(await accountService.verifyStoredCredentials(), isFalse);
+    expect(await accountService.isAuthKnownInvalid(), isTrue);
 
     final service = buildService(
       (request) async => http.Response('ok', 200),
-      isAuthKnownInvalid: () async => authInvalid,
+      isAuthKnownInvalid: () => accountService.isAuthKnownInvalid(),
     );
 
     await expectLater(
@@ -556,7 +571,9 @@ void main() {
       throwsA(isA<DecentAccountAuthInvalidException>()),
     );
 
-    authInvalid = false;
+    // A successful login flips the real auth state; proxy traffic flows again.
+    expect(await accountService.login('new@example.com', 'goodpw'), isTrue);
+    expect(await accountService.isAuthKnownInvalid(), isFalse);
 
     final response = await service.proxyGet(
       callerId: 'skin',

--- a/test/services/account/decent_proxy_service_test.dart
+++ b/test/services/account/decent_proxy_service_test.dart
@@ -43,6 +43,7 @@ void main() {
     String baseUrl = 'https://decentespresso.com',
     Future<bool> Function(String callerId) requireConsent = _allowConsent,
     void Function()? onAuthFailure,
+    Future<bool> Function()? isAuthKnownInvalid,
   }) {
     return DecentProxyService(
       httpClient: http_testing.MockClient(handler),
@@ -50,6 +51,7 @@ void main() {
       requireConsent: requireConsent,
       baseUrl: baseUrl,
       onAuthFailure: onAuthFailure,
+      isAuthKnownInvalid: isAuthKnownInvalid,
     );
   }
 
@@ -505,5 +507,111 @@ void main() {
     await service.proxyGet(callerId: 'skin', path: 'support/api/sn');
 
     expect(failures, 0);
+  });
+
+  test('forwards when auth is not known-invalid', () async {
+    await linkAccount();
+    final service = buildService(
+      (request) async => http.Response('ok', 200),
+      isAuthKnownInvalid: () async => false,
+    );
+
+    final response = await service.proxyGet(
+      callerId: 'skin',
+      path: 'support/api/sn',
+    );
+
+    expect(response.statusCode, 200);
+  });
+
+  test(
+    'blocks known-invalid credentials locally without upstream traffic',
+    () async {
+      await linkAccount();
+      final service = buildService((request) async {
+        fail(
+          'must not call upstream when credentials are known-invalid: '
+          '${request.url}',
+        );
+      }, isAuthKnownInvalid: () async => true);
+
+      await expectLater(
+        service.proxyGet(callerId: 'skin', path: 'support/api/sn'),
+        throwsA(isA<DecentAccountAuthInvalidException>()),
+      );
+    },
+  );
+
+  test('successful login restores proxy access after a block', () async {
+    await linkAccount();
+    var authInvalid = true;
+
+    final service = buildService(
+      (request) async => http.Response('ok', 200),
+      isAuthKnownInvalid: () async => authInvalid,
+    );
+
+    await expectLater(
+      service.proxyGet(callerId: 'skin', path: 'support/api/sn'),
+      throwsA(isA<DecentAccountAuthInvalidException>()),
+    );
+
+    authInvalid = false;
+
+    final response = await service.proxyGet(
+      callerId: 'skin',
+      path: 'support/api/sn',
+    );
+    expect(response.statusCode, 200);
+  });
+
+  test(
+    'upstream 401 invalidates auth and the next proxy call is blocked',
+    () async {
+      await linkAccount();
+      var authInvalid = false;
+      var upstreamCalls = 0;
+
+      final service = buildService(
+        (request) async {
+          upstreamCalls++;
+          if (upstreamCalls == 1) {
+            return http.Response('unauthorized', 401);
+          } else {
+            fail('must not call upstream after auth is known-invalid');
+          }
+        },
+        onAuthFailure: () => authInvalid = true,
+        isAuthKnownInvalid: () async => authInvalid,
+      );
+
+      final response = await service.proxyGet(
+        callerId: 'skin',
+        path: 'support/api/sn',
+      );
+      expect(response.statusCode, 401);
+      expect(upstreamCalls, 1);
+
+      await expectLater(
+        service.proxyGet(callerId: 'skin', path: 'support/api/sn'),
+        throwsA(isA<DecentAccountAuthInvalidException>()),
+      );
+      expect(upstreamCalls, 1);
+    },
+  );
+
+  test('indeterminate auth state does not block proxy traffic', () async {
+    await linkAccount();
+    final service = buildService(
+      (request) async => http.Response('ok', 200),
+      isAuthKnownInvalid: () async => false,
+    );
+
+    final response = await service.proxyGet(
+      callerId: 'skin',
+      path: 'support/api/sn',
+    );
+
+    expect(response.statusCode, 200);
   });
 }

--- a/test/webserver/account_proxy_handler_test.dart
+++ b/test/webserver/account_proxy_handler_test.dart
@@ -115,6 +115,68 @@ void main() {
     expect(upstream, isNull);
   });
 
+  test('known-invalid credentials through GET proxy return 401', () async {
+    await linkAccount();
+    final app = Router().plus;
+    final proxy = DecentProxyService(
+      requireConsent: (_) async => true,
+      httpClient: http_testing.MockClient((request) async {
+        upstream = request;
+        return http.Response('SN001\nSN002', 200);
+      }),
+      credentialStore: store,
+      isAuthKnownInvalid: () async => true,
+    );
+    AccountProxyHandler(proxy: proxy).addRoutes(app);
+    handler = const Pipeline()
+        .addMiddleware(proxyAuthMiddleware(tokens))
+        .addHandler(app.call);
+
+    final response = await get(
+      '/api/v1/account/proxy/support/api/sn',
+      token: 'skin-token',
+    );
+
+    expect(response.statusCode, 401);
+    final body = jsonDecode(await response.readAsString());
+    expect(body['error'], contains('credentials are invalid'));
+    expect(upstream, isNull);
+  });
+
+  test('known-invalid credentials through write proxy return 401', () async {
+    await linkAccount();
+    registerWriteToken();
+    final app = Router().plus;
+    final proxy = DecentProxyService(
+      requireConsent: (_) async => true,
+      httpClient: http_testing.MockClient((request) async {
+        upstream = request;
+        return http.Response('SN001\nSN002', 200);
+      }),
+      credentialStore: store,
+      isAuthKnownInvalid: () async => true,
+    );
+    AccountProxyHandler(proxy: proxy, enableWrites: true).addRoutes(app);
+    handler = const Pipeline()
+        .addMiddleware(proxyAuthMiddleware(tokens))
+        .addHandler(app.call);
+
+    for (final method in ['POST', 'PUT']) {
+      final response = await send(
+        method,
+        '/api/v1/account/proxy/support/api/email',
+        token: 'write-token',
+        body: '{"subject":"hi"}',
+        contentType: 'application/json',
+      );
+
+      expect(response.statusCode, 401);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['error'], contains('credentials are invalid'));
+      expect(upstream, isNull);
+    }
+  });
+
   test(
     'authenticated + linked forwards with Basic auth and relays body',
     () async {


### PR DESCRIPTION
## Summary

What changed, and why?

- `DecentAccountService` exposes `isAuthKnownInvalid()` and logs accepted / rejected / indeterminate outcomes for login and stored-credential validation (no secrets in logs).
- `DecentProxyService` gains an optional `isAuthKnownInvalid` hook. In `proxy()`, right after the not-linked check and before consent, known-invalid credentials fail locally with `DecentAccountAuthInvalidException` and a warning log instead of being sent upstream again.
- `lib/main.dart` wires the account service hook into the proxy.
- Tests cover: valid creds forward; known-invalid blocks locally with zero upstream traffic; an upstream 401 invalidates auth and the next call blocks; successful login restores access; indeterminate (network/5xx) state still forwards.

## Linked Issue

Fixes #704

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `flutter test` full suite: 3420 passed, 1 skipped
- `flutter analyze`: no issues
- `dart format --set-exit-if-changed` on the four changed files: clean
- Focused suites: `decent_proxy_service_test.dart` (28 tests incl. 5 new), `decent_account_service_test.dart` (46 tests, incl. existing failed-login-preserves-account coverage)

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- User-visible: after a definitive auth rejection (401 or login_test rejection), plugin/shot-upload proxy calls fail fast with a clear account error instead of repeated upstream 401s. Successful login or revalidation restores traffic immediately.
- None: no API/spec changes, no schema/migration, no skins/profiles/plugin-event changes, no credentials in logs.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->