### PR TITLE
fix: publish connectingMachine during USB attach probe (#738)

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -435,9 +435,22 @@ class ConnectionManager {
     if (_machineConnected) return true;
     _isConnecting = true;
     _attachProbeInFlight = true;
+    var adopted = false;
     try {
       final probe = _attachProbe;
       if (probe == null) return false;
+      // The probe is committed to connecting the attached machine; publish
+      // the public progress phase before the (potentially slow) USB
+      // open/handshake so the discovery UI shows the connection in
+      // progress instead of a stale idle/error state. The concrete
+      // transport is not known until the probe result is available.
+      _publishStatus(
+        currentStatus.copyWith(
+          phase: ConnectionPhase.connectingMachine,
+          pendingAmbiguity: () => null,
+          activeTargetTransport: () => null,
+        ),
+      );
       final AttachProbeResult result;
       try {
         result = await probe.connectAttachedMachine(event);
@@ -463,6 +476,7 @@ class ConnectionManager {
             _log.warning('Adopting the attached machine failed', e, st);
             return false;
           }
+          adopted = true;
           return true;
         case AttachProbeUnsupported():
           _log.fine(
@@ -503,6 +517,14 @@ class ConnectionManager {
     } finally {
       _attachProbeInFlight = false;
       _isConnecting = false;
+      // If the probe published connectingMachine but did not hand off to an
+      // adopted machine (unsupported/failed/unavailable/exception/adoption
+      // failure), leave that transient phase unless a newer status already
+      // replaced it.
+      if (!adopted &&
+          currentStatus.phase == ConnectionPhase.connectingMachine) {
+        _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
+      }
     }
   }
 

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -436,6 +436,10 @@ class ConnectionManager {
     _isConnecting = true;
     _attachProbeInFlight = true;
     var adopted = false;
+    // Preserve the interrupted picker so a probe that does not adopt a
+    // machine can restore it instead of dropping the user into the generic
+    // results view.
+    final interruptedAmbiguity = currentStatus.pendingAmbiguity;
     try {
       final probe = _attachProbe;
       if (probe == null) return false;
@@ -472,7 +476,8 @@ class ConnectionManager {
           } catch (e, st) {
             // A failed adoption (e.g. preference persistence) must not
             // leave the latch set forever; fall back like an unavailable
-            // probe so the lifecycle completes.
+            // probe so the lifecycle completes and recovery/replay
+            // scheduling stays ungated.
             _log.warning('Adopting the attached machine failed', e, st);
             return false;
           }
@@ -523,7 +528,19 @@ class ConnectionManager {
       // replaced it.
       if (!adopted &&
           currentStatus.phase == ConnectionPhase.connectingMachine) {
-        _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.idle));
+        if (_machineConnected) {
+          // The machine connected even though a later adoption step (e.g.
+          // preference persistence) failed; surface the connected state
+          // rather than dropping it, so onboarding/discovery advances.
+          _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
+        } else {
+          _publishStatus(
+            currentStatus.copyWith(
+              phase: ConnectionPhase.idle,
+              pendingAmbiguity: () => interruptedAmbiguity,
+            ),
+          );
+        }
       }
     }
   }

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -654,6 +654,60 @@ void main() {
       expect(manager.currentStatus.phase, ConnectionPhase.ready);
     });
 
+    test('unsupported probe restores an interrupted machine picker', () async {
+      probeScanner.addDevice(_FakeDe1(deviceId: 'de1-a'));
+      probeScanner.addDevice(_FakeDe1(deviceId: 'de1-b'));
+      probeScanner.probeResult = const AttachProbeUnsupported();
+
+      await manager.connect();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        manager.currentStatus.pendingAmbiguity,
+        AmbiguityReason.machinePicker,
+      );
+
+      probeScanner.attach();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(manager.currentStatus.phase, ConnectionPhase.idle);
+      expect(
+        manager.currentStatus.pendingAmbiguity,
+        AmbiguityReason.machinePicker,
+      );
+    });
+
+    test('adoption failure after the machine connected settles to ready, '
+        'not idle', () async {
+      probeScanner.probeResult = AttachProbeConnected(
+        _FakeDe1(deviceId: 'usb-machine-id'),
+      );
+      settingsService.failSetPreferredMachineId = true;
+
+      final phases = <ConnectionPhase>[];
+      var seenConnecting = false;
+      final sub = manager.status.listen((s) {
+        if (s.phase == ConnectionPhase.connectingMachine) {
+          seenConnecting = true;
+        }
+        if (seenConnecting) phases.add(s.phase);
+      });
+
+      await attachAndSettle();
+      // The failed adoption falls back to the preferred-machine attempt
+      // (see 'an adoption failure still completes the latch lifecycle');
+      // neither that nor the probe's own cleanup may drop a genuinely
+      // connected machine back to idle.
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(phases, isNot(contains(ConnectionPhase.idle)));
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+      expect(manager.currentStatus.pendingAmbiguity, isNull);
+    });
+
     test('unavailable probe falls back to preferred-machine policy', () async {
       await settings.setPreferredMachineId('ble-machine-id');
       probeScanner.probeResult = const AttachProbeUnavailable();

--- a/test/controllers/connection_manager_usb_attach_test.dart
+++ b/test/controllers/connection_manager_usb_attach_test.dart
@@ -615,6 +615,45 @@ void main() {
       },
     );
 
+    test('attach probe reports connectingMachine while the USB connection '
+        'is in progress', () async {
+      probeScanner.probeResult = AttachProbeConnected(
+        _FakeDe1(deviceId: 'usb-machine-id'),
+      );
+      probeScanner.probeGate = Completer<void>();
+      // Seed a retryable machine error so the stale-Retry symptom is
+      // reproducible: entering connectingMachine must clear it.
+      manager.reportError(
+        ConnectionError(
+          kind: ConnectionErrorKind.machineConnectFailed,
+          severity: ConnectionErrorSeverity.error,
+          timestamp: DateTime.now().toUtc(),
+          deviceId: 'usb-machine-id',
+          deviceName: 'DE1',
+          message: 'Attached machine DE1 failed to connect.',
+        ),
+      );
+      expect(manager.currentStatus.error, isNotNull);
+
+      probeScanner.attach();
+      await probeScanner.probeStarted.future;
+
+      // The USB probe is still inside connectAttachedMachine() (the gate
+      // is unresolved); the public status must already say a machine
+      // connection is in progress and the stale Retry error must be gone.
+      expect(manager.currentStatus.phase, ConnectionPhase.connectingMachine);
+      expect(manager.currentStatus.error, isNull);
+
+      probeScanner.probeGate!.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(probeScanner.probeCallCount, 1);
+      expect(probeScanner.scanCallCount, 0);
+      expect(probeScanner.quickConnectCallCount, 0);
+      expect(settings.preferredMachineId, 'usb-machine-id');
+      expect(manager.currentStatus.phase, ConnectionPhase.ready);
+    });
+
     test('unavailable probe falls back to preferred-machine policy', () async {
       await settings.setPreferredMachineId('ble-machine-id');
       probeScanner.probeResult = const AttachProbeUnavailable();

--- a/test/device_discovery_view_test.dart
+++ b/test/device_discovery_view_test.dart
@@ -281,5 +281,48 @@ void main() {
         );
       });
     });
