### PR TITLE
feat(feedback): link native feedback to Decent support

### DIFF
--- a/doc/plans/archive/feedback-contact-link/issue-728-feedback-contact-design.md
+++ b/doc/plans/archive/feedback-contact-link/issue-728-feedback-contact-design.md
@@ -10,17 +10,24 @@ GitHub issue look like a failed submission.
 
 Native feedback creates the GitHub issue first. When stored Decent account
 credentials are present, Decaid sends a support message whose body is exactly
-the GitHub issue URL. The returned contact identifier is then added to the
-GitHub issue body with a PATCH request.
+the GitHub issue URL. After support returns the contact identifier, Decaid
+reads the current GitHub issue body, appends the identifier, and patches that
+body. This preserves edits made while the support request was in flight.
 
 `DecentAccountService` owns the authenticated support request. Its existing
 serial-mismatch email becomes a caller of the general support-message method.
 The returned identifier must be non-empty, must not be `0`, and must be safe to
 place inside a single-line Markdown code span.
 
-The complete account lookup, support request, and GitHub PATCH are best-effort
-and time-bounded after issue creation. Their failure is logged but does not
-change the original successful `FeedbackSubmissionResult`.
+The account lookup, support request, and GitHub update are best-effort and
+time-bounded after issue creation. The HTTP requests are abortable, and a
+timeout guard prevents a completed support request from starting a late GitHub
+update. Their failure is logged but does not change the original successful
+`FeedbackSubmissionResult`.
+
+A support `401` invalidates cached account authentication. Later feedback
+submissions skip the authenticated support request until the user logs in
+again.
 
 ## Security Boundary
 
@@ -31,5 +38,7 @@ cannot trigger authenticated Decent Support messages.
 ## Verification
 
 Service tests cover the authenticated support request, response validation,
-the POST to GET to PATCH sequence, the exact support body, and successful
-submission when support linking fails.
+authentication rejection, the POST to support GET to issue GET to PATCH
+sequence, preservation of the current issue body, the exact support body, no
+late PATCH after timeout, and successful submission when support linking
+fails.

