### PR TITLE
fix(connection): stop adoptDevice() emitting an interim null on re-adopt

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -321,6 +321,22 @@ physical connection. On Android/Linux/Windows, direct
 The identity check happens during `onConnect()` — for machines, `v13Model`
 is read and compared against the expected `DeviceImplementation`.
 
+### Cross-listener ordering after adopt (PR #746)
+
+`De1Controller.adoptDevice()` emits exactly one event on the `de1` stream
+when replacing an already-connected device — no interim null — so
+`DisconnectSupervisor` has nothing to misread as a disconnect. Do not
+"flush" the supervisor with a fresh `de1.firstWhere(...)` subscription
+instead: the `de1` stream is a default-async `BehaviorSubject` (async
+broadcast), and Dart gives no delivery-ordering guarantee across
+independently scheduled listeners, so the fresh subscription can see the
+new device while the supervisor's own listener still has the earlier
+value queued. When a caller must know the supervisor has caught up
+(e.g. `_tryQuickConnectMachine` reading `_machineConnected` right after
+adopt), use `DisconnectSupervisor.waitForMachine(deviceId)` — it resolves
+from inside the supervisor's own pre-existing listener, so ordering is
+correct by construction.
+
 ## DE1 MMR model mapping (`DecentMachineModel`)
 
 `v13Model` (MMR `0x0080000C`) is the machine model read on connect. For the

