### PR TITLE
fix: keep onboarding and SkinView usable offline

### DIFF
--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -64,6 +64,14 @@ backgrounded. After ten minutes in the background, it unloads the page and
 reloads the selected skin when the app returns. Skin state that must survive
 this reload should be persisted through the Decaid API or browser storage.
 
+### Offline Operation
+
+Decaid serves installed skins from `localhost`, so Wi-Fi and internet access
+are not required for machine control or the embedded skin itself. Release
+builds include a bundled skin for first-run offline use. Account features, skin
+downloads and updates, and any external resources requested by a skin remain
+unavailable until internet access returns.
+
 ---
 
 ## Getting Started

--- a/lib/src/onboarding_feature/steps/login_step.dart
+++ b/lib/src/onboarding_feature/steps/login_step.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:reaprime/src/account/decent_login_form.dart';
 import 'package:reaprime/src/onboarding_feature/onboarding_controller.dart';
 import 'package:reaprime/src/onboarding_feature/widgets/onboarding_scaffold.dart';
 import 'package:reaprime/src/services/account/decent_account_service.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/widgets/accessible_button.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 OnboardingStep createLoginStep({
@@ -14,7 +16,7 @@ OnboardingStep createLoginStep({
     id: 'login',
     shouldShow: () async =>
         !settingsController.accountStepSeen &&
-        !(await accountService.isLoggedIn()),
+        !(await accountService.hasLinkedAccount()),
     builder: (controller) => LoginStepWidget(
       accountService: accountService,
       onComplete: () async {
@@ -25,7 +27,7 @@ OnboardingStep createLoginStep({
   );
 }
 
-class LoginStepWidget extends StatelessWidget {
+class LoginStepWidget extends StatefulWidget {
   final DecentAccountService accountService;
   final VoidCallback onComplete;
 
@@ -36,7 +38,54 @@ class LoginStepWidget extends StatelessWidget {
   });
 
   @override
+  State<LoginStepWidget> createState() => _LoginStepWidgetState();
+}
+
+class _LoginStepWidgetState extends State<LoginStepWidget>
+    with WidgetsBindingObserver {
+  late Future<bool> _reachability;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _reachability = widget.accountService.isBackendReachable();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _checkAgain();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    return FutureBuilder<bool>(
+      future: _reachability,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return _buildChecking();
+        }
+        return snapshot.data == true
+            ? _buildLogin(context)
+            : _buildOffline(context);
+      },
+    );
+  }
+
+  Widget _buildChecking() {
+    return const OnboardingScaffold(
+      semanticsLabel: 'Checking internet connection',
+      body: [Center(child: SizedBox(width: 200, child: ShadProgress()))],
+    );
+  }
+
+  Widget _buildLogin(BuildContext context) {
     final theme = ShadTheme.of(context);
 
     return OnboardingScaffold(
@@ -56,12 +105,61 @@ class LoginStepWidget extends StatelessWidget {
         ),
         const SizedBox(height: 32),
         DecentLoginForm(
-          accountService: accountService,
-          onSuccess: onComplete,
+          accountService: widget.accountService,
+          onSuccess: widget.onComplete,
           secondaryLabel: 'Skip for now',
-          onSecondary: onComplete,
+          onSecondary: widget.onComplete,
         ),
       ],
     );
+  }
+
+  Widget _buildOffline(BuildContext context) {
+    final theme = ShadTheme.of(context);
+
+    return OnboardingScaffold(
+      title: 'Connect to the internet',
+      semanticsLabel: 'Internet connection unavailable',
+      body: [
+        Icon(LucideIcons.wifiOff, size: 64, color: theme.colorScheme.primary),
+        const SizedBox(height: 16),
+        Text(
+          'Account login, cloud sync, and skin downloads need an internet '
+          'connection. Machine control and installed skins remain available '
+          'offline.',
+          style: theme.textTheme.muted,
+          textAlign: TextAlign.center,
+        ),
+      ],
+      primaryAction: AccessibleButton(
+        label: 'Open Settings',
+        onTap: _openSettings,
+        child: ShadButton(
+          onPressed: _openSettings,
+          leading: const Icon(LucideIcons.settings, size: 16),
+          child: const Text('Open Settings'),
+        ),
+      ),
+      secondaryAction: AccessibleButton(
+        label: 'Continue offline',
+        onTap: widget.onComplete,
+        child: ShadButton.outline(
+          onPressed: widget.onComplete,
+          child: const Text('Continue offline'),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openSettings() async {
+    await openAppSettings();
+    if (mounted) _checkAgain();
+  }
+
+  void _checkAgain() {
+    if (!mounted) return;
+    setState(() {
+      _reachability = widget.accountService.isBackendReachable();
+    });
   }
 }

--- a/lib/src/onboarding_feature/steps/login_step.dart
+++ b/lib/src/onboarding_feature/steps/login_step.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:reaprime/src/account/decent_login_form.dart';
 import 'package:reaprime/src/onboarding_feature/onboarding_controller.dart';
 import 'package:reaprime/src/onboarding_feature/widgets/onboarding_scaffold.dart';
@@ -41,26 +40,13 @@ class LoginStepWidget extends StatefulWidget {
   State<LoginStepWidget> createState() => _LoginStepWidgetState();
 }
 
-class _LoginStepWidgetState extends State<LoginStepWidget>
-    with WidgetsBindingObserver {
+class _LoginStepWidgetState extends State<LoginStepWidget> {
   late Future<bool> _reachability;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
     _reachability = widget.accountService.isBackendReachable();
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) _checkAgain();
   }
 
   @override
@@ -132,12 +118,12 @@ class _LoginStepWidgetState extends State<LoginStepWidget>
         ),
       ],
       primaryAction: AccessibleButton(
-        label: 'Open Settings',
-        onTap: _openSettings,
+        label: 'Check again',
+        onTap: _checkAgain,
         child: ShadButton(
-          onPressed: _openSettings,
-          leading: const Icon(LucideIcons.settings, size: 16),
-          child: const Text('Open Settings'),
+          onPressed: _checkAgain,
+          leading: const Icon(LucideIcons.refreshCw, size: 16),
+          child: const Text('Check again'),
         ),
       ),
       secondaryAction: AccessibleButton(
@@ -149,11 +135,6 @@ class _LoginStepWidgetState extends State<LoginStepWidget>
         ),
       ),
     );
