### PR TITLE
fix(connection): early-connect simulated scale in demo mode

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -30,6 +30,7 @@ import 'package:reaprime/src/models/device/device_scanner.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/simulated_device.dart';
 import 'package:reaprime/src/models/device/usb_attach_probe.dart';
 import 'package:reaprime/src/models/scan_report.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
@@ -1187,6 +1188,7 @@ class ConnectionManager {
 
   void _checkEarlyStop(bool earlyStopEnabled) {
     if (!earlyStopEnabled) return;
+    if (_earlyStopFired) return;
     final preferredMachineId = settingsController.preferredMachineId;
     final preferredScaleId = settingsController.preferredScaleId;
     if (preferredMachineId != null && preferredScaleId != null) {
@@ -1880,7 +1882,7 @@ class ConnectionManager {
       );
       return;
     }
-    if (_shouldDeferEarlyScaleConnect()) {
+    if (_shouldDeferEarlyScaleConnect(scale)) {
       _log.fine(
         'Deferring external scale early-connect until machine resolves',
       );
@@ -1889,8 +1891,9 @@ class ConnectionManager {
     await _connectScaleTracked(scale, scanReport);
   }
 
-  bool _shouldDeferEarlyScaleConnect() {
+  bool _shouldDeferEarlyScaleConnect(Scale scale) {
     if (_isBengleAboutToBeMachine()) return true;
+    if (scale is SimulatedDevice) return false;
     final preferredMachineId = settingsController.preferredMachineId;
     final machineResolved = _disconnectSupervisor.latestMachine != null;
     if (preferredMachineId != null && !machineResolved) return true;

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -8,6 +8,7 @@ import 'package:reaprime/src/controllers/connection_manager.dart';
 import 'package:reaprime/src/controllers/remembered_devices_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
+import 'package:reaprime/src/models/device/simulated_device.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/adapter_state.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
@@ -20,6 +21,7 @@ import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/scan_report.dart';
 import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/settings/settings_service.dart';
 
 import '../helpers/mock_de1_controller.dart';
 import '../helpers/mock_device_discovery_service.dart';
@@ -90,6 +92,14 @@ class _FakeDe1 implements De1Interface {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeSimulatedDe1 extends _FakeDe1 implements SimulatedDevice {
+  _FakeSimulatedDe1({super.deviceId = 'MockDe1'});
+}
+
+class _FakeSimulatedScale extends TestScale implements SimulatedDevice {
+  _FakeSimulatedScale({super.deviceId = 'MockScale'});
 }
 
 class _TrackingScale extends TestScale {
@@ -1005,6 +1015,44 @@ void main() {
             await connectFuture;
 
             expect(mockScanner.stopScanCallCount, 1);
+          },
+        );
+
+        test(
+          'simulated preferred devices emitted together early-connect '
+          'and stop the scan',
+          () async {
+            settingsController.enableSimulatedDevicesForSession({
+              SimulatedDevicesTypes.machine,
+              SimulatedDevicesTypes.scale,
+            });
+
+            mockScanner.scanCompleter = Completer<void>();
+
+            final fakeDe1 = _FakeSimulatedDe1(deviceId: 'MockDe1');
+            final fakeScale = _FakeSimulatedScale(deviceId: 'MockScale');
+            mockScanner.queuedScanResults.add([fakeDe1, fakeScale]);
+
+            final connectFuture = connectionManager.connect();
+            await mockScanner.scanningStream.firstWhere((s) => s);
+            await Future.delayed(Duration.zero);
+            await Future.delayed(Duration.zero);
+
+            expect(mockDe1Controller.lastConnectedDe1, same(fakeDe1));
+            expect(mockScaleController.connectCalls, hasLength(1));
+            expect(mockScaleController.connectCalls.first, same(fakeScale));
+            expect(
+              mockScanner.stopScanCallCount,
+              1,
+              reason: 'both simulated preferred devices are connected; '
+                  'the scan must stop while still pending',
+            );
+
+            mockScanner.completeScan();
+            await connectFuture;
+
+            expect(mockScaleController.connectCalls, hasLength(1));
+            expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
           },
         );
 

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -1018,43 +1018,41 @@ void main() {
           },
         );
 
-        test(
-          'simulated preferred devices emitted together early-connect '
-          'and stop the scan',
-          () async {
-            settingsController.enableSimulatedDevicesForSession({
-              SimulatedDevicesTypes.machine,
-              SimulatedDevicesTypes.scale,
-            });
+        test('simulated preferred devices emitted together early-connect '
+            'and stop the scan', () async {
+          settingsController.enableSimulatedDevicesForSession({
+            SimulatedDevicesTypes.machine,
+            SimulatedDevicesTypes.scale,
+          });
 
-            mockScanner.scanCompleter = Completer<void>();
+          mockScanner.scanCompleter = Completer<void>();
 
-            final fakeDe1 = _FakeSimulatedDe1(deviceId: 'MockDe1');
-            final fakeScale = _FakeSimulatedScale(deviceId: 'MockScale');
-            mockScanner.queuedScanResults.add([fakeDe1, fakeScale]);
+          final fakeDe1 = _FakeSimulatedDe1(deviceId: 'MockDe1');
+          final fakeScale = _FakeSimulatedScale(deviceId: 'MockScale');
+          mockScanner.queuedScanResults.add([fakeDe1, fakeScale]);
 
-            final connectFuture = connectionManager.connect();
-            await mockScanner.scanningStream.firstWhere((s) => s);
-            await Future.delayed(Duration.zero);
-            await Future.delayed(Duration.zero);
+          final connectFuture = connectionManager.connect();
+          await mockScanner.scanningStream.firstWhere((s) => s);
+          await Future.delayed(Duration.zero);
+          await Future.delayed(Duration.zero);
 
-            expect(mockDe1Controller.lastConnectedDe1, same(fakeDe1));
-            expect(mockScaleController.connectCalls, hasLength(1));
-            expect(mockScaleController.connectCalls.first, same(fakeScale));
-            expect(
-              mockScanner.stopScanCallCount,
-              1,
-              reason: 'both simulated preferred devices are connected; '
-                  'the scan must stop while still pending',
-            );
+          expect(mockDe1Controller.lastConnectedDe1, same(fakeDe1));
+          expect(mockScaleController.connectCalls, hasLength(1));
+          expect(mockScaleController.connectCalls.first, same(fakeScale));
+          expect(
+            mockScanner.stopScanCallCount,
+            1,
+            reason:
+                'both simulated preferred devices are connected; '
+                'the scan must stop while still pending',
+          );
 
-            mockScanner.completeScan();
-            await connectFuture;
+          mockScanner.completeScan();
+          await connectFuture;
 
-            expect(mockScaleController.connectCalls, hasLength(1));
-            expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
-          },
-        );
+          expect(mockScaleController.connectCalls, hasLength(1));
+          expect(connectionManager.currentStatus.phase, ConnectionPhase.ready);
+        });
 
         test(
           'only preferred machine set → calls stopScan on machine connect',


### PR DESCRIPTION
## Summary

Try Demo Mode connects MockDe1 + MockScale almost instantly, but the BLE scan indicator kept spinning for the full scan duration instead of stopping early.

Root cause: `SimulatedDeviceService` emits both devices in one scan update. `EarlyConnectWatcher` starts the machine early-connect, then the scale path hits `_shouldDeferEarlyScaleConnect()` before the preferred machine appears on the connected-machine stream. The unresolved-preferred-machine guard (added in `fb949f9b` for the Bengle external-scale race) defers the scale, so `_checkEarlyStop()` never sees both preferred devices connected and `stopScan()` never fires — MockScale connects only in the post-scan scale phase.

Fix:

- `_shouldDeferEarlyScaleConnect(scale)` now exempts simulated scales (`SimulatedDevice`) from the unresolved-preferred-machine fallback. The Bengle gate still runs first and is unchanged, so the external-scale-before-Bengle protection from `fb949f9b` is preserved for physical scales.
- `_checkEarlyStop()` is guarded by `_earlyStopFired` so two simulated pendings completing back-to-back cannot double-call `stopScan()`.

## Linked Issue

Fixes #734

## Verification

- New regression test `simulated preferred devices emitted together early-connect and stop the scan` — fails on `main` (scale deferred, `stopScan` uncalled), passes with the fix.
- `early-stop` group: 10 pass.
- `test/integration/connection_manager_bengle_scale_test.dart`: 7 pass — external scale visible before preferred Bengle still loses the slot to the virtual scale.
- `flutter analyze`: no issues.
- Full `flutter test`: 3700 pass, 1 pre-existing skip.

## Impact

None. Restores the documented Try Demo Mode behavior (PR #222 listed this as a known issue); no API/spec/documentation changes.