### PR TITLE
feat(api): add /api/v1/equipment REST resource

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -2663,6 +2663,231 @@ paths:
         "500":
           description: Internal Server Error
 
+  # Equipment API
+  #
+  # Prep equipment that isn't a grinder: baskets, portafilters, drippers, and
+  # anything else via `other`. A single resource with a `type` discriminator,
+  # rather than one endpoint per equipment kind, since they share the same
+  # shape (name/style/notes/archived) and most clients just want "everything
+  # that isn't a grinder" or one filtered slice of it.
+  /api/v1/equipment:
+    get:
+      summary: List all equipment
+      description: Returns all equipment, optionally filtered by type and/or including archived ones.
+      tags: [Equipment]
+      parameters:
+        - name: includeArchived
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: Include archived equipment in results
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [basket, portafilter, dripper, other]
+          description: Filter by equipment type
+      responses:
+        "200":
+          description: Array of equipment
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: |
+                Strong entity tag derived from the response body. Echo back as
+                `If-None-Match` on subsequent requests for conditional GET.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Equipment"
+        "304":
+          description: Not Modified — client's `If-None-Match` matched the current ETag.
+        "500":
+          description: Internal Server Error
+    post:
+      summary: Create a new equipment entry
+      description: Creates a new equipment entry. Requires name; type defaults to "other" if omitted.
+      tags: [Equipment]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                type:
+                  type: string
+                  enum: [basket, portafilter, dripper, other]
+                  default: "other"
+                name:
+                  type: string
+                  description: Equipment name
+                style:
+                  type: string
+                  nullable: true
+                  description: "Free-text variant descriptor (e.g. double, bottomless, precision)"
+                diameterMm:
+                  type: number
+                  format: double
+                  nullable: true
+                  description: Diameter in mm, mainly for baskets/portafilters
+                notes:
+                  type: string
+                  nullable: true
+                tools:
+                  type: array
+                  items:
+                    type: string
+                  nullable: true
+                  description: Sub-items associated with this equipment (e.g. WDT tool, puck screen)
+                extras:
+                  type: object
+                  nullable: true
+                  additionalProperties: true
+            examples:
+              basket:
+                summary: A precision basket
+                value:
+                  type: "basket"
+                  name: "IMS Superfine 18g"
+                  style: "double"
+                  diameterMm: 58.0
+              portafilter:
+                summary: A bottomless portafilter
+                value:
+                  type: "portafilter"
+                  name: "Bottomless Portafilter"
+                  style: "bottomless"
+      responses:
+        "201":
+          description: Equipment created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Equipment"
+        "400":
+          description: Bad Request (missing required fields)
+        "500":
+          description: Internal Server Error
+
+  /api/v1/equipment/{id}:
+    get:
+      summary: Get equipment by ID
+      tags: [Equipment]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Equipment ID (UUID)
+      responses:
+        "200":
+          description: Equipment found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Equipment"
+        "404":
+          description: Equipment not found
+        "500":
+          description: Internal Server Error
+    put:
+      summary: Update equipment
+      description: |
+        Updates an existing equipment entry. Omitted fields preserve their current values,
+        explicit `null` clears nullable fields, and supplied values replace them.
+        Explicit `null` for a non-nullable field returns `400`.
+      tags: [Equipment]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Equipment ID (UUID)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum: [basket, portafilter, dripper, other]
+                name:
+                  type: string
+                style:
+                  type: string
+                  nullable: true
+                diameterMm:
+                  type: number
+                  format: double
+                  nullable: true
+                notes:
+                  type: string
+                  nullable: true
+                archived:
+                  type: boolean
+                tools:
+                  type: array
+                  items:
+                    type: string
+                  nullable: true
+                extras:
+                  type: object
+                  nullable: true
+                  additionalProperties: true
+      responses:
+        "200":
+          description: Equipment updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Equipment"
+        "400":
+          description: Bad Request
+        "404":
+          description: Equipment not found
+        "500":
+          description: Internal Server Error
+    delete:
+      summary: Delete equipment
+      description: Permanently deletes an equipment entry.
+      tags: [Equipment]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Equipment ID (UUID)
+      responses:
+        "200":
+          description: Equipment deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  id:
+                    type: string
+        "404":
+          description: Equipment not found
+        "500":
+          description: Internal Server Error
+
   # REA Key-Value Store for clients
   /api/v1/store/{namespace}:
     get:
@@ -7923,6 +8148,69 @@ components:
           type: string
           format: date-time
           description: When the grinder was last updated
+        extras:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Arbitrary key-value pairs for custom data
+
+    Equipment:
+      type: object
+      required:
+        - id
+        - type
+        - name
+        - archived
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          description: Unique equipment identifier (UUID)
+          example: "880e8400-e29b-41d4-a716-446655440003"
+        type:
+          type: string
+          enum: [basket, portafilter, dripper, other]
+          description: Equipment category
+          default: "other"
+        name:
+          type: string
+          description: Equipment name
+          example: "IMS Superfine 18g"
+        style:
+          type: string
+          nullable: true
+          description: "Free-text variant descriptor (e.g. double, bottomless, precision)"
+          example: "double"
+        diameterMm:
+          type: number
+          format: double
+          nullable: true
+          description: Diameter in millimeters, mainly for baskets/portafilters
+          example: 58.0
+        notes:
+          type: string
+          nullable: true
+          description: Notes about the equipment
+        archived:
+          type: boolean
+          description: Whether this equipment is archived
+          default: false
+        tools:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: Sub-items associated with this equipment
+          example: ["WDT tool", "Puck screen"]
+        createdAt:
+          type: string
+          format: date-time
+          description: When the equipment was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the equipment was last updated
         extras:
           type: object
           nullable: true

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -14,7 +14,7 @@ Read this when changing REST endpoints, WebSocket topics, API specs, auth proxy,
 
 - Update the spec file in the same commit as endpoint changes. The spec is authoritative — stale spec = stale agent knowledge.
 - Every handler has `addRoutes()`, registered in `webserver_service.dart` `_init()`.
-- Most handlers use `part of webserver_service.dart`. Standalone imports: `shots_handler`, `beans_handler`, `grinders_handler`, `workflow_handler`, `data_export_handler`, `data_sync_handler`, `info_handler`.
+- Most handlers use `part of webserver_service.dart`. Standalone imports: `shots_handler`, `beans_handler`, `grinders_handler`, `equipment_handler`, `workflow_handler`, `data_export_handler`, `data_sync_handler`, `info_handler`.
 - API docs served on port 4001. REST on port 8080.
 
 ## REST API Conventions

--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -44,7 +44,7 @@ Gotchas:
 
 | Store | Owner | Purpose |
 |-------|-------|---------|
-| Drift DB | `AppDatabase` | Shots, workflows, beans, grinders, profiles, settings |
+| Drift DB | `AppDatabase` | Shots, workflows, beans, grinders, equipment, profiles, settings |
 | `SharedPreferences` | `SharedPreferencesSettingsService` | App settings (telemetry consent, feature flags, preferences) |
 | Secure store | `DecentAccountService`, `PluginLoaderService` | Account credentials, API tokens, secure plugin settings |
 | File system | `StorageService` | Data export, log files, skin assets |
@@ -67,7 +67,7 @@ libsecret.
 
 Persistence uses Drift (SQLite) via `AppDatabase`. DAOs in `lib/src/daos/`, mappers in `lib/src/mappers/`.
 
-**Key tables:** `shots`, `steams`, `workflows`, `profiles`, `beans`, `bean_batches`, `grinders`, `settings`.
+**Key tables:** `shots`, `steams`, `workflows`, `profiles`, `beans`, `bean_batches`, `grinders`, `equipment_records`, `settings`.
 
 **Schema migration:** The `@Database` annotation's `version` field is the schema version. Migrations run in `onUpgrade` callback. Each version bump needs a corresponding migration step.
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -34,6 +34,7 @@ The following list endpoints set a strong `ETag` on every `200 OK` response and 
 - `GET /api/v1/beans`
 - `GET /api/v1/beans/{beanId}/batches`
 - `GET /api/v1/grinders`
+- `GET /api/v1/equipment`
 - `GET /api/v1/profiles`
 - `GET /api/v1/shots` (per query-param combination — filters and pagination are part of the tag)
 
@@ -274,6 +275,18 @@ supplied values replace them. Explicit `null` for non-nullable fields returns
 | GET | `/api/v1/grinders/:id` | Get grinder | |
 | PUT | `/api/v1/grinders/:id` | Update grinder | |
 | DELETE | `/api/v1/grinders/:id` | Delete grinder | |
