### PR TITLE
fix(profiles): give A-Flow Pause a 15s timeout after 2nd Fill (#580)

### DIFF
--- a/assets/defaultProfiles/A-Flow____default-dark.json
+++ b/assets/defaultProfiles/A-Flow____default-dark.json
@@ -85,7 +85,7 @@
       "transition": "fast",
       "temperature": "95.0",
       "sensor": "coffee",
-      "seconds": "0.0",
+      "seconds": "15.0",
       "volume": "100.0",
       "weight": "0.0",
       "pressure": "1.0",

--- a/assets/defaultProfiles/A-Flow____default-light.json
+++ b/assets/defaultProfiles/A-Flow____default-light.json
@@ -85,7 +85,7 @@
       "transition": "fast",
       "temperature": "95.0",
       "sensor": "coffee",
-      "seconds": "0.0",
+      "seconds": "15.0",
       "volume": "100.0",
       "weight": "0.0",
       "pressure": "1.0",

--- a/assets/defaultProfiles/A-Flow____default-like-dflow.json
+++ b/assets/defaultProfiles/A-Flow____default-like-dflow.json
@@ -85,7 +85,7 @@
       "transition": "fast",
       "temperature": "95.0",
       "sensor": "coffee",
-      "seconds": "0.0",
+      "seconds": "15.0",
       "volume": "100.0",
       "weight": "0.0",
       "pressure": "1.0",

--- a/assets/defaultProfiles/A-Flow____default-medium.json
+++ b/assets/defaultProfiles/A-Flow____default-medium.json
@@ -85,7 +85,7 @@
       "transition": "fast",
       "temperature": "95.0",
       "sensor": "coffee",
-      "seconds": "0.0",
+      "seconds": "15.0",
       "volume": "100.0",
       "weight": "0.0",
       "pressure": "1.0",

--- a/assets/defaultProfiles/A-Flow____default-very-dark.json
+++ b/assets/defaultProfiles/A-Flow____default-very-dark.json
@@ -85,7 +85,7 @@
       "transition": "fast",
       "temperature": "95.0",
       "sensor": "coffee",
-      "seconds": "0.0",
+      "seconds": "15.0",
       "volume": "100.0",
       "weight": "0.0",
       "pressure": "1.0",

--- a/test/profiles/default_profiles_bundled_test.dart
+++ b/test/profiles/default_profiles_bundled_test.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/data/profile.dart'
+    show ExitCondition, ExitType, Profile;
 import 'package:reaprime/src/models/data/profile_hash.dart';
 
 void main() {
@@ -68,6 +69,64 @@ void main() {
       );
       byHash[hash] = entry.key;
     }
+  });
+
+  test('A-Flow Pause after 2nd Fill has a 15s timeout, not zero', () {
+    // Issue #580: on DE1, a zero-duration frame with a machine-side exit
+    // times out on the next control tick instead of waiting for the exit.
+    // The official A-Flow generator assigns this Pause a 15s timeout.
+    const expected = 15.0;
+    final checked = <String>[];
+    for (final entry in profiles.entries) {
+      final steps = entry.value.steps;
+      for (var i = 1; i < steps.length - 1; i++) {
+        final prev = steps[i - 1];
+        final step = steps[i];
+        final next = steps[i + 1];
+        if (prev.name != '2nd Fill' ||
+            step.name != 'Pause' ||
+            next.name != 'Pressure Up') {
+          continue;
+        }
+        checked.add(entry.key);
+        expect(
+          step.exit,
+          isNotNull,
+          reason: '${entry.key}: Pause must keep its machine-side exit',
+        );
+        expect(
+          step.seconds,
+          expected,
+          reason: '${entry.key}: Pause must cap at 15s instead of timing out',
+        );
+        expect(
+          step.exit!.type,
+          ExitType.flow,
+          reason: '${entry.key}: Pause exit must remain flow-under',
+        );
+        expect(
+          step.exit!.condition,
+          ExitCondition.under,
+          reason: '${entry.key}: Pause exit must remain flow-under',
+        );
+        expect(
+          step.exit!.value,
+          1.0,
+          reason: '${entry.key}: Pause exit must remain flow < 1.0',
+        );
+      }
+    }
+    expect(checked, isNotEmpty, reason: 'expected at least one A-Flow variant');
+    expect(
+      checked,
+      containsAll(<String>[
+        'A-Flow____default-dark.json',
+        'A-Flow____default-light.json',
+        'A-Flow____default-like-dflow.json',
+        'A-Flow____default-medium.json',
+        'A-Flow____default-very-dark.json',
+      ]),
+    );
   });
 
   test('the four Baseline variants are present with canonical titles', () {


### PR DESCRIPTION
## Summary

Fixes issue #580. On DE1, a zero-duration frame with a machine-side exit (`FrameLen == 0`) is not a "wait indefinitely for condition" semantic: the frame survives its entry tick, then times out on the next control tick, and the following `Pressure Up` frame can be evaluated in the same sequencer call with the same stale flow sample — skipping that stage too.

The official A-Flow generator works around this by assigning the Pause a **15 second timeout** when the second-fill sequence is enabled. This PR applies the same fix on the Decaid profile side: the `Pause` step after `2nd Fill` in all five bundled A-Flow variants goes from `seconds: 0` to `seconds: 15`, keeping its `flow < 1.0 ml/s` exit as the condition with a 15s maximum timeout.

## Linked Issue

Fixes #580

## Verification

- `dart format` — no changes needed
- `flutter analyze` — clean (only pre-existing missing plugin-asset warning in pubspec.yaml, untouched)
- `test/profiles/default_profiles_bundled_test.dart` — new regression test asserts every bundled A-Flow profile with the `2nd Fill -> Pause -> Pressure Up` sequence has `Pause.seconds == 15.0` and keeps its flow-under-1.0 exit
- Confirmed the new test **fails against the old profiles** (`Expected: <15.0>`) and passes after the fix
- `test/profiles/` — 13/13 pass; full suite: 3489 pass, 31 pre-existing failures all in `test/plugins/*` (missing `assets/plugins/shot-upload.reaplugin/` dir, unrelated)

## Impact

Profile-content change only. On startup, existing installations seed the corrected A-Flow defaults under their new content hashes and retire the previous bundled versions. Existing user-created/imported profiles and workflows that already embed the old A-Flow profile are not modified; re-selecting the updated bundled A-Flow profile applies the fix.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