-  }
-
-  Future<void> _openSettings() async {
-    await openAppSettings();
-    if (mounted) _checkAgain();
   }
 
   void _checkAgain() {

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -325,11 +325,26 @@ class DecentAccountService {
   Future<bool> isBackendReachable({
     Duration timeout = const Duration(seconds: 5),
   }) async {
+    final abort = Completer<void>();
+    final timer = Timer(timeout, abort.complete);
+    final request = http.AbortableRequest(
+      'HEAD',
+      Uri.parse(baseUrl),
+      abortTrigger: abort.future,
+    );
     try {
-      await _httpClient.head(Uri.parse(baseUrl)).timeout(timeout);
+      await _httpClient
+          .send(request)
+          .then(http.Response.fromStream)
+          .timeout(timeout);
       return true;
+    } on TimeoutException {
+      if (!abort.isCompleted) abort.complete();
+      return false;
     } on Exception {
       return false;
+    } finally {
+      timer.cancel();
     }
   }
 

--- a/lib/src/services/account/decent_account_service.dart
+++ b/lib/src/services/account/decent_account_service.dart
@@ -78,6 +78,17 @@ class DecentAccountService {
       await _store.read(key: 'email') != null &&
       await _store.read(key: 'password') != null;
 
+  Future<bool> isBackendReachable({
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    try {
+      await _httpClient.head(Uri.parse(baseUrl)).timeout(timeout);
+      return true;
+    } on Exception {
+      return false;
+    }
+  }
+
   Future<bool> isLoggedIn() async {
     if (!await hasLinkedAccount()) return false;
     final cached = _authenticated;

--- a/lib/src/webui_support/webui_service.dart
+++ b/lib/src/webui_support/webui_service.dart
@@ -222,7 +222,7 @@ class WebUIService {
     _resolvedHosts.clear();
     final tokenProvider = skinProxyTokenProvider;
     if (tokenProvider != null) _revokeSkinProxyToken();
-    _localIP ??= await _resolveLocalIP();
+    _localIP = await _resolveLocalIP();
 
     final webUI = createStaticHandler(
       path,

--- a/lib/src/webui_support/webui_service.dart
+++ b/lib/src/webui_support/webui_service.dart
@@ -115,6 +115,7 @@ Future<List<String>> _listDeviceAddresses() async {
 class WebUIService {
   final _log = Logger("WebUIService");
   final Future<List<String>> Function() _listLocalAddresses;
+  final Duration _wifiIpResolutionTimeout;
   HttpServer? _server;
   HttpServer? _entryServer;
   final Set<int> _usedPorts = {};
@@ -135,12 +136,15 @@ class WebUIService {
   static const int _resolvedHostLimit = 128;
   final Map<String, _ResolvedHost> _resolvedHosts = {};
 
-  WebUIService({Future<List<String>> Function()? listLocalAddresses})
-    : _listLocalAddresses = listLocalAddresses ?? _listDeviceAddresses;
+  WebUIService({
+    Future<List<String>> Function()? listLocalAddresses,
+    Duration wifiIpResolutionTimeout = const Duration(seconds: 2),
+  }) : _listLocalAddresses = listLocalAddresses ?? _listDeviceAddresses,
+       _wifiIpResolutionTimeout = wifiIpResolutionTimeout;
 
   Future<String> _resolveLocalIP() async {
     try {
-      final ip = await resolveWifiIP();
+      final ip = await resolveWifiIP().timeout(_wifiIpResolutionTimeout);
       if (ip != null && ip.isNotEmpty) return ip;
     } catch (e) {
       _log.warning('Failed to resolve WiFi IP, falling back to localhost', e);

--- a/test/onboarding/login_step_test.dart
+++ b/test/onboarding/login_step_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -90,7 +91,7 @@ void main() {
       ),
       findsOneWidget,
     );
-    expect(find.text('Open Settings'), findsOneWidget);
+    expect(find.text('Check again'), findsOneWidget);
     expect(find.text('Continue offline'), findsOneWidget);
 
     await tester.tap(find.text('Continue offline'));
@@ -117,5 +118,64 @@ void main() {
     expect(find.text('Link Your Decent Account'), findsOneWidget);
     expect(find.text('Email'), findsOneWidget);
     expect(find.text('Login'), findsOneWidget);
+  });
+
+  testWidgets('check again shows login after connectivity returns', (
+    tester,
+  ) async {
+    var requests = 0;
+    final accountService = _accountService(
+      MockClient((_) async {
+        requests++;
+        if (requests == 1) throw http.ClientException('offline');
+        return http.Response('', 401);
+      }),
+    );
+
+    await tester.pumpWidget(
+      ShadApp(
+        home: LoginStepWidget(
+          accountService: accountService,
+          onComplete: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Check again'));
+    await tester.pumpAndSettle();
+
+    expect(requests, 2);
+    expect(find.text('Link Your Decent Account'), findsOneWidget);
+  });
+
+  testWidgets('resuming the app preserves entered login details', (
+    tester,
+  ) async {
+    var requests = 0;
+    final accountService = _accountService(
+      MockClient((_) async {
+        requests++;
+        return http.Response('', 401);
+      }),
+    );
+
+    await tester.pumpWidget(
+      ShadApp(
+        home: LoginStepWidget(
+          accountService: accountService,
+          onComplete: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(ShadInput).first, 'user@example.com');
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+
+    expect(requests, 1);
+    expect(find.text('user@example.com'), findsOneWidget);
   });
 }

--- a/test/onboarding/login_step_test.dart
+++ b/test/onboarding/login_step_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:reaprime/src/onboarding_feature/steps/login_step.dart';
+import 'package:reaprime/src/services/account/decent_account_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+import '../helpers/mock_settings_service.dart';
+
+class _CredentialStore implements CredentialStore {
+  final Map<String, String> values = {};
+
+  @override
+  Future<void> delete({required String key}) async => values.remove(key);
+
+  @override
+  Future<String?> read({required String key}) async => values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    values[key] = value;
+  }
+}
+
+DecentAccountService _accountService(
+  MockClient client, {
+  _CredentialStore? store,
+}) {
+  return DecentAccountService(
+    httpClient: client,
+    credentialStore: store ?? _CredentialStore(),
+  );
+}
+
+void main() {
+  test(
+    'linked account bypasses onboarding without a network request',
+    () async {
+      final settingsService = MockSettingsService();
+      await settingsService.setAccountStepSeen(false);
+      final settingsController = SettingsController(settingsService);
+      await settingsController.loadSettings();
+      final store = _CredentialStore();
+      await store.write(key: 'email', value: 'user@example.com');
+      await store.write(key: 'password', value: 'cryptpw');
+      var requests = 0;
+      final accountService = _accountService(
+        MockClient((_) async {
+          requests++;
+          return http.Response('cryptpw', 200);
+        }),
+        store: store,
+      );
+
+      final step = createLoginStep(
+        accountService: accountService,
+        settingsController: settingsController,
+      );
+
+      expect(await step.shouldShow(), isFalse);
+      expect(requests, 0);
+    },
+  );
+
+  testWidgets('offline state explains limitations and can continue', (
+    tester,
+  ) async {
+    var completed = false;
+    final accountService = _accountService(
+      MockClient((_) async => throw http.ClientException('offline')),
+    );
+
+    await tester.pumpWidget(
+      ShadApp(
+        home: LoginStepWidget(
+          accountService: accountService,
+          onComplete: () => completed = true,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Connect to the internet'), findsOneWidget);
+    expect(
+      find.text(
+        'Account login, cloud sync, and skin downloads need an internet '
+        'connection. Machine control and installed skins remain available '
+        'offline.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Open Settings'), findsOneWidget);
+    expect(find.text('Continue offline'), findsOneWidget);
+
+    await tester.tap(find.text('Continue offline'));
+    await tester.pump();
+
+    expect(completed, isTrue);
+  });
+
+  testWidgets('reachable backend shows the login form', (tester) async {
+    final accountService = _accountService(
+      MockClient((_) async => http.Response('', 401)),
+    );
+
+    await tester.pumpWidget(
+      ShadApp(
+        home: LoginStepWidget(
+          accountService: accountService,
+          onComplete: () {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Link Your Decent Account'), findsOneWidget);
+    expect(find.text('Email'), findsOneWidget);
+    expect(find.text('Login'), findsOneWidget);
+  });
+}

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -53,6 +53,57 @@ void main() {
       );
     });
 
+    group('isBackendReachable', () {
+      test('uses an unauthenticated HEAD request', () async {
+        late http.Request request;
+        httpClient = http_testing.MockClient((captured) async {
+          request = captured;
+          return http.Response('', 503);
+        });
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.isBackendReachable(), isTrue);
+        expect(request.method, 'HEAD');
+        expect(request.url, Uri.parse(_baseUrl));
+        expect(request.headers, isNot(contains('authorization')));
+      });
+
+      test('returns false on a network error', () async {
+        httpClient = http_testing.MockClient(
+          (_) async => throw http.ClientException('offline'),
+        );
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(await service.isBackendReachable(), isFalse);
+      });
+
+      test('returns false when the check times out', () async {
+        httpClient = http_testing.MockClient(
+          (_) => Completer<http.Response>().future,
+        );
+        service = DecentAccountService(
+          httpClient: httpClient,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(
+          await service.isBackendReachable(
+            timeout: const Duration(milliseconds: 10),
+          ),
+          isFalse,
+        );
+      });
+    });
+
     group('login', () {
       late http.BaseRequest capturedRequest;
 

--- a/test/services/account/decent_account_service_test.dart
+++ b/test/services/account/decent_account_service_test.dart
@@ -148,6 +148,18 @@ class _GateFirstMachinesDeleteStore implements CredentialStore {
   }
 }
 
+class _AbortAwareClient extends http.BaseClient {
+  final aborted = Completer<void>();
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final abortable = request as http.AbortableRequest;
+    await abortable.abortTrigger;
+    aborted.complete();
+    throw http.RequestAbortedException(request.url);
+  }
+}
+
 const _baseUrl = 'https://decentespresso.com';
 
 http_testing.MockClient _mockClient({
@@ -223,6 +235,23 @@ void main() {
           ),
           isFalse,
         );
+      });
+
+      test('aborts the request when the check times out', () async {
+        final client = _AbortAwareClient();
+        service = DecentAccountService(
+          httpClient: client,
+          credentialStore: store,
+          baseUrl: _baseUrl,
+        );
+
+        expect(
+          await service.isBackendReachable(
+            timeout: const Duration(milliseconds: 10),
+          ),
+          isFalse,
+        );
+        await client.aborted.future.timeout(const Duration(seconds: 1));
       });
     });
 

--- a/test/webui_support/webui_token_injection_test.dart
+++ b/test/webui_support/webui_token_injection_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -445,6 +446,18 @@ const bodyExample = "</body>";
 
     test('falls back to localhost when getWifiIP throws (gh#337)', () async {
       WebUIService.resolveWifiIP = () async => throw Exception('no wifi');
+
+      await service.serveFolderAtPath(tempDir.path);
+
+      expect(service.isServing, isTrue);
+      expect(service.deviceIp(), 'localhost');
+    });
+
+    test('falls back to localhost when getWifiIP does not return', () async {
+      WebUIService.resolveWifiIP = () => Completer<String?>().future;
+      service = WebUIService(
+        wifiIpResolutionTimeout: const Duration(milliseconds: 10),
+      );
 
       await service.serveFolderAtPath(tempDir.path);
 

--- a/test/webui_support/webui_token_injection_test.dart
+++ b/test/webui_support/webui_token_injection_test.dart
@@ -474,6 +474,20 @@ const bodyExample = "</body>";
       expect(service.deviceIp(), 'localhost');
     });
 
+    test('re-resolves the WiFi address after an offline start', () async {
+      const lanIp = '10.0.0.7';
+      var online = false;
+      WebUIService.resolveWifiIP = () async => online ? lanIp : null;
+
+      await service.serveFolderAtPath(tempDir.path);
+      expect(service.deviceIp(), 'localhost');
+
+      online = true;
+      await service.serveFolderAtPath(tempDir.path);
+
+      expect(service.deviceIp(), lanIp);
+    });
+
     test(
       'falls back to localhost when getWifiIP returns empty string',
       () async {


### PR DESCRIPTION
## Summary

What changed, and why?

- Keep the existing release-time bundled-skin pipeline instead of adding a duplicate bundled asset path; installed and bundled skins already fall back locally.
- Make the account onboarding decision from locally stored account linkage, then run a bounded, unauthenticated Decent backend reachability check inside the login step.
- Abort the reachability request at its transport deadline so repeated checks cannot leave requests outstanding.
- When offline, offer Check again and Continue offline with a limitation notice, and bound Wi-Fi IP resolution before the local skin server falls back to `localhost`.
- Re-resolve the Wi-Fi address whenever the local skin server is served so an offline start does not leave the WebUI and QR URL stuck on `localhost`.
- Preserve entered login details across ordinary app lifecycle changes instead of restarting the reachability probe on every resume.

## Linked Issue

Fixes #724

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `dart format lib test`
- `flutter test test/services/account/decent_account_service_test.dart test/webui_support/webui_token_injection_test.dart` - 125 passed
- `flutter analyze` - no issues
- `flutter test` - 3,709 passed, 1 skipped
- No hardware testing was required; account and local WebUI network behavior is covered with controlled clients and resolvers.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- User-visible: offline onboarding explains unavailable online features and allows local operation to continue or connectivity to be checked again. WebUI and QR URLs recover when Wi-Fi becomes available and the skin server is served again.
- Compatibility: no migration or REST/WebSocket contract changes.
- Documentation: offline skin behavior is documented in `doc/Skins.md`.
- Security: the reachability probe is an unauthenticated `HEAD` request, never sends stored account credentials, and aborts the underlying transport at five seconds.
- Performance: Wi-Fi IP resolution is bounded to two seconds and re-runs only when serving or switching the local skin.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->