+
+### Equipment
+
+Baskets, portafilters, drippers, and other prep equipment that isn't a grinder. Filter the list with `?type=basket|portafilter|dripper|other`.
+
+| Method | Path | Description | Handler |
+|--------|------|-------------|---------|
+| GET | `/api/v1/equipment` | List all equipment, optionally filtered by `type` | `equipment_handler.dart` |
+| POST | `/api/v1/equipment` | Create equipment | |
+| GET | `/api/v1/equipment/:id` | Get equipment | |
+| PUT | `/api/v1/equipment/:id` | Update equipment | |
+| DELETE | `/api/v1/equipment/:id` | Delete equipment | |
 
 ### Settings
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,6 +48,7 @@ import 'package:reaprime/src/services/database/mappers/bean_mapper.dart';
 import 'package:reaprime/src/services/database/mappers/grinder_mapper.dart';
 import 'package:reaprime/src/services/storage/app_directories.dart';
 import 'package:reaprime/src/services/storage/drift_bean_storage.dart';
+import 'package:reaprime/src/services/storage/drift_equipment_storage.dart';
 import 'package:reaprime/src/services/storage/drift_grinder_storage.dart';
 import 'package:reaprime/src/services/storage/drift_profile_storage.dart';
 import 'package:reaprime/src/services/storage/bean_storage_service.dart';
@@ -306,6 +307,7 @@ void main(List<String> args) async {
 
   final beanStorage = DriftBeanStorageService(appDatabase);
   final grinderStorage = DriftGrinderStorageService(appDatabase);
+  final equipmentStorage = DriftEquipmentStorageService(appDatabase);
   final profileStorage = DriftProfileStorageService(appDatabase);
 
   final WorkflowController workflowController = WorkflowController();
@@ -522,6 +524,7 @@ void main(List<String> args) async {
       displayController,
       beanStorage: beanStorage,
       grinderStorage: grinderStorage,
+      equipmentStorage: equipmentStorage,
       connectionManager: connectionManager,
       backupSources: BackupDataSources(
         pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) async {

--- a/lib/src/models/data/equipment.dart
+++ b/lib/src/models/data/equipment.dart
@@ -1,0 +1,131 @@
+import 'package:reaprime/src/models/data/utils.dart';
+import 'package:uuid/uuid.dart';
+
+enum EquipmentType {
+  basket,
+  portafilter,
+  dripper,
+  other;
+
+  static EquipmentType fromString(String s) {
+    return EquipmentType.values.firstWhere(
+      (e) => e.name == s,
+      orElse: () => EquipmentType.other,
+    );
+  }
+}
+
+class Equipment {
+  final String id;
+  final EquipmentType type;
+  final String name;
+  final String? style;
+  final double? diameterMm;
+  final String? notes;
+  final bool archived;
+  final List<String>? tools;
+
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final Map<String, dynamic>? extras;
+
+  const Equipment({
+    required this.id,
+    required this.type,
+    required this.name,
+    this.style,
+    this.diameterMm,
+    this.notes,
+    this.archived = false,
+    this.tools,
+    required this.createdAt,
+    required this.updatedAt,
+    this.extras,
+  });
+
+  factory Equipment.create({
+    required EquipmentType type,
+    required String name,
+    String? style,
+    double? diameterMm,
+    String? notes,
+    List<String>? tools,
+    Map<String, dynamic>? extras,
+  }) {
+    final now = DateTime.now();
+    return Equipment(
+      id: const Uuid().v4(),
+      type: type,
+      name: name,
+      style: style,
+      diameterMm: diameterMm,
+      notes: notes,
+      tools: tools,
+      createdAt: now,
+      updatedAt: now,
+      extras: extras,
+    );
+  }
+
+  factory Equipment.fromJson(Map<String, dynamic> json) {
+    return Equipment(
+      id: json['id'] as String,
+      type: json['type'] != null
+          ? EquipmentType.fromString(json['type'] as String)
+          : EquipmentType.other,
+      name: json['name'] as String,
+      style: json['style'] as String?,
+      diameterMm: parseOptionalDouble(json['diameterMm']),
+      notes: json['notes'] as String?,
+      archived: json['archived'] as bool? ?? false,
+      tools: (json['tools'] as List?)?.cast<String>(),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      extras: json['extras'] as Map<String, dynamic>?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'type': type.name,
+      'name': name,
+      if (style != null) 'style': style,
+      if (diameterMm != null) 'diameterMm': diameterMm,
+      if (notes != null) 'notes': notes,
+      'archived': archived,
+      if (tools != null) 'tools': tools,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
+      if (extras != null) 'extras': extras,
+    };
+  }
+
+  Equipment copyWith({
+    EquipmentType? type,
+    String? name,
+    String? style,
+    double? diameterMm,
+    String? notes,
+    bool? archived,
+    List<String>? tools,
+    Map<String, dynamic>? extras,
+  }) {
+    return Equipment(
+      id: id,
+      type: type ?? this.type,
+      name: name ?? this.name,
+      style: style ?? this.style,
+      diameterMm: diameterMm ?? this.diameterMm,
+      notes: notes ?? this.notes,
+      archived: archived ?? this.archived,
+      tools: tools ?? this.tools,
+      createdAt: createdAt,
+      updatedAt: DateTime.now(),
+      extras: extras ?? this.extras,
+    );
+  }
+
+  @override
+  String toString() => 'Equipment(${type.name}, $name, id: $id)';
+}

--- a/lib/src/services/database/daos/equipment_dao.dart
+++ b/lib/src/services/database/daos/equipment_dao.dart
@@ -1,0 +1,57 @@
+import 'package:drift/drift.dart';
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/database/tables/equipment_tables.dart';
+
+part 'equipment_dao.g.dart';
+
+@DriftAccessor(tables: [EquipmentRecords])
+class EquipmentDao extends DatabaseAccessor<AppDatabase>
+    with _$EquipmentDaoMixin {
+  EquipmentDao(super.db);
+
+  Future<List<EquipmentRecord>> getAllEquipment({
+    bool includeArchived = false,
+    String? type,
+  }) {
+    final query = select(equipmentRecords);
+    if (!includeArchived) {
+      query.where((e) => e.archived.equals(false));
+    }
+    if (type != null) {
+      query.where((e) => e.type.equals(type));
+    }
+    query.orderBy([(e) => OrderingTerm.desc(e.updatedAt)]);
+    return query.get();
+  }
+
+  Stream<List<EquipmentRecord>> watchAllEquipment({
+    bool includeArchived = false,
+  }) {
+    final query = select(equipmentRecords);
+    if (!includeArchived) {
+      query.where((e) => e.archived.equals(false));
+    }
+    query.orderBy([(e) => OrderingTerm.desc(e.updatedAt)]);
+    return query.watch();
+  }
+
+  Future<EquipmentRecord?> getEquipmentById(String id) {
+    return (select(
+      equipmentRecords,
+    )..where((e) => e.id.equals(id))).getSingleOrNull();
+  }
+
+  Future<void> insertEquipment(EquipmentRecordsCompanion equipment) {
+    return into(equipmentRecords).insert(equipment);
+  }
+
+  Future<void> updateEquipment(EquipmentRecordsCompanion equipment) {
+    return (update(
+      equipmentRecords,
+    )..where((e) => e.id.equals(equipment.id.value))).write(equipment);
+  }
+
+  Future<void> deleteEquipment(String id) {
+    return (delete(equipmentRecords)..where((e) => e.id.equals(id))).go();
+  }
+}

--- a/lib/src/services/database/daos/equipment_dao.g.dart
+++ b/lib/src/services/database/daos/equipment_dao.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'equipment_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$EquipmentDaoMixin on DatabaseAccessor<AppDatabase> {
+  $EquipmentRecordsTable get equipmentRecords =>
+      attachedDatabase.equipmentRecords;
+  EquipmentDaoManager get managers => EquipmentDaoManager(this);
+}
+
+class EquipmentDaoManager {
+  final _$EquipmentDaoMixin _db;
+  EquipmentDaoManager(this._db);
+  $$EquipmentRecordsTableTableManager get equipmentRecords =>
+      $$EquipmentRecordsTableTableManager(
+        _db.attachedDatabase,
+        _db.equipmentRecords,
+      );
+}

--- a/lib/src/services/database/database.dart
+++ b/lib/src/services/database/database.dart
@@ -2,12 +2,14 @@ import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 import 'package:reaprime/src/services/database/converters/json_converters.dart';
 import 'package:reaprime/src/services/database/daos/bean_dao.dart';
+import 'package:reaprime/src/services/database/daos/equipment_dao.dart';
 import 'package:reaprime/src/services/database/daos/grinder_dao.dart';
 import 'package:reaprime/src/services/database/daos/profile_dao.dart';
 import 'package:reaprime/src/services/database/daos/shot_dao.dart';
 import 'package:reaprime/src/services/database/daos/steam_dao.dart';
 import 'package:reaprime/src/services/database/daos/workflow_dao.dart';
 import 'package:reaprime/src/services/database/tables/bean_tables.dart';
+import 'package:reaprime/src/services/database/tables/equipment_tables.dart';
 import 'package:reaprime/src/services/database/tables/grinder_tables.dart';
 import 'package:reaprime/src/services/database/tables/profile_tables.dart';
 import 'package:reaprime/src/services/database/tables/shot_tables.dart';
@@ -22,12 +24,21 @@ part 'database.g.dart';
     Beans,
     BeanBatches,
     Grinders,
+    EquipmentRecords,
     ShotRecords,
     SteamRecords,
     Workflows,
     ProfileRecords,
   ],
-  daos: [BeanDao, GrinderDao, ShotDao, SteamDao, WorkflowDao, ProfileDao],
+  daos: [
+    BeanDao,
+    GrinderDao,
+    EquipmentDao,
+    ShotDao,
+    SteamDao,
+    WorkflowDao,
+    ProfileDao,
+  ],
 )
 class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
