### PR TITLE
fix(attach): USB machine intent wins over preferred BLE during automatic connection (#659)

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -253,6 +253,33 @@ failed attachments preserve the previous preference and return control to the
 existing preferred-machine recovery policy (or surface the normal connection
 failure). A connected machine is never replaced.
 
+USB intent is latched on the attach event, before the 500 ms settle delay, and
+automatic preferred-machine selection is paused while latched:
+`AttachReconnectCoordinator.onLatched` cancels the machine reconnect timer and
+supersedes an in-flight automatic/adapter-recovery attempt (generation bump +
+`stopScan`). Automatic connects are refused at `connectMachine` and deferred at
+`_executeConnect` while latched; explicit direct connects, explicit scans, and
+scale-only work are untouched. The `_activeAutomaticMachineAttempt` gate
+requires an active `_isConnecting` operation with automatic/adapter-recovery
+intent, so the sticky default status intent cannot misclassify a direct REST or
+picker connect. A machine connected by the superseded attempt inside the
+settle window is released through the intentional `disconnectMachine()` path
+(both the tracked-connect and remembered quick-connect routes) before the
+queued probe runs, so a BLE connect that finishes mid-window cannot win.
+`_shouldAttemptAttachReconnect` treats that transient machine as
+not-established so settle expiry queues the attach instead of skipping it. A
+single completion helper clears the latch, consumes the supersession marker,
+and resumes whatever the latch interrupted — replaying a deferred automatic
+connect or re-arming recovery.
+
+Startup ordering matters: `ConnectionManager` (and the coordinator
+subscription) is constructed before onboarding initializes `DeviceController`,
+and `DeviceController` subscribes to each service's attach stream before
+awaiting its `initialize()`. `SerialServiceAndroid.initialize()` therefore
+emits one metadata-free startup hint for a non-empty enumeration, and the hint
+flows through the existing latch → settle → probe → adopt path before the
+onboarding scan step calls `connect()`.
+
 Attach attempts never run in parallel with another connect. An attach arriving
 while an automatic/recovery connect is in flight supersedes that scan via the
 existing generation mechanism and runs one coalesced probe as soon as the

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -219,7 +219,10 @@ Detach and unknown USB actions do not emit attach hints.
 `DeviceController` aggregates notifier streams without adding attach events to
 the required `DeviceScanner` interface. A scanner exposes attach hints only when
 it also implements `DeviceAttachNotifier`, so BLE, Wi-Fi, and simulated scanners
-remain unchanged.
+remain unchanged. It subscribes to each service's attach stream before awaiting
+that service's `initialize()`, so an attach hint emitted from inside
+initialization (such as the serial service's startup enumeration hint) is not
+lost.
 
 `AttachReconnectCoordinator` owns the attach subscription, configurable 500 ms
 settle timer, burst coalescing, in-flight guard, and disposal. Disposal waits
@@ -247,13 +250,28 @@ adopts the connected machine, and persists its USB device id as the preferred
 machine. A stale BLE preference, a different preferred USB machine, a
 simulated preference, or no preference at all are all overridden by the
 physically attached machine; no BLE scan runs and no machine picker opens.
+
+USB intent is latched as soon as the attach event is received, not at settle
+expiry. `AttachReconnectCoordinator.onLatched` arms while `ConnectionManager`
+pauses passive automatic selection: the machine reconnect timer is cancelled,
+and an in-flight automatic/adapter-recovery attempt is superseded through the
+scan-generation mechanism and `stopScan()`. While latched, automatic machine
+connects are refused at `connectMachine()` and deferred at `_executeConnect`;
+explicit direct connects, explicit scans, and scale-only work are not
+interrupted. A machine that an already-superseded automatic attempt connects
+inside the settle window is released through the intentional disconnect path
+before the queued probe runs, so the USB machine cannot lose the race to a BLE
+connection that completes mid-window.
 An attached machine that fails to connect preserves the previous preference
 and returns control to the existing preferred-machine recovery policy (or
 surfaces the normal machine-connection failure when no preference exists).
 Unsupported or uncorrelated attachments change nothing — no scan, no picker,
 no preference update, and an already scheduled recovery attempt is left
 alone. A machine that is already connected is never replaced; the attach
-attempt re-checks before executing.
+attempt re-checks before executing. When the latch pauses an interrupted
+automatic connect or recovery attempt and the probe does not adopt a machine,
+the interrupted automatic policy resumes (recovery re-arms its reconnect
+timer, or the deferred automatic connect replays) once the latch clears.
 
 When the probe capability is unavailable (a notifier-only scanner, or a
 `DeviceController` whose originating service cannot probe), the original
@@ -268,6 +286,16 @@ is superseded through the existing scan-generation mechanism, while explicit
 user scans and scale-only connects are waited out. The queued probe runs
 before other drained work, re-checks that no machine connected meanwhile, and
 never runs in parallel with another connect.
+
+At startup, `SerialServiceAndroid.initialize()` subscribes to the platform USB
+event stream before enumerating (closing the list-versus-listener gap) and,
+when enumeration finds devices, emits one metadata-free startup attach hint.
+The hint reuses the latch → settle → probe → adopt path, so a supported USB
+DE1 already attached before Decaid starts takes priority over a saved BLE
+preference. One generic hint is deliberate: the coordinator keeps only the
+latest burst event, and a null-id event makes the probe inspect all not-yet-
+known USB devices; an unrelated keyboard or scale still resolves to
+"unsupported" and the normal policy continues.
 
 The original incident showed 20.3 seconds between USB enumeration and connection
 because recovery was waiting for its backoff timer; the existing backoff can

--- a/doc/plans/archive/659-usb-latch-vs-preferred-ble/2026-08-28-design.md
+++ b/doc/plans/archive/659-usb-latch-vs-preferred-ble/2026-08-28-design.md
@@ -259,3 +259,13 @@ No REST/WebSocket/DB/skin/plugin changes.
   during the latch window. An abort hook inside
   `DeviceController.connectToDe1` or the transport is more invasive and is not
   recommended.
+
+## Known follow-up (post-review)
+
+- A direct explicit `connectMachine()` is intentionally allowed while an
+  attach probe is in flight. A successful serial probe has already opened the
+  USB transport before it returns, so an explicit BLE connect can overlap it;
+  depending on completion order, `De1Controller` replaces its current machine
+  reference without disconnecting the other physical transport. Closing this
+  needs a larger serialization of machine adoption across transports; tracked
+  as a follow-up rather than folded into #659.

--- a/doc/plans/archive/659-usb-latch-vs-preferred-ble/2026-08-28-design.md
+++ b/doc/plans/archive/659-usb-latch-vs-preferred-ble/2026-08-28-design.md
@@ -1,0 +1,261 @@
+# USB machine intent can lose to preferred BLE machine during automatic connection (issue #659)
+
+## Problem
+
+`AttachReconnectCoordinator` waits the USB settle delay (500 ms) before probing,
+and only then supersedes the automatic preferred-machine path. During that
+window the automatic path can find and connect the saved preferred BLE machine.
+At settle expiry `shouldAttempt()` returns false (machine connected), the attach
+attempt is skipped, and the USB DE1 loses.
+
+Second gap: `SerialServiceAndroid.initialize()` enumerates an already-attached
+USB DE1 but never emits a `DeviceAttachedEvent`, so a saved BLE preference wins
+at startup.
+
+## Root cause
+
+1. USB intent is not latched until settle expiry, so the automatic path is never
+   told to stand down during the window.
+2. The supersession mechanism (`_explicitScanGeneration` bump + `stopScan()` in
+   `ConnectionManager._attemptAttachReconnect`) only kills in-flight scans, not
+   a transport connect that already selected the BLE machine.
+3. Remembered-machine quick-connect bypasses `connectMachine()` and adopts the
+   returned machine directly, so a gate in `connectMachine()` alone cannot
+   pause all automatic machine selection.
+4. Startup enumeration results are logged and dropped. Additionally,
+   `DeviceController.initialize()` subscribes to each service's attach stream
+   only after awaiting that service's `initialize()`, so an event emitted from
+   `SerialServiceAndroid.initialize()` would currently be lost.
+
+## Design
+
+### Rule
+
+When Android reports a USB attachment (or enumeration finds one at startup) and
+no machine is connected, the USB intent is latched immediately. While latched,
+passive automatic preferred-machine selection is paused. After the settle delay
+the existing probe/adoption path runs. Unsupported or failed probes clear the
+latch and resume only automatic work that the latch interrupted. A machine
+connected by a superseded automatic attempt during the window is released
+before the probe runs. Explicit direct connects, explicit scans, scale-only
+work, and already-established machine connections are not superseded.
+
+### 1. `AttachReconnectCoordinator` — latch on attach, not on settle
+
+Add two optional callbacks:
+
+- `onLatched` — called synchronously when the first event of a coalesced burst
+  passes `shouldAttempt()` and arms the settle timer.
+- `onSettled` — called when settle expiry skips the attempt because
+  `!shouldAttempt()`, allowing the manager to clear a latch that lost to a
+  non-superseded explicit or already-established machine connection.
+
+Burst coalescing, in-flight absorption, `_pendingEvent` replacement, and the
+settle-time re-check remain unchanged.
+
+### 2. `ConnectionManager` — own the latch and active automatic attempt
+
+New state:
+
+- `bool _usbAttachLatched = false` — set by `onLatched`, cleared only after the
+  actual probe/fallback lifecycle finishes (including a queued probe).
+- `bool _automaticMachineAttemptSuperseded = false` — marks the currently
+  active automatic/adapter-recovery machine attempt for release; consumed on
+  every completion outcome so it cannot affect a later attempt.
+- `bool _resumeAutomaticAfterUsbAttach = false` — records that startup,
+  recovery, or another automatic machine attempt was paused or superseded and
+  must resume if USB adoption does not succeed.
+
+Use active operation ownership rather than `currentStatus.intent` alone:
+
+```dart
+bool get _activeAutomaticMachineAttempt =>
+    _isConnecting &&
+    !_activeScaleOnlyScan &&
+    (currentStatus.intent == ConnectionIntent.automatic ||
+        currentStatus.intent == ConnectionIntent.adapterRecovery);
+```
+
+The `_isConnecting` requirement prevents the sticky/default status intent from
+misclassifying direct REST or picker connects as automatic.
+
+`onLatched`:
+
+- set `_usbAttachLatched = true`;
+- remember whether `_machineRecoveryActive`, `_machineReconnect`, or an active
+  automatic machine attempt requires resumption;
+- cancel and null `_machineReconnect`;
+- when `_activeAutomaticMachineAttempt` is true, set
+  `_automaticMachineAttemptSuperseded`, bump `_explicitScanGeneration`, and
+  call `deviceScanner.stopScan()`.
+
+Pause gates:
+
+- `_maybeScheduleMachineReconnect` returns early while latched.
+- `_executeConnect` returns before automatic/adapter-recovery machine work when
+  the latch was already active, and records that the attempt must resume. This
+  gate is above remembered quick-connect and scan policy.
+- `connectMachine()` returns `ConnectionResult.cancelled()` only when called
+  from an active automatic/adapter-recovery operation while latched. Direct
+  explicit connects and explicit-scan selections pass.
+
+`_shouldAttemptAttachReconnect()` and `_attemptAttachReconnect()` must not treat
+a transient machine from `_automaticMachineAttemptSuperseded` as an established
+machine. This keeps settle expiry from skipping the attach between the BLE
+connection-state emission and its intentional release.
+
+### 3. Release a machine connected by the superseded attempt
+
+There are two automatic machine connection paths:
+
+1. `_connectMachineTracked` covers early-connect and post-scan policy.
+2. `_tryQuickConnectMachine` bypasses `connectMachine()` and adopts directly.
+
+Both paths call one helper immediately after their transport attempt completes.
+The helper consumes `_automaticMachineAttemptSuperseded` on success, failure,
+or cancellation. If it was set and a machine connected, call
+`disconnectMachine()` and stop that automatic path before scale policy,
+ambiguity publication, or ready settlement continues.
+
+`disconnectMachine()` is the intentional-disconnect path: it marks the machine
+offline and calls `markExpectingDisconnect`, so unexpected-disconnect recovery
+is suppressed. `_runConnect` can then drain the queued attach probe with the
+machine slot free.
+
+`_executeConnect` clears any unconsumed supersession marker in `finally` as a
+backstop for a scan that was stopped before selecting a machine.
+
+### 4. Latch completion and policy resumption
+
+Do not clear the latch in `_attemptAttachReconnect`'s `_isConnecting` queue
+branch. That branch only records `_pendingAttachAttempt`; the attach lifecycle
+continues later in `_runConnect`'s drain.
+
+Use one completion helper from:
+
+- the direct attach probe/fallback path;
+- the queued probe/fallback path after `_executeAttachProbe` completes;
+- `onSettled` when a non-superseded machine made the settle attempt unnecessary.
+
+The helper:
+
+1. clears `_usbAttachLatched` and any stale supersession marker;
+2. discards `_resumeAutomaticAfterUsbAttach` when a machine is connected;
+3. otherwise replays a blocked startup/automatic attempt or re-arms
+   `_machineRecoveryActive` after the latch gate is gone;
+4. ensures `_machineReconnect` is scheduled when recovery remains active.
+
+This is required because `AttachProbeUnsupported` is currently considered
+handled and does not invoke coordinator recovery, while `AttachProbeFailed`
+calls `_ensureMachineRecoveryArmed()` before the proposed latch gate is gone.
+Cancelling the old reconnect timer without this completion step would leave
+recovery active but unscheduled.
+
+### 5. Startup enumeration must be observable and coalesce safely
+
+`DeviceController.initialize()` subscribes to a service's
+`DeviceAttachNotifier.deviceAttached` stream before awaiting that service's
+`initialize()`. Disposal still cancels the subscription, including disposal
+while initialization is pending. Device and adapter subscriptions can retain
+their existing ordering.
+
+`SerialServiceAndroid.initialize()`:
+
+1. subscribes to the platform USB event stream before enumeration, closing the
+   list-versus-listener gap;
+2. calls `_listDevices()`;
+3. if the list is non-empty, emits one metadata-free startup attach hint rather
+   than one event per enumerated device.
+
+One generic event is deliberate. `AttachReconnectCoordinator` keeps only the
+latest event in a burst, so per-device events could leave a USB DE1 unprobed
+when a keyboard happened to be enumerated last. A null-id event already makes
+`SerialServiceAndroid.connectAttachedMachine` inspect all not-yet-known USB
+devices; normal serial admission and identity probing remain the support
+filter.
+
+`ConnectionManager` is constructed before onboarding initializes
+`DeviceController`, so once the controller subscribes before service
+initialization the startup hint flows through the existing coordinator before
+the onboarding scan step calls `connect()`.
+
+## Concurrency
+
+- Attach probes still hold `_isConnecting`; no parallel connects.
+- A superseded scan bails on generation mismatch; a superseded tracked or
+  quick-connect machine is released before the queued probe runs.
+- The supersession marker keeps `shouldAttempt()` true during the narrow window
+  where the automatic machine has emitted connected but has not yet been
+  released.
+- A queued attach keeps the latch until its real probe and fallback complete.
+- Explicit direct connects, explicit scans, and scale-only connects are not
+  classified as active automatic machine attempts and are not blocked or
+  released.
+- A machine connected before the attach event never arms the latch because the
+  first `shouldAttempt()` check returns false.
+
+## Files
+
+- `lib/src/controllers/connection/attach_reconnect_coordinator.dart` — add
+  `onLatched`, `onSettled`.
+- `lib/src/controllers/connection_manager.dart` — latch/supersession/resumption
+  state, active-intent gate, quick-connect and tracked-connect release,
+  settle-time superseded-machine handling, queued lifecycle completion, and
+  recovery resumption.
+- `lib/src/controllers/device_controller.dart` — subscribe to attach notifier
+  streams before service initialization.
+- `lib/src/services/serial/serial_service_android.dart` — subscribe to platform
+  events before enumeration and emit one generic startup hint.
+
+No REST/WebSocket/DB/skin/plugin changes.
+
+## Tests
+
+- `test/controllers/connection/attach_reconnect_coordinator_test.dart`:
+  `onLatched` fires once for the first event in a burst, not for duplicates or
+  when a machine is already connected; `onSettled` fires on the skip path.
+- `test/controllers/device_controller_test.dart`: an attach event emitted from
+  inside a service's `initialize()` reaches `DeviceController.deviceAttached`;
+  disposal during pending initialization still removes the listener.
+- `test/controllers/connection_manager_usb_attach_test.dart` (probe-capable
+  group):
+  1. Attach during an automatic preferred-BLE scan supersedes the scan and USB
+     adoption wins.
+  2. Attach while a tracked preferred-BLE connect is in flight releases BLE
+     and adopts USB, including settle expiry after BLE emitted connected but
+     before release completed.
+  3. Attach while remembered BLE quick-connect is in flight releases BLE and
+     adopts USB.
+  4. Startup hint before `connect()` with a saved, remembered BLE preference
+     prevents quick-connect and adopts USB first.
+  5. Unsupported startup/attach clears the latch and resumes the interrupted
+     BLE automatic policy.
+  6. Probe failure after releasing BLE reconnects it through recovery.
+  7. A failed/cancelled automatic machine connect consumes the supersession
+     marker; a later unrelated connect is not released.
+  8. A direct explicit machine connect is not superseded even when the
+     published status intent is still `automatic`.
+- `test/services/serial/usb_attach_event_test.dart`: initialization emits one
+  generic hint for a non-empty enumeration, none for an empty enumeration, and
+  establishes the platform event listener before enumeration completes.
+- `test/services/serial/usb_attach_probe_test.dart`: a generic startup hint with
+  multiple enumerated devices (for example DE1 plus keyboard, in either order)
+  still finds and connects the supported machine.
+
+## Docs
+
+- `doc/DeviceManagement.md` — update the USB attach section with latch,
+  automatic-policy resumption, and startup enumeration behavior.
+- `doc/AI_BLE_NOTES.md` — mirror the connection-lifecycle and startup-ordering
+  constraints.
+- Archived design
+  `doc/plans/archive/android-usb-attach-machine-adoption/2026-07-18-design.md`
+  remains the original #473 rationale; this plan records the #659 latch delta.
+
+## Open questions
+
+- Release-then-probe is the one design decision not present in the #473 design.
+  It remains scoped to machines connected by a superseded automatic attempt
+  during the latch window. An abort hook inside
+  `DeviceController.connectToDe1` or the transport is more invasive and is not
+  recommended.

--- a/lib/src/controllers/connection/attach_reconnect_coordinator.dart
+++ b/lib/src/controllers/connection/attach_reconnect_coordinator.dart
@@ -7,6 +7,8 @@ class AttachReconnectCoordinator {
   final bool Function() shouldAttempt;
   final Future<bool> Function(DeviceAttachedEvent event) attempt;
   final FutureOr<void> Function() recover;
+  final void Function()? onLatched;
+  final void Function()? onSettled;
 
   late final StreamSubscription<DeviceAttachedEvent> _subscription;
   Timer? _settleTimer;
@@ -21,6 +23,8 @@ class AttachReconnectCoordinator {
     required this.shouldAttempt,
     required this.attempt,
     required this.recover,
+    this.onLatched,
+    this.onSettled,
   }) {
     _subscription = attachEvents.listen(_onAttach);
   }
@@ -30,9 +34,14 @@ class AttachReconnectCoordinator {
     _pendingEvent = event;
     if (_settleTimer != null) return;
     if (!shouldAttempt()) return;
+    onLatched?.call();
     _settleTimer = Timer(settleDelay, () {
       _settleTimer = null;
-      if (_disposed || _inFlight || !shouldAttempt()) return;
+      if (_disposed || _inFlight) return;
+      if (!shouldAttempt()) {
+        onSettled?.call();
+        return;
+      }
       final event = _pendingEvent;
       if (event == null) return;
       _inFlight = true;

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -422,7 +422,16 @@ class ConnectionManager {
     try {
       final probe = _attachProbe;
       if (probe == null) return false;
-      final result = await probe.connectAttachedMachine(event);
+      final AttachProbeResult result;
+      try {
+        result = await probe.connectAttachedMachine(event);
+      } catch (e, st) {
+        // An exceptional probe must not leave the latch set forever: treat
+        // it as unavailable so the fallback path completes the lifecycle
+        // and recovery/replay scheduling stays ungated.
+        _log.warning('Attach probe raised an exception', e, st);
+        return false;
+      }
       switch (result) {
         case AttachProbeConnected(machine: final machine):
           _log.info(
@@ -944,6 +953,18 @@ class ConnectionManager {
           }
         }
         _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
+        return;
+      }
+      // Quick-connect missed. If USB intent latched while it was pending,
+      // defer the automatic scan to the latch lifecycle instead of
+      // starting a fresh scan that the queued attach probe would wait
+      // behind (the latch's stopScan already ran before this scan existed).
+      if (_usbAttachLatched) {
+        _resumeAutomaticAfterUsbAttach = true;
+        _log.fine(
+          'USB attach latched during quick-connect; deferring automatic '
+          'scan',
+        );
         return;
       }
     }

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -338,6 +338,7 @@ class ConnectionManager {
   }
 
   Future<void> _completeUsbAttachLifecycle() async {
+    if (_pendingAttachAttempt) return;
     _usbAttachLatched = false;
     _automaticMachineAttemptSuperseded = false;
     if (_machineConnected) {

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -1488,8 +1488,14 @@ class ConnectionManager {
     return connectMachine(resolved);
   }
 
-  Future<ConnectionResult> connectMachine(De1Interface machine) async {
-    if (_usbAttachLatched && _activeAutomaticMachineAttempt) {
+  Future<ConnectionResult> connectMachine(
+    De1Interface machine, {
+    bool automatic = false,
+  }) async {
+    // Only the passive automatic attempt may be superseded by USB attach
+    // intent. Explicit direct connects (REST/WS) are never superseded, even
+    // when they overlap an in-flight automatic scan.
+    if (automatic && _usbAttachLatched && _activeAutomaticMachineAttempt) {
       _log.fine(
         'connectMachine: superseded by USB attach intent, skipping '
         '${machine.deviceId}',
@@ -1524,7 +1530,7 @@ class ConnectionManager {
 
     try {
       await de1Controller.connectToDe1(machine).timeout(_connectTimeout);
-      if (_automaticMachineAttemptSuperseded) {
+      if (automatic && _automaticMachineAttemptSuperseded) {
         // This connect was in flight when USB intent latched; it may still
         // have completed its transport connect, but it must not persist its
         // own preference. The release path disconnects it afterwards. Flush
@@ -1748,7 +1754,7 @@ class ConnectionManager {
     ScanReportBuilder scanReport,
   ) async {
     scanReport.markAttempted(machine.deviceId);
-    final result = await connectMachine(machine);
+    final result = await connectMachine(machine, automatic: true);
     scanReport.recordResult(machine.deviceId, result);
     return _releaseSupersededAutomaticMachine();
   }

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -312,8 +312,15 @@ class ConnectionManager {
         _machineRecoveryActive ||
         _machineReconnect != null ||
         _activeAutomaticMachineAttempt;
-    _machineReconnect?.cancel();
-    _machineReconnect = null;
+    if (_machineReconnect != null) {
+      _machineReconnect?.cancel();
+      _machineReconnect = null;
+      if (_machineReconnectFailures > 0) {
+        // A pending timer already counted its backoff tier; no attempt ran,
+        // so undo the tier so the rescheduled attempt keeps the same delay.
+        _machineReconnectFailures--;
+      }
+    }
     if (_activeAutomaticMachineAttempt) {
       _automaticMachineAttemptSuperseded = true;
       _explicitScanGeneration++;
@@ -332,20 +339,22 @@ class ConnectionManager {
       _resumeAutomaticAfterUsbAttach = false;
       return;
     }
-    if (!_resumeAutomaticAfterUsbAttach) return;
-    _resumeAutomaticAfterUsbAttach = false;
     if (_machineRecoveryActive) {
+      // Recovery may have been armed during the probe (e.g. a failed attach
+      // machine) while scheduling was gated by the latch, or suspended at
+      // latch time; either way the timer must be (re)armed now that the
+      // latch gate is gone.
+      _resumeAutomaticAfterUsbAttach = false;
       _maybeScheduleMachineReconnect();
       return;
     }
-    if (settingsController.preferredMachineId != null &&
-        settingsController.preferredMachineId!.isNotEmpty) {
-      _log.info(
-        'USB attach resolved without adoption; resuming automatic '
-        'machine selection',
-      );
-      await _attemptAutomaticConnect();
-    }
+    if (!_resumeAutomaticAfterUsbAttach) return;
+    _resumeAutomaticAfterUsbAttach = false;
+    _log.info(
+      'USB attach resolved without adoption; resuming automatic '
+      'machine selection',
+    );
+    await _attemptAutomaticConnect();
   }
 
   Future<bool> _releaseSupersededAutomaticMachine() async {
@@ -384,10 +393,13 @@ class ConnectionManager {
     );
     if (!handled && settingsController.preferredMachineId != null) {
       _resumeAutomaticAfterUsbAttach = false;
-      await _completeUsbAttachLifecycle();
+      unawaited(_completeUsbAttachLifecycle());
       return _attemptAutomaticConnect();
     }
-    await _completeUsbAttachLifecycle();
+    // Do not await the resume replay here: the coordinator releases its
+    // in-flight guard when this attempt returns, so a second USB attach
+    // during the resumed scan must be able to latch again.
+    unawaited(_completeUsbAttachLifecycle());
     return true;
   }
 
@@ -1260,6 +1272,9 @@ class ConnectionManager {
   @visibleForTesting
   bool get machineRecoveryActive => _machineRecoveryActive;
 
+  @visibleForTesting
+  int get machineReconnectFailures => _machineReconnectFailures;
+
   bool _shouldRetryMachine() {
     return _machineRecoveryActive &&
         !_machineConnected &&
@@ -1509,6 +1524,22 @@ class ConnectionManager {
 
     try {
       await de1Controller.connectToDe1(machine).timeout(_connectTimeout);
+      if (_automaticMachineAttemptSuperseded) {
+        // This connect was in flight when USB intent latched; it may still
+        // have completed its transport connect, but it must not persist its
+        // own preference. The release path disconnects it afterwards. Flush
+        // the registration so the release sees the machine as connected
+        // (the de1 subject delivers asynchronously).
+        _log.fine(
+          'connectMachine: connected but superseded by USB attach intent, '
+          'not persisting preference for ${machine.deviceId}',
+        );
+        await de1Controller.de1.firstWhere(
+          (connected) => connected == machine,
+          orElse: () => machine,
+        );
+        return const ConnectionResult.conflict();
+      }
       await settingsController.setPreferredMachineId(machine.deviceId);
       selectionSession?.scanReport.recordResult(
         machine.deviceId,

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -308,7 +308,12 @@ class ConnectionManager {
 
   void _onUsbAttachLatched() {
     _usbAttachLatched = true;
+    // Preserve an already-recorded replay obligation: a second attach may
+    // latch while the first attach's probe is in flight, when the ambient
+    // automatic state is false, and must not clear the interrupted
+    // automatic attempt's right to resume.
     _resumeAutomaticAfterUsbAttach =
+        _resumeAutomaticAfterUsbAttach ||
         _machineRecoveryActive ||
         _machineReconnect != null ||
         _activeAutomaticMachineAttempt;
@@ -438,7 +443,15 @@ class ConnectionManager {
             'Attach probe: machine ${machine.name} (${machine.deviceId}) '
             'connected, adopting',
           );
-          await _adoptAttachedMachine(machine);
+          try {
+            await _adoptAttachedMachine(machine);
+          } catch (e, st) {
+            // A failed adoption (e.g. preference persistence) must not
+            // leave the latch set forever; fall back like an unavailable
+            // probe so the lifecycle completes.
+            _log.warning('Adopting the attached machine failed', e, st);
+            return false;
+          }
           return true;
         case AttachProbeUnsupported():
           _log.fine(

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -159,6 +159,17 @@ class ConnectionManager {
   StreamSubscription<AdapterState>? _adapterSub;
   AttachReconnectCoordinator? _attachReconnectCoordinator;
 
+  bool _usbAttachLatched = false;
+  bool _automaticMachineAttemptSuperseded = false;
+  bool _resumeAutomaticAfterUsbAttach = false;
+
+  bool get _activeAutomaticMachineAttempt =>
+      _isConnecting &&
+      !_activeScaleOnlyScan &&
+      !_attachProbeInFlight &&
+      (currentStatus.intent == ConnectionIntent.automatic ||
+          currentStatus.intent == ConnectionIntent.adapterRecovery);
+
   final DisconnectExpectations _disconnectExpectations =
       DisconnectExpectations();
 
@@ -276,11 +287,13 @@ class ConnectionManager {
             shouldAttempt: _shouldAttemptAttachReconnect,
             attempt: _attemptAttachReconnect,
             recover: _ensureMachineRecoveryArmed,
+            onLatched: _onUsbAttachLatched,
+            onSettled: _onUsbAttachSettled,
           );
   }
 
   bool _shouldAttemptAttachReconnect() {
-    if (_machineConnected) return false;
+    if (_machineConnected && !_automaticMachineAttemptSuperseded) return false;
     if (_attachProbe != null) return true;
     final preferredMachineId = settingsController.preferredMachineId;
     return preferredMachineId != null && preferredMachineId.isNotEmpty;
@@ -291,10 +304,68 @@ class ConnectionManager {
 
   bool _pendingAttachAttempt = false;
   DeviceAttachedEvent? _pendingAttachEvent;
+  bool _attachProbeInFlight = false;
+
+  void _onUsbAttachLatched() {
+    _usbAttachLatched = true;
+    _resumeAutomaticAfterUsbAttach =
+        _machineRecoveryActive ||
+        _machineReconnect != null ||
+        _activeAutomaticMachineAttempt;
+    _machineReconnect?.cancel();
+    _machineReconnect = null;
+    if (_activeAutomaticMachineAttempt) {
+      _automaticMachineAttemptSuperseded = true;
+      _explicitScanGeneration++;
+      deviceScanner.stopScan();
+    }
+  }
+
+  void _onUsbAttachSettled() {
+    unawaited(_completeUsbAttachLifecycle());
+  }
+
+  Future<void> _completeUsbAttachLifecycle() async {
+    _usbAttachLatched = false;
+    _automaticMachineAttemptSuperseded = false;
+    if (_machineConnected) {
+      _resumeAutomaticAfterUsbAttach = false;
+      return;
+    }
+    if (!_resumeAutomaticAfterUsbAttach) return;
+    _resumeAutomaticAfterUsbAttach = false;
+    if (_machineRecoveryActive) {
+      _maybeScheduleMachineReconnect();
+      return;
+    }
+    if (settingsController.preferredMachineId != null &&
+        settingsController.preferredMachineId!.isNotEmpty) {
+      _log.info(
+        'USB attach resolved without adoption; resuming automatic '
+        'machine selection',
+      );
+      await _attemptAutomaticConnect();
+    }
+  }
+
+  Future<bool> _releaseSupersededAutomaticMachine() async {
+    if (!_automaticMachineAttemptSuperseded) return false;
+    _automaticMachineAttemptSuperseded = false;
+    if (!_machineConnected) return false;
+    _log.info(
+      'USB attach superseded automatic machine connect; releasing '
+      '${_disconnectSupervisor.latestMachine?.deviceId}',
+    );
+    await disconnectMachine();
+    return true;
+  }
 
   Future<bool> _attemptAttachReconnect(DeviceAttachedEvent event) async {
-    if (_machineConnected) return true;
-    if (_attachProbe == null) return _attemptAutomaticConnect();
+    if (_machineConnected && !_automaticMachineAttemptSuperseded) return true;
+    if (_attachProbe == null) {
+      _completeUsbAttachLifecycle();
+      return _attemptAutomaticConnect();
+    }
     if (_isConnecting) {
       _pendingAttachEvent = event;
       _pendingAttachAttempt = true;
@@ -312,8 +383,11 @@ class ConnectionManager {
       attachEvent: event,
     );
     if (!handled && settingsController.preferredMachineId != null) {
+      _resumeAutomaticAfterUsbAttach = false;
+      await _completeUsbAttachLifecycle();
       return _attemptAutomaticConnect();
     }
+    await _completeUsbAttachLifecycle();
     return true;
   }
 
@@ -332,6 +406,7 @@ class ConnectionManager {
   Future<bool> _executeAttachProbe(DeviceAttachedEvent event) async {
     if (_machineConnected) return true;
     _isConnecting = true;
+    _attachProbeInFlight = true;
     try {
       final probe = _attachProbe;
       if (probe == null) return false;
@@ -381,6 +456,7 @@ class ConnectionManager {
           return true;
       }
     } finally {
+      _attachProbeInFlight = false;
       _isConnecting = false;
     }
   }
@@ -393,6 +469,10 @@ class ConnectionManager {
       ),
     );
     de1Controller.adoptDevice(machine);
+    await de1Controller.de1.firstWhere(
+      (connected) => connected == machine,
+      orElse: () => machine,
+    );
     await settingsController.setPreferredMachineId(machine.deviceId);
     _log.info('Attach probe: machine adopted (${machine.deviceId})');
     if (machine is BengleInterface) {
@@ -653,8 +733,14 @@ class ConnectionManager {
           if (event != null && !_machineConnected) {
             final handled = await _executeAttachProbe(event);
             if (!handled && settingsController.preferredMachineId != null) {
+              _resumeAutomaticAfterUsbAttach = false;
+              await _completeUsbAttachLifecycle();
               await _attemptAutomaticConnect();
+            } else {
+              await _completeUsbAttachLifecycle();
             }
+          } else {
+            await _completeUsbAttachLifecycle();
           }
           continue;
         }
@@ -701,16 +787,26 @@ class ConnectionManager {
     required ConnectionAttemptPolicy policy,
     ConnectionIntent? intent,
   }) async {
+    final resolvedIntent =
+        intent ??
+        (identical(policy, ConnectionAttemptPolicy.explicitScan)
+            ? ConnectionIntent.explicitDiscovery
+            : identical(policy, ConnectionAttemptPolicy.scaleRecovery)
+            ? ConnectionIntent.scaleRecovery
+            : ConnectionIntent.automatic);
+    final isAutomaticMachineAttempt =
+        !scaleOnly &&
+        (resolvedIntent == ConnectionIntent.automatic ||
+            resolvedIntent == ConnectionIntent.adapterRecovery);
+    if (isAutomaticMachineAttempt && _usbAttachLatched) {
+      _resumeAutomaticAfterUsbAttach = true;
+      _log.fine('USB attach latched; deferring automatic machine connect');
+      return;
+    }
     _isConnecting = true;
     _publishStatus(
       currentStatus.copyWith(
-        intent:
-            intent ??
-            (identical(policy, ConnectionAttemptPolicy.explicitScan)
-                ? ConnectionIntent.explicitDiscovery
-                : identical(policy, ConnectionAttemptPolicy.scaleRecovery)
-                ? ConnectionIntent.scaleRecovery
-                : ConnectionIntent.automatic),
+        intent: resolvedIntent,
         activeTargetTransport: () => null,
       ),
     );
@@ -724,6 +820,9 @@ class ConnectionManager {
         _activeScaleOnlyScan = false;
       }
       _isConnecting = false;
+      if (_automaticMachineAttemptSuperseded && !_machineConnected) {
+        _automaticMachineAttemptSuperseded = false;
+      }
     }
   }
 
@@ -821,6 +920,7 @@ class ConnectionManager {
       );
       final qcMachine = await _tryQuickConnectMachine();
       if (qcMachine != null) {
+        if (await _releaseSupersededAutomaticMachine()) return;
         _log.info('Quick-connect: machine connected, proceeding to ready');
         if (qcMachine is BengleInterface) {
           await _attachBengleVirtualScale(qcMachine);
@@ -955,7 +1055,7 @@ class ConnectionManager {
     );
     switch (machineAction) {
       case ConnectMachineAction(machine: final m):
-        await _connectMachineTracked(m, scanReport);
+        if (await _connectMachineTracked(m, scanReport)) return;
         final alternatives = machines.where((machine) => machine != m).toList();
         if (!_machineConnected && alternatives.isNotEmpty) {
           _publishStatus(
@@ -1167,6 +1267,7 @@ class ConnectionManager {
   }
 
   void _maybeScheduleMachineReconnect() {
+    if (_usbAttachLatched) return;
     if (_machineReconnect != null) return;
     if (!_shouldRetryMachine()) return;
     final delay = _machineReconnectBackoff;
@@ -1373,6 +1474,13 @@ class ConnectionManager {
   }
 
   Future<ConnectionResult> connectMachine(De1Interface machine) async {
+    if (_usbAttachLatched && _activeAutomaticMachineAttempt) {
+      _log.fine(
+        'connectMachine: superseded by USB attach intent, skipping '
+        '${machine.deviceId}',
+      );
+      return const ConnectionResult.conflict();
+    }
     if (_isConnectingMachine) {
       _log.fine('connectMachine: already connecting, skipping');
       return const ConnectionResult.conflict();
@@ -1604,13 +1712,14 @@ class ConnectionManager {
     return result;
   }
 
-  Future<void> _connectMachineTracked(
+  Future<bool> _connectMachineTracked(
     De1Interface machine,
     ScanReportBuilder scanReport,
   ) async {
     scanReport.markAttempted(machine.deviceId);
     final result = await connectMachine(machine);
     scanReport.recordResult(machine.deviceId, result);
+    return _releaseSupersededAutomaticMachine();
   }
 
   Future<void> _connectScaleTrackedGated(

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -103,6 +103,16 @@ class DeviceController
 
     for (var service in _services) {
       try {
+        if (service case final DeviceAttachNotifier notifier) {
+          final attachSub = notifier.deviceAttached.listen((event) {
+            _attachOrigins[event] = service;
+            _log.info("device attached on $service: $event");
+            if (!_deviceAttachedStream.isClosed) {
+              _deviceAttachedStream.add(event);
+            }
+          });
+          _serviceSubscriptions.add(attachSub);
+        }
         await service.initialize();
         if (_disposed) return;
         final subscription = service.devices.listen(
@@ -116,16 +126,6 @@ class DeviceController
             }
           });
           _serviceSubscriptions.add(adapterSub);
-        }
-        if (service case final DeviceAttachNotifier notifier) {
-          final attachSub = notifier.deviceAttached.listen((event) {
-            _attachOrigins[event] = service;
-            _log.info("device attached on $service: $event");
-            if (!_deviceAttachedStream.isClosed) {
-              _deviceAttachedStream.add(event);
-            }
-          });
-          _serviceSubscriptions.add(attachSub);
         }
       } catch (e) {
         _log.warning("Service $service failed to init:", e);

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -66,16 +66,19 @@ class SerialServiceAndroid
   @override
   Future<void> initialize() async {
     try {
-      final devices = await _listDevices();
-      _log.info("found $devices");
-    } catch (e, st) {
-      _log.warning('USB enumeration unavailable during initialization', e, st);
-    }
-    if (_disposed) return;
-    try {
       _usbEventSubscription = _usbEventStream()?.listen(handleUsbEvent);
     } catch (e, st) {
       _log.warning('USB event stream unavailable', e, st);
+    }
+    if (_disposed) return;
+    try {
+      final devices = await _listDevices();
+      _log.info("found $devices");
+      if (devices.isNotEmpty && !_disposed) {
+        _announceAttach(null);
+      }
+    } catch (e, st) {
+      _log.warning('USB enumeration unavailable during initialization', e, st);
     }
   }
 

--- a/test/controllers/connection/attach_reconnect_coordinator_test.dart
+++ b/test/controllers/connection/attach_reconnect_coordinator_test.dart
@@ -208,33 +208,36 @@ void main() {
     });
   });
 
-  test('onLatched fires once when the settle timer arms, not per burst event', () {
-    fakeAsync((async) {
-      final events = StreamController<DeviceAttachedEvent>.broadcast(
-        sync: true,
-      );
-      var latches = 0;
-      final coordinator = AttachReconnectCoordinator(
-        attachEvents: events.stream,
-        settleDelay: settleDelay,
-        shouldAttempt: () => true,
-        attempt: (_) async => true,
-        recover: () {},
-        onLatched: () => latches++,
-      );
+  test(
+    'onLatched fires once when the settle timer arms, not per burst event',
+    () {
+      fakeAsync((async) {
+        final events = StreamController<DeviceAttachedEvent>.broadcast(
+          sync: true,
+        );
+        var latches = 0;
+        final coordinator = AttachReconnectCoordinator(
+          attachEvents: events.stream,
+          settleDelay: settleDelay,
+          shouldAttempt: () => true,
+          attempt: (_) async => true,
+          recover: () {},
+          onLatched: () => latches++,
+        );
 
-      events
-        ..add(const DeviceAttachedEvent())
-        ..add(const DeviceAttachedEvent())
-        ..add(const DeviceAttachedEvent());
-      async.elapse(settleDelay);
-      async.flushMicrotasks();
+        events
+          ..add(const DeviceAttachedEvent())
+          ..add(const DeviceAttachedEvent())
+          ..add(const DeviceAttachedEvent());
+        async.elapse(settleDelay);
+        async.flushMicrotasks();
 
-      expect(latches, 1);
-      coordinator.dispose();
-      events.close();
-    });
-  });
+        expect(latches, 1);
+        coordinator.dispose();
+        events.close();
+      });
+    },
+  );
 
   test('onLatched does not fire when a machine is already connected', () {
     fakeAsync((async) {

--- a/test/controllers/connection/attach_reconnect_coordinator_test.dart
+++ b/test/controllers/connection/attach_reconnect_coordinator_test.dart
@@ -208,6 +208,90 @@ void main() {
     });
   });
 
+  test('onLatched fires once when the settle timer arms, not per burst event', () {
+    fakeAsync((async) {
+      final events = StreamController<DeviceAttachedEvent>.broadcast(
+        sync: true,
+      );
+      var latches = 0;
+      final coordinator = AttachReconnectCoordinator(
+        attachEvents: events.stream,
+        settleDelay: settleDelay,
+        shouldAttempt: () => true,
+        attempt: (_) async => true,
+        recover: () {},
+        onLatched: () => latches++,
+      );
+
+      events
+        ..add(const DeviceAttachedEvent())
+        ..add(const DeviceAttachedEvent())
+        ..add(const DeviceAttachedEvent());
+      async.elapse(settleDelay);
+      async.flushMicrotasks();
+
+      expect(latches, 1);
+      coordinator.dispose();
+      events.close();
+    });
+  });
+
+  test('onLatched does not fire when a machine is already connected', () {
+    fakeAsync((async) {
+      final events = StreamController<DeviceAttachedEvent>.broadcast(
+        sync: true,
+      );
+      var latches = 0;
+      final coordinator = AttachReconnectCoordinator(
+        attachEvents: events.stream,
+        settleDelay: settleDelay,
+        shouldAttempt: () => false,
+        attempt: (_) async => true,
+        recover: () {},
+        onLatched: () => latches++,
+      );
+
+      events.add(const DeviceAttachedEvent());
+      async.elapse(settleDelay);
+
+      expect(latches, 0);
+      coordinator.dispose();
+      events.close();
+    });
+  });
+
+  test('onSettled fires when settle expiry skips the attempt', () {
+    fakeAsync((async) {
+      final events = StreamController<DeviceAttachedEvent>.broadcast(
+        sync: true,
+      );
+      var settled = 0;
+      var attempts = 0;
+      var shouldAttempt = true;
+      final coordinator = AttachReconnectCoordinator(
+        attachEvents: events.stream,
+        settleDelay: settleDelay,
+        shouldAttempt: () => shouldAttempt,
+        attempt: (_) async {
+          attempts++;
+          return true;
+        },
+        recover: () {},
+        onSettled: () => settled++,
+      );
+
+      events.add(const DeviceAttachedEvent());
+      shouldAttempt = false;
+      async.elapse(settleDelay);
+      async.flushMicrotasks();
+
+      expect(attempts, 0);
+      expect(settled, 1);
+      coordinator.dispose();
+      events.close();
+    });
+  });
+
   test('attempt receives the latest event of a coalesced burst', () {
     fakeAsync((async) {
       final events = StreamController<DeviceAttachedEvent>.broadcast(

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -943,5 +943,106 @@ void main() {
         expect(settings.preferredMachineId, 'ble-machine-id');
       },
     );
+
+    test('unsupported attach replays an interrupted no-preference '
+        'automatic scan', () async {
+      probeScanner.probeResult = const AttachProbeUnsupported();
+      probeScanner.scanCompleter = Completer<void>();
+
+      final connecting = manager.connect();
+      await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+      probeScanner.completeScan();
+      await connecting;
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(probeScanner.scanCallCount, 2);
+      expect(settings.preferredMachineId, isNull);
+      expect(manager.currentStatus.phase, ConnectionPhase.idle);
+    });
+
+    test(
+      'a second USB attach during the resumed scan is not dropped',
+      () async {
+        probeScanner.probeResult = const AttachProbeUnsupported();
+        probeScanner.scanCompleter = Completer<void>();
+
+        final connecting = manager.connect();
+        await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+        probeScanner.completeScan();
+
+        // The unsupported attach interrupts the no-preference automatic
+        // scan and replays it; gate the resumed scan.
+        probeScanner.scanCompleter = Completer<void>();
+        await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+
+        // A real DE1 attach during the resumed scan must latch again
+        // instead of being dropped by the coordinator's in-flight guard.
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+
+        probeScanner.completeScan();
+        await connecting;
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        expect(probeScanner.probeCallCount, 2);
+        expect(settings.preferredMachineId, 'usb-machine-id');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+
+    test(
+      'suspending recovery for a USB attach preserves the backoff tier',
+      () async {
+        await settings.setPreferredMachineId('ble-machine-id');
+        probeScanner.probeResult = const AttachProbeFailed(
+          deviceId: 'usb-machine-id',
+          deviceName: 'DE1',
+        );
+
+        await attachAndSettle();
+        expect(manager.machineRecoveryActive, isTrue);
+        expect(manager.machineReconnectFailures, 1);
+
+        // The pending reconnect timer is cancelled and re-armed; the tier
+        // must not advance because no reconnect attempt actually ran.
+        probeScanner.probeResult = const AttachProbeUnsupported();
+        await attachAndSettle();
+
+        expect(manager.machineRecoveryActive, isTrue);
+        expect(manager.machineReconnectFailures, 1);
+      },
+    );
+
+    test(
+      'a superseded in-flight connect does not persist its own preference',
+      () async {
+        final bleMachine = _FakeDe1(deviceId: 'ble-machine-id')
+          ..connectGate = Completer<void>();
+        probeScanner.addDevice(bleMachine);
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+
+        final connecting = manager.connect();
+        await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+        await Future<void>.delayed(Duration.zero);
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+
+        bleMachine.connectGate!.complete();
+        await connecting;
+
+        expect(probeScanner.probeCallCount, 1);
+        expect(settingsService.preferredMachineIdWrites, ['usb-machine-id']);
+        expect(settings.preferredMachineId, 'usb-machine-id');
+      },
+    );
   });
 }

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -917,6 +917,59 @@ void main() {
       remembered.dispose();
     });
 
+    test(
+      'a second latch during the probe preserves the replay obligation',
+      () async {
+        probeScanner.probeResult = const AttachProbeUnsupported();
+        probeScanner.scanCompleter = Completer<void>();
+        probeScanner.probeGate = Completer<void>();
+
+        // An automatic no-preference scan is interrupted by the first
+        // attach; the queued probe runs after the scan bails.
+        final connecting = manager.connect();
+        await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+        probeScanner.completeScan();
+        await probeScanner.probeStarted.future;
+
+        // A second attach latches while the first probe is in flight; the
+        // recorded replay obligation must survive this latch.
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+
+        probeScanner.probeGate!.complete();
+        await connecting;
+
+        expect(probeScanner.probeCallCount, 2);
+        expect(probeScanner.scanCallCount, 2);
+        expect(settings.preferredMachineId, isNull);
+        expect(manager.currentStatus.phase, ConnectionPhase.idle);
+      },
+    );
+
+    test('an adoption failure still completes the latch lifecycle', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      final usbMachine = _FakeDe1(deviceId: 'usb-machine-id');
+      probeScanner.probeResult = AttachProbeConnected(usbMachine);
+      settingsService.failSetPreferredMachineId = true;
+
+      await attachAndSettle();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(probeScanner.probeCallCount, 1);
+      // The failed adoption falls back to the preferred-machine attempt;
+      // the latch must not suppress that scan or later recovery.
+      expect(probeScanner.scanCallCount, 1);
+      expect(settingsService.preferredMachineIdWrites.last, 'usb-machine-id');
+
+      // The adopted machine goes away; recovery scheduling must not be
+      // gated by the latch either.
+      await usbMachine.disconnect();
+      await Future<void>.delayed(Duration.zero);
+      expect(manager.machineReconnectFailures, 1);
+    });
+
     test('unsupported probe clears the latch and resumes the interrupted '
         'automatic policy', () async {
       await settings.setPreferredMachineId('ble-machine-id');

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -49,6 +49,7 @@ class _ProbeScanner extends _AttachScanner implements UsbAttachProbe {
   Completer<void>? probeGate;
   final Completer<void> probeStarted = Completer<void>();
 
+  Object? probeError;
   Completer<void>? quickConnectGate;
 
   @override
@@ -60,6 +61,8 @@ class _ProbeScanner extends _AttachScanner implements UsbAttachProbe {
     if (!probeStarted.isCompleted) probeStarted.complete();
     final gate = probeGate;
     if (gate != null) await gate.future;
+    final error = probeError;
+    if (error != null) throw error;
     return probeResult;
   }
 
@@ -628,6 +631,84 @@ void main() {
       expect(probeScanner.scanCallCount, 0);
       expect(settings.preferredMachineId, isNull);
       expect(manager.currentStatus.pendingAmbiguity, isNull);
+    });
+
+    test('a throwing attach probe completes the latch lifecycle and leaves '
+        'recovery armed', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      probeScanner.probeError = Exception('usb transport failure');
+
+      await attachAndSettle();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(probeScanner.probeCallCount, 1);
+      // The probe exception falls back to the preferred-machine attempt;
+      // the latch must not gate recovery scheduling afterwards.
+      expect(manager.machineRecoveryActive, isTrue);
+      expect(manager.machineReconnectFailures, 1);
+    });
+
+    test('a USB latch during quick-connect defers the fallback scan until '
+        'the probe runs', () async {
+      await manager.dispose();
+      await settings.setPreferredMachineId('pref-de1');
+      settingsService.setRememberedDevices(
+        RememberedDevice.encodeList([
+          const RememberedDevice(
+            id: 'pref-de1',
+            name: 'DE1',
+            type: DeviceType.machine,
+            implementation: DeviceImplementation.unifiedDe1,
+            transportType: TransportType.serial,
+          ),
+        ]),
+      );
+      final remembered = RememberedDevicesController(
+        machineConnections: const Stream.empty(),
+        scaleConnections: const Stream.empty(),
+        settings: settingsService,
+      );
+      await remembered.initialize();
+      final actualDe1Controller = De1Controller(
+        controller: DeviceController([discovery]),
+      );
+      probeScanner.probeResult = AttachProbeConnected(
+        _FakeDe1(deviceId: 'usb-machine-id'),
+      );
+      probeScanner.quickConnectResult = null;
+      probeScanner.quickConnectGate = Completer<void>();
+      manager = ConnectionManager(
+        deviceScanner: probeScanner,
+        de1Controller: actualDe1Controller,
+        scaleController: scaleController,
+        settingsController: settings,
+        rememberedDevices: remembered,
+        deviceAttachSettleDelay: Duration.zero,
+      );
+      manager.machineReconnectBaseDelay = const Duration(days: 1);
+
+      // Remembered quick-connect is in flight...
+      final connecting = manager.connect();
+      await Future<void>.delayed(Duration.zero);
+      expect(probeScanner.quickConnectCallCount, 1);
+      expect(probeScanner.scanCallCount, 0);
+
+      // ...when USB intent latches and settles while it is still
+      // pending; the queued attach stops a scan that does not exist yet.
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+
+      // Quick-connect misses; the fallback automatic scan must not
+      // start while the latch is active.
+      probeScanner.quickConnectGate!.complete();
+      await connecting;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(probeScanner.scanCallCount, 0);
+      expect(probeScanner.probeCallCount, 1);
+      expect(settings.preferredMachineId, 'usb-machine-id');
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      remembered.dispose();
     });
 
     test(

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -944,6 +944,46 @@ void main() {
       },
     );
 
+    test('an explicit connect overlapping a latched automatic scan is not '
+        'superseded', () async {
+      probeScanner.probeResult = const AttachProbeUnsupported();
+      probeScanner.scanCompleter = Completer<void>();
+      final bleMachine = _FakeDe1(deviceId: 'ble-machine-id')
+        ..connectGate = Completer<void>();
+
+      // An automatic no-preference scan is in flight...
+      final connecting = manager.connect();
+      await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+
+      // ...and a direct REST/WS connect for a BLE machine starts.
+      final direct = manager.connectMachine(bleMachine);
+      await Future<void>.delayed(Duration.zero);
+
+      // USB intent latches while the explicit connect is in flight; the
+      // ambient automatic state is still active, so the latch marks the
+      // automatic attempt superseded. The explicit connect must not be
+      // caught by that marker.
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+
+      bleMachine.connectGate!.complete();
+      final directResult = await direct;
+
+      probeScanner.completeScan();
+      await connecting;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(directResult.success, isTrue);
+      expect(
+        (await realDe1Controller.de1.firstWhere(
+          (machine) => machine?.deviceId == 'ble-machine-id',
+        )),
+        isNotNull,
+      );
+      expect(settingsService.preferredMachineIdWrites, ['ble-machine-id']);
+      expect(settings.preferredMachineId, 'ble-machine-id');
+    });
+
     test('unsupported attach replays an interrupted no-preference '
         'automatic scan', () async {
       probeScanner.probeResult = const AttachProbeUnsupported();

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -16,6 +16,7 @@ import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/usb_attach_probe.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:rxdart/subjects.dart';
 
 import '../helpers/mock_de1_controller.dart';
 import '../helpers/mock_device_discovery_service.dart';
@@ -48,6 +49,8 @@ class _ProbeScanner extends _AttachScanner implements UsbAttachProbe {
   Completer<void>? probeGate;
   final Completer<void> probeStarted = Completer<void>();
 
+  Completer<void>? quickConnectGate;
+
   @override
   Future<AttachProbeResult> connectAttachedMachine(
     DeviceAttachedEvent event,
@@ -59,10 +62,21 @@ class _ProbeScanner extends _AttachScanner implements UsbAttachProbe {
     if (gate != null) await gate.future;
     return probeResult;
   }
+
+  @override
+  Future<Device?> tryQuickConnect(RememberedDevice remembered) async {
+    quickConnectCallCount++;
+    final gate = quickConnectGate;
+    if (gate != null) await gate.future;
+    return quickConnectResult;
+  }
 }
 
 class _FakeDe1 implements De1Interface {
   final _snapshots = StreamController<MachineSnapshot>.broadcast();
+  final _connectionState = BehaviorSubject<ConnectionState>.seeded(
+    ConnectionState.connected,
+  );
 
   @override
   final String deviceId;
@@ -81,9 +95,14 @@ class _FakeDe1 implements De1Interface {
 
   _FakeDe1({this.deviceId = 'pref-de1'});
 
+  Completer<void>? connectGate;
+  Completer<void>? disconnectGate;
+  bool failConnect = false;
+  int disconnectCalls = 0;
+  int onConnectCalls = 0;
+
   @override
-  Stream<ConnectionState> get connectionState =>
-      Stream.value(ConnectionState.connected);
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
 
   @override
   Stream<MachineSnapshot> get currentSnapshot => _snapshots.stream;
@@ -92,14 +111,25 @@ class _FakeDe1 implements De1Interface {
   Stream<bool> get ready => const Stream.empty();
 
   @override
-  Future<void> onConnect() async {}
+  Future<void> onConnect() async {
+    onConnectCalls++;
+    final gate = connectGate;
+    if (gate != null) await gate.future;
+    if (failConnect) throw Exception('simulated connect failure');
+  }
 
   @override
-  Future<void> disconnect() async {}
+  Future<void> disconnect() async {
+    disconnectCalls++;
+    final gate = disconnectGate;
+    if (gate != null) await gate.future;
+    _connectionState.add(ConnectionState.disconnected);
+  }
 
   @override
   Future<void> dispose() async {
     await _snapshots.close();
+    await _connectionState.close();
   }
 
   @override
@@ -599,5 +629,319 @@ void main() {
       expect(settings.preferredMachineId, isNull);
       expect(manager.currentStatus.pendingAmbiguity, isNull);
     });
+
+    test(
+      'attach during an automatic preferred-BLE scan supersedes the scan',
+      () async {
+        await settings.setPreferredMachineId('ble-machine-id');
+        probeScanner.probeResult = AttachProbeConnected(
+          _FakeDe1(deviceId: 'usb-machine-id'),
+        );
+        probeScanner.scanCompleter = Completer<void>();
+
+        final connecting = manager.connect();
+        await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+
+        // Preferred BLE machine appears mid-scan; the latch must block it.
+        probeScanner.addDevice(_FakeDe1(deviceId: 'ble-machine-id'));
+        await Future<void>.delayed(Duration.zero);
+        probeScanner.completeScan();
+        await connecting;
+
+        expect(probeScanner.probeCallCount, 1);
+        expect(probeScanner.stopScanCallCount, greaterThan(0));
+        expect(settings.preferredMachineId, 'usb-machine-id');
+        expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      },
+    );
+
+    test('attach while a preferred-BLE connect is in flight releases BLE '
+        'and adopts USB', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      final bleMachine = _FakeDe1(deviceId: 'ble-machine-id')
+        ..connectGate = Completer<void>();
+      probeScanner.addDevice(bleMachine);
+      probeScanner.probeResult = AttachProbeConnected(
+        _FakeDe1(deviceId: 'usb-machine-id'),
+      );
+
+      final connecting = manager.connect();
+      await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+      await Future<void>.delayed(Duration.zero);
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+
+      // BLE connect completes inside the settle window.
+      bleMachine.connectGate!.complete();
+      await connecting;
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(bleMachine.disconnectCalls, 1);
+      expect(settings.preferredMachineId, 'usb-machine-id');
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+    });
+
+    test('settle expiry during the superseded connect window still queues '
+        'the attach', () async {
+      await manager.dispose();
+      await settings.setPreferredMachineId('ble-machine-id');
+      final bleMachine = _FakeDe1(deviceId: 'ble-machine-id')
+        ..connectGate = Completer<void>()
+        ..disconnectGate = Completer<void>();
+      probeScanner.addDevice(bleMachine);
+      probeScanner.probeResult = AttachProbeConnected(
+        _FakeDe1(deviceId: 'usb-machine-id'),
+      );
+      final actualDe1Controller = De1Controller(
+        controller: DeviceController([discovery]),
+      );
+      manager = ConnectionManager(
+        deviceScanner: probeScanner,
+        de1Controller: actualDe1Controller,
+        scaleController: scaleController,
+        settingsController: settings,
+        deviceAttachSettleDelay: const Duration(milliseconds: 50),
+      );
+      manager.machineReconnectBaseDelay = const Duration(days: 1);
+
+      final connecting = manager.connect();
+      await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+      await Future<void>.delayed(Duration.zero);
+      probeScanner.attach();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(probeScanner.probeCallCount, 0);
+
+      // BLE connect completes: machine now connected, but the intentional
+      // release is still pending on the disconnect gate. Settle expiry
+      // must queue the attach rather than treat the transient machine as
+      // an established connection.
+      bleMachine.connectGate!.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+      expect(probeScanner.probeCallCount, 0);
+
+      bleMachine.disconnectGate!.complete();
+      await connecting;
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(bleMachine.disconnectCalls, 1);
+      expect(settings.preferredMachineId, 'usb-machine-id');
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+    });
+
+    test('attach while remembered BLE quick-connect is in flight releases '
+        'BLE and adopts USB', () async {
+      await manager.dispose();
+      await settings.setPreferredMachineId('pref-de1');
+      settingsService.setRememberedDevices(
+        RememberedDevice.encodeList([
+          const RememberedDevice(
+            id: 'pref-de1',
+            name: 'DE1',
+            type: DeviceType.machine,
+            implementation: DeviceImplementation.unifiedDe1,
+            transportType: TransportType.serial,
+          ),
+        ]),
+      );
+      final remembered = RememberedDevicesController(
+        machineConnections: const Stream.empty(),
+        scaleConnections: const Stream.empty(),
+        settings: settingsService,
+      );
+      await remembered.initialize();
+      final actualDe1Controller = De1Controller(
+        controller: DeviceController([discovery]),
+      );
+      probeScanner.quickConnectGate = Completer<void>();
+      probeScanner.quickConnectResult = _FakeDe1(deviceId: 'pref-de1');
+      probeScanner.probeResult = AttachProbeConnected(
+        _FakeDe1(deviceId: 'usb-machine-id'),
+      );
+      manager = ConnectionManager(
+        deviceScanner: probeScanner,
+        de1Controller: actualDe1Controller,
+        scaleController: scaleController,
+        settingsController: settings,
+        rememberedDevices: remembered,
+        deviceAttachSettleDelay: Duration.zero,
+      );
+      manager.machineReconnectBaseDelay = const Duration(days: 1);
+
+      final connecting = manager.connect();
+      await Future<void>.delayed(Duration.zero);
+      expect(probeScanner.quickConnectCallCount, 1);
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+
+      probeScanner.quickConnectGate!.complete();
+      await connecting;
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(settings.preferredMachineId, 'usb-machine-id');
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      probeScanner.quickConnectGate = null;
+      remembered.dispose();
+    });
+
+    test('startup attach hint before connect() prevents remembered '
+        'quick-connect and adopts USB first', () async {
+      await manager.dispose();
+      await settings.setPreferredMachineId('pref-de1');
+      settingsService.setRememberedDevices(
+        RememberedDevice.encodeList([
+          const RememberedDevice(
+            id: 'pref-de1',
+            name: 'DE1',
+            type: DeviceType.machine,
+            implementation: DeviceImplementation.unifiedDe1,
+            transportType: TransportType.serial,
+          ),
+        ]),
+      );
+      final remembered = RememberedDevicesController(
+        machineConnections: const Stream.empty(),
+        scaleConnections: const Stream.empty(),
+        settings: settingsService,
+      );
+      await remembered.initialize();
+      final actualDe1Controller = De1Controller(
+        controller: DeviceController([discovery]),
+      );
+      probeScanner.quickConnectResult = _FakeDe1(deviceId: 'pref-de1');
+      probeScanner.probeResult = AttachProbeConnected(
+        _FakeDe1(deviceId: 'usb-machine-id'),
+      );
+      manager = ConnectionManager(
+        deviceScanner: probeScanner,
+        de1Controller: actualDe1Controller,
+        scaleController: scaleController,
+        settingsController: settings,
+        rememberedDevices: remembered,
+        deviceAttachSettleDelay: const Duration(milliseconds: 50),
+      );
+      manager.machineReconnectBaseDelay = const Duration(days: 1);
+
+      probeScanner.attach();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await manager.connect();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(probeScanner.quickConnectCallCount, 0);
+      expect(probeScanner.scanCallCount, 0);
+      expect(probeScanner.probeCallCount, 1);
+      expect(settings.preferredMachineId, 'usb-machine-id');
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      remembered.dispose();
+    });
+
+    test('unsupported probe clears the latch and resumes the interrupted '
+        'automatic policy', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      final bleMachine = _FakeDe1(deviceId: 'ble-machine-id')
+        ..connectGate = Completer<void>();
+      probeScanner.addDevice(bleMachine);
+      probeScanner.probeResult = const AttachProbeUnsupported();
+
+      final connecting = manager.connect();
+      await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+      await Future<void>.delayed(Duration.zero);
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+
+      bleMachine.connectGate!.complete();
+      await connecting;
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(bleMachine.disconnectCalls, 1);
+      expect(bleMachine.onConnectCalls, 2);
+      expect(settings.preferredMachineId, 'ble-machine-id');
+    });
+
+    test(
+      'probe failure after releasing BLE reconnects it through recovery',
+      () async {
+        await settings.setPreferredMachineId('ble-machine-id');
+        final bleMachine = _FakeDe1(deviceId: 'ble-machine-id')
+          ..connectGate = Completer<void>();
+        probeScanner.addDevice(bleMachine);
+        probeScanner.probeResult = const AttachProbeFailed(
+          deviceId: 'usb-machine-id',
+          deviceName: 'DE1',
+        );
+
+        final connecting = manager.connect();
+        await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+        await Future<void>.delayed(Duration.zero);
+        probeScanner.attach();
+        await Future<void>.delayed(Duration.zero);
+
+        bleMachine.connectGate!.complete();
+        await connecting;
+
+        expect(probeScanner.probeCallCount, 1);
+        expect(bleMachine.disconnectCalls, 1);
+        expect(settings.preferredMachineId, 'ble-machine-id');
+        expect(manager.machineRecoveryActive, isTrue);
+      },
+    );
+
+    test('a failed automatic connect consumes the supersession marker; a '
+        'later connect is not released', () async {
+      await settings.setPreferredMachineId('ble-machine-id');
+      final bleMachine = _FakeDe1(deviceId: 'ble-machine-id')
+        ..connectGate = Completer<void>();
+      probeScanner.addDevice(bleMachine);
+      probeScanner.probeResult = const AttachProbeUnsupported();
+
+      final connecting = manager.connect();
+      await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+      await Future<void>.delayed(Duration.zero);
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+
+      bleMachine.failConnect = true;
+      bleMachine.connectGate!.complete();
+      await connecting;
+      expect(bleMachine.onConnectCalls, 2);
+
+      bleMachine.failConnect = false;
+      await manager.connect();
+
+      expect(bleMachine.onConnectCalls, 3);
+      expect(bleMachine.disconnectCalls, 0);
+      expect(
+        (await realDe1Controller.de1.firstWhere(
+          (machine) => machine?.deviceId == 'ble-machine-id',
+        )),
+        isNotNull,
+      );
+    });
+
+    test(
+      'a direct explicit machine connect is not superseded while latched',
+      () async {
+        probeScanner.probeResult = const AttachProbeUnsupported();
+        probeScanner.probeGate = Completer<void>();
+        probeScanner.attach();
+        await probeScanner.probeStarted.future;
+
+        final bleMachine = _FakeDe1(deviceId: 'ble-machine-id');
+        final result = await manager.connectMachine(bleMachine);
+
+        expect(result.success, isTrue);
+        expect(
+          (await realDe1Controller.de1.firstWhere(
+            (machine) => machine?.deviceId == 'ble-machine-id',
+          )),
+          isNotNull,
+        );
+
+        probeScanner.probeGate!.complete();
+        await Future<void>.delayed(Duration.zero);
+        expect(settings.preferredMachineId, 'ble-machine-id');
+      },
+    );
   });
 }

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -43,6 +43,7 @@ class _AttachScanner extends MockDeviceScanner implements DeviceAttachNotifier {
 
 class _ProbeScanner extends _AttachScanner implements UsbAttachProbe {
   AttachProbeResult probeResult = const AttachProbeUnsupported();
+  List<AttachProbeResult> probeResults = const [];
   int probeCallCount = 0;
   final List<DeviceAttachedEvent> probeEvents = [];
 
@@ -58,12 +59,15 @@ class _ProbeScanner extends _AttachScanner implements UsbAttachProbe {
   ) async {
     probeCallCount++;
     probeEvents.add(event);
+    final result = probeCallCount <= probeResults.length
+        ? probeResults[probeCallCount - 1]
+        : probeResult;
     if (!probeStarted.isCompleted) probeStarted.complete();
     final gate = probeGate;
     if (gate != null) await gate.future;
     final error = probeError;
     if (error != null) throw error;
-    return probeResult;
+    return result;
   }
 
   @override
@@ -947,6 +951,35 @@ void main() {
         expect(manager.currentStatus.phase, ConnectionPhase.idle);
       },
     );
+
+    test('a queued attach is probed before automatic replay', () async {
+      final usbMachine = _FakeDe1(deviceId: 'usb-machine-id');
+      final bleMachine = _FakeDe1(deviceId: 'ble-machine-id');
+      probeScanner.probeResults = [
+        const AttachProbeUnsupported(),
+        AttachProbeConnected(usbMachine),
+      ];
+      probeScanner.probeGate = Completer<void>();
+      probeScanner.scanCompleter = Completer<void>();
+
+      final connecting = manager.connect();
+      await probeScanner.scanningStream.firstWhere((scanning) => scanning);
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+      probeScanner.completeScan();
+      await probeScanner.probeStarted.future;
+
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+      probeScanner.addDevice(bleMachine);
+      probeScanner.probeGate!.complete();
+      await connecting;
+      await Future<void>.delayed(Duration.zero);
+
+      expect(probeScanner.probeCallCount, 2);
+      expect(bleMachine.onConnectCalls, 0);
+      expect(settings.preferredMachineId, 'usb-machine-id');
+    });
 
     test('an adoption failure still completes the latch lifecycle', () async {
       await settings.setPreferredMachineId('ble-machine-id');

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -123,8 +123,12 @@ class _AttachNotifyingDiscoveryService
   final _controller = BehaviorSubject<List<Device>>.seeded(const []);
   final _attached = PublishSubject<DeviceAttachedEvent>();
   final Future<void>? initialization;
+  final bool emitAttachInInitialize;
 
-  _AttachNotifyingDiscoveryService({this.initialization});
+  _AttachNotifyingDiscoveryService({
+    this.initialization,
+    this.emitAttachInInitialize = false,
+  });
 
   bool get hasAttachListener => _attached.hasListener;
 
@@ -137,6 +141,11 @@ class _AttachNotifyingDiscoveryService
   @override
   Future<void> initialize() async {
     await initialization;
+    if (emitAttachInInitialize) {
+      _attached.add(
+        const DeviceAttachedEvent(deviceId: 'startup-usb', name: 'DE1'),
+      );
+    }
   }
 
   @override
@@ -378,6 +387,23 @@ void main() {
         expect(notifier.hasAttachListener, isFalse);
       },
     );
+
+    test('an attach emitted during a service initialize is not lost',
+        () async {
+      final notifier = _AttachNotifyingDiscoveryService(
+        emitAttachInInitialize: true,
+      );
+      final controller = DeviceController([notifier]);
+      final seen = <DeviceAttachedEvent>[];
+      final sub = controller.deviceAttached.listen(seen.add);
+
+      await controller.initialize();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(seen, hasLength(1));
+      expect(seen.single.deviceId, 'startup-usb');
+      await sub.cancel();
+    });
   });
 
   group('disconnect tracking keys (comms-harden #20)', () {

--- a/test/controllers/device_controller_test.dart
+++ b/test/controllers/device_controller_test.dart
@@ -388,8 +388,7 @@ void main() {
       },
     );
 
-    test('an attach emitted during a service initialize is not lost',
-        () async {
+    test('an attach emitted during a service initialize is not lost', () async {
       final notifier = _AttachNotifyingDiscoveryService(
         emitAttachInInitialize: true,
       );

--- a/test/helpers/mock_connection_manager.dart
+++ b/test/helpers/mock_connection_manager.dart
@@ -99,7 +99,10 @@ class MockConnectionManager extends ConnectionManager {
   }
 
   @override
-  Future<ConnectionResult> connectMachine(De1Interface machine) async {
+  Future<ConnectionResult> connectMachine(
+    De1Interface machine, {
+    bool automatic = false,
+  }) async {
     if (shouldFailMachineConnect) {
       final error = ConnectionError(
         kind: ConnectionErrorKind.machineConnectFailed,

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -100,12 +100,16 @@ class MockSettingsService extends SettingsService {
   Future<void> setStopHotWaterAtWeight(bool value) async =>
       _stopHotWaterAtWeight = value;
   final List<String?> preferredMachineIdWrites = [];
+  bool failSetPreferredMachineId = false;
 
   @override
   Future<String?> preferredMachineId() async => _preferredMachineId;
   @override
   Future<void> setPreferredMachineId(String? machineId) async {
     preferredMachineIdWrites.add(machineId);
+    if (failSetPreferredMachineId) {
+      throw Exception('simulated preference persist failure');
+    }
     _preferredMachineId = machineId;
   }
 

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -99,11 +99,16 @@ class MockSettingsService extends SettingsService {
   @override
   Future<void> setStopHotWaterAtWeight(bool value) async =>
       _stopHotWaterAtWeight = value;
+  final List<String?> preferredMachineIdWrites = [];
+
   @override
   Future<String?> preferredMachineId() async => _preferredMachineId;
   @override
-  Future<void> setPreferredMachineId(String? machineId) async =>
-      _preferredMachineId = machineId;
+  Future<void> setPreferredMachineId(String? machineId) async {
+    preferredMachineIdWrites.add(machineId);
+    _preferredMachineId = machineId;
+  }
+
   @override
   Future<String?> preferredScaleId() async => _preferredScaleId;
   @override

--- a/test/services/serial/usb_attach_event_test.dart
+++ b/test/services/serial/usb_attach_event_test.dart
@@ -174,4 +174,66 @@ void main() {
       await service.dispose();
     },
   );
+
+  test('initialization emits one generic hint for a non-empty enumeration',
+      () async {
+    final usbEvents = StreamController<UsbEvent>.broadcast();
+    service = SerialServiceAndroid(
+      listDevices: () async => [_device(), _device(serial: 'OTHER')],
+      usbEventStream: () => usbEvents.stream,
+    );
+    final events = <DeviceAttachedEvent>[];
+    final subscription = service.deviceAttached.listen(events.add);
+
+    await service.initialize();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, hasLength(1));
+    expect(events.single.deviceId, isNull);
+    await subscription.cancel();
+    await usbEvents.close();
+  });
+
+  test('initialization emits no hint for an empty enumeration', () async {
+    final usbEvents = StreamController<UsbEvent>.broadcast();
+    service = SerialServiceAndroid(
+      listDevices: () async => const [],
+      usbEventStream: () => usbEvents.stream,
+    );
+    final events = <DeviceAttachedEvent>[];
+    final subscription = service.deviceAttached.listen(events.add);
+
+    await service.initialize();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, isEmpty);
+    await subscription.cancel();
+    await usbEvents.close();
+  });
+
+  test('platform listener is established before enumeration completes',
+      () async {
+    final listedDevices = Completer<List<UsbDevice>>();
+    final usbEvents = StreamController<UsbEvent>.broadcast();
+    service = SerialServiceAndroid(
+      listDevices: () => listedDevices.future,
+      usbEventStream: () => usbEvents.stream,
+    );
+    final events = <DeviceAttachedEvent>[];
+    final subscription = service.deviceAttached.listen(events.add);
+
+    final initializing = service.initialize();
+    await Future<void>.delayed(Duration.zero);
+    expect(usbEvents.hasListener, isTrue);
+    usbEvents.add(_event(UsbEvent.ACTION_USB_ATTACHED, device: _device()));
+    listedDevices.complete([_device(serial: 'OTHER')]);
+    await initializing;
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, hasLength(2));
+    expect(events[0].deviceId, 'usb-2e8a-a-8549628789ABCDEF');
+    expect(events[1].deviceId, isNull);
+    await subscription.cancel();
+    await usbEvents.close();
+  });
 }

--- a/test/services/serial/usb_attach_event_test.dart
+++ b/test/services/serial/usb_attach_event_test.dart
@@ -175,24 +175,26 @@ void main() {
     },
   );
 
-  test('initialization emits one generic hint for a non-empty enumeration',
-      () async {
-    final usbEvents = StreamController<UsbEvent>.broadcast();
-    service = SerialServiceAndroid(
-      listDevices: () async => [_device(), _device(serial: 'OTHER')],
-      usbEventStream: () => usbEvents.stream,
-    );
-    final events = <DeviceAttachedEvent>[];
-    final subscription = service.deviceAttached.listen(events.add);
+  test(
+    'initialization emits one generic hint for a non-empty enumeration',
+    () async {
+      final usbEvents = StreamController<UsbEvent>.broadcast();
+      service = SerialServiceAndroid(
+        listDevices: () async => [_device(), _device(serial: 'OTHER')],
+        usbEventStream: () => usbEvents.stream,
+      );
+      final events = <DeviceAttachedEvent>[];
+      final subscription = service.deviceAttached.listen(events.add);
 
-    await service.initialize();
-    await Future<void>.delayed(Duration.zero);
+      await service.initialize();
+      await Future<void>.delayed(Duration.zero);
 
-    expect(events, hasLength(1));
-    expect(events.single.deviceId, isNull);
-    await subscription.cancel();
-    await usbEvents.close();
-  });
+      expect(events, hasLength(1));
+      expect(events.single.deviceId, isNull);
+      await subscription.cancel();
+      await usbEvents.close();
+    },
+  );
 
   test('initialization emits no hint for an empty enumeration', () async {
     final usbEvents = StreamController<UsbEvent>.broadcast();
@@ -211,29 +213,31 @@ void main() {
     await usbEvents.close();
   });
 
-  test('platform listener is established before enumeration completes',
-      () async {
-    final listedDevices = Completer<List<UsbDevice>>();
-    final usbEvents = StreamController<UsbEvent>.broadcast();
-    service = SerialServiceAndroid(
-      listDevices: () => listedDevices.future,
-      usbEventStream: () => usbEvents.stream,
-    );
-    final events = <DeviceAttachedEvent>[];
-    final subscription = service.deviceAttached.listen(events.add);
+  test(
+    'platform listener is established before enumeration completes',
+    () async {
+      final listedDevices = Completer<List<UsbDevice>>();
+      final usbEvents = StreamController<UsbEvent>.broadcast();
+      service = SerialServiceAndroid(
+        listDevices: () => listedDevices.future,
+        usbEventStream: () => usbEvents.stream,
+      );
+      final events = <DeviceAttachedEvent>[];
+      final subscription = service.deviceAttached.listen(events.add);
 
-    final initializing = service.initialize();
-    await Future<void>.delayed(Duration.zero);
-    expect(usbEvents.hasListener, isTrue);
-    usbEvents.add(_event(UsbEvent.ACTION_USB_ATTACHED, device: _device()));
-    listedDevices.complete([_device(serial: 'OTHER')]);
-    await initializing;
-    await Future<void>.delayed(Duration.zero);
+      final initializing = service.initialize();
+      await Future<void>.delayed(Duration.zero);
+      expect(usbEvents.hasListener, isTrue);
+      usbEvents.add(_event(UsbEvent.ACTION_USB_ATTACHED, device: _device()));
+      listedDevices.complete([_device(serial: 'OTHER')]);
+      await initializing;
+      await Future<void>.delayed(Duration.zero);
 
-    expect(events, hasLength(2));
-    expect(events[0].deviceId, 'usb-2e8a-a-8549628789ABCDEF');
-    expect(events[1].deviceId, isNull);
-    await subscription.cancel();
-    await usbEvents.close();
-  });
+      expect(events, hasLength(2));
+      expect(events[0].deviceId, 'usb-2e8a-a-8549628789ABCDEF');
+      expect(events[1].deviceId, isNull);
+      await subscription.cancel();
+      await usbEvents.close();
+    },
+  );
 }

--- a/test/services/serial/usb_attach_probe_test.dart
+++ b/test/services/serial/usb_attach_probe_test.dart
@@ -327,4 +327,35 @@ void main() {
     expect(result, isA<AttachProbeUnsupported>());
     expect(await service.devices.first, isEmpty);
   });
+
+  for (final order in ['de1-first', 'keyboard-first']) {
+    test(
+      'generic startup hint with multiple devices ($order) still finds '
+      'the supported machine',
+      () async {
+        final machine = _FakeMachine();
+        final keyboard = _device(
+          vid: 0x046D,
+          pid: 0xC31C,
+          serial: 'kbd-1',
+          productName: 'USB Keyboard',
+        );
+        listed = order == 'de1-first'
+            ? [_device(), keyboard]
+            : [keyboard, _device()];
+        detection = (d) async =>
+            d.productName == 'USB Keyboard' ? null : machine;
+        service = build();
+
+        final result = await service.connectAttachedMachine(
+          const DeviceAttachedEvent(),
+        );
+
+        expect(result, isA<AttachProbeConnected>());
+        expect((result as AttachProbeConnected).machine, same(machine));
+        expect(machine.onConnectCalls, 1);
+        expect(await service.devices.first, contains(machine));
+      },
+    );
+  }
 }

--- a/test/services/serial/usb_attach_probe_test.dart
+++ b/test/services/serial/usb_attach_probe_test.dart
@@ -329,33 +329,29 @@ void main() {
   });
 
   for (final order in ['de1-first', 'keyboard-first']) {
-    test(
-      'generic startup hint with multiple devices ($order) still finds '
-      'the supported machine',
-      () async {
-        final machine = _FakeMachine();
-        final keyboard = _device(
-          vid: 0x046D,
-          pid: 0xC31C,
-          serial: 'kbd-1',
-          productName: 'USB Keyboard',
-        );
-        listed = order == 'de1-first'
-            ? [_device(), keyboard]
-            : [keyboard, _device()];
-        detection = (d) async =>
-            d.productName == 'USB Keyboard' ? null : machine;
-        service = build();
+    test('generic startup hint with multiple devices ($order) still finds '
+        'the supported machine', () async {
+      final machine = _FakeMachine();
+      final keyboard = _device(
+        vid: 0x046D,
+        pid: 0xC31C,
+        serial: 'kbd-1',
+        productName: 'USB Keyboard',
+      );
+      listed = order == 'de1-first'
+          ? [_device(), keyboard]
+          : [keyboard, _device()];
+      detection = (d) async => d.productName == 'USB Keyboard' ? null : machine;
+      service = build();
 
-        final result = await service.connectAttachedMachine(
-          const DeviceAttachedEvent(),
-        );
+      final result = await service.connectAttachedMachine(
+        const DeviceAttachedEvent(),
+      );
 
-        expect(result, isA<AttachProbeConnected>());
-        expect((result as AttachProbeConnected).machine, same(machine));
-        expect(machine.onConnectCalls, 1);
-        expect(await service.devices.first, contains(machine));
-      },
-    );
+      expect(result, isA<AttachProbeConnected>());
+      expect((result as AttachProbeConnected).machine, same(machine));
+      expect(machine.onConnectCalls, 1);
+      expect(await service.devices.first, contains(machine));
+    });
   }
 }


### PR DESCRIPTION
## Summary

Fixes the race where a passive automatic preferred-BLE scan can beat an explicit Android USB attachment during the attach settle window (#659). USB intent is now latched the moment the attach event arrives, automatic machine selection is paused while latched, and a machine connected by a superseded automatic attempt is released before the queued probe runs. A USB DE1 already attached at startup now gets the same priority via a startup enumeration hint.

Three changes:

- `AttachReconnectCoordinator` gains `onLatched` (fired when the settle timer arms) and `onSettled` (fired when settle expiry skips the attempt).
- `ConnectionManager` owns the latch: `_maybeScheduleMachineReconnect` defers, `connectMachine` refuses automatic/adapter-recovery connects, `_executeConnect` defers automatic machine work, and a single completion helper clears the latch and resumes whatever it interrupted (replayed automatic connect or re-armed recovery). Explicit direct connects, explicit scans, and scale-only work are never superseded.
- Startup: `DeviceController` subscribes to attach streams before service `initialize()`, and `SerialServiceAndroid.initialize()` subscribes to the platform USB stream before enumeration and emits one generic metadata-free startup hint when devices are found.

## Linked Issue

Fixes #659

## Verification

- New regression tests (all green):
  - Coordinator: `onLatched` fires once per burst, not when a machine is connected; `onSettled` on the skip path.
  - `DeviceController`: attach emitted from inside a service `initialize()` reaches the controller.
  - Serial: one generic hint for a non-empty enumeration, none for empty, platform listener established before enumeration completes, and the generic hint finds the supported machine regardless of DE1/keyboard enumeration order.
  - `ConnectionManager` (probe-capable group): attach during automatic scan supersedes the scan; attach during an in-flight tracked BLE connect releases BLE and adopts USB (including settle expiry inside the transient connected-but-not-yet-released window); attach during remembered quick-connect releases BLE; startup hint before `connect()` prevents quick-connect; unsupported probe clears the latch and resumes the interrupted automatic policy; probe failure after releasing BLE re-arms recovery; supersession marker is consumed by a failed connect so a later connect is not released; a direct explicit connect is not superseded while latched.
- `dart format` clean, `flutter analyze` clean (1 pre-existing pubspec asset warning).
- Full `flutter test`: 0 failures outside the pre-existing `shot_upload` plugin suite (those fail on `main` too — the bundled `assets/plugins/shot-upload.reaplugin/` directory is absent in this checkout).

## Impact

- USB attach behavior on Android: a supported attached DE1 now reliably wins over a saved BLE preference during the settle window and at startup. Unsupported devices and probe failures fall back to the existing preferred-machine policy.
- No REST/WebSocket/DB/skin/plugin API changes. Explicit discovery, scale-only, BLE-only, simulated-device, and non-Android behavior unchanged.
- Docs updated: `doc/DeviceManagement.md`, `doc/AI_BLE_NOTES.md`; design plan archived at `doc/plans/archive/659-usb-latch-vs-preferred-ble/2026-08-28-design.md`.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