+
+    testWidgets('shows machine connection progress for connectingMachine '
+        'status', (tester) async {
+      final origOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.toString().contains('overflowed') ||
+            details.toString().contains('deactivated')) {
+          return;
+        }
+        origOnError?.call(details);
+      };
+      addTearDown(() => FlutterError.onError = origOnError);
+
+      final fakeCm = FakeConnectionManager();
+      addTearDown(fakeCm.dispose);
+      fakeCm.emitStatus(
+        const ConnectionStatus(phase: ConnectionPhase.connectingMachine),
+      );
+
+      Widget view() => MediaQuery(
+        data: MediaQueryData(size: Size(1024, 768)),
+        child: ShadApp(
+          home: Scaffold(
+            body: DeviceDiscoveryView(
+              connectionManager: fakeCm,
+              deviceController: deviceController,
+              settingsController: settingsController,
+              webUIService: webUIService,
+              webUIStorage: webUIStorage,
+              logger: Logger('test'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.runAsync(() async {
+        await tester.pumpWidget(view());
+        await tester.pump();
+
+        expect(find.text('Connecting to your machine...'), findsOneWidget);
+        expect(find.text('Retry'), findsNothing);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes decentespresso/decaid#738: when Decaid detects a direct USB machine and is actively probing/connecting it, the discovery UI now shows the normal machine connection progress state ("Connecting to your machine..." + progress indicator) instead of appearing empty/stuck with a stale `Retry` action.

## Root cause

`ConnectionManager._executeAttachProbe()` only published `ConnectionPhase.connectingMachine` after `UsbAttachProbe.connectAttachedMachine()` returned an `AttachProbeConnected` result. The potentially slow USB open/handshake therefore ran with no matching public phase, and `StatusPublisher` never got a chance to clear an earlier `machineConnectFailed` / `machineDisconnected` state — leaving the stale `Retry` visible.

## Changes

- `lib/src/controllers/connection_manager.dart`:
  - Publish `ConnectionPhase.connectingMachine` (clearing `pendingAmbiguity`, without guessing the transport) as soon as the probe is committed, before awaiting `connectAttachedMachine()`. `StatusPublisher`'s existing non-sticky error clearing now applies, so a stale `Retry` disappears while the connection is legitimately in progress.
  - Guarded `finally` cleanup: if the probe published `connectingMachine` but did not hand off to an adopted machine (unsupported / failed / unavailable / exception / adoption failure), the transient phase is reset to `idle` unless a newer status already replaced it.
- `test/controllers/connection_manager_usb_attach_test.dart`: regression test holding the probe open on the `probeGate` seam, asserting `connectingMachine` with a cleared error mid-probe, then the unchanged successful outcome.
- `test/device_discovery_view_test.dart`: locks the UI contract — `connectingMachine` shows "Connecting to your machine..." and no `Retry`.

USB-vs-BLE priority/latch behavior from #723 is unchanged; no transport, `UsbAttachProbe` API, or recovery policy changes.

## Verification

- `dart format lib test` — clean
- `flutter test test/controllers/connection_manager_usb_attach_test.dart` — 43/43 pass (new regression test fails on unchanged `main` at the in-flight phase assertion)
- `flutter test test/device_discovery_view_test.dart` — 7/7 pass
- `flutter analyze` — 1 pre-existing warning (missing `assets/plugins/shot-upload.reaplugin/` dir, unrelated)
- `flutter test` — 3689 pass; 31 failures all reproduce identically on unchanged `main`: `PathNotFoundException: assets/plugins/shot-upload.reaplugin/manifest.json` (missing asset in this checkout, verified via worktree on `origin/main`)