--- a/lib/src/controllers/connection/disconnect_supervisor.dart
+++ b/lib/src/controllers/connection/disconnect_supervisor.dart
@@ -33,11 +33,6 @@ class DisconnectSupervisor {
   Completer<void>? _machineSeenCompleter;
   String? _awaitedMachineId;
 
-  /// Resolves once this supervisor's own machine-stream listener has
-  /// processed a non-null device with the given [deviceId]. Unlike
-  /// subscribing separately to the machine stream, this is driven by the
-  /// listener already registered in [_start], so it cannot race a fresh
-  /// subscription against events already queued for this one.
   Future<void> waitForMachine(String deviceId) {
     if (_latestDe1?.deviceId == deviceId) return Future<void>.value();
     final completer = Completer<void>();

--- a/lib/src/controllers/connection/disconnect_supervisor.dart
+++ b/lib/src/controllers/connection/disconnect_supervisor.dart
@@ -30,6 +30,22 @@ class DisconnectSupervisor {
   device.ConnectionState _latestScaleState = device.ConnectionState.discovered;
   String? _lastKnownMachineId;
 
+  Completer<void>? _machineSeenCompleter;
+  String? _awaitedMachineId;
+
+  /// Resolves once this supervisor's own machine-stream listener has
+  /// processed a non-null device with the given [deviceId]. Unlike
+  /// subscribing separately to the machine stream, this is driven by the
+  /// listener already registered in [_start], so it cannot race a fresh
+  /// subscription against events already queued for this one.
+  Future<void> waitForMachine(String deviceId) {
+    if (_latestDe1?.deviceId == deviceId) return Future<void>.value();
+    final completer = Completer<void>();
+    _awaitedMachineId = deviceId;
+    _machineSeenCompleter = completer;
+    return completer.future;
+  }
+
   StreamSubscription<De1Interface?>? _machineSub;
   StreamSubscription<device.ConnectionState>? _scaleSub;
 
@@ -80,6 +96,11 @@ class DisconnectSupervisor {
       _latestDe1 = de1;
       if (de1 != null) {
         _lastKnownMachineId = de1.deviceId;
+        if (de1.deviceId == _awaitedMachineId) {
+          _awaitedMachineId = null;
+          _machineSeenCompleter?.complete();
+          _machineSeenCompleter = null;
+        }
         _onMachineConnected?.call();
         return;
       }
@@ -173,5 +194,8 @@ class DisconnectSupervisor {
     _scaleSub?.cancel();
     _machineSub = null;
     _scaleSub = null;
+    _awaitedMachineId = null;
+    _machineSeenCompleter?.complete();
+    _machineSeenCompleter = null;
   }
 }

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -513,26 +513,21 @@ class ConnectionManager {
         activeTargetTransport: () => machine.transportType,
       ),
     );
-    _isConnectingMachine = true;
-    try {
-      de1Controller.adoptDevice(machine);
-      await de1Controller.de1.firstWhere(
-        (connected) => connected == machine,
-        orElse: () => machine,
-      );
-      await settingsController.setPreferredMachineId(machine.deviceId);
-      _log.info('Attach probe: machine adopted (${machine.deviceId})');
-      if (machine is BengleInterface) {
-        await _attachBengleVirtualScale(machine);
-      } else if (!_scaleConnected) {
-        if (settingsController.preferredScaleId != null) {
-          _ensureScaleReacquisition();
-        } else {
-          _armPostQuickConnectScaleScan();
-        }
+    de1Controller.adoptDevice(machine);
+    await de1Controller.de1.firstWhere(
+      (connected) => connected == machine,
+      orElse: () => machine,
+    );
+    await settingsController.setPreferredMachineId(machine.deviceId);
+    _log.info('Attach probe: machine adopted (${machine.deviceId})');
+    if (machine is BengleInterface) {
+      await _attachBengleVirtualScale(machine);
+    } else if (!_scaleConnected) {
+      if (settingsController.preferredScaleId != null) {
+        _ensureScaleReacquisition();
+      } else {
+        _armPostQuickConnectScaleScan();
       }
-    } finally {
-      _isConnectingMachine = false;
     }
     _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
   }
@@ -963,10 +958,7 @@ class ConnectionManager {
       final device = await deviceScanner.tryQuickConnect(remembered);
       if (device is De1Interface) {
         de1Controller.adoptDevice(device);
-        await de1Controller.de1.firstWhere(
-          (connected) => connected == device,
-          orElse: () => device,
-        );
+        await _disconnectSupervisor.waitForMachine(device.deviceId);
         _log.info('Quick-connect: machine adopted (${device.deviceId})');
         return device;
       }
@@ -1008,13 +1000,7 @@ class ConnectionManager {
       _publishStatus(
         currentStatus.copyWith(phase: ConnectionPhase.connectingMachine),
       );
-      final De1Interface? qcMachine;
-      _isConnectingMachine = true;
-      try {
-        qcMachine = await _tryQuickConnectMachine();
-      } finally {
-        _isConnectingMachine = false;
-      }
+      final qcMachine = await _tryQuickConnectMachine();
       if (qcMachine != null) {
         if (await _releaseSupersededAutomaticMachine()) return;
         _log.info('Quick-connect: machine connected, proceeding to ready');

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -513,21 +513,26 @@ class ConnectionManager {
         activeTargetTransport: () => machine.transportType,
       ),
     );
-    de1Controller.adoptDevice(machine);
-    await de1Controller.de1.firstWhere(
-      (connected) => connected == machine,
-      orElse: () => machine,
-    );
-    await settingsController.setPreferredMachineId(machine.deviceId);
-    _log.info('Attach probe: machine adopted (${machine.deviceId})');
-    if (machine is BengleInterface) {
-      await _attachBengleVirtualScale(machine);
-    } else if (!_scaleConnected) {
-      if (settingsController.preferredScaleId != null) {
-        _ensureScaleReacquisition();
-      } else {
-        _armPostQuickConnectScaleScan();
+    _isConnectingMachine = true;
+    try {
+      de1Controller.adoptDevice(machine);
+      await de1Controller.de1.firstWhere(
+        (connected) => connected == machine,
+        orElse: () => machine,
+      );
+      await settingsController.setPreferredMachineId(machine.deviceId);
+      _log.info('Attach probe: machine adopted (${machine.deviceId})');
+      if (machine is BengleInterface) {
+        await _attachBengleVirtualScale(machine);
+      } else if (!_scaleConnected) {
+        if (settingsController.preferredScaleId != null) {
+          _ensureScaleReacquisition();
+        } else {
+          _armPostQuickConnectScaleScan();
+        }
       }
+    } finally {
+      _isConnectingMachine = false;
     }
     _publishStatus(currentStatus.copyWith(phase: ConnectionPhase.ready));
   }
@@ -958,6 +963,10 @@ class ConnectionManager {
       final device = await deviceScanner.tryQuickConnect(remembered);
       if (device is De1Interface) {
         de1Controller.adoptDevice(device);
+        await de1Controller.de1.firstWhere(
+          (connected) => connected == device,
+          orElse: () => device,
+        );
         _log.info('Quick-connect: machine adopted (${device.deviceId})');
         return device;
       }
@@ -999,7 +1008,13 @@ class ConnectionManager {
       _publishStatus(
         currentStatus.copyWith(phase: ConnectionPhase.connectingMachine),
       );
-      final qcMachine = await _tryQuickConnectMachine();
+      final De1Interface? qcMachine;
+      _isConnectingMachine = true;
+      try {
+        qcMachine = await _tryQuickConnectMachine();
+      } finally {
+        _isConnectingMachine = false;
+      }
       if (qcMachine != null) {
         if (await _releaseSupersededAutomaticMachine()) return;
         _log.info('Quick-connect: machine connected, proceeding to ready');

--- a/lib/src/controllers/de1_controller.dart
+++ b/lib/src/controllers/de1_controller.dart
@@ -188,7 +188,8 @@ class De1Controller {
       _log.fine('adoptDevice: already connected to this device, exit early');
       return;
     }
-    _onDisconnect();
+    _log.info('adopting de1 (${de1Interface.deviceId})');
+    _resetForNewDevice();
     _de1 = de1Interface;
     _connectionMachineIdentity = _machineIdentity(de1Interface);
     _de1Controller.add(_de1);
@@ -232,11 +233,8 @@ class De1Controller {
     }
   }
 
-  void _onDisconnect() {
-    _log.info("resetting de1");
+  void _resetForNewDevice() {
     _connectionGeneration++;
-    _de1 = null;
-    _de1Controller.add(_de1);
     _dataInitialized = false;
     _initSettledSubject.add(null);
     _shotSettingsDebounce?.cancel();
@@ -245,6 +243,13 @@ class De1Controller {
       sub.cancel();
     }
     _subscriptions.clear();
+  }
+
+  void _onDisconnect() {
+    _log.info("resetting de1");
+    _resetForNewDevice();
+    _de1 = null;
+    _de1Controller.add(_de1);
   }
 
   Future<void> _initializeData() async {

--- a/test/controllers/connection/disconnect_supervisor_test.dart
+++ b/test/controllers/connection/disconnect_supervisor_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
 import 'package:reaprime/src/controllers/connection/disconnect_supervisor.dart';
 import 'package:reaprime/src/controllers/connection/status_publisher.dart';
-import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 
 class _FakeDe1 implements De1Interface {
@@ -17,103 +16,79 @@ class _FakeDe1 implements De1Interface {
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
+DisconnectSupervisor _buildSupervisor(
+  StreamController<De1Interface?> machineController,
+) {
+  return DisconnectSupervisor(
+    machineStream: machineController.stream,
+    scaleStream: const Stream.empty(),
+    statusPublisher: StatusPublisher(),
+    expectations: DisconnectExpectations(),
+    isConnectingMachine: () => false,
+    isConnectingScale: () => false,
+    scaleLastConnectedId: () => null,
+    preferredScaleId: () => null,
+  );
+}
+
 void main() {
-  group('DisconnectSupervisor', () {
+  group('DisconnectSupervisor.waitForMachine', () {
     late StreamController<De1Interface?> machineController;
-    late StatusPublisher statusPublisher;
     late DisconnectSupervisor supervisor;
-    bool connecting = false;
 
     setUp(() {
       machineController = StreamController<De1Interface?>.broadcast();
-      statusPublisher = StatusPublisher();
-      connecting = false;
-      supervisor = DisconnectSupervisor(
-        machineStream: machineController.stream,
-        scaleStream: const Stream.empty(),
-        statusPublisher: statusPublisher,
-        expectations: DisconnectExpectations(),
-        isConnectingMachine: () => connecting,
-        isConnectingScale: () => false,
-        scaleLastConnectedId: () => null,
-        preferredScaleId: () => null,
-      );
+      supervisor = _buildSupervisor(machineController);
     });
 
     tearDown(() async {
       supervisor.dispose();
-      statusPublisher.dispose();
       await machineController.close();
     });
 
-    // De1Controller.adoptDevice() unconditionally resets (emits null) before
-    // emitting the newly adopted De1Interface, even when re-adopting a
-    // machine that was already connected (e.g. a fresh transport object for
-    // the same physical USB device). Any automatic reconnect path that
-    // drives this churn must hold isConnectingMachine for its duration, or
-    // the reset half of the churn reads as an unexpected disconnect.
-    test('reset-then-adopt churn while isConnectingMachine is held through a '
-        'flush does not surface an error', () async {
+    test('resolves immediately when the device is already current', () async {
       machineController.add(_FakeDe1('de1-1'));
       await Future<void>.delayed(Duration.zero);
-      expect(statusPublisher.current.error, isNull);
 
-      connecting = true;
-      machineController.add(null);
-      machineController.add(_FakeDe1('de1-1'));
-      // The churn is delivered asynchronously (broadcast/BehaviorSubject
-      // listeners fire via microtasks), so the guard must still be held
-      // when this delivery actually happens.
-      await Future<void>.delayed(Duration.zero);
-      connecting = false;
-
-      expect(
-        statusPublisher.current.error,
-        isNull,
-        reason:
-            'internal reset-then-adopt churn while isConnectingMachine is '
-            'held must not be reported as an unexpected disconnect',
-      );
+      await supervisor
+          .waitForMachine('de1-1')
+          .timeout(const Duration(milliseconds: 100));
     });
 
-    test('releasing isConnectingMachine before the churn is delivered still '
-        'surfaces a spurious error', () async {
-      // A caller that flips the guard back to false immediately after
-      // calling adoptDevice(), without first waiting for the de1 stream to
-      // actually deliver the churn, gains nothing: the guard is already
-      // false by the time DisconnectSupervisor's listener runs. Callers
-      // must await the adopted device settling (e.g.
-      // de1Controller.de1.firstWhere(...)) before releasing the guard.
-      machineController.add(_FakeDe1('de1-1'));
-      await Future<void>.delayed(Duration.zero);
-      expect(statusPublisher.current.error, isNull);
+    test('resolves once the awaited device arrives on the stream', () async {
+      final future = supervisor.waitForMachine('de1-1');
+      var resolved = false;
+      unawaited(future.then((_) => resolved = true));
 
-      connecting = true;
-      machineController.add(null);
-      machineController.add(_FakeDe1('de1-1'));
-      connecting = false; // released without flushing — too early
       await Future<void>.delayed(Duration.zero);
+      expect(resolved, isFalse);
 
-      expect(
-        statusPublisher.current.error?.kind,
-        ConnectionErrorKind.machineDisconnected,
-      );
+      machineController.add(_FakeDe1('de1-1'));
+      await future.timeout(const Duration(milliseconds: 100));
+      expect(resolved, isTrue);
     });
 
-    test('a null emission while isConnectingMachine is not held is reported as '
-        'an unexpected disconnect', () async {
-      machineController.add(_FakeDe1('de1-1'));
-      await Future<void>.delayed(Duration.zero);
-      expect(statusPublisher.current.error, isNull);
+    test(
+      'ignores an unrelated device before the awaited one arrives',
+      () async {
+        final future = supervisor.waitForMachine('de1-2');
 
-      machineController.add(null);
-      machineController.add(_FakeDe1('de1-1'));
-      await Future<void>.delayed(Duration.zero);
+        machineController.add(_FakeDe1('de1-1'));
+        await Future<void>.delayed(Duration.zero);
 
-      expect(
-        statusPublisher.current.error?.kind,
-        ConnectionErrorKind.machineDisconnected,
-      );
-    });
+        machineController.add(_FakeDe1('de1-2'));
+        await future.timeout(const Duration(milliseconds: 100));
+      },
+    );
+
+    test(
+      'dispose resolves a pending wait instead of hanging forever',
+      () async {
+        final future = supervisor.waitForMachine('de1-1');
+        supervisor.dispose();
+
+        await future.timeout(const Duration(milliseconds: 100));
+      },
+    );
   });
 }

--- a/test/controllers/connection/disconnect_supervisor_test.dart
+++ b/test/controllers/connection/disconnect_supervisor_test.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart';
+import 'package:reaprime/src/controllers/connection/disconnect_supervisor.dart';
+import 'package:reaprime/src/controllers/connection/status_publisher.dart';
+import 'package:reaprime/src/controllers/connection_error.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+
+class _FakeDe1 implements De1Interface {
+  @override
+  final String deviceId;
+
+  _FakeDe1(this.deviceId);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  group('DisconnectSupervisor', () {
+    late StreamController<De1Interface?> machineController;
+    late StatusPublisher statusPublisher;
+    late DisconnectSupervisor supervisor;
+    bool connecting = false;
+
+    setUp(() {
+      machineController = StreamController<De1Interface?>.broadcast();
+      statusPublisher = StatusPublisher();
+      connecting = false;
+      supervisor = DisconnectSupervisor(
+        machineStream: machineController.stream,
+        scaleStream: const Stream.empty(),
+        statusPublisher: statusPublisher,
+        expectations: DisconnectExpectations(),
+        isConnectingMachine: () => connecting,
+        isConnectingScale: () => false,
+        scaleLastConnectedId: () => null,
+        preferredScaleId: () => null,
+      );
+    });
+
+    tearDown(() async {
+      supervisor.dispose();
+      statusPublisher.dispose();
+      await machineController.close();
+    });
+
+    // De1Controller.adoptDevice() unconditionally resets (emits null) before
+    // emitting the newly adopted De1Interface, even when re-adopting a
+    // machine that was already connected (e.g. a fresh transport object for
+    // the same physical USB device). Any automatic reconnect path that
+    // drives this churn must hold isConnectingMachine for its duration, or
+    // the reset half of the churn reads as an unexpected disconnect.
+    test('reset-then-adopt churn while isConnectingMachine is held through a '
+        'flush does not surface an error', () async {
+      machineController.add(_FakeDe1('de1-1'));
+      await Future<void>.delayed(Duration.zero);
+      expect(statusPublisher.current.error, isNull);
+
+      connecting = true;
+      machineController.add(null);
+      machineController.add(_FakeDe1('de1-1'));
+      // The churn is delivered asynchronously (broadcast/BehaviorSubject
+      // listeners fire via microtasks), so the guard must still be held
+      // when this delivery actually happens.
+      await Future<void>.delayed(Duration.zero);
+      connecting = false;
+
+      expect(
+        statusPublisher.current.error,
+        isNull,
+        reason:
+            'internal reset-then-adopt churn while isConnectingMachine is '
+            'held must not be reported as an unexpected disconnect',
+      );
+    });
+
+    test('releasing isConnectingMachine before the churn is delivered still '
+        'surfaces a spurious error', () async {
+      // A caller that flips the guard back to false immediately after
+      // calling adoptDevice(), without first waiting for the de1 stream to
+      // actually deliver the churn, gains nothing: the guard is already
+      // false by the time DisconnectSupervisor's listener runs. Callers
+      // must await the adopted device settling (e.g.
+      // de1Controller.de1.firstWhere(...)) before releasing the guard.
+      machineController.add(_FakeDe1('de1-1'));
+      await Future<void>.delayed(Duration.zero);
+      expect(statusPublisher.current.error, isNull);
+
+      connecting = true;
+      machineController.add(null);
+      machineController.add(_FakeDe1('de1-1'));
+      connecting = false; // released without flushing — too early
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        statusPublisher.current.error?.kind,
+        ConnectionErrorKind.machineDisconnected,
+      );
+    });
+
+    test('a null emission while isConnectingMachine is not held is reported as '
+        'an unexpected disconnect', () async {
+      machineController.add(_FakeDe1('de1-1'));
+      await Future<void>.delayed(Duration.zero);
+      expect(statusPublisher.current.error, isNull);
+
+      machineController.add(null);
+      machineController.add(_FakeDe1('de1-1'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        statusPublisher.current.error?.kind,
+        ConnectionErrorKind.machineDisconnected,
+      );
+    });
+  });
+}

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -165,31 +165,25 @@ void main() {
   });
 
   group('initial shot settings', () {
-    test(
-      'missing initial settings do not block initialization',
-      () async {
-        final deviceController = DeviceController([
-          MockDeviceDiscoveryService(),
-        ]);
-        await deviceController.initialize();
-        final de1Controller = De1Controller(controller: deviceController);
-        final testDe1 = TestDe1();
+    test('missing initial settings do not block initialization', () async {
+      final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+      await deviceController.initialize();
+      final de1Controller = De1Controller(controller: deviceController);
+      final testDe1 = TestDe1();
 
-        await de1Controller.connectToDe1(testDe1);
+      await de1Controller.connectToDe1(testDe1);
 
-        expect(
-          await de1Controller.initSettled
-              .firstWhere((generation) => generation != null)
-              .timeout(const Duration(seconds: 3)),
-          isNotNull,
-        );
-        expect(de1Controller.connectedDe1OrNull, same(testDe1));
+      expect(
+        await de1Controller.initSettled
+            .firstWhere((generation) => generation != null)
+            .timeout(const Duration(seconds: 3)),
+        isNotNull,
+      );
+      expect(de1Controller.connectedDe1OrNull, same(testDe1));
 
-        testDe1.dispose();
-        de1Controller.dispose();
-      },
-      timeout: const Timeout(Duration(seconds: 5)),
-    );
+      testDe1.dispose();
+      de1Controller.dispose();
+    }, timeout: const Timeout(Duration(seconds: 5)));
   });
 
   group('shot-settings debounce race (comms-harden #5)', () {

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -73,6 +73,47 @@ void main() {
     });
   });
 
+  group('adoptDevice', () {
+    test('replacing an already-adopted device does not emit an interim null '
+        'on de1', () async {
+      await runZonedGuarded(() async {
+        final deviceController = DeviceController([
+          MockDeviceDiscoveryService(),
+        ]);
+        await deviceController.initialize();
+        final de1Controller = De1Controller(controller: deviceController);
+        final first = TestDe1(deviceId: 'de1-a');
+        final second = TestDe1(deviceId: 'de1-b');
+
+        final emissions = <De1Interface?>[];
+        final sub = de1Controller.de1.listen(emissions.add);
+
+        de1Controller.adoptDevice(first);
+        first.emitShotSettings(_emptyShotSettings());
+        await Future<void>.delayed(Duration.zero);
+        expect(de1Controller.connectedDe1OrNull, same(first));
+
+        de1Controller.adoptDevice(second);
+        second.emitShotSettings(_emptyShotSettings());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(de1Controller.connectedDe1OrNull, same(second));
+        expect(
+          emissions,
+          [null, first, second],
+          reason:
+              'adopting a replacement device must transition directly '
+              'from the previous device to the new one — an interim '
+              'null reads as an unexpected disconnect downstream',
+        );
+
+        await sub.cancel();
+        await first.dispose();
+        await second.dispose();
+      }, (_, _) {});
+    });
+  });
+
   group('seenSerials', () {
     test('retains serials after the device disconnects', () async {
       await runZonedGuarded(() async {
@@ -124,25 +165,31 @@ void main() {
   });
 
   group('initial shot settings', () {
-    test('missing initial settings do not block initialization', () async {
-      final deviceController = DeviceController([MockDeviceDiscoveryService()]);
-      await deviceController.initialize();
-      final de1Controller = De1Controller(controller: deviceController);
-      final testDe1 = TestDe1();
+    test(
+      'missing initial settings do not block initialization',
+      () async {
+        final deviceController = DeviceController([
+          MockDeviceDiscoveryService(),
+        ]);
+        await deviceController.initialize();
+        final de1Controller = De1Controller(controller: deviceController);
+        final testDe1 = TestDe1();
 
-      await de1Controller.connectToDe1(testDe1);
+        await de1Controller.connectToDe1(testDe1);
 
-      expect(
-        await de1Controller.initSettled
-            .firstWhere((generation) => generation != null)
-            .timeout(const Duration(seconds: 3)),
-        isNotNull,
-      );
-      expect(de1Controller.connectedDe1OrNull, same(testDe1));
+        expect(
+          await de1Controller.initSettled
+              .firstWhere((generation) => generation != null)
+              .timeout(const Duration(seconds: 3)),
+          isNotNull,
+        );
+        expect(de1Controller.connectedDe1OrNull, same(testDe1));
 
-      testDe1.dispose();
-      de1Controller.dispose();
-    }, timeout: const Timeout(Duration(seconds: 5)));
+        testDe1.dispose();
+        de1Controller.dispose();
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
   });
 
   group('shot-settings debounce race (comms-harden #5)', () {


### PR DESCRIPTION
## Summary

What changed, and why?

- Fixes a race where the skin shows "Machine disconnected unexpectedly"
  while a USB-connected DE1 is still attached and streaming data.
  `De1Controller.adoptDevice()` unconditionally resets (emits `null` on
  the `de1` stream) before emitting the newly adopted device, even when
  re-adopting an already-connected machine (e.g. a fresh transport
  object for the same physical USB device after re-enumeration).
  `DisconnectSupervisor` only suppresses that internal churn while
  `isConnectingMachine()` is true, but that guard was only ever set by
  the manual `connectMachine()` path — the automatic quick-connect
  (`_tryQuickConnectMachine`) and USB attach-probe
  (`_adoptAttachedMachine`) paths called `adoptDevice()` without holding
  it, so their reset-then-adopt churn could be misread as an unexpected
  disconnect.
- Fixed at the source rather than widening the guard:
  `De1Controller.adoptDevice()` no longer emits an interim `null` at all
  when replacing an already-connected device. The internal reset
  (generation bump, `dataInitialized` reset, subscription teardown) is
  factored into `_resetForNewDevice()`, which `adoptDevice()` now uses
  directly, going straight from the old device to the new one in a
  single emission. There is no churn left for `DisconnectSupervisor` to
  misread. `connectToDe1()` (the `connectMachine()`-only path) is
  unchanged; it was never implicated.
- Removing the interim null surfaced a second, independent, pre-existing
  race: `_releaseSupersededAutomaticMachine()` reads `_machineConnected`
  (backed by `DisconnectSupervisor`'s async-updated `_latestDe1`)
  immediately after `adoptDevice()` returns. The old code's
  null-then-device pair was accidentally providing microtask headroom
  for the supervisor to catch up; without it a usb-attach test failed.
  Fixed with `DisconnectSupervisor.waitForMachine(deviceId)`, a `Future`
  resolved from inside the supervisor's own pre-existing listener
  rather than a fresh subscription (a new `de1.firstWhere(...)` listener
  would race cross-listener delivery ordering on the async broadcast
  stream), so completion is ordered correctly by construction.
  `_tryQuickConnectMachine` awaits it before returning.

## Linked Issue

N/A — reported by a user via chat log analysis, not a tracked issue.

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- Diagnosed against a user-provided app log
  (`de1crops/log.txt`, 2026-08-31): `Quick-connect: machine adopted` →
  `machine connected, proceeding to ready` → SEVERE
  `machineDisconnected` all within ~1ms, followed by the machine
  reconnecting on its own a couple ms later — confirming the DE1 never
  actually dropped.
- Added a regression test in `test/controllers/de1_controller_test.dart`
  (`adoptDevice` group) that drives the real `De1Controller.adoptDevice()`
  with two real `TestDe1` instances over the real `BehaviorSubject`-backed
  `de1` stream, asserting the emission sequence has no interim null when
  replacing an already-adopted device. Confirmed it fails (hangs/times
  out) against the pre-fix `adoptDevice()` and passes against the fix.
- Added focused unit tests for `DisconnectSupervisor.waitForMachine()` in
  `test/controllers/connection/disconnect_supervisor_test.dart`:
  resolves immediately when already current, resolves when the awaited
  device arrives, ignores an unrelated device, resolves on dispose
  instead of hanging.
- `dart format`, `flutter analyze` — clean on all changed files.
- `flutter test test/controllers/connection/ test/controllers/de1_controller_test.dart`
  — all pass (72 tests).
- Full `flutter test` — no regressions; the only failures are
  pre-existing/unrelated (missing `assets/plugins/shot-upload.reaplugin/`
  directory in this environment, reproduces identically on unmodified
  `origin/main`).
- Reviewed by an independent Opus 5 pass and the maintainer review on
  this PR; the previous review round's correctness blockers (unreliable
  `firstWhere` flush, over-broad `_isConnectingMachine` guard) are
  resolved by the root-cause fix described above.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- User-visible: fixes spurious "Machine disconnected unexpectedly"
  banners/reconnect churn on the skin during automatic quick-connect
  and USB attach-probe adoption, while the machine is actually still
  connected.
- Behavior change (edge case): `adoptDevice()` no longer resets the
  `de1` stream's exposed value through an interim `null` when replacing
  an already-connected device. Any downstream listener that depended on
  observing a `null` between two adopted devices would see the direct
  transition instead; the only in-tree listener (`DisconnectSupervisor`)
  is the one the bug was about. Internal `_onDisconnect()` bookkeeping
  is unchanged for genuine disconnects.
- No API/spec changes (`assets/api/*.yml` untouched — internal
  connection-manager behavior only).

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