@@ -44,7 +55,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration {
@@ -64,6 +75,9 @@ class AppDatabase extends _$AppDatabase {
         }
         if (from < 4) {
           await m.addColumn(shotRecords, shotRecords.stopReason);
+        }
+        if (from < 5) {
+          await m.createTable(equipmentRecords);
         }
       },
       beforeOpen: (details) async {

--- a/lib/src/services/database/database.g.dart
+++ b/lib/src/services/database/database.g.dart
@@ -3071,6 +3071,664 @@ class GrindersCompanion extends UpdateCompanion<Grinder> {
   }
 }
 
+class $EquipmentRecordsTable extends EquipmentRecords
+    with TableInfo<$EquipmentRecordsTable, EquipmentRecord> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $EquipmentRecordsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _typeMeta = const VerificationMeta('type');
+  @override
+  late final GeneratedColumn<String> type = GeneratedColumn<String>(
+    'type',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('other'),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _styleMeta = const VerificationMeta('style');
+  @override
+  late final GeneratedColumn<String> style = GeneratedColumn<String>(
+    'style',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _diameterMmMeta = const VerificationMeta(
+    'diameterMm',
+  );
+  @override
+  late final GeneratedColumn<double> diameterMm = GeneratedColumn<double>(
+    'diameter_mm',
+    aliasedName,
+    true,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _notesMeta = const VerificationMeta('notes');
+  @override
+  late final GeneratedColumn<String> notes = GeneratedColumn<String>(
+    'notes',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _archivedMeta = const VerificationMeta(
+    'archived',
+  );
+  @override
+  late final GeneratedColumn<bool> archived = GeneratedColumn<bool>(
+    'archived',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("archived" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<List<String>?, String> tools =
+      GeneratedColumn<String>(
+        'tools',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      ).withConverter<List<String>?>($EquipmentRecordsTable.$convertertools);
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String>
+  extras =
+      GeneratedColumn<String>(
+        'extras',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      ).withConverter<Map<String, dynamic>?>(
+        $EquipmentRecordsTable.$converterextras,
+      );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    type,
+    name,
+    style,
+    diameterMm,
+    notes,
+    archived,
+    tools,
+    createdAt,
+    updatedAt,
+    extras,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'equipment_records';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<EquipmentRecord> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('type')) {
+      context.handle(
+        _typeMeta,
+        type.isAcceptableOrUnknown(data['type']!, _typeMeta),
+      );
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('style')) {
+      context.handle(
+        _styleMeta,
+        style.isAcceptableOrUnknown(data['style']!, _styleMeta),
+      );
+    }
+    if (data.containsKey('diameter_mm')) {
+      context.handle(
+        _diameterMmMeta,
+        diameterMm.isAcceptableOrUnknown(data['diameter_mm']!, _diameterMmMeta),
+      );
+    }
+    if (data.containsKey('notes')) {
+      context.handle(
+        _notesMeta,
+        notes.isAcceptableOrUnknown(data['notes']!, _notesMeta),
+      );
+    }
+    if (data.containsKey('archived')) {
+      context.handle(
+        _archivedMeta,
+        archived.isAcceptableOrUnknown(data['archived']!, _archivedMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  EquipmentRecord map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return EquipmentRecord(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      type: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}type'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      style: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}style'],
+      ),
+      diameterMm: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}diameter_mm'],
+      ),
+      notes: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}notes'],
+      ),
+      archived: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}archived'],
+      )!,
+      tools: $EquipmentRecordsTable.$convertertools.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}tools'],
+        ),
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      extras: $EquipmentRecordsTable.$converterextras.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}extras'],
+        ),
+      ),
+    );
+  }
+
+  @override
+  $EquipmentRecordsTable createAlias(String alias) {
+    return $EquipmentRecordsTable(attachedDatabase, alias);
+  }
+
+  static TypeConverter<List<String>?, String?> $convertertools =
+      const NullableStringListConverter();
+  static TypeConverter<Map<String, dynamic>?, String?> $converterextras =
+      const NullableJsonMapConverter();
+}
+
+class EquipmentRecord extends DataClass implements Insertable<EquipmentRecord> {
+  final String id;
+  final String type;
+  final String name;
+  final String? style;
+  final double? diameterMm;
+  final String? notes;
+  final bool archived;
+  final List<String>? tools;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final Map<String, dynamic>? extras;
+  const EquipmentRecord({
+    required this.id,
+    required this.type,
+    required this.name,
+    this.style,
+    this.diameterMm,
+    this.notes,
+    required this.archived,
+    this.tools,
+    required this.createdAt,
+    required this.updatedAt,
+    this.extras,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['type'] = Variable<String>(type);
+    map['name'] = Variable<String>(name);
+    if (!nullToAbsent || style != null) {
+      map['style'] = Variable<String>(style);
+    }
+    if (!nullToAbsent || diameterMm != null) {
+      map['diameter_mm'] = Variable<double>(diameterMm);
+    }
+    if (!nullToAbsent || notes != null) {
+      map['notes'] = Variable<String>(notes);
+    }
+    map['archived'] = Variable<bool>(archived);
+    if (!nullToAbsent || tools != null) {
+      map['tools'] = Variable<String>(
+        $EquipmentRecordsTable.$convertertools.toSql(tools),
+      );
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    if (!nullToAbsent || extras != null) {
+      map['extras'] = Variable<String>(
+        $EquipmentRecordsTable.$converterextras.toSql(extras),
+      );
+    }
+    return map;
+  }
+
+  EquipmentRecordsCompanion toCompanion(bool nullToAbsent) {
+    return EquipmentRecordsCompanion(
+      id: Value(id),
+      type: Value(type),
+      name: Value(name),
+      style: style == null && nullToAbsent
+          ? const Value.absent()
+          : Value(style),
+      diameterMm: diameterMm == null && nullToAbsent
+          ? const Value.absent()
+          : Value(diameterMm),
+      notes: notes == null && nullToAbsent
+          ? const Value.absent()
+          : Value(notes),
+      archived: Value(archived),
+      tools: tools == null && nullToAbsent
+          ? const Value.absent()
+          : Value(tools),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      extras: extras == null && nullToAbsent
+          ? const Value.absent()
+          : Value(extras),
+    );
+  }
+
+  factory EquipmentRecord.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return EquipmentRecord(
+      id: serializer.fromJson<String>(json['id']),
+      type: serializer.fromJson<String>(json['type']),
+      name: serializer.fromJson<String>(json['name']),
+      style: serializer.fromJson<String?>(json['style']),
+      diameterMm: serializer.fromJson<double?>(json['diameterMm']),
+      notes: serializer.fromJson<String?>(json['notes']),
+      archived: serializer.fromJson<bool>(json['archived']),
+      tools: serializer.fromJson<List<String>?>(json['tools']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      extras: serializer.fromJson<Map<String, dynamic>?>(json['extras']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'type': serializer.toJson<String>(type),
+      'name': serializer.toJson<String>(name),
+      'style': serializer.toJson<String?>(style),
+      'diameterMm': serializer.toJson<double?>(diameterMm),
+      'notes': serializer.toJson<String?>(notes),
+      'archived': serializer.toJson<bool>(archived),
+      'tools': serializer.toJson<List<String>?>(tools),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'extras': serializer.toJson<Map<String, dynamic>?>(extras),
+    };
+  }
+
+  EquipmentRecord copyWith({
+    String? id,
+    String? type,
+    String? name,
+    Value<String?> style = const Value.absent(),
+    Value<double?> diameterMm = const Value.absent(),
+    Value<String?> notes = const Value.absent(),
+    bool? archived,
+    Value<List<String>?> tools = const Value.absent(),
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    Value<Map<String, dynamic>?> extras = const Value.absent(),
+  }) => EquipmentRecord(
+    id: id ?? this.id,
+    type: type ?? this.type,
+    name: name ?? this.name,
+    style: style.present ? style.value : this.style,
+    diameterMm: diameterMm.present ? diameterMm.value : this.diameterMm,
+    notes: notes.present ? notes.value : this.notes,
+    archived: archived ?? this.archived,
+    tools: tools.present ? tools.value : this.tools,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    extras: extras.present ? extras.value : this.extras,
+  );
+  EquipmentRecord copyWithCompanion(EquipmentRecordsCompanion data) {
+    return EquipmentRecord(
+      id: data.id.present ? data.id.value : this.id,
+      type: data.type.present ? data.type.value : this.type,
+      name: data.name.present ? data.name.value : this.name,
+      style: data.style.present ? data.style.value : this.style,
+      diameterMm: data.diameterMm.present
+          ? data.diameterMm.value
+          : this.diameterMm,
+      notes: data.notes.present ? data.notes.value : this.notes,
+      archived: data.archived.present ? data.archived.value : this.archived,
+      tools: data.tools.present ? data.tools.value : this.tools,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      extras: data.extras.present ? data.extras.value : this.extras,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('EquipmentRecord(')
+          ..write('id: $id, ')
+          ..write('type: $type, ')
+          ..write('name: $name, ')
+          ..write('style: $style, ')
+          ..write('diameterMm: $diameterMm, ')
+          ..write('notes: $notes, ')
+          ..write('archived: $archived, ')
+          ..write('tools: $tools, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('extras: $extras')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    type,
+    name,
+    style,
+    diameterMm,
+    notes,
+    archived,
+    tools,
+    createdAt,
+    updatedAt,
+    extras,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is EquipmentRecord &&
+          other.id == this.id &&
+          other.type == this.type &&
+          other.name == this.name &&
+          other.style == this.style &&
+          other.diameterMm == this.diameterMm &&
+          other.notes == this.notes &&
+          other.archived == this.archived &&
+          other.tools == this.tools &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.extras == this.extras);
+}
+
+class EquipmentRecordsCompanion extends UpdateCompanion<EquipmentRecord> {
+  final Value<String> id;
+  final Value<String> type;
+  final Value<String> name;
+  final Value<String?> style;
+  final Value<double?> diameterMm;
+  final Value<String?> notes;
+  final Value<bool> archived;
+  final Value<List<String>?> tools;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<Map<String, dynamic>?> extras;
+  final Value<int> rowid;
+  const EquipmentRecordsCompanion({
+    this.id = const Value.absent(),
+    this.type = const Value.absent(),
+    this.name = const Value.absent(),
+    this.style = const Value.absent(),
+    this.diameterMm = const Value.absent(),
+    this.notes = const Value.absent(),
+    this.archived = const Value.absent(),
+    this.tools = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.extras = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  EquipmentRecordsCompanion.insert({
+    required String id,
+    this.type = const Value.absent(),
+    required String name,
+    this.style = const Value.absent(),
+    this.diameterMm = const Value.absent(),
+    this.notes = const Value.absent(),
+    this.archived = const Value.absent(),
+    this.tools = const Value.absent(),
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    this.extras = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       name = Value(name),
+       createdAt = Value(createdAt),
+       updatedAt = Value(updatedAt);
+  static Insertable<EquipmentRecord> custom({
+    Expression<String>? id,
+    Expression<String>? type,
+    Expression<String>? name,
+    Expression<String>? style,
+    Expression<double>? diameterMm,
+    Expression<String>? notes,
+    Expression<bool>? archived,
+    Expression<String>? tools,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<String>? extras,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (type != null) 'type': type,
+      if (name != null) 'name': name,
+      if (style != null) 'style': style,
+      if (diameterMm != null) 'diameter_mm': diameterMm,
+      if (notes != null) 'notes': notes,
+      if (archived != null) 'archived': archived,
+      if (tools != null) 'tools': tools,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (extras != null) 'extras': extras,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  EquipmentRecordsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? type,
+    Value<String>? name,
+    Value<String?>? style,
+    Value<double?>? diameterMm,
+    Value<String?>? notes,
+    Value<bool>? archived,
+    Value<List<String>?>? tools,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<Map<String, dynamic>?>? extras,
+    Value<int>? rowid,
+  }) {
+    return EquipmentRecordsCompanion(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      name: name ?? this.name,
+      style: style ?? this.style,
+      diameterMm: diameterMm ?? this.diameterMm,
+      notes: notes ?? this.notes,
+      archived: archived ?? this.archived,
+      tools: tools ?? this.tools,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      extras: extras ?? this.extras,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (type.present) {
+      map['type'] = Variable<String>(type.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (style.present) {
+      map['style'] = Variable<String>(style.value);
+    }
+    if (diameterMm.present) {
+      map['diameter_mm'] = Variable<double>(diameterMm.value);
+    }
+    if (notes.present) {
+      map['notes'] = Variable<String>(notes.value);
+    }
+    if (archived.present) {
+      map['archived'] = Variable<bool>(archived.value);
+    }
+    if (tools.present) {
+      map['tools'] = Variable<String>(
+        $EquipmentRecordsTable.$convertertools.toSql(tools.value),
+      );
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (extras.present) {
+      map['extras'] = Variable<String>(
+        $EquipmentRecordsTable.$converterextras.toSql(extras.value),
+      );
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('EquipmentRecordsCompanion(')
+          ..write('id: $id, ')
+          ..write('type: $type, ')
+          ..write('name: $name, ')
+          ..write('style: $style, ')
+          ..write('diameterMm: $diameterMm, ')
+          ..write('notes: $notes, ')
+          ..write('archived: $archived, ')
+          ..write('tools: $tools, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('extras: $extras, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $ShotRecordsTable extends ShotRecords
     with TableInfo<$ShotRecordsTable, ShotRecord> {
   @override
@@ -3525,9 +4183,6 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
   final double? targetYield;
   final double? enjoyment;
   final String? espressoNotes;
-
-  /// Why the shot ended (ShotDecisionReason.name, open set). Added in schema
-  /// v4; null for shots recorded before then or not sequenced by the app.
   final String? stopReason;
   final Map<String, dynamic> workflowJson;
   final Map<String, dynamic>? annotationsJson;
@@ -5411,12 +6066,16 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $BeansTable beans = $BeansTable(this);
   late final $BeanBatchesTable beanBatches = $BeanBatchesTable(this);
   late final $GrindersTable grinders = $GrindersTable(this);
+  late final $EquipmentRecordsTable equipmentRecords = $EquipmentRecordsTable(
+    this,
+  );
   late final $ShotRecordsTable shotRecords = $ShotRecordsTable(this);
   late final $SteamRecordsTable steamRecords = $SteamRecordsTable(this);
   late final $WorkflowsTable workflows = $WorkflowsTable(this);
   late final $ProfileRecordsTable profileRecords = $ProfileRecordsTable(this);
   late final BeanDao beanDao = BeanDao(this as AppDatabase);
   late final GrinderDao grinderDao = GrinderDao(this as AppDatabase);
+  late final EquipmentDao equipmentDao = EquipmentDao(this as AppDatabase);
   late final ShotDao shotDao = ShotDao(this as AppDatabase);
   late final SteamDao steamDao = SteamDao(this as AppDatabase);
   late final WorkflowDao workflowDao = WorkflowDao(this as AppDatabase);
@@ -5429,6 +6088,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     beans,
     beanBatches,
     grinders,
+    equipmentRecords,
     shotRecords,
     steamRecords,
     workflows,
@@ -7030,6 +7690,334 @@ typedef $$GrindersTableProcessedTableManager =
       Grinder,
       PrefetchHooks Function()
     >;
+typedef $$EquipmentRecordsTableCreateCompanionBuilder =
+    EquipmentRecordsCompanion Function({
+      required String id,
+      Value<String> type,
+      required String name,
+      Value<String?> style,
+      Value<double?> diameterMm,
+      Value<String?> notes,
+      Value<bool> archived,
+      Value<List<String>?> tools,
+      required DateTime createdAt,
+      required DateTime updatedAt,
+      Value<Map<String, dynamic>?> extras,
+      Value<int> rowid,
+    });
+typedef $$EquipmentRecordsTableUpdateCompanionBuilder =
+    EquipmentRecordsCompanion Function({
+      Value<String> id,
+      Value<String> type,
+      Value<String> name,
+      Value<String?> style,
+      Value<double?> diameterMm,
+      Value<String?> notes,
+      Value<bool> archived,
+      Value<List<String>?> tools,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<Map<String, dynamic>?> extras,
+      Value<int> rowid,
+    });
+
+class $$EquipmentRecordsTableFilterComposer
+    extends Composer<_$AppDatabase, $EquipmentRecordsTable> {
+  $$EquipmentRecordsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get style => $composableBuilder(
+    column: $table.style,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get diameterMm => $composableBuilder(
+    column: $table.diameterMm,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get archived => $composableBuilder(
+    column: $table.archived,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<List<String>?, List<String>, String>
+  get tools => $composableBuilder(
+    column: $table.tools,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<
+    Map<String, dynamic>?,
+    Map<String, dynamic>,
+    String
+  >
+  get extras => $composableBuilder(
+    column: $table.extras,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+}
+
+class $$EquipmentRecordsTableOrderingComposer
+    extends Composer<_$AppDatabase, $EquipmentRecordsTable> {
+  $$EquipmentRecordsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get style => $composableBuilder(
+    column: $table.style,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get diameterMm => $composableBuilder(
+    column: $table.diameterMm,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get archived => $composableBuilder(
+    column: $table.archived,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get tools => $composableBuilder(
+    column: $table.tools,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get extras => $composableBuilder(
+    column: $table.extras,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$EquipmentRecordsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $EquipmentRecordsTable> {
+  $$EquipmentRecordsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get type =>
+      $composableBuilder(column: $table.type, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<String> get style =>
+      $composableBuilder(column: $table.style, builder: (column) => column);
+
+  GeneratedColumn<double> get diameterMm => $composableBuilder(
+    column: $table.diameterMm,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => column);
+
+  GeneratedColumn<bool> get archived =>
+      $composableBuilder(column: $table.archived, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<List<String>?, String> get tools =>
+      $composableBuilder(column: $table.tools, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<Map<String, dynamic>?, String> get extras =>
+      $composableBuilder(column: $table.extras, builder: (column) => column);
+}
+
+class $$EquipmentRecordsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $EquipmentRecordsTable,
+          EquipmentRecord,
+          $$EquipmentRecordsTableFilterComposer,
+          $$EquipmentRecordsTableOrderingComposer,
+          $$EquipmentRecordsTableAnnotationComposer,
+          $$EquipmentRecordsTableCreateCompanionBuilder,
+          $$EquipmentRecordsTableUpdateCompanionBuilder,
+          (
+            EquipmentRecord,
+            BaseReferences<
+              _$AppDatabase,
+              $EquipmentRecordsTable,
+              EquipmentRecord
+            >,
+          ),
+          EquipmentRecord,
+          PrefetchHooks Function()
+        > {
+  $$EquipmentRecordsTableTableManager(
+    _$AppDatabase db,
+    $EquipmentRecordsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$EquipmentRecordsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$EquipmentRecordsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$EquipmentRecordsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> type = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<String?> style = const Value.absent(),
+                Value<double?> diameterMm = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                Value<bool> archived = const Value.absent(),
+                Value<List<String>?> tools = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<Map<String, dynamic>?> extras = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => EquipmentRecordsCompanion(
+                id: id,
+                type: type,
+                name: name,
+                style: style,
+                diameterMm: diameterMm,
+                notes: notes,
+                archived: archived,
+                tools: tools,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                extras: extras,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                Value<String> type = const Value.absent(),
+                required String name,
+                Value<String?> style = const Value.absent(),
+                Value<double?> diameterMm = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                Value<bool> archived = const Value.absent(),
+                Value<List<String>?> tools = const Value.absent(),
+                required DateTime createdAt,
+                required DateTime updatedAt,
+                Value<Map<String, dynamic>?> extras = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => EquipmentRecordsCompanion.insert(
+                id: id,
+                type: type,
+                name: name,
+                style: style,
+                diameterMm: diameterMm,
+                notes: notes,
+                archived: archived,
+                tools: tools,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                extras: extras,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$EquipmentRecordsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $EquipmentRecordsTable,
+      EquipmentRecord,
+      $$EquipmentRecordsTableFilterComposer,
+      $$EquipmentRecordsTableOrderingComposer,
+      $$EquipmentRecordsTableAnnotationComposer,
+      $$EquipmentRecordsTableCreateCompanionBuilder,
+      $$EquipmentRecordsTableUpdateCompanionBuilder,
+      (
+        EquipmentRecord,
+        BaseReferences<_$AppDatabase, $EquipmentRecordsTable, EquipmentRecord>,
+      ),
+      EquipmentRecord,
+      PrefetchHooks Function()
+    >;
 typedef $$ShotRecordsTableCreateCompanionBuilder =
     ShotRecordsCompanion Function({
       required String id,
@@ -8209,6 +9197,8 @@ class $AppDatabaseManager {
       $$BeanBatchesTableTableManager(_db, _db.beanBatches);
   $$GrindersTableTableManager get grinders =>
       $$GrindersTableTableManager(_db, _db.grinders);
+  $$EquipmentRecordsTableTableManager get equipmentRecords =>
+      $$EquipmentRecordsTableTableManager(_db, _db.equipmentRecords);
   $$ShotRecordsTableTableManager get shotRecords =>
       $$ShotRecordsTableTableManager(_db, _db.shotRecords);
   $$SteamRecordsTableTableManager get steamRecords =>

--- a/lib/src/services/database/mappers/equipment_mapper.dart
+++ b/lib/src/services/database/mappers/equipment_mapper.dart
@@ -1,0 +1,37 @@
+import 'package:drift/drift.dart';
+import 'package:reaprime/src/models/data/equipment.dart' as domain;
+import 'package:reaprime/src/services/database/database.dart';
+
+class EquipmentMapper {
+  static domain.Equipment fromRow(EquipmentRecord row) {
+    return domain.Equipment(
+      id: row.id,
+      type: domain.EquipmentType.fromString(row.type),
+      name: row.name,
+      style: row.style,
+      diameterMm: row.diameterMm,
+      notes: row.notes,
+      archived: row.archived,
+      tools: row.tools,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      extras: row.extras,
+    );
+  }
+
+  static EquipmentRecordsCompanion toCompanion(domain.Equipment equipment) {
+    return EquipmentRecordsCompanion(
+      id: Value(equipment.id),
+      type: Value(equipment.type.name),
+      name: Value(equipment.name),
+      style: Value(equipment.style),
+      diameterMm: Value(equipment.diameterMm),
+      notes: Value(equipment.notes),
+      archived: Value(equipment.archived),
+      tools: Value(equipment.tools),
+      createdAt: Value(equipment.createdAt),
+      updatedAt: Value(equipment.updatedAt),
+      extras: Value(equipment.extras),
+    );
+  }
+}

--- a/lib/src/services/database/tables/equipment_tables.dart
+++ b/lib/src/services/database/tables/equipment_tables.dart
@@ -1,0 +1,22 @@
+import 'package:drift/drift.dart';
+import 'package:reaprime/src/services/database/converters/json_converters.dart';
+
+class EquipmentRecords extends Table {
+  TextColumn get id => text()();
+  TextColumn get type => text().withDefault(const Constant('other'))();
+  TextColumn get name => text()();
+  TextColumn get style => text().nullable()();
+  RealColumn get diameterMm => real().nullable()();
+  TextColumn get notes => text().nullable()();
+  BoolColumn get archived => boolean().withDefault(const Constant(false))();
+  TextColumn get tools =>
+      text().map(const NullableStringListConverter()).nullable()();
+
+  DateTimeColumn get createdAt => dateTime()();
+  DateTimeColumn get updatedAt => dateTime()();
+  TextColumn get extras =>
+      text().map(const NullableJsonMapConverter()).nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/src/services/storage/drift_equipment_storage.dart
+++ b/lib/src/services/storage/drift_equipment_storage.dart
@@ -1,0 +1,56 @@
+import 'package:reaprime/src/models/data/equipment.dart' as domain;
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/database/mappers/equipment_mapper.dart';
+import 'package:reaprime/src/services/storage/equipment_storage_service.dart';
+
+class DriftEquipmentStorageService implements EquipmentStorageService {
+  final AppDatabase _db;
+
+  DriftEquipmentStorageService(this._db);
+
+  @override
+  Future<List<domain.Equipment>> getAllEquipment({
+    bool includeArchived = false,
+    domain.EquipmentType? type,
+  }) async {
+    final rows = await _db.equipmentDao.getAllEquipment(
+      includeArchived: includeArchived,
+      type: type?.name,
+    );
+    return rows.map(EquipmentMapper.fromRow).toList();
+  }
+
+  @override
+  Stream<List<domain.Equipment>> watchAllEquipment({
+    bool includeArchived = false,
+  }) {
+    return _db.equipmentDao
+        .watchAllEquipment(includeArchived: includeArchived)
+        .map((rows) => rows.map(EquipmentMapper.fromRow).toList());
+  }
+
+  @override
+  Future<domain.Equipment?> getEquipmentById(String id) async {
+    final row = await _db.equipmentDao.getEquipmentById(id);
+    return row == null ? null : EquipmentMapper.fromRow(row);
+  }
+
+  @override
+  Future<void> insertEquipment(domain.Equipment equipment) {
+    return _db.equipmentDao.insertEquipment(
+      EquipmentMapper.toCompanion(equipment),
+    );
+  }
+
+  @override
+  Future<void> updateEquipment(domain.Equipment equipment) {
+    return _db.equipmentDao.updateEquipment(
+      EquipmentMapper.toCompanion(equipment),
+    );
+  }
+
+  @override
+  Future<void> deleteEquipment(String id) {
+    return _db.equipmentDao.deleteEquipment(id);
+  }
+}

--- a/lib/src/services/storage/equipment_storage_service.dart
+++ b/lib/src/services/storage/equipment_storage_service.dart
@@ -1,0 +1,13 @@
+import 'package:reaprime/src/models/data/equipment.dart';
+
+abstract class EquipmentStorageService {
+  Future<List<Equipment>> getAllEquipment({
+    bool includeArchived = false,
+    EquipmentType? type,
+  });
+  Stream<List<Equipment>> watchAllEquipment({bool includeArchived = false});
+  Future<Equipment?> getEquipmentById(String id);
+  Future<void> insertEquipment(Equipment equipment);
+  Future<void> updateEquipment(Equipment equipment);
+  Future<void> deleteEquipment(String id);
+}

--- a/lib/src/services/webserver/equipment_handler.dart
+++ b/lib/src/services/webserver/equipment_handler.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/data/equipment.dart';
+import 'package:reaprime/src/services/storage/equipment_storage_service.dart';
+import 'package:reaprime/src/services/webserver/bounded_request_body.dart';
+import 'package:reaprime/src/services/webserver/json_patch.dart';
+import 'package:reaprime/src/services/webserver/json_response.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class EquipmentHandler {
+  final EquipmentStorageService _storage;
+  final Logger _log = Logger('EquipmentHandler');
+
+  EquipmentHandler({required EquipmentStorageService storage})
+    : _storage = storage;
+
+  void addRoutes(RouterPlus app) {
+    app.get('/api/v1/equipment', _getEquipment);
+    app.get('/api/v1/equipment/<id>', _getEquipmentById);
+    app.post('/api/v1/equipment', _createEquipment);
+    app.put('/api/v1/equipment/<id>', _updateEquipment);
+    app.delete('/api/v1/equipment/<id>', _deleteEquipment);
+  }
+
+  Future<Response> _getEquipment(Request req) async {
+    try {
+      final includeArchived =
+          req.url.queryParameters['includeArchived'] == 'true';
+      final typeParam = req.url.queryParameters['type'];
+      final type = typeParam != null
+          ? EquipmentType.fromString(typeParam)
+          : null;
+      final equipment = await _storage.getAllEquipment(
+        includeArchived: includeArchived,
+        type: type,
+      );
+      return jsonOkConditional(
+        req,
+        equipment.map((e) => e.toJson()).toList(),
+      );
+    } catch (e, st) {
+      _log.severe('Error getting equipment', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _getEquipmentById(Request req, String id) async {
+    id = Uri.decodeComponent(id);
+    try {
+      final equipment = await _storage.getEquipmentById(id);
+      if (equipment == null) {
+        return jsonNotFound({'error': 'Equipment not found'});
+      }
+      return jsonOk(equipment.toJson());
+    } catch (e, st) {
+      _log.severe('Error getting equipment $id', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _createEquipment(Request req) async {
+    try {
+      final body = await readBoundedRequestBodyString(
+        req,
+        maxBytes: largeRequestBodyBytes,
+      );
+      final json = jsonDecode(body) as Map<String, dynamic>;
+      final equipment = Equipment.create(
+        type: json['type'] != null
+            ? EquipmentType.fromString(json['type'] as String)
+            : EquipmentType.other,
+        name: json['name'] as String,
+        style: json['style'] as String?,
+        diameterMm: (json['diameterMm'] as num?)?.toDouble(),
+        notes: json['notes'] as String?,
+        tools: (json['tools'] as List?)?.cast<String>(),
+        extras: json['extras'] as Map<String, dynamic>?,
+      );
+      await _storage.insertEquipment(equipment);
+      return jsonCreated(equipment.toJson());
+    } on RequestBodyReadException {
+      rethrow;
+    } catch (e, st) {
+      _log.severe('Error creating equipment', e, st);
+      return jsonBadRequest({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _updateEquipment(Request req, String id) async {
+    id = Uri.decodeComponent(id);
+    try {
+      final existing = await _storage.getEquipmentById(id);
+      if (existing == null) {
+        return jsonNotFound({'error': 'Equipment not found'});
+      }
+
+      final body = await readBoundedRequestBodyString(
+        req,
+        maxBytes: largeRequestBodyBytes,
+      );
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      rejectExplicitNulls(json, const ['type', 'name', 'archived']);
+      validatePatchFieldTypes(
+        json,
+        numberFields: const ['diameterMm'],
+        stringListFields: const ['tools'],
+      );
+      final updated = Equipment.fromJson({
+        ...existing.toJson(),
+        ...json,
+        'id': existing.id,
+        'createdAt': existing.createdAt.toIso8601String(),
+        'updatedAt': DateTime.now().toIso8601String(),
+      });
+
+      await _storage.updateEquipment(updated);
+      return jsonOk(updated.toJson());
+    } on RequestBodyReadException {
+      rethrow;
+    } on FormatException catch (e) {
+      return jsonBadRequest({'error': e.toString()});
+    } on TypeError catch (e) {
+      return jsonBadRequest({'error': e.toString()});
+    } catch (e, st) {
+      _log.severe('Error updating equipment $id', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+
+  Future<Response> _deleteEquipment(Request req, String id) async {
+    id = Uri.decodeComponent(id);
+    try {
+      await _storage.deleteEquipment(id);
+      return jsonOk({'success': true, 'id': id});
+    } catch (e, st) {
+      _log.severe('Error deleting equipment $id', e, st);
+      return jsonError({'error': e.toString()});
+    }
+  }
+}

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -44,11 +44,13 @@ import 'package:reaprime/src/services/webserver/data_export/kv_store_export_sect
 import 'package:reaprime/src/services/webserver/data_export/bean_export_section.dart';
 import 'package:reaprime/src/services/webserver/data_export/grinder_export_section.dart';
 import 'package:reaprime/src/services/webserver/beans_handler.dart';
+import 'package:reaprime/src/services/webserver/equipment_handler.dart';
 import 'package:reaprime/src/services/webserver/grinders_handler.dart';
 import 'package:reaprime/src/services/webserver/shots_handler.dart';
 import 'package:reaprime/src/services/webserver/steams_handler.dart';
 import 'package:reaprime/src/services/webserver/workflow_handler.dart';
 import 'package:reaprime/src/services/storage/bean_storage_service.dart';
+import 'package:reaprime/src/services/storage/equipment_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/settings/gateway_mode.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
@@ -151,6 +153,7 @@ Future<void> startWebServer(
   DisplayController? displayController, {
   BeanStorageService? beanStorage,
   GrinderStorageService? grinderStorage,
+  EquipmentStorageService? equipmentStorage,
   required ConnectionManager connectionManager,
   required BackupDataSources backupSources,
   WifiScaleDiscoveryService? wifiScaleDiscoveryService,
@@ -262,6 +265,11 @@ Future<void> startWebServer(
     grindersHandler = GrindersHandler(storage: grinderStorage);
   }
 
+  EquipmentHandler? equipmentHandler;
+  if (equipmentStorage != null) {
+    equipmentHandler = EquipmentHandler(storage: equipmentStorage);
+  }
+
   final kvStoreHandler = KvStoreHandler();
   await kvStoreHandler.store.initialize();
 
@@ -369,6 +377,7 @@ Future<void> startWebServer(
       dataSyncHandler,
       beansHandler,
       grindersHandler,
+      equipmentHandler,
       infoHandler,
       debugHandler,
       wifiScaleHandler,
@@ -410,6 +419,7 @@ Handler _init(
   DataSyncHandler dataSyncHandler,
   BeansHandler? beansHandler,
   GrindersHandler? grindersHandler,
+  EquipmentHandler? equipmentHandler,
   InfoHandler infoHandler,
   DebugHandler? debugHandler,
   WifiScaleHandler? wifiScaleHandler,
@@ -455,6 +465,9 @@ Handler _init(
   }
   if (grindersHandler != null) {
     grindersHandler.addRoutes(app);
+  }
+  if (equipmentHandler != null) {
+    equipmentHandler.addRoutes(app);
   }
   infoHandler.addRoutes(app);
   updateHandler?.addRoutes(app);

--- a/test/database/equipment_dao_test.dart
+++ b/test/database/equipment_dao_test.dart
@@ -1,0 +1,123 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/database/database.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  EquipmentRecordsCompanion makeEquipment({
+    String id = 'eq-1',
+    String type = 'basket',
+    String name = 'Test Basket',
+    bool archived = false,
+  }) {
+    final now = DateTime.now();
+    return EquipmentRecordsCompanion(
+      id: Value(id),
+      type: Value(type),
+      name: Value(name),
+      archived: Value(archived),
+      createdAt: Value(now),
+      updatedAt: Value(now),
+    );
+  }
+
+  test('inserts and retrieves equipment', () async {
+    await db.equipmentDao.insertEquipment(makeEquipment());
+    final equipment = await db.equipmentDao.getAllEquipment();
+    expect(equipment, hasLength(1));
+    expect(equipment.first.name, 'Test Basket');
+  });
+
+  test('filters archived equipment by default', () async {
+    await db.equipmentDao.insertEquipment(makeEquipment(id: 'e1'));
+    await db.equipmentDao.insertEquipment(
+      makeEquipment(id: 'e2', archived: true),
+    );
+
+    final active = await db.equipmentDao.getAllEquipment();
+    expect(active, hasLength(1));
+
+    final all = await db.equipmentDao.getAllEquipment(includeArchived: true);
+    expect(all, hasLength(2));
+  });
+
+  test('filters by type', () async {
+    await db.equipmentDao.insertEquipment(
+      makeEquipment(id: 'e1', type: 'basket'),
+    );
+    await db.equipmentDao.insertEquipment(
+      makeEquipment(id: 'e2', type: 'portafilter'),
+    );
+
+    final baskets = await db.equipmentDao.getAllEquipment(type: 'basket');
+    expect(baskets, hasLength(1));
+    expect(baskets.first.type, 'basket');
+  });
+
+  test('gets equipment by ID', () async {
+    await db.equipmentDao.insertEquipment(
+      makeEquipment(id: 'e1', name: 'IMS Superfine'),
+    );
+    final equipment = await db.equipmentDao.getEquipmentById('e1');
+    expect(equipment, isNotNull);
+    expect(equipment!.name, 'IMS Superfine');
+  });
+
+  test('updates equipment', () async {
+    await db.equipmentDao.insertEquipment(
+      makeEquipment(id: 'e1', name: 'Old'),
+    );
+    await db.equipmentDao.updateEquipment(
+      EquipmentRecordsCompanion(
+        id: const Value('e1'),
+        name: const Value('New'),
+        updatedAt: Value(DateTime.now()),
+      ),
+    );
+    final equipment = await db.equipmentDao.getEquipmentById('e1');
+    expect(equipment!.name, 'New');
+  });
+
+  test('deletes equipment', () async {
+    await db.equipmentDao.insertEquipment(makeEquipment(id: 'e1'));
+    await db.equipmentDao.deleteEquipment('e1');
+    final equipment = await db.equipmentDao.getAllEquipment(
+      includeArchived: true,
+    );
+    expect(equipment, isEmpty);
+  });
+
+  test('watches equipment changes', () async {
+    final stream = db.equipmentDao.watchAllEquipment();
+    await db.equipmentDao.insertEquipment(makeEquipment(id: 'e1'));
+    final equipment = await stream.first;
+    expect(equipment, hasLength(1));
+  });
+
+  test('stores tools list', () async {
+    final now = DateTime.now();
+    await db.equipmentDao.insertEquipment(
+      EquipmentRecordsCompanion(
+        id: const Value('e1'),
+        type: const Value('basket'),
+        name: const Value('DYE2'),
+        tools: const Value(['WDT tool', 'Puck screen']),
+        createdAt: Value(now),
+        updatedAt: Value(now),
+      ),
+    );
+
+    final equipment = await db.equipmentDao.getEquipmentById('e1');
+    expect(equipment!.tools, ['WDT tool', 'Puck screen']);
+  });
+}

--- a/test/models/equipment_test.dart
+++ b/test/models/equipment_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/data/equipment.dart';
+
+void main() {
+  final now = DateTime(2026, 1, 15, 10, 0, 0);
+
+  group('EquipmentType', () {
+    test('fromString parses known values', () {
+      expect(EquipmentType.fromString('basket'), EquipmentType.basket);
+      expect(
+        EquipmentType.fromString('portafilter'),
+        EquipmentType.portafilter,
+      );
+      expect(EquipmentType.fromString('dripper'), EquipmentType.dripper);
+      expect(EquipmentType.fromString('other'), EquipmentType.other);
+    });
+
+    test('fromString defaults to other for unknown', () {
+      expect(EquipmentType.fromString('unknown'), EquipmentType.other);
+    });
+  });
+
+  group('Equipment', () {
+    test('round-trip serialization with all fields', () {
+      final equipment = Equipment(
+        id: 'eq-1',
+        type: EquipmentType.basket,
+        name: 'IMS Superfine 18g',
+        style: 'double',
+        diameterMm: 58.0,
+        notes: 'Precision basket',
+        archived: false,
+        tools: ['WDT tool'],
+        createdAt: now,
+        updatedAt: now,
+        extras: {'bcUuid': 'abc-123'},
+      );
+
+      final json = equipment.toJson();
+      final restored = Equipment.fromJson(json);
+
+      expect(restored.id, 'eq-1');
+      expect(restored.type, EquipmentType.basket);
+      expect(restored.name, 'IMS Superfine 18g');
+      expect(restored.style, 'double');
+      expect(restored.diameterMm, 58.0);
+      expect(restored.notes, 'Precision basket');
+      expect(restored.archived, false);
+      expect(restored.tools, ['WDT tool']);
+      expect(restored.extras, {'bcUuid': 'abc-123'});
+    });
+
+    test('nullable fields omitted from JSON', () {
+      final equipment = Equipment(
+        id: 'eq-2',
+        type: EquipmentType.portafilter,
+        name: 'Bottomless Portafilter',
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      final json = equipment.toJson();
+      expect(json.containsKey('style'), false);
+      expect(json.containsKey('diameterMm'), false);
+      expect(json.containsKey('notes'), false);
+      expect(json.containsKey('tools'), false);
+      expect(json.containsKey('extras'), false);
+      expect(json['type'], 'portafilter');
+      expect(json['archived'], false);
+    });
+
+    test('create factory generates id and timestamps', () {
+      final equipment = Equipment.create(
+        type: EquipmentType.dripper,
+        name: 'V60',
+      );
+
+      expect(equipment.id, isNotEmpty);
+      expect(equipment.createdAt, isNotNull);
+      expect(equipment.updatedAt, isNotNull);
+      expect(equipment.archived, false);
+      expect(equipment.type, EquipmentType.dripper);
+    });
+
+    test('copyWith preserves unchanged fields', () {
+      final equipment = Equipment(
+        id: 'eq-3',
+        type: EquipmentType.basket,
+        name: 'Stock Double',
+        diameterMm: 58.0,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      final updated = equipment.copyWith(diameterMm: 58.5);
+
+      expect(updated.id, 'eq-3');
+      expect(updated.name, 'Stock Double');
+      expect(updated.type, EquipmentType.basket);
+      expect(updated.diameterMm, 58.5);
+    });
+
+    test('fromJson handles int values for doubles', () {
+      final json = {
+        'id': 'eq-4',
+        'type': 'basket',
+        'name': 'Test',
+        'diameterMm': 58,
+        'createdAt': now.toIso8601String(),
+        'updatedAt': now.toIso8601String(),
+      };
+
+      final equipment = Equipment.fromJson(json);
+      expect(equipment.diameterMm, 58.0);
+    });
+
+    test('fromJson defaults missing type to other', () {
+      final json = {
+        'id': 'eq-5',
+        'name': 'Unlabelled',
+        'createdAt': now.toIso8601String(),
+        'updatedAt': now.toIso8601String(),
+      };
+
+      final equipment = Equipment.fromJson(json);
+      expect(equipment.type, EquipmentType.other);
+    });
+  });
+}

--- a/test/webserver/equipment_handler_test.dart
+++ b/test/webserver/equipment_handler_test.dart
@@ -1,0 +1,287 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/data/equipment.dart';
+import 'package:reaprime/src/services/storage/equipment_storage_service.dart';
+import 'package:reaprime/src/services/webserver/equipment_handler.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+
+class MockEquipmentStorageService implements EquipmentStorageService {
+  final List<Equipment> equipment = [];
+
+  @override
+  Future<List<Equipment>> getAllEquipment({
+    bool includeArchived = false,
+    EquipmentType? type,
+  }) async {
+    var result = includeArchived
+        ? List.of(equipment)
+        : equipment.where((e) => !e.archived).toList();
+    if (type != null) {
+      result = result.where((e) => e.type == type).toList();
+    }
+    return result;
+  }
+
+  @override
+  Stream<List<Equipment>> watchAllEquipment({bool includeArchived = false}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Equipment?> getEquipmentById(String id) async {
+    return equipment.where((e) => e.id == id).firstOrNull;
+  }
+
+  @override
+  Future<void> insertEquipment(Equipment item) async {
+    equipment.add(item);
+  }
+
+  @override
+  Future<void> updateEquipment(Equipment item) async {
+    equipment.removeWhere((e) => e.id == item.id);
+    equipment.add(item);
+  }
+
+  @override
+  Future<void> deleteEquipment(String id) async {
+    equipment.removeWhere((e) => e.id == id);
+  }
+}
+
+void main() {
+  late MockEquipmentStorageService storage;
+  late Handler handler;
+
+  setUp(() {
+    storage = MockEquipmentStorageService();
+    final equipmentHandler = EquipmentHandler(storage: storage);
+    final app = Router().plus;
+    equipmentHandler.addRoutes(app);
+    handler = app.call;
+  });
+
+  Future<Response> sendGet(String path) async {
+    return await handler(Request('GET', Uri.parse('http://localhost$path')));
+  }
+
+  Future<Response> sendPost(String path, Map<String, dynamic> body) async {
+    return await handler(
+      Request(
+        'POST',
+        Uri.parse('http://localhost$path'),
+        body: jsonEncode(body),
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+  }
+
+  Future<Response> sendPut(String path, Map<String, dynamic> body) async {
+    return await handler(
+      Request(
+        'PUT',
+        Uri.parse('http://localhost$path'),
+        body: jsonEncode(body),
+        headers: {'content-type': 'application/json'},
+      ),
+    );
+  }
+
+  Future<Response> sendDelete(String path) async {
+    return await handler(Request('DELETE', Uri.parse('http://localhost$path')));
+  }
+
+  group('EquipmentHandler', () {
+    test('GET /api/v1/equipment returns empty list', () async {
+      final response = await sendGet('/api/v1/equipment');
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body, isEmpty);
+    });
+
+    test('POST /api/v1/equipment creates a basket', () async {
+      final response = await sendPost('/api/v1/equipment', {
+        'type': 'basket',
+        'name': 'IMS Superfine 18g',
+        'style': 'double',
+        'diameterMm': 58.0,
+      });
+      expect(response.statusCode, 201);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['type'], 'basket');
+      expect(body['name'], 'IMS Superfine 18g');
+      expect(body['style'], 'double');
+      expect(body['diameterMm'], 58.0);
+      expect(body['id'], isNotEmpty);
+    });
+
+    test('POST /api/v1/equipment defaults type to other when omitted', () async {
+      final response = await sendPost('/api/v1/equipment', {
+        'name': 'Unlabelled tool',
+      });
+      expect(response.statusCode, 201);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['type'], 'other');
+    });
+
+    test('GET /api/v1/equipment filters by type', () async {
+      await sendPost('/api/v1/equipment', {
+        'type': 'basket',
+        'name': 'Basket A',
+      });
+      await sendPost('/api/v1/equipment', {
+        'type': 'portafilter',
+        'name': 'Portafilter A',
+      });
+
+      final response = await sendGet('/api/v1/equipment?type=basket');
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body, hasLength(1));
+      expect(body.first['type'], 'basket');
+    });
+
+    test('GET /api/v1/equipment/<id> returns specific equipment', () async {
+      final createRes = await sendPost('/api/v1/equipment', {
+        'type': 'basket',
+        'name': 'IMS Superfine 18g',
+      });
+      final created = jsonDecode(await createRes.readAsString());
+      final id = created['id'];
+
+      final response = await sendGet('/api/v1/equipment/$id');
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['id'], id);
+      expect(body['name'], 'IMS Superfine 18g');
+    });
+
+    test('GET /api/v1/equipment/<id> returns 404 for missing equipment', () async {
+      final response = await sendGet('/api/v1/equipment/nonexistent');
+      expect(response.statusCode, 404);
+    });
+
+    test('PUT /api/v1/equipment/<id> updates equipment', () async {
+      final createRes = await sendPost('/api/v1/equipment', {
+        'type': 'basket',
+        'name': 'IMS Superfine 18g',
+      });
+      final created = jsonDecode(await createRes.readAsString());
+      final id = created['id'];
+
+      final response = await sendPut('/api/v1/equipment/$id', {
+        'name': 'IMS Superfine 20g',
+        'notes': 'Swapped for a bigger dose',
+      });
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['name'], 'IMS Superfine 20g');
+      expect(body['notes'], 'Swapped for a bigger dose');
+    });
+
+    test(
+      'PUT /api/v1/equipment/<id> applies tri-state patch semantics',
+      () async {
+        final createRes = await sendPost('/api/v1/equipment', {
+          'type': 'basket',
+          'name': 'IMS Superfine 18g',
+          'notes': 'Original',
+        });
+        final created = jsonDecode(await createRes.readAsString());
+        final id = created['id'];
+
+        final preserved = await sendPut('/api/v1/equipment/$id', {
+          'style': 'double',
+        });
+        expect(
+          jsonDecode(await preserved.readAsString())['notes'],
+          'Original',
+        );
+
+        final cleared = await sendPut('/api/v1/equipment/$id', {
+          'notes': null,
+        });
+        expect(
+          (jsonDecode(await cleared.readAsString()) as Map).containsKey(
+            'notes',
+          ),
+          isFalse,
+        );
+
+        final rejected = await sendPut('/api/v1/equipment/$id', {
+          'name': null,
+        });
+        expect(rejected.statusCode, 400);
+      },
+    );
+
+    test('PUT /api/v1/equipment/<id> returns 404 for missing equipment', () async {
+      final response = await sendPut('/api/v1/equipment/nonexistent', {
+        'name': 'Test',
+      });
+      expect(response.statusCode, 404);
+    });
+
+    test('DELETE /api/v1/equipment/<id> deletes equipment', () async {
+      final createRes = await sendPost('/api/v1/equipment', {
+        'type': 'basket',
+        'name': 'IMS Superfine 18g',
+      });
+      final created = jsonDecode(await createRes.readAsString());
+      final id = created['id'];
+
+      final response = await sendDelete('/api/v1/equipment/$id');
+      expect(response.statusCode, 200);
+
+      final getRes = await sendGet('/api/v1/equipment/$id');
+      expect(getRes.statusCode, 404);
+    });
+
+    test('GET /api/v1/equipment sets ETag and honours If-None-Match', () async {
+      final empty = await sendGet('/api/v1/equipment');
+      expect(empty.statusCode, 200);
+      expect(empty.headers['etag'], isNotNull);
+
+      await sendPost('/api/v1/equipment', {
+        'type': 'basket',
+        'name': 'IMS Superfine 18g',
+      });
+      final populated = await sendGet('/api/v1/equipment');
+      final etag = populated.headers['etag'];
+      expect(etag, isNotNull);
+      expect(etag, isNot(empty.headers['etag']));
+
+      final cached = await handler(
+        Request(
+          'GET',
+          Uri.parse('http://localhost/api/v1/equipment'),
+          headers: {'If-None-Match': etag!},
+        ),
+      );
+      expect(cached.statusCode, 304);
+      expect(cached.headers['etag'], etag);
+      expect(await cached.readAsString(), isEmpty);
+    });
+
+    test('GET /api/v1/equipment filters out archived by default', () async {
+      final createRes = await sendPost('/api/v1/equipment', {
+        'type': 'basket',
+        'name': 'IMS Superfine 18g',
+      });
+      final created = jsonDecode(await createRes.readAsString());
+      final id = created['id'];
+
+      await sendPut('/api/v1/equipment/$id', {'archived': true});
+
+      final response = await sendGet('/api/v1/equipment');
+      final body = jsonDecode(await response.readAsString()) as List;
+      expect(body, isEmpty);
+
+      final archivedRes = await sendGet(
+        '/api/v1/equipment?includeArchived=true',
+      );
+      final archivedBody = jsonDecode(await archivedRes.readAsString()) as List;
+      expect(archivedBody, hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a general **Equipment** REST resource (`type: basket|portafilter|dripper|other`) for prep equipment that isn't a grinder. Baskets, portafilters, and drippers currently have no home in the bridge API — plugins that track them (e.g. the DYE2 plugin) have been parking that data in the generic plugin KV store instead of a proper resource.
- Follows the same layered pattern as `Grinders`: domain model → Drift table (schema v4 → v5 migration) → DAO → mapper → storage service → REST handler, wired through `webserver_service.dart` / `main.dart` the same way `grinderStorage` is.
- `GET /api/v1/equipment` supports `?type=<type>` filtering and `?includeArchived=true`, plus conditional GET (ETag), matching Grinders' conventions. `PUT` uses the same tri-state patch semantics (omit = keep, explicit `null` = clear nullable field / reject non-nullable field, value = replace) as the rest of the API.
- Docs updated: `assets/api/rest_v1.yml` (new paths + `Equipment` schema), `doc/Api.md`, `doc/AI_API_NOTES.md`, `doc/AI_STORAGE_NOTES.md`.

## Deliberately out of scope

To keep this PR reviewable, I did not add a data-export/backup section or DE1-app import support for Equipment, even though Grinders has both. Happy to follow up with either if wanted.

## Test plan

- [x] `dart analyze lib/` — no issues
- [x] New tests: `test/models/equipment_test.dart`, `test/database/equipment_dao_test.dart`, `test/webserver/equipment_handler_test.dart` (model round-trip, DAO CRUD/filter/watch, handler request/response incl. ETag + tri-state PATCH) — all passing
- [x] Existing `grinder`-related tests re-run after this change — all passing (one pre-existing flaky test in `de1handler_machine_swap_ws_test.dart`, unrelated to this change and reproducible on `main` without it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZKqRkAaE9jCTBKr3S7f9G