--- a/doc/plans/archive/feedback-contact-link/issue-728-feedback-contact-design.md
+++ b/doc/plans/archive/feedback-contact-link/issue-728-feedback-contact-design.md
@@ -1,0 +1,35 @@
+# Issue 728 Feedback Contact Linking
+
+## Goal
+
+Link native in-app feedback to Decent Support without exposing account
+credentials or allowing a support-side failure to make an already-created
+GitHub issue look like a failed submission.
+
+## Design
+
+Native feedback creates the GitHub issue first. When stored Decent account
+credentials are present, Decaid sends a support message whose body is exactly
+the GitHub issue URL. The returned contact identifier is then added to the
+GitHub issue body with a PATCH request.
+
+`DecentAccountService` owns the authenticated support request. Its existing
+serial-mismatch email becomes a caller of the general support-message method.
+The returned identifier must be non-empty, must not be `0`, and must be safe to
+place inside a single-line Markdown code span.
+
+The complete account lookup, support request, and GitHub PATCH are best-effort
+and time-bounded after issue creation. Their failure is logged but does not
+change the original successful `FeedbackSubmissionResult`.
+
+## Security Boundary
+
+Only the native feedback dialog receives `DecentAccountService`. The
+`POST /api/v1/feedback` construction remains unchanged so a LAN or API caller
+cannot trigger authenticated Decent Support messages.
+
+## Verification
+
+Service tests cover the authenticated support request, response validation,
+the POST to GET to PATCH sequence, the exact support body, and successful
+submission when support linking fails.

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -463,6 +463,7 @@ class _MyAppState extends State<MyApp> {
                         controller: widget.settingsController,
                         persistenceController: widget.persistenceController,
                         de1Controller: widget.de1Controller,
+                        decentAccountService: widget.decentAccountService,
                         profileStorageService: widget.profileStorageService,
                         beanStorageService: widget.beanStorage,
                         grinderStorageService: widget.grinderStorage,

--- a/lib/src/feedback_feature/feedback_view.dart
+++ b/lib/src/feedback_feature/feedback_view.dart
@@ -175,7 +175,9 @@ class _FeedbackDialogState extends State<FeedbackDialog> {
       title: const Text('Send Feedback'),
       description: const Text(
         'Feedback will be submitted as a public GitHub issue. When a Decent '
-        'account is linked, Decent Support also receives the issue link.',
+        'account is linked, Decent Support receives the issue link, and a '
+        'support contact ID associated with that account is added to the '
+        'public issue.',
       ),
       actions: _buildActions(context),
       child: _buildContent(context),

--- a/lib/src/feedback_feature/feedback_view.dart
+++ b/lib/src/feedback_feature/feedback_view.dart
@@ -6,6 +6,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:reaprime/src/controllers/feedback_controller.dart';
 import 'package:reaprime/src/models/feedback/feedback_request.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/services/feedback_service.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -16,22 +17,28 @@ void showFeedbackDialog(
   BuildContext context, {
   required String githubToken,
   required List<String> Function() serialNumbers,
+  required DecentAccountService? accountService,
 }) {
   showShadDialog(
     context: context,
-    builder: (context) =>
-        FeedbackDialog(githubToken: githubToken, serialNumbers: serialNumbers),
+    builder: (context) => FeedbackDialog(
+      githubToken: githubToken,
+      serialNumbers: serialNumbers,
+      accountService: accountService,
+    ),
   );
 }
 
 class FeedbackDialog extends StatefulWidget {
   final String githubToken;
   final List<String> Function() serialNumbers;
+  final DecentAccountService? accountService;
 
   const FeedbackDialog({
     super.key,
     required this.githubToken,
     required this.serialNumbers,
+    required this.accountService,
   });
 
   @override
@@ -57,6 +64,7 @@ class _FeedbackDialogState extends State<FeedbackDialog> {
     _service = FeedbackService(
       githubToken: widget.githubToken,
       currentSerialNumbers: widget.serialNumbers,
+      accountService: widget.accountService,
     );
     _controller = FeedbackController(service: _service);
     _controller.addListener(_onControllerChanged);
@@ -166,7 +174,8 @@ class _FeedbackDialogState extends State<FeedbackDialog> {
     return ShadDialog(
       title: const Text('Send Feedback'),
       description: const Text(
-        'Feedback will be submitted as a public GitHub issue.',
+        'Feedback will be submitted as a public GitHub issue. When a Decent '
+        'account is linked, Decent Support also receives the issue link.',
       ),
       actions: _buildActions(context),
       child: _buildContent(context),

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -28,6 +28,7 @@ enum DecentAccountStatus { authenticated, unauthenticated, indeterminate }
 
 class DecentAccountService {
   static const bool kEnableSerialVerification = true;
+  static const int _maxContactIdLength = 256;
 
   final http.Client _httpClient;
   final CredentialStore _store;
@@ -243,30 +244,44 @@ class DecentAccountService {
     return response;
   }
 
-  Future<void> emailSerialMismatch(String serial) async {
+  Future<String> sendSupportMessage({
+    required String subject,
+    required String body,
+  }) async {
     final email = await _store.read(key: 'email');
     final password = await _store.read(key: 'password');
     if (email == null || password == null) {
       throw StateError('not logged in');
     }
-    final subject = Uri.encodeComponent(
-      'My machine serial number #$serial is not associated with my login',
-    );
-    final body = Uri.encodeComponent(
-      'I linked my de1app to my Decent account, and found that this '
-      'account does not list the machine #$serial I am connected to.',
-    );
+    final query = Uri(
+      queryParameters: {'subject': subject, 'body': body},
+    ).query;
     final response = await _authedGet(
       email,
       password,
-      '/support/api/email?subject=$subject&body=$body',
+      '/support/api/email?$query',
     );
-    final responseBody = response.body.trim();
-    if (response.statusCode != 200 || responseBody == '0') {
-      throw Exception(
-        'email serial mismatch failed (${response.statusCode}): ${response.body}',
-      );
+    final contactId = response.body.trim();
+    if (response.statusCode != 200 ||
+        contactId.isEmpty ||
+        contactId == '0' ||
+        contactId.length > _maxContactIdLength ||
+        contactId.contains('\r') ||
+        contactId.contains('\n') ||
+        contactId.contains('`')) {
+      throw Exception('support message failed (${response.statusCode})');
     }
+    return contactId;
+  }
+
+  Future<void> emailSerialMismatch(String serial) async {
+    await sendSupportMessage(
+      subject:
+          'My machine serial number #$serial is not associated with my login',
+      body:
+          'I linked my de1app to my Decent account, and found that this '
+          'account does not list the machine #$serial I am connected to.',
+    );
   }
 
   Future<http.Response> _authedGet(

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -247,11 +247,19 @@ class DecentAccountService {
   Future<String> sendSupportMessage({
     required String subject,
     required String body,
+    Future<void>? abortTrigger,
   }) async {
+    final generation = _authGeneration;
+    if (await isAuthKnownInvalid()) {
+      throw StateError('account authentication rejected');
+    }
     final email = await _store.read(key: 'email');
     final password = await _store.read(key: 'password');
     if (email == null || password == null) {
       throw StateError('not logged in');
+    }
+    if (generation != _authGeneration) {
+      throw StateError('account authentication changed');
     }
     final query = Uri(
       queryParameters: {'subject': subject, 'body': body},
@@ -260,7 +268,11 @@ class DecentAccountService {
       email,
       password,
       '/support/api/email?$query',
+      abortTrigger: abortTrigger,
     );
+    if (response.statusCode == 401 && generation == _authGeneration) {
+      reportAuthenticationFailure();
+    }
     final contactId = response.body.trim();
     if (response.statusCode != 200 ||
         contactId.isEmpty ||
@@ -287,11 +299,20 @@ class DecentAccountService {
   Future<http.Response> _authedGet(
     String email,
     String password,
-    String path,
-  ) async {
+    String path, {
+    Future<void>? abortTrigger,
+  }) async {
     final basic = base64Encode(
       utf8.encode("${email.trim()}:${password.trim()}"),
     );
+    if (abortTrigger != null) {
+      final request = http.AbortableRequest(
+        'GET',
+        Uri.parse('$baseUrl$path'),
+        abortTrigger: abortTrigger,
+      )..headers['authorization'] = "Basic $basic";
+      return http.Response.fromStream(await _httpClient.send(request));
+    }
     return _httpClient.get(
       Uri.parse('$baseUrl$path'),
       headers: {'authorization': "Basic $basic"},

--- a/lib/src/services/feedback_service.dart
+++ b/lib/src/services/feedback_service.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/models/feedback/feedback_request.dart';
 import 'package:reaprime/src/models/feedback/feedback_result.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/services/storage/app_directories.dart';
 import 'package:reaprime/src/services/telemetry/anonymization.dart';
 
@@ -16,17 +17,21 @@ class FeedbackService {
   final String _githubToken;
   final String _repo;
   final List<String> Function() _currentSerialNumbers;
+  final DecentAccountService? _accountService;
   final Logger _log = Logger('FeedbackService');
 
   static const String _githubApiBase = 'https://api.github.com';
+  static const Duration _supportLinkTimeout = Duration(seconds: 30);
 
   FeedbackService({
     required String githubToken,
     String repo = 'decentespresso/decaid',
     required List<String> Function() currentSerialNumbers,
+    DecentAccountService? accountService,
   }) : _githubToken = githubToken,
        _repo = repo,
-       _currentSerialNumbers = currentSerialNumbers;
+       _currentSerialNumbers = currentSerialNumbers,
+       _accountService = accountService;
 
   bool get isConfigured => _githubToken.isNotEmpty;
 
@@ -73,6 +78,18 @@ class FeedbackService {
 
       final issueNumber = issueResult['number'] as int;
       final issueUrl = issueResult['html_url'] as String;
+
+      try {
+        await _linkFeedbackToSupport(
+          request: request,
+          systemInfo: systemInfo,
+          gistUrl: gistUrl,
+          issueNumber: issueNumber,
+          issueUrl: issueUrl,
+        ).timeout(_supportLinkTimeout);
+      } catch (e, st) {
+        _log.warning('Could not link feedback to Decent support', e, st);
+      }
 
       _log.info('Feedback submitted successfully as issue #$issueNumber');
       return FeedbackSubmissionResult.succeeded(
@@ -263,12 +280,19 @@ class FeedbackService {
     required FeedbackRequest request,
     required String systemInfo,
     String? gistUrl,
+    String? contactId,
   }) {
     final body = StringBuffer();
 
     body.writeln('## Description');
     body.writeln(request.description);
     body.writeln();
+
+    if (contactId != null) {
+      body.writeln('---');
+      body.writeln('**Contact:** `$contactId`');
+      body.writeln();
+    }
 
     if (systemInfo.isNotEmpty) {
       body.writeln('## System Info');
@@ -317,6 +341,45 @@ class FeedbackService {
     } catch (e) {
       _log.severe('Failed to create GitHub issue', e);
       return null;
+    }
+  }
+
+  Future<void> _linkFeedbackToSupport({
+    required FeedbackRequest request,
+    required String systemInfo,
+    required String? gistUrl,
+    required int issueNumber,
+    required String issueUrl,
+  }) async {
+    final accountService = _accountService;
+    if (accountService == null || !await accountService.hasLinkedAccount()) {
+      return;
+    }
+    final contactId = await accountService.sendSupportMessage(
+      subject: 'Decaid feedback #$issueNumber',
+      body: issueUrl,
+    );
+    await _updateGitHubIssueBody(
+      issueNumber,
+      _buildIssueBody(
+        request: request,
+        systemInfo: systemInfo,
+        gistUrl: gistUrl,
+        contactId: contactId,
+      ),
+    );
+  }
+
+  Future<void> _updateGitHubIssueBody(int issueNumber, String body) async {
+    final response = await http.patch(
+      Uri.parse('$_githubApiBase/repos/$_repo/issues/$issueNumber'),
+      headers: _authHeaders,
+      body: jsonEncode({'body': body}),
+    );
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Failed to update GitHub issue #$issueNumber (${response.statusCode})',
+      );
     }
   }
 

--- a/lib/src/services/feedback_service.dart
+++ b/lib/src/services/feedback_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -18,20 +19,22 @@ class FeedbackService {
   final String _repo;
   final List<String> Function() _currentSerialNumbers;
   final DecentAccountService? _accountService;
+  final Duration _supportLinkTimeout;
   final Logger _log = Logger('FeedbackService');
 
   static const String _githubApiBase = 'https://api.github.com';
-  static const Duration _supportLinkTimeout = Duration(seconds: 30);
 
   FeedbackService({
     required String githubToken,
     String repo = 'decentespresso/decaid',
     required List<String> Function() currentSerialNumbers,
     DecentAccountService? accountService,
+    Duration supportLinkTimeout = const Duration(seconds: 30),
   }) : _githubToken = githubToken,
        _repo = repo,
        _currentSerialNumbers = currentSerialNumbers,
-       _accountService = accountService;
+       _accountService = accountService,
+       _supportLinkTimeout = supportLinkTimeout;
 
   bool get isConfigured => _githubToken.isNotEmpty;
 
@@ -79,14 +82,19 @@ class FeedbackService {
       final issueNumber = issueResult['number'] as int;
       final issueUrl = issueResult['html_url'] as String;
 
+      final supportLinkAbort = Completer<void>();
       try {
         await _linkFeedbackToSupport(
-          request: request,
-          systemInfo: systemInfo,
-          gistUrl: gistUrl,
           issueNumber: issueNumber,
           issueUrl: issueUrl,
-        ).timeout(_supportLinkTimeout);
+          abort: supportLinkAbort,
+        ).timeout(
+          _supportLinkTimeout,
+          onTimeout: () {
+            supportLinkAbort.complete();
+            throw TimeoutException('Decent Support linking timed out');
+          },
+        );
       } catch (e, st) {
         _log.warning('Could not link feedback to Decent support', e, st);
       }
@@ -280,19 +288,12 @@ class FeedbackService {
     required FeedbackRequest request,
     required String systemInfo,
     String? gistUrl,
-    String? contactId,
   }) {
     final body = StringBuffer();
 
     body.writeln('## Description');
     body.writeln(request.description);
     body.writeln();
-
-    if (contactId != null) {
-      body.writeln('---');
-      body.writeln('**Contact:** `$contactId`');
-      body.writeln();
-    }
 
     if (systemInfo.isNotEmpty) {
       body.writeln('## System Info');
@@ -345,37 +346,61 @@ class FeedbackService {
   }
 
   Future<void> _linkFeedbackToSupport({
-    required FeedbackRequest request,
-    required String systemInfo,
-    required String? gistUrl,
     required int issueNumber,
     required String issueUrl,
+    required Completer<void> abort,
   }) async {
     final accountService = _accountService;
-    if (accountService == null || !await accountService.hasLinkedAccount()) {
+    if (accountService == null || abort.isCompleted) return;
+    if (!await accountService.hasLinkedAccount() || abort.isCompleted) {
       return;
     }
     final contactId = await accountService.sendSupportMessage(
       subject: 'Decaid feedback #$issueNumber',
       body: issueUrl,
+      abortTrigger: abort.future,
     );
-    await _updateGitHubIssueBody(
-      issueNumber,
-      _buildIssueBody(
-        request: request,
-        systemInfo: systemInfo,
-        gistUrl: gistUrl,
-        contactId: contactId,
-      ),
-    );
+    if (abort.isCompleted) return;
+    await _updateGitHubIssueBody(issueNumber, contactId, abort);
   }
 
-  Future<void> _updateGitHubIssueBody(int issueNumber, String body) async {
-    final response = await http.patch(
-      Uri.parse('$_githubApiBase/repos/$_repo/issues/$issueNumber'),
-      headers: _authHeaders,
-      body: jsonEncode({'body': body}),
+  Future<void> _updateGitHubIssueBody(
+    int issueNumber,
+    String contactId,
+    Completer<void> abort,
+  ) async {
+    final uri = Uri.parse('$_githubApiBase/repos/$_repo/issues/$issueNumber');
+    final currentRequest = http.AbortableRequest(
+      'GET',
+      uri,
+      abortTrigger: abort.future,
+    )..headers.addAll(_authHeaders);
+    final currentResponse = await http.Response.fromStream(
+      await currentRequest.send(),
     );
+    if (currentResponse.statusCode != 200) {
+      throw Exception(
+        'Failed to read GitHub issue #$issueNumber '
+        '(${currentResponse.statusCode})',
+      );
+    }
+    if (abort.isCompleted) return;
+    final currentBody =
+        (jsonDecode(currentResponse.body) as Map<String, dynamic>)['body']
+            as String? ??
+        '';
+    final separator = currentBody.isEmpty
+        ? ''
+        : currentBody.endsWith('\n')
+        ? '\n'
+        : '\n\n';
+    final request =
+        http.AbortableRequest('PATCH', uri, abortTrigger: abort.future)
+          ..headers.addAll(_authHeaders)
+          ..body = jsonEncode({
+            'body': '$currentBody$separator---\n**Contact:** `$contactId`\n',
+          });
+    final response = await http.Response.fromStream(await request.send());
     if (response.statusCode != 200) {
       throw Exception(
         'Failed to update GitHub issue #$issueNumber (${response.statusCode})',

--- a/lib/src/settings/data_management_page.dart
+++ b/lib/src/settings/data_management_page.dart
@@ -20,6 +20,7 @@ import 'package:reaprime/src/import/import_result.dart';
 import 'package:reaprime/src/import/widgets/import_progress_view.dart';
 import 'package:reaprime/src/import/widgets/import_result_view.dart';
 import 'package:reaprime/src/import/widgets/import_summary_view.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/services/storage/bean_storage_service.dart';
 import 'package:reaprime/src/services/storage/grinder_storage_service.dart';
 import 'package:reaprime/src/services/storage/profile_storage_service.dart';
@@ -49,6 +50,7 @@ class DataManagementPage extends StatefulWidget {
     required this.controller,
     required this.persistenceController,
     required this.de1Controller,
+    required this.decentAccountService,
     this.profileStorageService,
     this.beanStorageService,
     this.grinderStorageService,
@@ -60,6 +62,7 @@ class DataManagementPage extends StatefulWidget {
   final SettingsController controller;
   final PersistenceController persistenceController;
   final De1Controller de1Controller;
+  final DecentAccountService? decentAccountService;
   final ProfileStorageService? profileStorageService;
   final BeanStorageService? beanStorageService;
   final GrinderStorageService? grinderStorageService;
@@ -262,6 +265,7 @@ class _DataManagementPageState extends State<DataManagementPage> {
                 ),
               ),
               serialNumbers: () => widget.de1Controller.seenSerials,
+              accountService: widget.decentAccountService,
             ),
             child: const Text("Send Feedback"),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,7 +90,7 @@ dependencies:
   firebase_crashlytics: ^5.0.6
   firebase_performance: ^0.11.1+3
   firebase_analytics: ^12.1.0
-  http: ^1.2.2
+  http: ^1.5.0
   html: ^0.15.6
   flutter_secure_storage: ^10.3.1
   # network_info_plus HELD at 7.x — 8.x needs win32 ^6, blocked by file_picker

--- a/test/feedback_view_test.dart
+++ b/test/feedback_view_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/feedback_feature/feedback_view.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+void main() {
+  testWidgets('discloses the public account-linked contact id', (tester) async {
+    await tester.pumpWidget(
+      ShadApp(
+        home: Scaffold(
+          body: FeedbackDialog(
+            githubToken: '',
+            serialNumbers: () => const [],
+            accountService: null,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('associated with that account'), findsOneWidget);
+    expect(find.textContaining('added to the public issue'), findsOneWidget);
+  });
+}

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -673,6 +673,73 @@ void main() {
       });
     });
 
+    group('sendSupportMessage', () {
+      test(
+        'sends an authenticated request and returns the contact id',
+        () async {
+          late http.Request capturedRequest;
+          final client = http_testing.MockClient((request) async {
+            capturedRequest = request;
+            return http.Response('  GhwAHSEAAAAAAAAGBgAdAxAcCUgGCgQ=\n', 200);
+          });
+          final supportService = DecentAccountService(
+            httpClient: client,
+            credentialStore: store,
+            baseUrl: _baseUrl,
+          );
+          await store.write(key: 'email', value: 'test@example.com');
+          await store.write(key: 'password', value: 'cryptpw_abc123');
+
+          final contactId = await supportService.sendSupportMessage(
+            subject: 'Decaid feedback #728 & details',
+            body: 'https://github.com/decentespresso/decaid/issues/728?a=1&b=2',
+          );
+
+          expect(contactId, 'GhwAHSEAAAAAAAAGBgAdAxAcCUgGCgQ=');
+          expect(capturedRequest.method, 'GET');
+          expect(capturedRequest.url.path, '/support/api/email');
+          expect(capturedRequest.url.queryParameters, {
+            'subject': 'Decaid feedback #728 & details',
+            'body':
+                'https://github.com/decentespresso/decaid/issues/728?a=1&b=2',
+          });
+          expect(
+            capturedRequest.headers['authorization'],
+            'Basic dGVzdEBleGFtcGxlLmNvbTpjcnlwdHB3X2FiYzEyMw==',
+          );
+        },
+      );
+
+      test('rejects failed and unsafe responses', () async {
+        final responses = [
+          (statusCode: 500, body: 'failed'),
+          (statusCode: 200, body: ''),
+          (statusCode: 200, body: '0'),
+          (statusCode: 200, body: 'bad\ncontact'),
+          (statusCode: 200, body: 'bad`contact'),
+          (statusCode: 200, body: List.filled(257, 'x').join()),
+        ];
+        await store.write(key: 'email', value: 'test@example.com');
+        await store.write(key: 'password', value: 'cryptpw_abc123');
+
+        for (final response in responses) {
+          final supportService = DecentAccountService(
+            httpClient: _mockClient(
+              statusCode: response.statusCode,
+              body: response.body,
+            ),
+            credentialStore: store,
+            baseUrl: _baseUrl,
+          );
+
+          await expectLater(
+            supportService.sendSupportMessage(subject: 'subject', body: 'body'),
+            throwsA(isA<Exception>()),
+          );
+        }
+      });
+    });
+
     group('parseSerialNumbers', () {
       test('parses bare serial numbers', () {
         expect(parseSerialNumbers('1337\n1338'), ['1337', '1338']);

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -1028,9 +1028,12 @@ void main() {
         final supportService = DecentAccountService(
           httpClient: http_testing.MockClient((request) async {
             requestCount++;
-            return requestCount == 1
-                ? http.Response('cryptpw_abc123', 200)
-                : http.Response('unauthorized', 401);
+            return switch (request.url.path) {
+              '/support/api/login_test' => http.Response('cryptpw_abc123', 200),
+              '/support/api/sn' => http.Response('', 200),
+              '/support/api/email' => http.Response('unauthorized', 401),
+              _ => http.Response('not found', 404),
+            };
           }),
           credentialStore: store,
           baseUrl: _baseUrl,
@@ -1050,7 +1053,7 @@ void main() {
           supportService.sendSupportMessage(subject: 'subject', body: 'body'),
           throwsA(isA<StateError>()),
         );
-        expect(requestCount, 2);
+        expect(requestCount, 3);
       });
     });
 

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -738,6 +738,36 @@ void main() {
           );
         }
       });
+
+      test('invalidates cached authentication after a 401', () async {
+        var requestCount = 0;
+        final supportService = DecentAccountService(
+          httpClient: http_testing.MockClient((request) async {
+            requestCount++;
+            return requestCount == 1
+                ? http.Response('cryptpw_abc123', 200)
+                : http.Response('unauthorized', 401);
+          }),
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(
+          await supportService.login('test@example.com', 'password'),
+          isTrue,
+        );
+        await expectLater(
+          supportService.sendSupportMessage(subject: 'subject', body: 'body'),
+          throwsA(isA<Exception>()),
+        );
+
+        expect(await supportService.isLoggedIn(), isFalse);
+        await expectLater(
+          supportService.sendSupportMessage(subject: 'subject', body: 'body'),
+          throwsA(isA<StateError>()),
+        );
+        expect(requestCount, 2);
+      });
     });
 
     group('parseSerialNumbers', () {

--- a/test/services/feedback_service_test.dart
+++ b/test/services/feedback_service_test.dart
@@ -1,9 +1,13 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:reaprime/src/models/feedback/feedback_request.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/services/feedback_service.dart';
 
 class _FakePathProvider extends Fake
@@ -15,6 +19,25 @@ class _FakePathProvider extends Fake
 
   @override
   Future<String?> getApplicationDocumentsPath() async => docsDir.path;
+}
+
+class _MemoryCredentialStore implements CredentialStore {
+  _MemoryCredentialStore(this._values);
+
+  final Map<String, String> _values;
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _values.remove(key);
+  }
 }
 
 void main() {
@@ -48,5 +71,124 @@ void main() {
     expect(report, isNot(contains('SN123456')));
     expect(report, isNot(contains('SN999888')));
     expect(report, contains('serial_'));
+  });
+
+  test(
+    'links native feedback to Decent Support and patches contact id',
+    () async {
+      const issueUrl = 'https://github.com/decentespresso/decaid/issues/728';
+      const contactId = 'GhwAHSEAAAAAAAAGBgAdAxAcCUgGCgQ=';
+      final requests = <http.Request>[];
+
+      Future<http.Response> handle(http.Request request) async {
+        requests.add(request);
+        return switch (requests.length) {
+          1 => http.Response(
+            jsonEncode({'number': 728, 'html_url': issueUrl}),
+            201,
+          ),
+          2 => http.Response(contactId, 200),
+          3 => http.Response('{}', 200),
+          _ => http.Response('unexpected request', 500),
+        };
+      }
+
+      final accountService = DecentAccountService(
+        httpClient: http_testing.MockClient(handle),
+        credentialStore: _MemoryCredentialStore({
+          'email': 'test@example.com',
+          'password': 'cryptpw_abc123',
+        }),
+      );
+      final service = FeedbackService(
+        githubToken: 'github-token',
+        currentSerialNumbers: () => const [],
+        accountService: accountService,
+      );
+
+      final result = await http.runWithClient(
+        () => service.submitFeedback(
+          FeedbackRequest(
+            description: 'The steam control stopped responding.',
+            type: FeedbackType.bug,
+            includeLogs: false,
+            includeSystemInfo: false,
+          ),
+        ),
+        () => http_testing.MockClient(handle),
+      );
+
+      expect(result.success, isTrue);
+      expect(result.issueNumber, 728);
+      expect(result.issueUrl, issueUrl);
+      expect(requests.map((request) => request.method), [
+        'POST',
+        'GET',
+        'PATCH',
+      ]);
+      expect(requests[0].url.path, '/repos/decentespresso/decaid/issues');
+
+      final initialIssue = jsonDecode(requests[0].body) as Map<String, dynamic>;
+      expect(initialIssue['body'], isNot(contains('**Contact:**')));
+
+      expect(requests[1].url.path, '/support/api/email');
+      expect(requests[1].url.queryParameters['body'], issueUrl);
+      expect(
+        requests[1].url.queryParameters['subject'],
+        'Decaid feedback #728',
+      );
+      expect(requests[1].headers['authorization'], startsWith('Basic '));
+
+      expect(requests[2].url.path, '/repos/decentespresso/decaid/issues/728');
+      final update = jsonDecode(requests[2].body) as Map<String, dynamic>;
+      expect(update['body'], contains('---\n**Contact:** `$contactId`\n'));
+      expect(update['body'], contains('The steam control stopped responding.'));
+    },
+  );
+
+  test('returns the GitHub result when Decent Support linking fails', () async {
+    const issueUrl = 'https://github.com/decentespresso/decaid/issues/729';
+    final requests = <http.Request>[];
+
+    Future<http.Response> handle(http.Request request) async {
+      requests.add(request);
+      if (requests.length == 1) {
+        return http.Response(
+          jsonEncode({'number': 729, 'html_url': issueUrl}),
+          201,
+        );
+      }
+      return http.Response('support unavailable', 503);
+    }
+
+    final accountService = DecentAccountService(
+      httpClient: http_testing.MockClient(handle),
+      credentialStore: _MemoryCredentialStore({
+        'email': 'test@example.com',
+        'password': 'cryptpw_abc123',
+      }),
+    );
+    final service = FeedbackService(
+      githubToken: 'github-token',
+      currentSerialNumbers: () => const [],
+      accountService: accountService,
+    );
+
+    final result = await http.runWithClient(
+      () => service.submitFeedback(
+        FeedbackRequest(
+          description: 'Feedback still reaches GitHub.',
+          type: FeedbackType.bug,
+          includeLogs: false,
+          includeSystemInfo: false,
+        ),
+      ),
+      () => http_testing.MockClient(handle),
+    );
+
+    expect(result.success, isTrue);
+    expect(result.issueNumber, 729);
+    expect(result.issueUrl, issueUrl);
+    expect(requests.map((request) => request.method), ['POST', 'GET']);
   });
 }

--- a/test/services/feedback_service_test.dart
+++ b/test/services/feedback_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -74,10 +75,13 @@ void main() {
   });
 
   test(
-    'links native feedback to Decent Support and patches contact id',
+    'preserves the current GitHub body when patching the contact id',
     () async {
       const issueUrl = 'https://github.com/decentespresso/decaid/issues/728';
       const contactId = 'GhwAHSEAAAAAAAAGBgAdAxAcCUgGCgQ=';
+      const currentBody =
+          '## Description\nThe steam control stopped responding.\n\n'
+          'Bot-added triage details.\n';
       final requests = <http.Request>[];
 
       Future<http.Response> handle(http.Request request) async {
@@ -88,7 +92,8 @@ void main() {
             201,
           ),
           2 => http.Response(contactId, 200),
-          3 => http.Response('{}', 200),
+          3 => http.Response(jsonEncode({'body': currentBody}), 200),
+          4 => http.Response('{}', 200),
           _ => http.Response('unexpected request', 500),
         };
       }
@@ -124,6 +129,7 @@ void main() {
       expect(requests.map((request) => request.method), [
         'POST',
         'GET',
+        'GET',
         'PATCH',
       ]);
       expect(requests[0].url.path, '/repos/decentespresso/decaid/issues');
@@ -140,9 +146,11 @@ void main() {
       expect(requests[1].headers['authorization'], startsWith('Basic '));
 
       expect(requests[2].url.path, '/repos/decentespresso/decaid/issues/728');
-      final update = jsonDecode(requests[2].body) as Map<String, dynamic>;
+      expect(requests[3].url.path, '/repos/decentespresso/decaid/issues/728');
+      final update = jsonDecode(requests[3].body) as Map<String, dynamic>;
       expect(update['body'], contains('---\n**Contact:** `$contactId`\n'));
-      expect(update['body'], contains('The steam control stopped responding.'));
+      expect(update['body'], startsWith(currentBody));
+      expect(update['body'], contains('Bot-added triage details.'));
     },
   );
 
@@ -190,5 +198,59 @@ void main() {
     expect(result.issueNumber, 729);
     expect(result.issueUrl, issueUrl);
     expect(requests.map((request) => request.method), ['POST', 'GET']);
+  });
+
+  test('does not patch after Decent Support times out', () async {
+    const issueUrl = 'https://github.com/decentespresso/decaid/issues/730';
+    final supportResponse = Completer<http.Response>();
+    final supportRequested = Completer<void>();
+    final githubRequests = <http.Request>[];
+
+    final accountService = DecentAccountService(
+      httpClient: http_testing.MockClient((request) {
+        supportRequested.complete();
+        return supportResponse.future;
+      }),
+      credentialStore: _MemoryCredentialStore({
+        'email': 'test@example.com',
+        'password': 'cryptpw_abc123',
+      }),
+    );
+    final service = FeedbackService(
+      githubToken: 'github-token',
+      currentSerialNumbers: () => const [],
+      accountService: accountService,
+      supportLinkTimeout: const Duration(milliseconds: 10),
+    );
+
+    final submission = http.runWithClient(
+      () => service.submitFeedback(
+        FeedbackRequest(
+          description: 'Support takes too long.',
+          type: FeedbackType.bug,
+          includeLogs: false,
+          includeSystemInfo: false,
+        ),
+      ),
+      () => http_testing.MockClient((request) async {
+        githubRequests.add(request);
+        if (request.method == 'POST') {
+          return http.Response(
+            jsonEncode({'number': 730, 'html_url': issueUrl}),
+            201,
+          );
+        }
+        return http.Response('unexpected request', 500);
+      }),
+    );
+
+    await supportRequested.future;
+    final result = await submission;
+    supportResponse.complete(http.Response('late.contact', 200));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(result.success, isTrue);
+    expect(result.issueNumber, 730);
+    expect(githubRequests.map((request) => request.method), ['POST']);
   });
 }


### PR DESCRIPTION
## Summary

- Send the created GitHub issue URL to Decent Support for native feedback from a linked account, then append the returned contact ID to the current issue body.
- Cancel support-link HTTP work after 30 seconds, prevent late GitHub updates, and preserve the successful GitHub result when linking fails.
- Invalidate cached account authentication on a support `401`. Raise the minimum `http` package version to 1.5.0 for abortable requests.
- Tell users that the public issue receives a support contact ID associated with their linked Decent account.

## Linked Issue

Fixes #728

## Verification

- `flutter test --no-pub`: 3,705 passed, 1 skipped.
- `flutter test --no-pub test/feedback_view_test.dart test/services/feedback_service_test.dart`: 5 passed.
- `flutter analyze --no-pub`: no issues found.

## Impact

- Linked-account feedback sends Decent Support only the public GitHub issue URL. The dialog discloses that an account-associated support contact ID is then added to the public issue.
- `POST /api/v1/feedback` cannot trigger authenticated support messages. No API specification, migration, or compatibility changes.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->