### PR TITLE
feat(devices): add MOTTO80 BLE grinder support

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -56,7 +56,7 @@ paths:
                       enum: [connected, disconnected]
                     type:
                       type: string
-                      enum: [machine, scale, sensor]
+                      enum: [machine, scale, sensor, grinder]
                     available:
                       type: boolean
                       description: >
@@ -6403,6 +6403,10 @@ components:
           type: string
           nullable: true
           example: "AA:BB:CC:DD:EE:FF"
+        preferredGrinderId:
+          description: Device ID of the preferred grinder for auto-connect on startup. When set, REA will automatically connect to this grinder when it's discovered during device scan. Set to null to clear the preference.
+          type: string
+          nullable: true
         defaultSkinId:
           description: ID of the default WebUI skin to serve
           type: string
@@ -6440,7 +6444,7 @@ components:
           type: array
           items:
             type: string
-            enum: [machine, scale, sensor, bengle]
+            enum: [machine, scale, sensor, bengle, grinder]
           nullable: true
         themeMode:
           description: App theme mode
@@ -6500,6 +6504,10 @@ components:
           description: Device ID of the preferred scale for auto-connect on startup. Returns null if no preferred device is set.
           type: string
           nullable: true
+        preferredGrinderId:
+          description: Device ID of the preferred grinder for auto-connect on startup. Returns null if no preferred device is set.
+          type: string
+          nullable: true
           example: "AA:BB:CC:DD:EE:FF"
         defaultSkinId:
           description: ID of the default WebUI skin being served
@@ -6536,7 +6544,7 @@ components:
           type: array
           items:
             type: string
-            enum: [machine, scale, sensor, bengle]
+            enum: [machine, scale, sensor, bengle, grinder]
         themeMode:
           description: App theme mode
           type: string

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -415,6 +415,44 @@ stalled write resume later and overwrite a newer one. Bound the actual
 unbounded read instead; a real anti-wedge mechanism needs explicit
 cancellation or fencing.
 
+## MOTTO80 (Bookoo) Grinder Protocol
+
+The MOTTO80 grinder advertises as "MOTTO80 BLE" (matched with
+`contains('motto80')`). Service `4d543830-0001-4b80-8f00-424f4f4b4f4f` with
+command characteristic `...-0002` (write-with-response) and status
+characteristic `...-0003` (notify, ~200ms status broadcasts). A legacy
+`0000ffff` service exists but is only used by the reference GUI for raw hex
+writes; the driver does not use it.
+
+Frames are `[A5 01][seq uint16 LE][payloadLen uint32 LE][UTF-8 JSON]`; seq
+starts at 0 on connect and wraps at 0xffff. Long frames fragment across
+notifications: continuation chunks may repeat the full header with the same
+seq, or arrive headerless. The parser keeps a pending `{seq, expect, bytes}`
+buffer, appends both continuation forms, drops stale pending when a
+different-seq frame arrives, and decodes UTF-8 once on the reassembled buffer
+with `allowMalformed: true` — the reference GUI decodes per fragment and
+mangles multi-byte characters (Chinese preset names) split across chunks.
+
+Connect sequence: subscribe status → handshake
+`{"request":{"appHello":{"op":"handshake"}}}` → 400ms →
+`{"request":{"grindSection":{"op":"get","selector":{"type":"all"}}}}` →
+400ms → `{"request":{"grindPreset":{"op":"get","selector":{"type":"all"}}}}`.
+Startup queries are fire-and-forget with per-query failure logs. Responses are
+identified by the `"response"` substring in the JSON; broadcasts carry the
+scalar fields (feedingRpm, grindRpm, brightness, standbySec, cupDetect,
+autoStop, fastClean, bladeGap, humidity, devState, netState, totalGrinds,
+wifiName, snCode, resetReason, releaseVer). Preset responses carry
+`"uid":"hex","name":"..."` entries.
+
+Command envelope `{"request":{<module>:{<op>|<data>}}}`: grind start/stop,
+grindSection set (index or name), grindPreset set (uid confirmed against the
+rig; index fallback), geneSetting set (numeric/bool keys with ranges:
+feedingRpm 0-65, grindRpm 0-1050, bladeGap 0-1000, brightness 0-10,
+standbySec 0-900, cupDetect/autoStop/fastClean bools), reboot. Grind
+start/stop, section and preset set payloads are educated guesses from the
+reference GUI and should be confirmed against the rig before relying on them;
+wifi/usage queries have no consumer yet.
+
 ## Keeping Notes Fresh
 
 Add lessons that would have saved debugging time: new footguns, thread-safety constraints, connection-lifecycle changes, non-obvious symptoms, and cross-transport dependencies. Prune stale claims. Prefer fewer, sharper notes over long background.

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -189,6 +189,7 @@ Discovery services use name-based matching via `DeviceMatcher` to create appropr
 - Name rules map advertisement names to device factories
 - Service verification happens during `onConnect()` using `BleServiceIdentifier`
 - DiFluid R2 reflectometers are matched separately from DiFluid scales by advertised name and the R2 BLE service UUID, then exposed as `Sensor` devices with a `measure` command
+- MOTTO80 grinders are matched by advertised name containing `motto80` and surface as `DeviceType.grinder` with a typed `Grinder` abstraction (`GrinderSnapshot` stream, start/stop/preset/geneSetting operations). Auto-connect uses `preferredGrinderId` (Settings > Devices > Auto-connect Grinder): `ConnectionManager._tryConnectPreferredGrinder` connects the discovered grinder matching the preferred id after each scan. Deferred: grinder picker ambiguity, background reacquisition watch, quick-connect execution for remembered grinders, and a scan-flow column (streamline.js work)
 
 ### Service Lifecycle
 

--- a/doc/plans/motto80-grinder.md
+++ b/doc/plans/motto80-grinder.md
@@ -1,0 +1,43 @@
+# MOTTO80 (Bookoo) BLE Grinder support
+
+## Why
+
+Add a new device kind to decaid: the MOTTO80 grinder, a BLE grinder with a
+~200ms status broadcast protocol reverse-engineered in the user's
+`grinder_gui` test rig. decaid had no grinder support at all (verified: zero
+matches across lib/; DeviceType was machine/scale/sensor only). Goal: the
+grinder appears in Devices, connects, streams typed state, and auto-connects
+by preferred id. streamline.js UI is a separate follow-up task.
+
+## Design
+
+- `DeviceType.grinder` + typed `Grinder` abstraction parallel to `Scale`
+  (user-confirmed; not the generic Sensor map channel): `GrinderSnapshot`
+  DTO, operations (start/stop/setPreset/setGrindSection/geneSetting setters).
+- `BookooGrinder` in `lib/src/models/device/impl/bookoo/` implements the
+  MOTTO80 protocol: A5 01 framed JSON with seq, long-frame reassembly
+  (repeated-header and headerless continuations, stale-pending drop, single
+  UTF-8 decode), handshake/section/preset startup queries with injectable
+  gaps.
+- `GrinderController` mirrors ScaleController (no deviceStream subscription;
+  ConnectionManager drives it).
+- Auto-connect: `preferredGrinderId` setting + `_tryConnectPreferredGrinder`
+  after each scan's machine/scale publish. Minimal honest scope; deferred:
+  picker ambiguity, background watch/reacquisition, quick-connect execution,
+  scan-flow column, ws/v1/grinder channel, wifi/usage queries.
+- `MockGrinder` simulated device for simulate-mode testing.
+
+## Protocol notes
+
+Full protocol spec and footguns in `doc/AI_BLE_NOTES.md` (MOTTO80 section):
+framing, reassembly rules, UTF-8 split-multibyte gotcha, connect sequence,
+confirmed vs guessed commands.
+
+## Verification
+
+- BookooGrinder fake-transport tests (15), GrinderController tests (4),
+  matcher/factory/remembered additions, connection_manager assertion updates.
+- Full `flutter test` suite green before PR.
+- E2E real: physical MOTTO80 → Devices shows "MOTTO80 Grinder" → connect →
+  snapshot stream; Settings auto-connect; restart + scan → auto-connect.
+- E2E simulate: MockGrinder appears and auto-connects.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -136,6 +136,7 @@ const _defaultSimulatedDevices = <SimulatedDevicesTypes>{
   SimulatedDevicesTypes.scale,
   SimulatedDevicesTypes.sensor,
   SimulatedDevicesTypes.bengle,
+  SimulatedDevicesTypes.grinder,
 };
 
 Set<SimulatedDevicesTypes> _parseSimulateFlag(String value) {

--- a/lib/src/controllers/connection/scan_orchestrator.dart
+++ b/lib/src/controllers/connection/scan_orchestrator.dart
@@ -10,6 +10,7 @@ import 'package:reaprime/src/controllers/connection_manager.dart'
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_scanner.dart';
+import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
@@ -20,11 +21,14 @@ class ScanRunResult {
 
   final List<Scale> scales;
 
+  final List<Grinder> grinders;
+
   final ScanReportBuilder reportBuilder;
 
   const ScanRunResult({
     required this.machines,
     required this.scales,
+    this.grinders = const [],
     required this.reportBuilder,
   });
 }
@@ -109,14 +113,17 @@ class ScanOrchestrator {
 
     final machines = allDevices.whereType<De1Interface>().toList();
     final scales = allDevices.whereType<Scale>().toList();
+    final grinders = allDevices.whereType<Grinder>().toList();
 
     _log.fine(
-      'Scan complete: ${machines.length} machines, ${scales.length} scales',
+      'Scan complete: ${machines.length} machines, ${scales.length} scales, '
+      '${grinders.length} grinders',
     );
 
     return ScanRunResult(
       machines: machines,
       scales: scales,
+      grinders: grinders,
       reportBuilder: reportBuilder,
     );
   }
@@ -146,7 +153,11 @@ class ScanOrchestrator {
           ),
           TransportCondition(
             transportType: TransportType.ble,
-            affectedDeviceTypes: const {DeviceType.machine, DeviceType.scale},
+            affectedDeviceTypes: const {
+              DeviceType.machine,
+              DeviceType.scale,
+              DeviceType.grinder,
+            },
             connectionError: error,
           ),
         ],

--- a/lib/src/controllers/connection_error.dart
+++ b/lib/src/controllers/connection_error.dart
@@ -2,6 +2,7 @@ class ConnectionErrorKind {
   static const scaleConnectFailed = 'scaleConnectFailed';
   static const machineConnectFailed = 'machineConnectFailed';
   static const sensorConnectFailed = 'sensorConnectFailed';
+  static const grinderConnectFailed = 'grinderConnectFailed';
   static const scaleDisconnected = 'scaleDisconnected';
   static const machineDisconnected = 'machineDisconnected';
   static const adapterOff = 'adapterOff';

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -17,7 +17,9 @@ import 'package:reaprime/src/controllers/connection/status_publisher.dart';
 import 'package:reaprime/src/controllers/connection_error.dart';
 import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/remembered_devices_controller.dart';
+import 'package:reaprime/src/controllers/grinder_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:reaprime/src/models/device/bengle_interface.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/transport/ble_connect_exception.dart';
@@ -118,6 +120,7 @@ class ConnectionManager {
   final DeviceScanner deviceScanner;
   final De1Controller de1Controller;
   final ScaleController scaleController;
+  final GrinderController grinderController;
   final SettingsController settingsController;
 
   final RememberedDevicesController? rememberedDevices;
@@ -244,9 +247,11 @@ class ConnectionManager {
     required this.scaleController,
     required this.settingsController,
     this.rememberedDevices,
+    GrinderController? grinderController,
     Duration deviceAttachSettleDelay = const Duration(milliseconds: 500),
     Duration? connectTimeout,
-  }) : _connectTimeout =
+  }) : grinderController = grinderController ?? GrinderController(),
+       _connectTimeout =
            connectTimeout ??
            (Platform.isLinux
                ? const Duration(seconds: 60)
@@ -607,7 +612,11 @@ class ConnectionManager {
   void _setTransportCondition(ConnectionError error) {
     final condition = TransportCondition(
       transportType: TransportType.ble,
-      affectedDeviceTypes: const {DeviceType.machine, DeviceType.scale},
+      affectedDeviceTypes: const {
+        DeviceType.machine,
+        DeviceType.scale,
+        DeviceType.grinder,
+      },
       connectionError: error,
     );
     _publishStatus(
@@ -1739,6 +1748,45 @@ class ConnectionManager {
       return Future.value(const ConnectionResult.conflict());
     }
     return _trackConnectionWork(() => _connectScale(scale));
+  }
+
+  Future<ConnectionResult> connectGrinder(Grinder grinder) {
+    if (_shuttingDown) {
+      return Future.value(const ConnectionResult.conflict());
+    }
+    return _trackConnectionWork(() => _connectGrinder(grinder));
+  }
+
+  Future<ConnectionResult> _connectGrinder(Grinder grinder) async {
+    if (grinderController.lastConnectedDeviceId == grinder.deviceId &&
+        grinderController.currentConnectionState == ConnectionState.connected) {
+      return const ConnectionResult.alreadyConnected();
+    }
+    _log.fine('connectGrinder: connecting to ${grinder.name}');
+    try {
+      await _trackConnectionWork(
+        () => grinderController.connectToGrinder(grinder),
+      ).timeout(_connectTimeout);
+      await settingsController.setPreferredGrinderId(grinder.deviceId);
+      return const ConnectionResult.succeeded();
+    } on TimeoutException {
+      return ConnectionResult.timedOut('Grinder connect timed out');
+    } catch (e) {
+      _log.warning('Grinder connect failed: $e');
+      _publishStatus(
+        currentStatus.copyWith(
+          error: () => ConnectionError(
+            kind: ConnectionErrorKind.grinderConnectFailed,
+            severity: ConnectionErrorSeverity.error,
+            timestamp: DateTime.now().toUtc(),
+            deviceId: grinder.deviceId,
+            deviceName: grinder.name,
+            message: e.toString(),
+          ),
+        ),
+      );
+      return ConnectionResult.failed(e.toString());
+    }
   }
 
   Future<ConnectionResult> _connectScale(Scale scale) async {

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -1130,6 +1130,8 @@ class ConnectionManager {
       currentStatus.copyWith(foundMachines: machines, foundScales: scales),
     );
 
+    await _tryConnectPreferredGrinder(scanRun.grinders);
+
     if (_machineConnected) {
       _log.fine('Machine connected, proceeding to scale phase');
       await _runScalePhase(
@@ -1755,6 +1757,30 @@ class ConnectionManager {
       return Future.value(const ConnectionResult.conflict());
     }
     return _trackConnectionWork(() => _connectGrinder(grinder));
+  }
+
+  Future<void> _tryConnectPreferredGrinder(List<Grinder> grinders) async {
+    final preferredGrinderId = settingsController.preferredGrinderId;
+    if (preferredGrinderId == null || grinders.isEmpty) return;
+    if (grinderController.lastConnectedDeviceId == preferredGrinderId &&
+        grinderController.currentConnectionState ==
+            ConnectionState.connected) {
+      return;
+    }
+    final match = grinders
+        .where((grinder) => grinder.deviceId == preferredGrinderId)
+        .firstOrNull;
+    if (match == null) {
+      _log.fine(
+        'Preferred grinder $preferredGrinderId not found in scan results',
+      );
+      return;
+    }
+    _log.fine('Connecting preferred grinder $preferredGrinderId');
+    final result = await connectGrinder(match);
+    if (!result.success) {
+      _log.warning('Preferred grinder connect failed: ${result.outcome.name}');
+    }
   }
 
   Future<ConnectionResult> _connectGrinder(Grinder grinder) async {

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -1763,8 +1763,7 @@ class ConnectionManager {
     final preferredGrinderId = settingsController.preferredGrinderId;
     if (preferredGrinderId == null || grinders.isEmpty) return;
     if (grinderController.lastConnectedDeviceId == preferredGrinderId &&
-        grinderController.currentConnectionState ==
-            ConnectionState.connected) {
+        grinderController.currentConnectionState == ConnectionState.connected) {
       return;
     }
     final match = grinders

--- a/lib/src/controllers/device_controller.dart
+++ b/lib/src/controllers/device_controller.dart
@@ -330,6 +330,7 @@ class DeviceController
     int machineCount = 0;
     int scaleCount = 0;
     int sensorCount = 0;
+    int grinderCount = 0;
 
     for (var device in devices) {
       _telemetryService!.setCustomKey(
@@ -347,12 +348,16 @@ class DeviceController
         case DeviceType.sensor:
           sensorCount++;
           break;
+        case DeviceType.grinder:
+          grinderCount++;
+          break;
       }
     }
 
     _telemetryService!.setCustomKey('connected_machines', machineCount);
     _telemetryService!.setCustomKey('connected_scales', scaleCount);
     _telemetryService!.setCustomKey('connected_sensors', sensorCount);
+    _telemetryService!.setCustomKey('connected_grinders', grinderCount);
   }
 
   void dispose() {

--- a/lib/src/controllers/grinder_controller.dart
+++ b/lib/src/controllers/grinder_controller.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/grinder.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:rxdart/rxdart.dart';
+
+class GrinderController {
+  Grinder? _grinder;
+
+  StreamSubscription<ConnectionState>? _grinderConnection;
+  StreamSubscription<GrinderSnapshot>? _grinderSnapshot;
+
+  String? _lastConnectedDeviceId;
+  String? get lastConnectedDeviceId => _lastConnectedDeviceId;
+
+  final Logger log = Logger('GrinderController');
+
+  final BehaviorSubject<ConnectionState> _connectionController =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+  final StreamController<GrinderSnapshot> _snapshotController =
+      StreamController.broadcast();
+
+  Stream<ConnectionState> get connectionState => _connectionController.stream;
+  ConnectionState get currentConnectionState => _connectionController.value;
+  Stream<GrinderSnapshot> get grinderSnapshot => _snapshotController.stream;
+
+  GrinderController();
+
+  void dispose() {
+    _grinderSnapshot?.cancel();
+    _grinderSnapshot = null;
+    _grinderConnection?.cancel();
+    _grinderConnection = null;
+    if (!_connectionController.isClosed) {
+      _connectionController.close();
+    }
+    if (!_snapshotController.isClosed) {
+      _snapshotController.close();
+    }
+  }
+
+  Future<void> connectToGrinder(Grinder grinder) async {
+    final previous = _grinder;
+    _onDisconnect();
+    if (previous != null && previous.deviceId != grinder.deviceId) {
+      try {
+        await previous.disconnect();
+      } catch (e) {
+        log.warning(
+          'Failed to disconnect previous grinder ${previous.deviceId}',
+          e,
+        );
+      }
+    }
+    _grinderSnapshot = grinder.currentSnapshot.listen(_processSnapshot);
+    try {
+      await grinder.onConnect();
+    } catch (e) {
+      log.warning('Grinder failed to connect (onConnect threw)', e);
+      _grinderSnapshot?.cancel();
+      _grinderSnapshot = null;
+      _connectionController.add(ConnectionState.disconnected);
+      rethrow;
+    }
+    final state = await grinder.connectionState.first;
+    if (state != ConnectionState.connected) {
+      log.warning('Grinder failed to connect (state: ${state.name})');
+      _grinderSnapshot?.cancel();
+      _grinderSnapshot = null;
+      _connectionController.add(ConnectionState.disconnected);
+      throw StateError('Grinder failed to connect (state: ${state.name})');
+    }
+    _grinder = grinder;
+    _lastConnectedDeviceId = grinder.deviceId;
+    _grinderConnection = grinder.connectionState.listen(_processConnection);
+  }
+
+  Future<void> adoptGrinder(Grinder grinder) async {
+    final previous = _grinder;
+    _onDisconnect();
+    if (previous != null && previous.deviceId != grinder.deviceId) {
+      try {
+        await previous.disconnect();
+      } catch (e) {
+        log.warning(
+          'Failed to disconnect previous grinder ${previous.deviceId}',
+          e,
+        );
+      }
+    }
+    _grinderSnapshot = grinder.currentSnapshot.listen(_processSnapshot);
+    final state = await grinder.connectionState.first;
+    if (state != ConnectionState.connected) {
+      log.warning('Adopted grinder not connected (state: ${state.name})');
+      _grinderSnapshot?.cancel();
+      _grinderSnapshot = null;
+      _connectionController.add(ConnectionState.disconnected);
+      throw StateError('Adopted grinder not connected (state: ${state.name})');
+    }
+    _grinder = grinder;
+    _lastConnectedDeviceId = grinder.deviceId;
+    _grinderConnection = grinder.connectionState.listen(_processConnection);
+  }
+
+  Grinder connectedGrinder() {
+    if (_grinder == null) {
+      throw const DeviceNotConnectedException.grinder();
+    }
+    return _grinder!;
+  }
+
+  void _onDisconnect() {
+    _grinderSnapshot?.cancel();
+    _grinderConnection?.cancel();
+    _grinder = null;
+    _grinderConnection = null;
+  }
+
+  void _processSnapshot(GrinderSnapshot snapshot) {
+    _snapshotController.add(snapshot);
+  }
+
+  void _processConnection(ConnectionState state) {
+    log.fine('Grinder connection state: ${state.name}');
+    _connectionController.add(state);
+  }
+}

--- a/lib/src/controllers/grinder_controller.dart
+++ b/lib/src/controllers/grinder_controller.dart
@@ -118,7 +118,10 @@ class GrinderController {
     _grinderConnection = null;
   }
 
+  GrinderSnapshot? latestSnapshot;
+
   void _processSnapshot(GrinderSnapshot snapshot) {
+    latestSnapshot = snapshot;
     _snapshotController.add(snapshot);
   }
 

--- a/lib/src/debug_feature/debug_item_list_view.dart
+++ b/lib/src/debug_feature/debug_item_list_view.dart
@@ -6,6 +6,7 @@ import 'package:reaprime/src/models/device/device.dart' as dev;
 import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/debug_feature/debug_item_details_view.dart';
+import 'package:reaprime/src/debug_feature/grinder_debug_view.dart';
 import 'package:reaprime/src/debug_feature/scale_debug_view.dart';
 import 'package:shadcn_ui/shadcn_ui.dart' hide Scale;
 
@@ -249,6 +250,11 @@ class DebugItemListView extends StatelessWidget {
       Navigator.push(
         context,
         MaterialPageRoute(builder: (_) => ScaleDebugView(scale: device)),
+      );
+    } else if (device is Grinder) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => GrinderDebugView(grinder: device)),
       );
     }
   }

--- a/lib/src/debug_feature/debug_item_list_view.dart
+++ b/lib/src/debug_feature/debug_item_list_view.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/src/controllers/de1_controller.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/device.dart' as dev;
+import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/debug_feature/debug_item_details_view.dart';
 import 'package:reaprime/src/debug_feature/scale_debug_view.dart';
@@ -118,11 +119,13 @@ class DebugItemListView extends StatelessWidget {
   Widget _buildGroupedList(BuildContext context, List<dev.Device> devices) {
     final machines = devices.whereType<De1Interface>().toList();
     final scales = devices.whereType<Scale>().toList();
+    final grinders = devices.whereType<Grinder>().toList();
     final sensors = devices
         .where(
           (d) =>
               d.type != dev.DeviceType.machine &&
-              d.type != dev.DeviceType.scale,
+              d.type != dev.DeviceType.scale &&
+              d.type != dev.DeviceType.grinder,
         )
         .toList();
 
@@ -135,6 +138,10 @@ class DebugItemListView extends StatelessWidget {
         if (scales.isNotEmpty) ...[
           _buildSectionHeader(context, 'Scales'),
           ...scales.map((s) => _buildDeviceRow(context, s)),
+        ],
+        if (grinders.isNotEmpty) ...[
+          _buildSectionHeader(context, 'Grinders'),
+          ...grinders.map((g) => _buildDeviceRow(context, g)),
         ],
         if (sensors.isNotEmpty) ...[
           _buildSectionHeader(context, 'Sensors'),

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -1,31 +1,57 @@
 import 'dart:async';
+import 'dart:ui' show PlatformDispatcher;
 
 import 'package:flutter/material.dart';
 import 'package:reaprime/src/models/device/device.dart' as dev;
 import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
-const _devStateNames = {
-  GrinderDevState.idle: '待机中',
-  GrinderDevState.grinding: '研磨中',
-  GrinderDevState.highspeedClean: '高转排粉',
-  GrinderDevState.setting: '设置中',
-  GrinderDevState.unknown: '未知',
-};
+String _t(String en, String zh) =>
+    PlatformDispatcher.instance.locale.languageCode == 'zh' ? zh : en;
+
+String _devStateName(GrinderDevState state) {
+  return switch (state) {
+    GrinderDevState.idle => _t('Idle', '待机中'),
+    GrinderDevState.grinding => _t('Grinding', '研磨中'),
+    GrinderDevState.highspeedClean => _t('High-speed clean', '高转排粉'),
+    GrinderDevState.setting => _t('Setting', '设置中'),
+    GrinderDevState.unknown => _t('Unknown', '未知'),
+  };
+}
 
 const _numSettings = [
-  ('feedingRpm', '下豆速度', 0, 65, 5),
-  ('grindRpm', '刀盘转速', 500, 1500, 50),
-  ('brightness', '亮度', 0, 10, 1),
-  ('standbySec', '熄屏秒', 0, 900, 30),
-  ('bladeGap', '研磨度', 0, 1000, 5),
+  ('feedingRpm', 0, 65, 5),
+  ('grindRpm', 500, 1500, 50),
+  ('brightness', 0, 10, 1),
+  ('standbySec', 0, 900, 30),
+  ('bladeGap', 0, 1000, 5),
 ];
 
+String _numSettingLabel(String key) {
+  return switch (key) {
+    'feedingRpm' => _t('Feed RPM', '下豆速度'),
+    'grindRpm' => _t('Grind RPM', '刀盘转速'),
+    'brightness' => _t('Brightness', '亮度'),
+    'standbySec' => _t('Standby (s)', '熄屏秒'),
+    'bladeGap' => _t('Grind size', '研磨度'),
+    _ => key,
+  };
+}
+
 const _boolSettings = [
-  ('cupDetect', '杯检'),
-  ('autoStop', '自动停止'),
-  ('fastClean', '强力清粉'),
+  ('cupDetect', 'cupDetect'),
+  ('autoStop', 'autoStop'),
+  ('fastClean', 'fastClean'),
 ];
+
+String _boolSettingLabel(String key) {
+  return switch (key) {
+    'cupDetect' => _t('Cup detect', '杯检'),
+    'autoStop' => _t('Auto stop', '自动停止'),
+    'fastClean' => _t('Fast clean', '强力清粉'),
+    _ => key,
+  };
+}
 
 class GrinderDebugView extends StatefulWidget {
   final Grinder grinder;
@@ -41,6 +67,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
   final List<GrinderLogEntry> _respLog = [];
   final List<GrinderLogEntry> _bcLog = [];
   StreamSubscription<GrinderLogEntry>? _logSub;
+  StreamSubscription<dev.ConnectionState>? _connectionSub;
   final Map<String, Timer> _debTimers = {};
   GrinderSnapshot? _last;
   bool _connected = false;
@@ -49,7 +76,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
   void initState() {
     super.initState();
     widget.grinder.onConnect();
-    widget.grinder.connectionState.listen((state) {
+    _connectionSub = widget.grinder.connectionState.listen((state) {
       if (mounted) {
         setState(() => _connected = state == dev.ConnectionState.connected);
       }
@@ -69,6 +96,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
   @override
   void dispose() {
     _logSub?.cancel();
+    _connectionSub?.cancel();
     for (final timer in _debTimers.values) {
       timer.cancel();
     }
@@ -120,7 +148,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Grinder Debug'),
+        title: Text(_t('Grinder Debug', '磨豆机调试')),
         leading: IconButton(
           icon: const Icon(LucideIcons.arrowLeft),
           onPressed: () => Navigator.of(context).pop(),
@@ -128,7 +156,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
         actions: [
           ShadButton.destructive(
             size: ShadButtonSize.sm,
-            child: const Text('Disconnect'),
+            child: Text(_t('Disconnect', '断开')),
             onPressed: () async {
               await widget.grinder.disconnect();
               if (!context.mounted) return;
@@ -158,9 +186,24 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
               ],
               _buildCommands(theme),
               const SizedBox(height: 16),
-              _buildLogSection(theme, '发送', _sendLog, Colors.blue.shade300),
-              _buildLogSection(theme, '响应', _respLog, Colors.green.shade300),
-              _buildLogSection(theme, '广播', _bcLog, Colors.purple.shade300),
+              _buildLogSection(
+                theme,
+                _t('Send', '发送'),
+                _sendLog,
+                Colors.blue.shade300,
+              ),
+              _buildLogSection(
+                theme,
+                _t('Response', '响应'),
+                _respLog,
+                Colors.green.shade300,
+              ),
+              _buildLogSection(
+                theme,
+                _t('Broadcast', '广播'),
+                _bcLog,
+                Colors.purple.shade300,
+              ),
             ],
           );
         },
@@ -182,19 +225,28 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
             s.bladeGap?.toString() ?? '--',
             style: theme.textTheme.h1.copyWith(fontWeight: FontWeight.w700),
           ),
-          Text(' μm', style: theme.textTheme.muted),
+          Text(_t(' μm', ' μm'), style: theme.textTheme.muted),
           const SizedBox(width: 24),
-          Text('下豆 ${s.feedingRpm ?? '--'}', style: theme.textTheme.h4),
+          Text(
+            '${_t('Feed', '下豆')} ${s.feedingRpm ?? '--'}',
+            style: theme.textTheme.h4,
+          ),
           Text(' RPM', style: theme.textTheme.muted),
           const SizedBox(width: 24),
-          Text('转速 ${s.grindRpm ?? '--'}', style: theme.textTheme.h4),
+          Text(
+            '${_t('Grind', '转速')} ${s.grindRpm ?? '--'}',
+            style: theme.textTheme.h4,
+          ),
           Text(' RPM', style: theme.textTheme.muted),
           const SizedBox(width: 24),
-          Text('湿度 ${s.humidity ?? '--'}', style: theme.textTheme.h4),
+          Text(
+            '${_t('Humidity', '湿度')} ${s.humidity ?? '--'}',
+            style: theme.textTheme.h4,
+          ),
           Text(' %RH', style: theme.textTheme.muted),
           const Spacer(),
           Text(
-            _devStateNames[s.devState] ?? s.devState.name,
+            _devStateName(s.devState),
             style: theme.textTheme.h4.copyWith(color: Colors.lightBlue),
           ),
         ],
@@ -205,18 +257,21 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
   Widget _buildStatusTable(ShadThemeData theme, GrinderSnapshot s) {
     String boolText(bool? v) => v == null ? '—' : (v ? '开' : '关');
     final rows = <(String, String)>[
-      ('杯检', boolText(s.cupDetect)),
-      ('自动停止', boolText(s.autoStop)),
-      ('强力清粉', boolText(s.fastClean)),
+      (_t('Cup detect', '杯检'), boolText(s.cupDetect)),
+      (_t('Auto stop', '自动停止'), boolText(s.autoStop)),
+      (_t('Fast clean', '强力清粉'), boolText(s.fastClean)),
       ('WiFi', s.wifiName ?? '—'),
-      ('连接状态', _connected ? '已连接' : '未连接'),
-      ('累计研磨', s.totalGrinds?.toString() ?? '—'),
-      ('亮度', s.brightness?.toString() ?? '—'),
-      ('熄屏秒', s.standbySec?.toString() ?? '—'),
-      ('网络', s.netState ?? '—'),
-      ('序列号', s.snCode ?? '—'),
-      ('开机原因', s.resetReason ?? '—'),
-      ('固件版本', s.releaseVer ?? '—'),
+      (
+        _t('Connection', '连接状态'),
+        _connected ? _t('Connected', '已连接') : _t('Not connected', '未连接'),
+      ),
+      (_t('Total grinds', '累计研磨'), s.totalGrinds?.toString() ?? '—'),
+      (_t('Brightness', '亮度'), s.brightness?.toString() ?? '—'),
+      (_t('Standby (s)', '熄屏秒'), s.standbySec?.toString() ?? '—'),
+      (_t('Network', '网络'), s.netState ?? '—'),
+      (_t('Serial', '序列号'), s.snCode ?? '—'),
+      (_t('Reset reason', '开机原因'), s.resetReason ?? '—'),
+      (_t('Firmware', '固件版本'), s.releaseVer ?? '—'),
     ];
     return Card(
       child: Padding(
@@ -224,7 +279,10 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('实时状态 (约200ms/条)', style: theme.textTheme.h3),
+            Text(
+              _t('Live status (~200ms/frame)', '实时状态 (约200ms/条)'),
+              style: theme.textTheme.h3,
+            ),
             const SizedBox(height: 8),
             ...rows.map(
               (r) => Padding(
@@ -251,15 +309,18 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('实时设置 (滑块拖动即发送)', style: theme.textTheme.h3),
+            Text(
+              _t('Live settings (drag to send)', '实时设置 (滑块拖动即发送)'),
+              style: theme.textTheme.h3,
+            ),
             const SizedBox(height: 8),
             ..._numSettings.map(
               (setting) => _NumericSettingRow(
                 key: ValueKey('num-${setting.$1}'),
-                label: setting.$2,
-                min: setting.$3,
-                max: setting.$4,
-                step: setting.$5,
+                label: _numSettingLabel(setting.$1),
+                min: setting.$2,
+                max: setting.$3,
+                step: setting.$4,
                 current: _valueFor(s, setting.$1),
                 onChanged: (v) => _debSend(setting.$1, v),
                 onCommit: (v) => _sendNum(setting.$1, v),
@@ -269,7 +330,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
             ..._boolSettings.map(
               (setting) => _BoolSettingRow(
                 key: ValueKey('bool-${setting.$1}'),
-                label: setting.$2,
+                label: _boolSettingLabel(setting.$1),
                 current: _boolValueFor(s, setting.$1),
                 onChanged: (on) => _setBool(setting.$1, on),
               ),
@@ -291,7 +352,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             if (s.presets.isNotEmpty) ...[
-              Text('预设', style: theme.textTheme.h3),
+              Text(_t('Presets', '预设'), style: theme.textTheme.h3),
               const SizedBox(height: 8),
               Wrap(
                 spacing: 8,
@@ -314,7 +375,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
             ],
             if (s.grindSections.isNotEmpty) ...[
               const SizedBox(height: 12),
-              Text('研磨段', style: theme.textTheme.h3),
+              Text(_t('Grind sections', '研磨段'), style: theme.textTheme.h3),
               const SizedBox(height: 8),
               Wrap(
                 spacing: 8,
@@ -367,11 +428,19 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
 
   Widget _buildCommands(ShadThemeData theme) {
     final commands = <(String, Future<void> Function(), bool disabled)>[
-      ('握手 appHello', widget.grinder.onConnect, false),
-      ('查询研磨段', widget.grinder.querySections, false),
-      ('查询预设', widget.grinder.queryPresets, false),
-      ('开始研磨 (尚未启用)', widget.grinder.start, true),
-      ('停止研磨 (尚未启用)', widget.grinder.stop, true),
+      (_t('Handshake', '握手 appHello'), widget.grinder.onConnect, false),
+      (_t('Query sections', '查询研磨段'), widget.grinder.querySections, false),
+      (_t('Query presets', '查询预设'), widget.grinder.queryPresets, false),
+      (
+        _t('Start grinding (not enabled)', '开始研磨 (尚未启用)'),
+        widget.grinder.start,
+        true,
+      ),
+      (
+        _t('Stop grinding (not enabled)', '停止研磨 (尚未启用)'),
+        widget.grinder.stop,
+        true,
+      ),
     ];
     return Card(
       child: Padding(
@@ -379,7 +448,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('指令', style: theme.textTheme.h3),
+            Text(_t('Commands', '指令'), style: theme.textTheme.h3),
             const SizedBox(height: 8),
             Wrap(
               spacing: 8,
@@ -591,7 +660,9 @@ class _BoolSettingRow extends StatelessWidget {
           Text(label, style: theme.textTheme.muted),
           const Spacer(),
           Text(
-            current == null ? '未知' : (current! ? '开' : '关'),
+            current == null
+                ? _t('Unknown', '未知')
+                : (current! ? _t('On', '开') : _t('Off', '关')),
             style: theme.textTheme.h4.copyWith(
               color: current == null
                   ? theme.colorScheme.mutedForeground
@@ -603,13 +674,13 @@ class _BoolSettingRow extends StatelessWidget {
           const SizedBox(width: 8),
           ShadButton(
             size: ShadButtonSize.sm,
-            child: const Text('开'),
+            child: Text(_t('On', '开')),
             onPressed: () => onChanged(true),
           ),
           const SizedBox(width: 4),
           ShadButton(
             size: ShadButtonSize.sm,
-            child: const Text('关'),
+            child: Text(_t('Off', '关')),
             onPressed: () => onChanged(false),
           ),
         ],

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:reaprime/src/models/device/grinder.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class GrinderDebugView extends StatefulWidget {
+  final Grinder grinder;
+
+  const GrinderDebugView({super.key, required this.grinder});
+
+  @override
+  State<GrinderDebugView> createState() => _GrinderDebugViewState();
+}
+
+class _GrinderDebugViewState extends State<GrinderDebugView> {
+  @override
+  void initState() {
+    super.initState();
+    widget.grinder.onConnect();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Grinder Debug'),
+        leading: IconButton(
+          icon: const Icon(LucideIcons.arrowLeft),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        actions: [
+          ShadButton.destructive(
+            size: ShadButtonSize.sm,
+            child: const Text('Disconnect'),
+            onPressed: () async {
+              await widget.grinder.disconnect();
+              if (!context.mounted) return;
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      ),
+      body: StreamBuilder<GrinderSnapshot>(
+        stream: widget.grinder.currentSnapshot,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.active) {
+            return _buildActiveView(theme, snapshot.data!);
+          } else if (snapshot.connectionState == ConnectionState.waiting) {
+            return Center(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  const SizedBox(width: 12),
+                  Text('Connecting…', style: theme.textTheme.muted),
+                ],
+              ),
+            );
+          }
+          return Center(
+            child: Text('Disconnected', style: theme.textTheme.muted),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildActiveView(ShadThemeData theme, GrinderSnapshot s) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        _row(theme, 'State', s.devState.name),
+        _row(theme, 'Feeding RPM', s.feedingRpm?.toString()),
+        _row(theme, 'Grind RPM', s.grindRpm?.toString()),
+        _row(
+          theme,
+          'Blade Gap',
+          s.bladeGap != null ? '${s.bladeGap} µm' : null,
+        ),
+        _row(
+          theme,
+          'Humidity',
+          s.humidity != null ? '${s.humidity} %RH' : null,
+        ),
+        _row(theme, 'Total Grinds', s.totalGrinds?.toString()),
+        _row(theme, 'Cup Detect', s.cupDetect?.toString()),
+        _row(theme, 'Auto Stop', s.autoStop?.toString()),
+        _row(theme, 'Fast Clean', s.fastClean?.toString()),
+        _row(theme, 'Brightness', s.brightness?.toString()),
+        _row(theme, 'Standby (s)', s.standbySec?.toString()),
+        _row(theme, 'Serial', s.snCode),
+        _row(theme, 'Firmware', s.releaseVer),
+        if (s.presets.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          Text('Presets', style: theme.textTheme.h3),
+          ...s.presets.map((p) => _row(theme, p.name, p.uid, indent: true)),
+        ],
+        if (s.grindSections.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          Text('Grind Sections', style: theme.textTheme.h3),
+          ...s.grindSections.map(
+            (g) => _row(theme, g.name, g.index.toString(), indent: true),
+          ),
+        ],
+        const SizedBox(height: 24),
+        Row(
+          children: [
+            ShadButton(
+              child: const Text('Start'),
+              onPressed: () => widget.grinder.start(),
+            ),
+            const SizedBox(width: 8),
+            ShadButton(
+              child: const Text('Stop'),
+              onPressed: () => widget.grinder.stop(),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _row(
+    ShadThemeData theme,
+    String label,
+    String? value, {
+    bool indent = false,
+  }) {
+    return Padding(
+      padding: EdgeInsets.only(left: indent ? 16.0 : 0.0, bottom: 8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: theme.textTheme.muted),
+          Text(value ?? '—', style: theme.textTheme.h4),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -24,7 +24,7 @@ const _numSettings = [
   ('grindRpm', 500, 1500, 50),
   ('brightness', 0, 10, 1),
   ('standbySec', 0, 900, 30),
-  ('bladeGap', 0, 1000, 5),
+  ('grindSetting', 0, 1000, 5),
 ];
 
 String _numSettingLabel(String key) {
@@ -33,7 +33,7 @@ String _numSettingLabel(String key) {
     'grindRpm' => _t('Grind RPM', '刀盘转速'),
     'brightness' => _t('Brightness', '亮度'),
     'standbySec' => _t('Standby (s)', '熄屏秒'),
-    'bladeGap' => _t('Grind size', '研磨度'),
+    'grindSetting' => _t('Grind size', '研磨度'),
     _ => key,
   };
 }
@@ -119,8 +119,8 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
         await widget.grinder.setBrightness(value.round());
       case 'standbySec':
         await widget.grinder.setStandbySec(value.round());
-      case 'bladeGap':
-        await widget.grinder.setBladeGap(value.round());
+      case 'grindSetting':
+        await widget.grinder.setGrindSetting(value.round());
     }
   }
 
@@ -222,7 +222,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
       child: Row(
         children: [
           Text(
-            s.bladeGap?.toString() ?? '--',
+            s.grindSetting?.toString() ?? '--',
             style: theme.textTheme.h1.copyWith(fontWeight: FontWeight.w700),
           ),
           Text(_t(' μm', ' μm'), style: theme.textTheme.muted),
@@ -551,8 +551,8 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
         return s.brightness?.toDouble();
       case 'standbySec':
         return s.standbySec?.toDouble();
-      case 'bladeGap':
-        return s.bladeGap?.toDouble();
+      case 'grindSetting':
+        return s.grindSetting?.toDouble();
       default:
         return null;
     }

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -147,9 +147,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
             padding: const EdgeInsets.all(16),
             children: [
               if (_last != null) ...[
-                _buildMockDisplay(theme, _last!),
-                const SizedBox(height: 16),
-                _buildStatusTable(theme, _last!),
+                _buildHeader(theme, _last!),
                 const SizedBox(height: 16),
                 _buildSettingsPanel(theme, _last!),
                 const SizedBox(height: 16),
@@ -168,79 +166,104 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
     );
   }
 
-  Widget _buildMockDisplay(ShadThemeData theme, GrinderSnapshot s) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.mutedForeground.withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: theme.colorScheme.border),
-      ),
-      child: Row(
-        children: [
-          Text(
-            s.bladeGap?.toString() ?? '--',
-            style: theme.textTheme.h1.copyWith(fontWeight: FontWeight.w700),
-          ),
-          Text(' μm', style: theme.textTheme.muted),
-          const SizedBox(width: 24),
-          Text('下豆 ${s.feedingRpm ?? '--'}', style: theme.textTheme.h4),
-          Text(' RPM', style: theme.textTheme.muted),
-          const SizedBox(width: 24),
-          Text('转速 ${s.grindRpm ?? '--'}', style: theme.textTheme.h4),
-          Text(' RPM', style: theme.textTheme.muted),
-          const SizedBox(width: 24),
-          Text('湿度 ${s.humidity ?? '--'}', style: theme.textTheme.h4),
-          Text(' %RH', style: theme.textTheme.muted),
-          const Spacer(),
-          Text(
-            _devStateNames[s.devState] ?? s.devState.name,
-            style: theme.textTheme.h4.copyWith(color: Colors.lightBlue),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildStatusTable(ShadThemeData theme, GrinderSnapshot s) {
+  Widget _buildHeader(ShadThemeData theme, GrinderSnapshot s) {
     String boolText(bool? v) => v == null ? '—' : (v ? '开' : '关');
-    final rows = <(String, String)>[
-      ('杯检', boolText(s.cupDetect)),
-      ('自动停止', boolText(s.autoStop)),
-      ('强力清粉', boolText(s.fastClean)),
-      ('WiFi', s.wifiName ?? '—'),
-      ('连接状态', _connected ? '已连接' : '未连接'),
-      ('累计研磨', s.totalGrinds?.toString() ?? '—'),
-      ('亮度', s.brightness?.toString() ?? '—'),
-      ('熄屏秒', s.standbySec?.toString() ?? '—'),
-      ('网络', s.netState ?? '—'),
-      ('序列号', s.snCode ?? '—'),
-      ('开机原因', s.resetReason ?? '—'),
-      ('固件版本', s.releaseVer ?? '—'),
+    final statusRows = <List<(String, String)>>[
+      [
+        ('杯检', boolText(s.cupDetect)),
+        ('自动停止', boolText(s.autoStop)),
+        ('强力清粉', boolText(s.fastClean)),
+        ('WiFi', s.wifiName ?? '—'),
+      ],
+      [
+        ('连接状态', _connected ? '已连接' : '未连接'),
+        ('累计研磨', s.totalGrinds?.toString() ?? '—'),
+        ('亮度', s.brightness?.toString() ?? '—'),
+        ('熄屏秒', s.standbySec?.toString() ?? '—'),
+      ],
+      [
+        ('网络', s.netState ?? '—'),
+        ('序列号', s.snCode ?? '—'),
+        ('开机原因', s.resetReason ?? '—'),
+        ('固件版本', s.releaseVer ?? '—'),
+      ],
     ];
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        child: Row(
           children: [
-            Text('实时状态 (约200ms/条)', style: theme.textTheme.h3),
-            const SizedBox(height: 8),
-            GridView.count(
-              crossAxisCount: 3,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              childAspectRatio: 2.6,
-              children: [
-                for (final row in rows)
+            Expanded(
+              flex: 1,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
                   Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.baseline,
+                    textBaseline: TextBaseline.alphabetic,
                     children: [
-                      Text(row.$1, style: theme.textTheme.muted),
-                      Text(row.$2, style: theme.textTheme.h4),
+                      Text(
+                        s.bladeGap?.toString() ?? '--',
+                        style: theme.textTheme.h1.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      Text(' μm', style: theme.textTheme.muted),
                     ],
                   ),
-              ],
+                  const SizedBox(height: 8),
+                  Text(
+                    '下豆 ${s.feedingRpm ?? '--'} RPM',
+                    style: theme.textTheme.h4,
+                  ),
+                  Text(
+                    '转速 ${s.grindRpm ?? '--'} RPM',
+                    style: theme.textTheme.h4,
+                  ),
+                  Text(
+                    '湿度 ${s.humidity ?? '--'} %RH',
+                    style: theme.textTheme.h4,
+                  ),
+                  Text(
+                    _devStateNames[s.devState] ?? s.devState.name,
+                    style: theme.textTheme.small.copyWith(
+                      color: Colors.lightBlue,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              flex: 3,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  for (final column in statusRows)
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          for (final row in column)
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Text(row.$1, style: theme.textTheme.small),
+                                Text(
+                                  row.$2,
+                                  style: theme.textTheme.small.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -1,6 +1,30 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+
+const _devStateNames = {
+  GrinderDevState.idle: '待机中',
+  GrinderDevState.grinding: '研磨中',
+  GrinderDevState.highspeedClean: '高转排粉',
+  GrinderDevState.setting: '设置中',
+  GrinderDevState.unknown: '未知',
+};
+
+const _numSettings = [
+  ('feedingRpm', '下豆速度', 0, 65, 5),
+  ('grindRpm', '刀盘转速', 0, 1050, 50),
+  ('brightness', '亮度', 0, 10, 1),
+  ('standbySec', '熄屏秒', 0, 900, 30),
+  ('bladeGap', '研磨度', 0, 1000, 5),
+];
+
+const _boolSettings = [
+  ('cupDetect', '杯检'),
+  ('autoStop', '自动停止'),
+  ('fastClean', '强力清粉'),
+];
 
 class GrinderDebugView extends StatefulWidget {
   final Grinder grinder;
@@ -12,10 +36,75 @@ class GrinderDebugView extends StatefulWidget {
 }
 
 class _GrinderDebugViewState extends State<GrinderDebugView> {
+  final List<GrinderLogEntry> _sendLog = [];
+  final List<GrinderLogEntry> _respLog = [];
+  final List<GrinderLogEntry> _bcLog = [];
+  StreamSubscription<GrinderLogEntry>? _logSub;
+  final Map<String, Timer> _debTimers = {};
+  GrinderSnapshot? _last;
+
   @override
   void initState() {
     super.initState();
     widget.grinder.onConnect();
+    _logSub = widget.grinder.logStream.listen((entry) {
+      switch (entry.kind) {
+        case GrinderLogKind.send:
+          _push(_sendLog, entry, 100);
+        case GrinderLogKind.response:
+          _push(_respLog, entry, 60);
+        case GrinderLogKind.broadcast:
+          _push(_bcLog, entry, 60);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _logSub?.cancel();
+    for (final timer in _debTimers.values) {
+      timer.cancel();
+    }
+    super.dispose();
+  }
+
+  void _push(List<GrinderLogEntry> list, GrinderLogEntry entry, int cap) {
+    list.insert(0, entry);
+    if (list.length > cap) list.removeLast();
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _sendNum(String key, double value) async {
+    switch (key) {
+      case 'feedingRpm':
+        await widget.grinder.setFeedingRpm(value.round());
+      case 'grindRpm':
+        await widget.grinder.setGrindRpm(value.round());
+      case 'brightness':
+        await widget.grinder.setBrightness(value.round());
+      case 'standbySec':
+        await widget.grinder.setStandbySec(value.round());
+      case 'bladeGap':
+        await widget.grinder.setBladeGap(value.round());
+    }
+  }
+
+  void _debSend(String key, double value) {
+    _debTimers[key]?.cancel();
+    _debTimers[key] = Timer(const Duration(milliseconds: 250), () {
+      _sendNum(key, value);
+    });
+  }
+
+  Future<void> _setBool(String key, bool on) async {
+    switch (key) {
+      case 'cupDetect':
+        await widget.grinder.setCupDetect(on);
+      case 'autoStop':
+        await widget.grinder.setAutoStop(on);
+      case 'fastClean':
+        await widget.grinder.setFastClean(on);
+    }
   }
 
   @override
@@ -45,99 +134,481 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
         stream: widget.grinder.currentSnapshot,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.active) {
-            return _buildActiveView(theme, snapshot.data!);
-          } else if (snapshot.connectionState == ConnectionState.waiting) {
-            return Center(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                  const SizedBox(width: 12),
-                  Text('Connecting…', style: theme.textTheme.muted),
-                ],
-              ),
-            );
+            _last = snapshot.data;
           }
-          return Center(
-            child: Text('Disconnected', style: theme.textTheme.muted),
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (_last != null) ...[
+                _buildMockDisplay(theme, _last!),
+                const SizedBox(height: 16),
+                _buildStatusTable(theme, _last!),
+                const SizedBox(height: 16),
+                _buildSettingsPanel(theme, _last!),
+                const SizedBox(height: 16),
+                _buildPresetPanel(theme, _last!),
+                const SizedBox(height: 16),
+              ],
+              _buildCommands(theme),
+              const SizedBox(height: 16),
+              _buildLogSection(theme, '发送', _sendLog, Colors.blue.shade300),
+              _buildLogSection(theme, '响应', _respLog, Colors.green.shade300),
+              _buildLogSection(theme, '广播', _bcLog, Colors.purple.shade300),
+            ],
           );
         },
       ),
     );
   }
 
-  Widget _buildActiveView(ShadThemeData theme, GrinderSnapshot s) {
-    return ListView(
+  Widget _buildMockDisplay(ShadThemeData theme, GrinderSnapshot s) {
+    return Container(
       padding: const EdgeInsets.all(16),
-      children: [
-        _row(theme, 'State', s.devState.name),
-        _row(theme, 'Feeding RPM', s.feedingRpm?.toString()),
-        _row(theme, 'Grind RPM', s.grindRpm?.toString()),
-        _row(
-          theme,
-          'Blade Gap',
-          s.bladeGap != null ? '${s.bladeGap} µm' : null,
-        ),
-        _row(
-          theme,
-          'Humidity',
-          s.humidity != null ? '${s.humidity} %RH' : null,
-        ),
-        _row(theme, 'Total Grinds', s.totalGrinds?.toString()),
-        _row(theme, 'Cup Detect', s.cupDetect?.toString()),
-        _row(theme, 'Auto Stop', s.autoStop?.toString()),
-        _row(theme, 'Fast Clean', s.fastClean?.toString()),
-        _row(theme, 'Brightness', s.brightness?.toString()),
-        _row(theme, 'Standby (s)', s.standbySec?.toString()),
-        _row(theme, 'Serial', s.snCode),
-        _row(theme, 'Firmware', s.releaseVer),
-        if (s.presets.isNotEmpty) ...[
-          const SizedBox(height: 16),
-          Text('Presets', style: theme.textTheme.h3),
-          ...s.presets.map((p) => _row(theme, p.name, p.uid, indent: true)),
-        ],
-        if (s.grindSections.isNotEmpty) ...[
-          const SizedBox(height: 16),
-          Text('Grind Sections', style: theme.textTheme.h3),
-          ...s.grindSections.map(
-            (g) => _row(theme, g.name, g.index.toString(), indent: true),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.mutedForeground.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: theme.colorScheme.border),
+      ),
+      child: Row(
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                s.bladeGap?.toString() ?? '--',
+                style: theme.textTheme.h1.copyWith(fontWeight: FontWeight.w700),
+              ),
+              Text('μm 研磨度', style: theme.textTheme.muted),
+            ],
+          ),
+          const SizedBox(width: 32),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('下豆 ${s.feedingRpm ?? '--'} RPM', style: theme.textTheme.h4),
+              Text('转速 ${s.grindRpm ?? '--'} RPM', style: theme.textTheme.h4),
+              Text('湿度 ${s.humidity ?? '--'} %RH', style: theme.textTheme.h4),
+            ],
+          ),
+          const Spacer(),
+          Text(
+            _devStateNames[s.devState] ?? s.devState.name,
+            style: theme.textTheme.h4.copyWith(color: Colors.lightBlue),
           ),
         ],
-        const SizedBox(height: 24),
-        Row(
-          children: [
-            ShadButton(
-              child: const Text('Start'),
-              onPressed: () => widget.grinder.start(),
-            ),
-            const SizedBox(width: 8),
-            ShadButton(
-              child: const Text('Stop'),
-              onPressed: () => widget.grinder.stop(),
-            ),
-          ],
-        ),
-      ],
+      ),
     );
   }
 
-  Widget _row(
+  Widget _buildStatusTable(ShadThemeData theme, GrinderSnapshot s) {
+    final rows = <(String, String?)>[
+      ('下豆速度', s.feedingRpm?.toString()),
+      ('刀盘转速', s.grindRpm?.toString()),
+      ('研磨度', s.bladeGap?.toString()),
+      ('湿度', s.humidity?.toString()),
+      ('累计研磨', s.totalGrinds?.toString()),
+      ('杯检', s.cupDetect?.toString()),
+      ('自动停止', s.autoStop?.toString()),
+      ('强力清粉', s.fastClean?.toString()),
+      ('亮度', s.brightness?.toString()),
+      ('熄屏秒', s.standbySec?.toString()),
+      ('网络', s.netState),
+      ('WiFi', s.wifiName),
+      ('序列号', s.snCode),
+      ('开机原因', s.resetReason),
+      ('固件版本', s.releaseVer),
+    ];
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('实时状态 (约200ms/条)', style: theme.textTheme.h3),
+            const SizedBox(height: 8),
+            ...rows.map(
+              (r) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(r.$1, style: theme.textTheme.muted),
+                    Text(r.$2 ?? '—', style: theme.textTheme.h4),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingsPanel(ShadThemeData theme, GrinderSnapshot s) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('实时设置 (滑块拖动即发送)', style: theme.textTheme.h3),
+            const SizedBox(height: 8),
+            ..._numSettings.map(
+              (setting) => _NumericSettingRow(
+                key: ValueKey('num-${setting.$1}'),
+                label: setting.$2,
+                min: setting.$3,
+                max: setting.$4,
+                step: setting.$5,
+                current: _valueFor(s, setting.$1),
+                onChanged: (v) => _debSend(setting.$1, v),
+                onCommit: (v) => _sendNum(setting.$1, v),
+              ),
+            ),
+            const SizedBox(height: 8),
+            ..._boolSettings.map(
+              (setting) => _BoolSettingRow(
+                key: ValueKey('bool-${setting.$1}'),
+                label: setting.$2,
+                current: _boolValueFor(s, setting.$1),
+                onChanged: (on) => _setBool(setting.$1, on),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPresetPanel(ShadThemeData theme, GrinderSnapshot s) {
+    if (s.presets.isEmpty && s.grindSections.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (s.presets.isNotEmpty) ...[
+              Text('预设', style: theme.textTheme.h3),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final preset in s.presets)
+                    _presetChip(
+                      theme,
+                      preset.name,
+                      selected:
+                          s.selectedPresetIndex != null &&
+                          preset.uid ==
+                              (s.selectedPresetIndex! < s.presets.length
+                                  ? s.presets[s.selectedPresetIndex!].uid
+                                  : null),
+                      onTap: () => widget.grinder.setPreset(uid: preset.uid),
+                    ),
+                ],
+              ),
+            ],
+            if (s.grindSections.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Text('研磨段', style: theme.textTheme.h3),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final section in s.grindSections)
+                    _presetChip(
+                      theme,
+                      section.name,
+                      selected: false,
+                      onTap: () =>
+                          widget.grinder.setGrindSection(index: section.index),
+                    ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _presetChip(
     ShadThemeData theme,
-    String label,
-    String? value, {
-    bool indent = false,
+    String name, {
+    required bool selected,
+    required VoidCallback onTap,
   }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected
+              ? const Color(0xFF1F6FEB)
+              : theme.colorScheme.mutedForeground.withValues(alpha: 0.06),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: theme.colorScheme.border),
+        ),
+        child: Text(
+          name,
+          style: theme.textTheme.h4.copyWith(
+            color: selected ? Colors.white : theme.colorScheme.foreground,
+            fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCommands(ShadThemeData theme) {
+    final commands = <(String, Future<void> Function())>[
+      ('握手 appHello', widget.grinder.onConnect),
+      ('查询研磨段', widget.grinder.querySections),
+      ('查询预设', widget.grinder.queryPresets),
+      ('开始研磨', widget.grinder.start),
+      ('停止研磨', widget.grinder.stop),
+    ];
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('指令', style: theme.textTheme.h3),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final command in commands)
+                  ShadButton(
+                    size: ShadButtonSize.sm,
+                    child: Text(command.$1),
+                    onPressed: () => command.$2(),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLogSection(
+    ShadThemeData theme,
+    String title,
+    List<GrinderLogEntry> entries,
+    Color color,
+  ) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: theme.textTheme.h3.copyWith(color: color)),
+            const SizedBox(height: 8),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 160),
+              child: SingleChildScrollView(
+                reverse: true,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    for (final entry in entries)
+                      Text(
+                        'seq=0x${entry.seq.toRadixString(16).padLeft(4, '0')} '
+                        '${entry.text}',
+                        style: theme.textTheme.small.copyWith(
+                          fontFamily: 'Menlo',
+                          fontSize: 11,
+                          color: color.withValues(alpha: 0.9),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  double? _valueFor(GrinderSnapshot s, String key) {
+    switch (key) {
+      case 'feedingRpm':
+        return s.feedingRpm?.toDouble();
+      case 'grindRpm':
+        return s.grindRpm?.toDouble();
+      case 'brightness':
+        return s.brightness?.toDouble();
+      case 'standbySec':
+        return s.standbySec?.toDouble();
+      case 'bladeGap':
+        return s.bladeGap?.toDouble();
+      default:
+        return null;
+    }
+  }
+
+  bool? _boolValueFor(GrinderSnapshot s, String key) {
+    switch (key) {
+      case 'cupDetect':
+        return s.cupDetect;
+      case 'autoStop':
+        return s.autoStop;
+      case 'fastClean':
+        return s.fastClean;
+      default:
+        return null;
+    }
+  }
+}
+
+class _NumericSettingRow extends StatefulWidget {
+  final String label;
+  final int min;
+  final int max;
+  final int step;
+  final double? current;
+  final ValueChanged<double> onChanged;
+  final ValueChanged<double> onCommit;
+
+  const _NumericSettingRow({
+    super.key,
+    required this.label,
+    required this.min,
+    required this.max,
+    required this.step,
+    required this.current,
+    required this.onChanged,
+    required this.onCommit,
+  });
+
+  @override
+  State<_NumericSettingRow> createState() => _NumericSettingRowState();
+}
+
+class _NumericSettingRowState extends State<_NumericSettingRow> {
+  late TextEditingController _controller;
+  double? _draggingValue;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(
+      text: (widget.current ?? widget.min).toString(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    final value = _draggingValue ?? widget.current ?? widget.min.toDouble();
     return Padding(
-      padding: EdgeInsets.only(left: indent ? 16.0 : 0.0, bottom: 8.0),
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${widget.label} (${widget.min}-${widget.max})',
+            style: theme.textTheme.muted,
+          ),
+          Row(
+            children: [
+              Expanded(
+                child: Slider(
+                  value: value.clamp(
+                    widget.min.toDouble(),
+                    widget.max.toDouble(),
+                  ),
+                  min: widget.min.toDouble(),
+                  max: widget.max.toDouble(),
+                  divisions: ((widget.max - widget.min) / widget.step).round(),
+                  onChanged: (v) {
+                    setState(() => _draggingValue = v);
+                    widget.onChanged(v);
+                  },
+                  onChangeEnd: (v) {
+                    setState(() => _draggingValue = null);
+                    widget.onCommit(v);
+                  },
+                ),
+              ),
+              SizedBox(
+                width: 80,
+                child: TextField(
+                  controller: _controller,
+                  keyboardType: TextInputType.number,
+                  onSubmitted: (text) {
+                    final v = double.tryParse(text);
+                    if (v != null) widget.onCommit(v);
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BoolSettingRow extends StatelessWidget {
+  final String label;
+  final bool? current;
+  final ValueChanged<bool> onChanged;
+
+  const _BoolSettingRow({
+    super.key,
+    required this.label,
+    required this.current,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(label, style: theme.textTheme.muted),
-          Text(value ?? '—', style: theme.textTheme.h4),
+          const Spacer(),
+          Text(
+            current == null ? '未知' : (current! ? '开' : '关'),
+            style: theme.textTheme.h4.copyWith(
+              color: current == null
+                  ? theme.colorScheme.mutedForeground
+                  : current!
+                  ? Colors.green
+                  : Colors.orange,
+            ),
+          ),
+          const SizedBox(width: 8),
+          ShadButton(
+            size: ShadButtonSize.sm,
+            child: const Text('开'),
+            onPressed: () => onChanged(true),
+          ),
+          const SizedBox(width: 4),
+          ShadButton(
+            size: ShadButtonSize.sm,
+            child: const Text('关'),
+            onPressed: () => onChanged(false),
+          ),
         ],
       ),
     );

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
-import 'dart:ui' show PlatformDispatcher;
 
 import 'package:flutter/material.dart';
 import 'package:reaprime/src/models/device/device.dart' as dev;
 import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
-String _t(String en, String zh) =>
-    PlatformDispatcher.instance.locale.languageCode == 'zh' ? zh : en;
+String _grinderLang = 'en';
+
+String _t(String en, String zh) => _grinderLang == 'zh' ? zh : en;
 
 String _devStateName(GrinderDevState state) {
   return switch (state) {
@@ -249,7 +249,39 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
             _devStateName(s.devState),
             style: theme.textTheme.h4.copyWith(color: Colors.lightBlue),
           ),
+          const SizedBox(width: 12),
+          _langButton('English', 'en'),
+          const SizedBox(width: 4),
+          _langButton('中文', 'zh'),
         ],
+      ),
+    );
+  }
+
+  Widget _langButton(String label, String lang) {
+    final selected = _grinderLang == lang;
+    return GestureDetector(
+      onTap: () {
+        if (_grinderLang == lang) return;
+        setState(() => _grinderLang = lang);
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xFF1F6FEB) : Colors.transparent,
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(
+            color: selected ? const Color(0xFF1F6FEB) : Colors.grey.shade500,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+            color: selected ? Colors.white : Colors.grey.shade400,
+          ),
+        ),
       ),
     );
   }

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -149,9 +149,9 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
               if (_last != null) ...[
                 _buildMockDisplay(theme, _last!),
                 const SizedBox(height: 16),
-                _buildStatusTable(theme, _last!),
-                const SizedBox(height: 16),
                 _buildSettingsPanel(theme, _last!),
+                const SizedBox(height: 16),
+                _buildStatusTable(theme, _last!),
                 const SizedBox(height: 16),
                 _buildPresetPanel(theme, _last!),
                 const SizedBox(height: 16),
@@ -204,23 +204,11 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
 
   Widget _buildStatusTable(ShadThemeData theme, GrinderSnapshot s) {
     String boolText(bool? v) => v == null ? '—' : (v ? '开' : '关');
-    Widget tile(String label, String value) => Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Text(label, style: theme.textTheme.small),
-        Text(
-          value,
-          style: theme.textTheme.h4.copyWith(fontWeight: FontWeight.w600),
-        ),
-      ],
-    );
-    final topRow = <(String, String)>[
+    final rows = <(String, String)>[
       ('杯检', boolText(s.cupDetect)),
       ('自动停止', boolText(s.autoStop)),
       ('强力清粉', boolText(s.fastClean)),
       ('WiFi', s.wifiName ?? '—'),
-    ];
-    final rest = <(String, String)>[
       ('连接状态', _connected ? '已连接' : '未连接'),
       ('累计研磨', s.totalGrinds?.toString() ?? '—'),
       ('亮度', s.brightness?.toString() ?? '—'),
@@ -238,27 +226,17 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
           children: [
             Text('实时状态 (约200ms/条)', style: theme.textTheme.h3),
             const SizedBox(height: 8),
-            Row(
-              children: [
-                for (final row in topRow) Expanded(child: tile(row.$1, row.$2)),
-              ],
-            ),
-            const SizedBox(height: 12),
-            GridView.count(
-              crossAxisCount: 3,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              childAspectRatio: 2.6,
-              children: [
-                for (final row in rest)
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(row.$1, style: theme.textTheme.small),
-                      Text(row.$2, style: theme.textTheme.h4),
-                    ],
-                  ),
-              ],
+            ...rows.map(
+              (r) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(r.$1, style: theme.textTheme.muted),
+                    Text(r.$2, style: theme.textTheme.h4),
+                  ],
+                ),
+              ),
             ),
           ],
         ),

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:reaprime/src/models/device/device.dart' as dev;
 import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
@@ -14,7 +15,7 @@ const _devStateNames = {
 
 const _numSettings = [
   ('feedingRpm', '下豆速度', 0, 65, 5),
-  ('grindRpm', '刀盘转速', 0, 1050, 50),
+  ('grindRpm', '刀盘转速', 500, 1500, 50),
   ('brightness', '亮度', 0, 10, 1),
   ('standbySec', '熄屏秒', 0, 900, 30),
   ('bladeGap', '研磨度', 0, 1000, 5),
@@ -42,11 +43,17 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
   StreamSubscription<GrinderLogEntry>? _logSub;
   final Map<String, Timer> _debTimers = {};
   GrinderSnapshot? _last;
+  bool _connected = false;
 
   @override
   void initState() {
     super.initState();
     widget.grinder.onConnect();
+    widget.grinder.connectionState.listen((state) {
+      if (mounted) {
+        setState(() => _connected = state == dev.ConnectionState.connected);
+      }
+    });
     _logSub = widget.grinder.logStream.listen((entry) {
       switch (entry.kind) {
         case GrinderLogKind.send:
@@ -163,7 +170,7 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
 
   Widget _buildMockDisplay(ShadThemeData theme, GrinderSnapshot s) {
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       decoration: BoxDecoration(
         color: theme.colorScheme.mutedForeground.withValues(alpha: 0.06),
         borderRadius: BorderRadius.circular(12),
@@ -171,25 +178,20 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
       ),
       child: Row(
         children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                s.bladeGap?.toString() ?? '--',
-                style: theme.textTheme.h1.copyWith(fontWeight: FontWeight.w700),
-              ),
-              Text('μm 研磨度', style: theme.textTheme.muted),
-            ],
+          Text(
+            s.bladeGap?.toString() ?? '--',
+            style: theme.textTheme.h1.copyWith(fontWeight: FontWeight.w700),
           ),
-          const SizedBox(width: 32),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('下豆 ${s.feedingRpm ?? '--'} RPM', style: theme.textTheme.h4),
-              Text('转速 ${s.grindRpm ?? '--'} RPM', style: theme.textTheme.h4),
-              Text('湿度 ${s.humidity ?? '--'} %RH', style: theme.textTheme.h4),
-            ],
-          ),
+          Text(' μm', style: theme.textTheme.muted),
+          const SizedBox(width: 24),
+          Text('下豆 ${s.feedingRpm ?? '--'}', style: theme.textTheme.h4),
+          Text(' RPM', style: theme.textTheme.muted),
+          const SizedBox(width: 24),
+          Text('转速 ${s.grindRpm ?? '--'}', style: theme.textTheme.h4),
+          Text(' RPM', style: theme.textTheme.muted),
+          const SizedBox(width: 24),
+          Text('湿度 ${s.humidity ?? '--'}', style: theme.textTheme.h4),
+          Text(' %RH', style: theme.textTheme.muted),
           const Spacer(),
           Text(
             _devStateNames[s.devState] ?? s.devState.name,
@@ -201,22 +203,20 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
   }
 
   Widget _buildStatusTable(ShadThemeData theme, GrinderSnapshot s) {
-    final rows = <(String, String?)>[
-      ('下豆速度', s.feedingRpm?.toString()),
-      ('刀盘转速', s.grindRpm?.toString()),
-      ('研磨度', s.bladeGap?.toString()),
-      ('湿度', s.humidity?.toString()),
-      ('累计研磨', s.totalGrinds?.toString()),
-      ('杯检', s.cupDetect?.toString()),
-      ('自动停止', s.autoStop?.toString()),
-      ('强力清粉', s.fastClean?.toString()),
-      ('亮度', s.brightness?.toString()),
-      ('熄屏秒', s.standbySec?.toString()),
-      ('网络', s.netState),
-      ('WiFi', s.wifiName),
-      ('序列号', s.snCode),
-      ('开机原因', s.resetReason),
-      ('固件版本', s.releaseVer),
+    String boolText(bool? v) => v == null ? '—' : (v ? '开' : '关');
+    final rows = <(String, String)>[
+      ('杯检', boolText(s.cupDetect)),
+      ('自动停止', boolText(s.autoStop)),
+      ('强力清粉', boolText(s.fastClean)),
+      ('WiFi', s.wifiName ?? '—'),
+      ('连接状态', _connected ? '已连接' : '未连接'),
+      ('累计研磨', s.totalGrinds?.toString() ?? '—'),
+      ('亮度', s.brightness?.toString() ?? '—'),
+      ('熄屏秒', s.standbySec?.toString() ?? '—'),
+      ('网络', s.netState ?? '—'),
+      ('序列号', s.snCode ?? '—'),
+      ('开机原因', s.resetReason ?? '—'),
+      ('固件版本', s.releaseVer ?? '—'),
     ];
     return Card(
       child: Padding(
@@ -226,17 +226,21 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
           children: [
             Text('实时状态 (约200ms/条)', style: theme.textTheme.h3),
             const SizedBox(height: 8),
-            ...rows.map(
-              (r) => Padding(
-                padding: const EdgeInsets.symmetric(vertical: 2),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(r.$1, style: theme.textTheme.muted),
-                    Text(r.$2 ?? '—', style: theme.textTheme.h4),
-                  ],
-                ),
-              ),
+            GridView.count(
+              crossAxisCount: 3,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              childAspectRatio: 2.6,
+              children: [
+                for (final row in rows)
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(row.$1, style: theme.textTheme.muted),
+                      Text(row.$2, style: theme.textTheme.h4),
+                    ],
+                  ),
+              ],
             ),
           ],
         ),
@@ -366,12 +370,12 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
   }
 
   Widget _buildCommands(ShadThemeData theme) {
-    final commands = <(String, Future<void> Function())>[
-      ('握手 appHello', widget.grinder.onConnect),
-      ('查询研磨段', widget.grinder.querySections),
-      ('查询预设', widget.grinder.queryPresets),
-      ('开始研磨', widget.grinder.start),
-      ('停止研磨', widget.grinder.stop),
+    final commands = <(String, Future<void> Function(), bool disabled)>[
+      ('握手 appHello', widget.grinder.onConnect, false),
+      ('查询研磨段', widget.grinder.querySections, false),
+      ('查询预设', widget.grinder.queryPresets, false),
+      ('开始研磨 (尚未启用)', widget.grinder.start, true),
+      ('停止研磨 (尚未启用)', widget.grinder.stop, true),
     ];
     return Card(
       child: Padding(
@@ -388,8 +392,8 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
                 for (final command in commands)
                   ShadButton(
                     size: ShadButtonSize.sm,
+                    onPressed: command.$3 ? null : () => command.$2(),
                     child: Text(command.$1),
-                    onPressed: () => command.$2(),
                   ),
               ],
             ),
@@ -538,7 +542,10 @@ class _NumericSettingRowState extends State<_NumericSettingRow> {
                   max: widget.max.toDouble(),
                   divisions: ((widget.max - widget.min) / widget.step).round(),
                   onChanged: (v) {
-                    setState(() => _draggingValue = v);
+                    setState(() {
+                      _draggingValue = v;
+                      _controller.text = v.toStringAsFixed(0);
+                    });
                     widget.onChanged(v);
                   },
                   onChangeEnd: (v) {

--- a/lib/src/debug_feature/grinder_debug_view.dart
+++ b/lib/src/debug_feature/grinder_debug_view.dart
@@ -147,7 +147,9 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
             padding: const EdgeInsets.all(16),
             children: [
               if (_last != null) ...[
-                _buildHeader(theme, _last!),
+                _buildMockDisplay(theme, _last!),
+                const SizedBox(height: 16),
+                _buildStatusTable(theme, _last!),
                 const SizedBox(height: 16),
                 _buildSettingsPanel(theme, _last!),
                 const SizedBox(height: 16),
@@ -166,104 +168,97 @@ class _GrinderDebugViewState extends State<GrinderDebugView> {
     );
   }
 
-  Widget _buildHeader(ShadThemeData theme, GrinderSnapshot s) {
+  Widget _buildMockDisplay(ShadThemeData theme, GrinderSnapshot s) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.mutedForeground.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: theme.colorScheme.border),
+      ),
+      child: Row(
+        children: [
+          Text(
+            s.bladeGap?.toString() ?? '--',
+            style: theme.textTheme.h1.copyWith(fontWeight: FontWeight.w700),
+          ),
+          Text(' μm', style: theme.textTheme.muted),
+          const SizedBox(width: 24),
+          Text('下豆 ${s.feedingRpm ?? '--'}', style: theme.textTheme.h4),
+          Text(' RPM', style: theme.textTheme.muted),
+          const SizedBox(width: 24),
+          Text('转速 ${s.grindRpm ?? '--'}', style: theme.textTheme.h4),
+          Text(' RPM', style: theme.textTheme.muted),
+          const SizedBox(width: 24),
+          Text('湿度 ${s.humidity ?? '--'}', style: theme.textTheme.h4),
+          Text(' %RH', style: theme.textTheme.muted),
+          const Spacer(),
+          Text(
+            _devStateNames[s.devState] ?? s.devState.name,
+            style: theme.textTheme.h4.copyWith(color: Colors.lightBlue),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatusTable(ShadThemeData theme, GrinderSnapshot s) {
     String boolText(bool? v) => v == null ? '—' : (v ? '开' : '关');
-    final statusRows = <List<(String, String)>>[
-      [
-        ('杯检', boolText(s.cupDetect)),
-        ('自动停止', boolText(s.autoStop)),
-        ('强力清粉', boolText(s.fastClean)),
-        ('WiFi', s.wifiName ?? '—'),
+    Widget tile(String label, String value) => Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label, style: theme.textTheme.small),
+        Text(
+          value,
+          style: theme.textTheme.h4.copyWith(fontWeight: FontWeight.w600),
+        ),
       ],
-      [
-        ('连接状态', _connected ? '已连接' : '未连接'),
-        ('累计研磨', s.totalGrinds?.toString() ?? '—'),
-        ('亮度', s.brightness?.toString() ?? '—'),
-        ('熄屏秒', s.standbySec?.toString() ?? '—'),
-      ],
-      [
-        ('网络', s.netState ?? '—'),
-        ('序列号', s.snCode ?? '—'),
-        ('开机原因', s.resetReason ?? '—'),
-        ('固件版本', s.releaseVer ?? '—'),
-      ],
+    );
+    final topRow = <(String, String)>[
+      ('杯检', boolText(s.cupDetect)),
+      ('自动停止', boolText(s.autoStop)),
+      ('强力清粉', boolText(s.fastClean)),
+      ('WiFi', s.wifiName ?? '—'),
+    ];
+    final rest = <(String, String)>[
+      ('连接状态', _connected ? '已连接' : '未连接'),
+      ('累计研磨', s.totalGrinds?.toString() ?? '—'),
+      ('亮度', s.brightness?.toString() ?? '—'),
+      ('熄屏秒', s.standbySec?.toString() ?? '—'),
+      ('网络', s.netState ?? '—'),
+      ('序列号', s.snCode ?? '—'),
+      ('开机原因', s.resetReason ?? '—'),
+      ('固件版本', s.releaseVer ?? '—'),
     ];
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(12),
-        child: Row(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Expanded(
-              flex: 1,
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
+            Text('实时状态 (约200ms/条)', style: theme.textTheme.h3),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                for (final row in topRow) Expanded(child: tile(row.$1, row.$2)),
+              ],
+            ),
+            const SizedBox(height: 12),
+            GridView.count(
+              crossAxisCount: 3,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              childAspectRatio: 2.6,
+              children: [
+                for (final row in rest)
                   Row(
-                    crossAxisAlignment: CrossAxisAlignment.baseline,
-                    textBaseline: TextBaseline.alphabetic,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Text(
-                        s.bladeGap?.toString() ?? '--',
-                        style: theme.textTheme.h1.copyWith(
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                      Text(' μm', style: theme.textTheme.muted),
+                      Text(row.$1, style: theme.textTheme.small),
+                      Text(row.$2, style: theme.textTheme.h4),
                     ],
                   ),
-                  const SizedBox(height: 8),
-                  Text(
-                    '下豆 ${s.feedingRpm ?? '--'} RPM',
-                    style: theme.textTheme.h4,
-                  ),
-                  Text(
-                    '转速 ${s.grindRpm ?? '--'} RPM',
-                    style: theme.textTheme.h4,
-                  ),
-                  Text(
-                    '湿度 ${s.humidity ?? '--'} %RH',
-                    style: theme.textTheme.h4,
-                  ),
-                  Text(
-                    _devStateNames[s.devState] ?? s.devState.name,
-                    style: theme.textTheme.small.copyWith(
-                      color: Colors.lightBlue,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              flex: 3,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  for (final column in statusRows)
-                    Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          for (final row in column)
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Text(row.$1, style: theme.textTheme.small),
-                                Text(
-                                  row.$2,
-                                  style: theme.textTheme.small.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                              ],
-                            ),
-                        ],
-                      ),
-                    ),
-                ],
-              ),
+              ],
             ),
           ],
         ),

--- a/lib/src/home_feature/widgets/device_selection_widget.dart
+++ b/lib/src/home_feature/widgets/device_selection_widget.dart
@@ -70,9 +70,12 @@ class _DeviceSelectionWidgetState extends State<DeviceSelectionWidget> {
   @override
   Widget build(BuildContext context) {
     if (_discoveredDevices.isEmpty) {
-      final label = widget.deviceType == dev.DeviceType.machine
-          ? 'machines'
-          : 'scales';
+      final label = switch (widget.deviceType) {
+        dev.DeviceType.machine => 'machines',
+        dev.DeviceType.scale => 'scales',
+        dev.DeviceType.sensor => 'devices',
+        dev.DeviceType.grinder => 'grinders',
+      };
       return Padding(
         padding: const EdgeInsets.all(8.0),
         child: Center(

--- a/lib/src/models/device/device.dart
+++ b/lib/src/models/device/device.dart
@@ -3,7 +3,7 @@ import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 
-enum DeviceType { machine, scale, sensor }
+enum DeviceType { machine, scale, sensor, grinder }
 
 abstract class Device {
   String get deviceId;

--- a/lib/src/models/device/device_implementation.dart
+++ b/lib/src/models/device/device_implementation.dart
@@ -20,4 +20,5 @@ enum DeviceImplementation {
   difluidR2Sensor,
   debugPort,
   sensorBasket,
+  bookooGrinder,
 }

--- a/lib/src/models/device/grinder.dart
+++ b/lib/src/models/device/grinder.dart
@@ -27,7 +27,7 @@ abstract class Grinder extends Device {
   Future<void> setPreset({String? uid, int? index});
   Future<void> setFeedingRpm(int rpm);
   Future<void> setGrindRpm(int rpm);
-  Future<void> setBladeGap(int micrometers);
+  Future<void> setGrindSetting(int value);
   Future<void> setBrightness(int level);
   Future<void> setStandbySec(int seconds);
   Future<void> setCupDetect(bool enabled);
@@ -61,7 +61,7 @@ class GrinderSnapshot {
   final GrinderDevState devState;
   final int? feedingRpm;
   final int? grindRpm;
-  final int? bladeGap;
+  final int? grindSetting;
   final int? humidity;
   final int? totalGrinds;
   final bool? cupDetect;
@@ -83,7 +83,7 @@ class GrinderSnapshot {
     required this.devState,
     this.feedingRpm,
     this.grindRpm,
-    this.bladeGap,
+    this.grindSetting,
     this.humidity,
     this.totalGrinds,
     this.cupDetect,
@@ -107,7 +107,7 @@ class GrinderSnapshot {
       'devState': devState.name,
       'feedingRpm': feedingRpm,
       'grindRpm': grindRpm,
-      'bladeGap': bladeGap,
+      'grindSetting': grindSetting,
       'humidity': humidity,
       'totalGrinds': totalGrinds,
       'cupDetect': cupDetect,

--- a/lib/src/models/device/grinder.dart
+++ b/lib/src/models/device/grinder.dart
@@ -1,10 +1,28 @@
 import 'device.dart';
 
+enum GrinderLogKind { send, response, broadcast }
+
+class GrinderLogEntry {
+  final GrinderLogKind kind;
+  final int seq;
+  final String text;
+
+  const GrinderLogEntry({
+    required this.kind,
+    required this.seq,
+    required this.text,
+  });
+}
+
 abstract class Grinder extends Device {
   Stream<GrinderSnapshot> get currentSnapshot;
 
+  Stream<GrinderLogEntry> get logStream;
+
   Future<void> start();
   Future<void> stop();
+  Future<void> querySections();
+  Future<void> queryPresets();
   Future<void> setGrindSection({int? index, String? name});
   Future<void> setPreset({String? uid, int? index});
   Future<void> setFeedingRpm(int rpm);
@@ -18,7 +36,7 @@ abstract class Grinder extends Device {
   Future<void> reboot();
 }
 
-enum GrinderDevState { idle, grinding, highspeedClean, unknown }
+enum GrinderDevState { idle, grinding, highspeedClean, setting, unknown }
 
 class GrinderPreset {
   final String uid;
@@ -58,6 +76,7 @@ class GrinderSnapshot {
   final String? releaseVer;
   final List<GrinderPreset> presets;
   final List<GrindSection> grindSections;
+  final int? selectedPresetIndex;
 
   const GrinderSnapshot({
     required this.timestamp,
@@ -78,6 +97,7 @@ class GrinderSnapshot {
     this.resetReason,
     this.releaseVer,
     this.presets = const [],
+    this.selectedPresetIndex,
     this.grindSections = const [],
   });
 
@@ -102,6 +122,7 @@ class GrinderSnapshot {
       'releaseVer': releaseVer,
       'presets': presets.map((p) => p.toJson()).toList(),
       'grindSections': grindSections.map((s) => s.toJson()).toList(),
+      'selectedPresetIndex': selectedPresetIndex,
     };
   }
 }

--- a/lib/src/models/device/grinder.dart
+++ b/lib/src/models/device/grinder.dart
@@ -1,0 +1,107 @@
+import 'device.dart';
+
+abstract class Grinder extends Device {
+  Stream<GrinderSnapshot> get currentSnapshot;
+
+  Future<void> start();
+  Future<void> stop();
+  Future<void> setGrindSection({int? index, String? name});
+  Future<void> setPreset({String? uid, int? index});
+  Future<void> setFeedingRpm(int rpm);
+  Future<void> setGrindRpm(int rpm);
+  Future<void> setBladeGap(int micrometers);
+  Future<void> setBrightness(int level);
+  Future<void> setStandbySec(int seconds);
+  Future<void> setCupDetect(bool enabled);
+  Future<void> setAutoStop(bool enabled);
+  Future<void> setFastClean(bool enabled);
+  Future<void> reboot();
+}
+
+enum GrinderDevState { idle, grinding, highspeedClean, unknown }
+
+class GrinderPreset {
+  final String uid;
+  final String name;
+
+  const GrinderPreset({required this.uid, required this.name});
+
+  Map<String, dynamic> toJson() => {'uid': uid, 'name': name};
+}
+
+class GrindSection {
+  final int index;
+  final String name;
+
+  const GrindSection({required this.index, required this.name});
+
+  Map<String, dynamic> toJson() => {'index': index, 'name': name};
+}
+
+class GrinderSnapshot {
+  final DateTime timestamp;
+  final GrinderDevState devState;
+  final int? feedingRpm;
+  final int? grindRpm;
+  final int? bladeGap;
+  final int? humidity;
+  final int? totalGrinds;
+  final bool? cupDetect;
+  final bool? autoStop;
+  final bool? fastClean;
+  final int? brightness;
+  final int? standbySec;
+  final String? wifiName;
+  final String? netState;
+  final String? snCode;
+  final String? resetReason;
+  final String? releaseVer;
+  final List<GrinderPreset> presets;
+  final List<GrindSection> grindSections;
+
+  const GrinderSnapshot({
+    required this.timestamp,
+    required this.devState,
+    this.feedingRpm,
+    this.grindRpm,
+    this.bladeGap,
+    this.humidity,
+    this.totalGrinds,
+    this.cupDetect,
+    this.autoStop,
+    this.fastClean,
+    this.brightness,
+    this.standbySec,
+    this.wifiName,
+    this.netState,
+    this.snCode,
+    this.resetReason,
+    this.releaseVer,
+    this.presets = const [],
+    this.grindSections = const [],
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'timestamp': timestamp.toIso8601String(),
+      'devState': devState.name,
+      'feedingRpm': feedingRpm,
+      'grindRpm': grindRpm,
+      'bladeGap': bladeGap,
+      'humidity': humidity,
+      'totalGrinds': totalGrinds,
+      'cupDetect': cupDetect,
+      'autoStop': autoStop,
+      'fastClean': fastClean,
+      'brightness': brightness,
+      'standbySec': standbySec,
+      'wifiName': wifiName,
+      'netState': netState,
+      'snCode': snCode,
+      'resetReason': resetReason,
+      'releaseVer': releaseVer,
+      'presets': presets.map((p) => p.toJson()).toList(),
+      'grindSections': grindSections.map((s) => s.toJson()).toList(),
+    };
+  }
+}

--- a/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
+++ b/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
@@ -459,7 +459,8 @@ class BookooGrinder implements Grinder {
         : decoded;
     _feedingRpm = _asInt(source['feedingRpm']) ?? _feedingRpm;
     _grindRpm = _asInt(source['grindRpm']) ?? _grindRpm;
-    _grindSetting = _asInt(source['grindSetting']) ?? _grindSetting;
+    _grindSetting =
+        _asInt(source['bladeGap']) ?? _asInt(source['grindSetting']) ?? _grindSetting;
     _humidity = _asInt(source['humidity']) ?? _humidity;
     _totalGrinds = _asInt(source['totalGrinds']) ?? _totalGrinds;
     _cupDetect = _asBool(source['cupDetect']) ?? _cupDetect;

--- a/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
+++ b/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
@@ -338,6 +338,10 @@ class BookooGrinder implements Grinder {
       _mergeBroadcast(decoded);
     }
     _streamController.add(_snapshot());
+    _log.info(
+      'Snapshot: ${_devState.name} rpm=$_grindRpm feeding=$_feedingRpm '
+      'gap=$_bladeGap presets=${_presets.length} sections=${_grindSections.length}',
+    );
   }
 
   void _handleResponse(Map<String, dynamic> decoded) {

--- a/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
+++ b/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
@@ -1,0 +1,460 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/ble_service_identifier.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:rxdart/subjects.dart';
+
+import '../../grinder.dart';
+
+class BookooGrinder implements Grinder {
+  final Logger _log = Logger('BookooGrinder');
+
+  static final BleServiceIdentifier serviceIdentifier =
+      BleServiceIdentifier.long('4d543830-0001-4b80-8f00-424f4f4b4f4f');
+  static final BleServiceIdentifier commandCharacteristic =
+      BleServiceIdentifier.long('4d543830-0002-4b80-8f00-424f4f4b4f4f');
+  static final BleServiceIdentifier statusCharacteristic =
+      BleServiceIdentifier.long('4d543830-0003-4b80-8f00-424f4f4b4f4f');
+
+  static const _startupQueries = <Map<String, dynamic>>[
+    {
+      'appHello': {'op': 'handshake'},
+    },
+    {
+      'grindSection': {
+        'op': 'get',
+        'selector': {'type': 'all'},
+      },
+    },
+    {
+      'grindPreset': {
+        'op': 'get',
+        'selector': {'type': 'all'},
+      },
+    },
+  ];
+
+  final BLETransport _transport;
+  final Duration _queryGap;
+
+  final StreamController<GrinderSnapshot> _streamController =
+      StreamController.broadcast();
+  final StreamController<ConnectionState> _connectionStateController =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+
+  int _seq = 0;
+  ({int seq, int expect, BytesBuilder bytes})? _pending;
+
+  GrinderDevState _devState = GrinderDevState.unknown;
+  int? _feedingRpm;
+  int? _grindRpm;
+  int? _bladeGap;
+  int? _humidity;
+  int? _totalGrinds;
+  bool? _cupDetect;
+  bool? _autoStop;
+  bool? _fastClean;
+  int? _brightness;
+  int? _standbySec;
+  String? _wifiName;
+  String? _netState;
+  String? _snCode;
+  String? _resetReason;
+  String? _releaseVer;
+  List<GrinderPreset> _presets = const [];
+  List<GrindSection> _grindSections = const [];
+
+  BookooGrinder({
+    required BLETransport transport,
+    Duration queryGap = const Duration(milliseconds: 400),
+  }) : _transport = transport,
+       _queryGap = queryGap;
+
+  @override
+  Stream<GrinderSnapshot> get currentSnapshot => _streamController.stream;
+
+  @override
+  String get deviceId => _transport.id;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.bookooGrinder;
+
+  @override
+  TransportType get transportType => _transport.transportType;
+
+  @override
+  String get name => 'MOTTO80 Grinder';
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      _connectionStateController.stream;
+
+  @override
+  Future<void> onConnect() async {
+    if (await _transport.connectionState.first == ConnectionState.connected) {
+      return;
+    }
+    _connectionStateController.add(ConnectionState.connecting);
+
+    StreamSubscription<ConnectionState>? disconnectSub;
+
+    try {
+      await _transport.connect();
+
+      disconnectSub = _transport.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .listen((_) {
+            _connectionStateController.add(ConnectionState.disconnected);
+            disconnectSub?.cancel();
+          });
+
+      final services = await _transport.discoverServices();
+      if (!serviceIdentifier.matchesAny(services)) {
+        throw Exception(
+          'Expected service ${serviceIdentifier.long} not found. '
+          'Discovered services: $services',
+        );
+      }
+      await _transport.subscribe(
+        serviceIdentifier.long,
+        statusCharacteristic.long,
+        _parseNotification,
+      );
+      _seq = 0;
+      _pending = null;
+      _connectionStateController.add(ConnectionState.connected);
+      unawaited(_runStartupQueries());
+    } catch (e) {
+      _log.warning('Connect failed: $e');
+      disconnectSub?.cancel();
+      _connectionStateController.add(ConnectionState.disconnected);
+      try {
+        await _transport.disconnect();
+      } catch (_) {}
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _transport.disconnect();
+  }
+
+  @override
+  DeviceType get type => DeviceType.grinder;
+
+  @override
+  Future<void> start() async {
+    await _send({
+      'grind': {'op': 'start'},
+    });
+  }
+
+  @override
+  Future<void> stop() async {
+    await _send({
+      'grind': {'op': 'stop'},
+    });
+  }
+
+  @override
+  Future<void> setGrindSection({int? index, String? name}) async {
+    final data = index != null
+        ? <String, dynamic>{'index': index}
+        : <String, dynamic>{'name': name};
+    await _send({
+      'grindSection': {'op': 'set', 'data': data},
+    });
+  }
+
+  @override
+  Future<void> setPreset({String? uid, int? index}) async {
+    final data = uid != null
+        ? <String, dynamic>{'uid': uid}
+        : <String, dynamic>{'index': index};
+    await _send({
+      'grindPreset': {'op': 'set', 'data': data},
+    });
+  }
+
+  @override
+  Future<void> setFeedingRpm(int rpm) async {
+    await _send({
+      'geneSetting': {
+        'op': 'set',
+        'data': {'feedingRpm': rpm},
+      },
+    });
+  }
+
+  @override
+  Future<void> setGrindRpm(int rpm) async {
+    await _send({
+      'geneSetting': {
+        'op': 'set',
+        'data': {'grindRpm': rpm},
+      },
+    });
+  }
+
+  @override
+  Future<void> setBladeGap(int micrometers) async {
+    await _send({
+      'geneSetting': {
+        'op': 'set',
+        'data': {'bladeGap': micrometers},
+      },
+    });
+  }
+
+  @override
+  Future<void> setBrightness(int level) async {
+    await _send({
+      'geneSetting': {
+        'op': 'set',
+        'data': {'brightness': level},
+      },
+    });
+  }
+
+  @override
+  Future<void> setStandbySec(int seconds) async {
+    await _send({
+      'geneSetting': {
+        'op': 'set',
+        'data': {'standbySec': seconds},
+      },
+    });
+  }
+
+  @override
+  Future<void> setCupDetect(bool enabled) async {
+    await _send({
+      'geneSetting': {
+        'op': 'set',
+        'data': {'cupDetect': enabled},
+      },
+    });
+  }
+
+  @override
+  Future<void> setAutoStop(bool enabled) async {
+    await _send({
+      'geneSetting': {
+        'op': 'set',
+        'data': {'autoStop': enabled},
+      },
+    });
+  }
+
+  @override
+  Future<void> setFastClean(bool enabled) async {
+    await _send({
+      'geneSetting': {
+        'op': 'set',
+        'data': {'fastClean': enabled},
+      },
+    });
+  }
+
+  @override
+  Future<void> reboot() async {
+    await _send({
+      'reboot': {'op': 'set', 'data': <String, dynamic>{}},
+    });
+  }
+
+  Future<void> _runStartupQueries() async {
+    for (final request in _startupQueries) {
+      await Future<void>.delayed(_queryGap);
+      try {
+        await _send(request);
+      } catch (e) {
+        _log.warning('Startup query failed: $request', e);
+      }
+    }
+  }
+
+  Future<void> _send(Map<String, dynamic> request) async {
+    final payload = utf8.encode(jsonEncode({'request': request}));
+    final frame = Uint8List(8 + payload.length);
+    final view = ByteData.sublistView(frame);
+    frame[0] = 0xA5;
+    frame[1] = 0x01;
+    view.setUint16(2, _seq, Endian.little);
+    view.setUint32(4, payload.length, Endian.little);
+    frame.setRange(8, 8 + payload.length, payload);
+    _seq = (_seq + 1) & 0xffff;
+    try {
+      await _transport.write(
+        serviceIdentifier.long,
+        commandCharacteristic.long,
+        frame,
+      );
+      // ignore: empty_catches
+    } on DeviceNotConnectedException {}
+  }
+
+  void _parseNotification(Uint8List chunk) {
+    BytesBuilder bytes;
+    int seq;
+    int expect;
+    if (chunk.length >= 8 && chunk[0] == 0xA5 && chunk[1] == 0x01) {
+      final view = ByteData.sublistView(chunk);
+      seq = view.getUint16(2, Endian.little);
+      expect = view.getUint32(4, Endian.little);
+      if (_pending == null || _pending!.seq != seq) {
+        bytes = BytesBuilder();
+        _pending = (seq: seq, expect: expect, bytes: bytes);
+      } else {
+        bytes = _pending!.bytes;
+      }
+      bytes.add(chunk.sublist(8));
+    } else if (_pending != null) {
+      bytes = _pending!.bytes;
+      seq = _pending!.seq;
+      expect = _pending!.expect;
+      bytes.add(chunk);
+    } else {
+      return;
+    }
+    if (bytes.length < expect) return;
+    _pending = null;
+    _handleFrame(seq, utf8.decode(bytes.takeBytes(), allowMalformed: true));
+  }
+
+  void _handleFrame(int seq, String text) {
+    final decoded = jsonDecode(text);
+    if (decoded is! Map<String, dynamic>) return;
+    if (text.contains('"response"')) {
+      _handleResponse(decoded);
+    } else {
+      _mergeBroadcast(decoded);
+    }
+    _streamController.add(_snapshot());
+  }
+
+  void _handleResponse(Map<String, dynamic> decoded) {
+    final request = decoded['request'];
+    if (request is Map<String, dynamic>) {
+      if (request.containsKey('grindPreset')) {
+        _presets = _extractPresets(decoded);
+      }
+      if (request.containsKey('grindSection')) {
+        _grindSections = _extractSections(decoded);
+      }
+    }
+    _mergeBroadcast(decoded);
+  }
+
+  List<GrinderPreset> _extractPresets(Map<String, dynamic> decoded) {
+    final result = <GrinderPreset>[];
+    void walk(dynamic node) {
+      if (node is Map<String, dynamic>) {
+        final uid = node['uid'];
+        final name = node['name'];
+        if (uid is String && name is String) {
+          result.add(GrinderPreset(uid: uid, name: name));
+        }
+        for (final value in node.values) {
+          walk(value);
+        }
+      } else if (node is List) {
+        for (final value in node) {
+          walk(value);
+        }
+      }
+    }
+
+    walk(decoded);
+    return result;
+  }
+
+  List<GrindSection> _extractSections(Map<String, dynamic> decoded) {
+    final result = <GrindSection>[];
+    void walk(dynamic node) {
+      if (node is Map<String, dynamic>) {
+        final index = node['index'];
+        final name = node['name'];
+        if (index is int && name is String) {
+          result.add(GrindSection(index: index, name: name));
+        }
+        for (final value in node.values) {
+          walk(value);
+        }
+      } else if (node is List) {
+        for (final value in node) {
+          walk(value);
+        }
+      }
+    }
+
+    walk(decoded);
+    return result;
+  }
+
+  void _mergeBroadcast(Map<String, dynamic> decoded) {
+    final fields = decoded['fields'];
+    final source = fields is Map<String, dynamic> ? fields : decoded;
+    _feedingRpm = _asInt(source['feedingRpm']) ?? _feedingRpm;
+    _grindRpm = _asInt(source['grindRpm']) ?? _grindRpm;
+    _bladeGap = _asInt(source['bladeGap']) ?? _bladeGap;
+    _humidity = _asInt(source['humidity']) ?? _humidity;
+    _totalGrinds = _asInt(source['totalGrinds']) ?? _totalGrinds;
+    _cupDetect = _asBool(source['cupDetect']) ?? _cupDetect;
+    _autoStop = _asBool(source['autoStop']) ?? _autoStop;
+    _fastClean = _asBool(source['fastClean']) ?? _fastClean;
+    _brightness = _asInt(source['brightness']) ?? _brightness;
+    _standbySec = _asInt(source['standbySec']) ?? _standbySec;
+    _wifiName = _asString(source['wifiName']) ?? _wifiName;
+    _netState = _asString(source['netState']) ?? _netState;
+    _snCode = _asString(source['snCode']) ?? _snCode;
+    _resetReason = _asString(source['resetReason']) ?? _resetReason;
+    _releaseVer = _asString(source['releaseVer']) ?? _releaseVer;
+    final devState = _asString(source['devState']);
+    if (devState != null) {
+      _devState = switch (devState) {
+        'IDLE' => GrinderDevState.idle,
+        'GRINDING' => GrinderDevState.grinding,
+        'HIGHSPEEDCLEAN' => GrinderDevState.highspeedClean,
+        _ => GrinderDevState.unknown,
+      };
+    }
+  }
+
+  GrinderSnapshot _snapshot() {
+    return GrinderSnapshot(
+      timestamp: DateTime.now(),
+      devState: _devState,
+      feedingRpm: _feedingRpm,
+      grindRpm: _grindRpm,
+      bladeGap: _bladeGap,
+      humidity: _humidity,
+      totalGrinds: _totalGrinds,
+      cupDetect: _cupDetect,
+      autoStop: _autoStop,
+      fastClean: _fastClean,
+      brightness: _brightness,
+      standbySec: _standbySec,
+      wifiName: _wifiName,
+      netState: _netState,
+      snCode: _snCode,
+      resetReason: _resetReason,
+      releaseVer: _releaseVer,
+      presets: _presets,
+      grindSections: _grindSections,
+    );
+  }
+
+  int? _asInt(dynamic value) => value is num ? value.toInt() : null;
+
+  bool? _asBool(dynamic value) => value is bool ? value : null;
+
+  String? _asString(dynamic value) => value is String ? value : null;
+}

--- a/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
+++ b/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
@@ -70,6 +70,7 @@ class BookooGrinder implements Grinder {
   String? _releaseVer;
   List<GrinderPreset> _presets = const [];
   List<GrindSection> _grindSections = const [];
+  int? _selectedPresetIndex;
 
   BookooGrinder({
     required BLETransport transport,
@@ -77,8 +78,14 @@ class BookooGrinder implements Grinder {
   }) : _transport = transport,
        _queryGap = queryGap;
 
+  final StreamController<GrinderLogEntry> _logController =
+      StreamController.broadcast();
+
   @override
   Stream<GrinderSnapshot> get currentSnapshot => _streamController.stream;
+
+  @override
+  Stream<GrinderLogEntry> get logStream => _logController.stream;
 
   @override
   String get deviceId => _transport.id;
@@ -160,6 +167,26 @@ class BookooGrinder implements Grinder {
   Future<void> stop() async {
     await _send({
       'grind': {'op': 'stop'},
+    });
+  }
+
+  @override
+  Future<void> querySections() async {
+    await _send({
+      'grindSection': {
+        'op': 'get',
+        'selector': {'type': 'all'},
+      },
+    });
+  }
+
+  @override
+  Future<void> queryPresets() async {
+    await _send({
+      'grindPreset': {
+        'op': 'get',
+        'selector': {'type': 'all'},
+      },
     });
   }
 
@@ -291,6 +318,13 @@ class BookooGrinder implements Grinder {
     view.setUint32(4, payload.length, Endian.little);
     frame.setRange(8, 8 + payload.length, payload);
     _seq = (_seq + 1) & 0xffff;
+    _logController.add(
+      GrinderLogEntry(
+        kind: GrinderLogKind.send,
+        seq: (_seq - 1) & 0xffff,
+        text: jsonEncode({'request': request}),
+      ),
+    );
     try {
       await _transport.write(
         serviceIdentifier.long,
@@ -330,6 +364,15 @@ class BookooGrinder implements Grinder {
   }
 
   void _handleFrame(int seq, String text) {
+    _logController.add(
+      GrinderLogEntry(
+        kind: text.contains('"response"')
+            ? GrinderLogKind.response
+            : GrinderLogKind.broadcast,
+        seq: seq,
+        text: text,
+      ),
+    );
     final decoded = jsonDecode(text);
     if (decoded is! Map<String, dynamic>) return;
     if (text.contains('"response"')) {
@@ -338,7 +381,7 @@ class BookooGrinder implements Grinder {
       _mergeBroadcast(decoded);
     }
     _streamController.add(_snapshot());
-    _log.info(
+    _log.fine(
       'Snapshot: ${_devState.name} rpm=$_grindRpm feeding=$_feedingRpm '
       'gap=$_bladeGap presets=${_presets.length} sections=${_grindSections.length}',
     );
@@ -404,8 +447,16 @@ class BookooGrinder implements Grinder {
   }
 
   void _mergeBroadcast(Map<String, dynamic> decoded) {
+    final broadcast = decoded['broadcast'];
+    final periodInfo = broadcast is Map<String, dynamic>
+        ? broadcast['periodInfo']
+        : null;
     final fields = decoded['fields'];
-    final source = fields is Map<String, dynamic> ? fields : decoded;
+    final source = fields is Map<String, dynamic>
+        ? fields
+        : periodInfo is Map<String, dynamic>
+        ? periodInfo
+        : decoded;
     _feedingRpm = _asInt(source['feedingRpm']) ?? _feedingRpm;
     _grindRpm = _asInt(source['grindRpm']) ?? _grindRpm;
     _bladeGap = _asInt(source['bladeGap']) ?? _bladeGap;
@@ -421,12 +472,15 @@ class BookooGrinder implements Grinder {
     _snCode = _asString(source['snCode']) ?? _snCode;
     _resetReason = _asString(source['resetReason']) ?? _resetReason;
     _releaseVer = _asString(source['releaseVer']) ?? _releaseVer;
+    _selectedPresetIndex =
+        _asInt(source['selectPreset']) ?? _selectedPresetIndex;
     final devState = _asString(source['devState']);
     if (devState != null) {
       _devState = switch (devState) {
         'IDLE' => GrinderDevState.idle,
         'GRINDING' => GrinderDevState.grinding,
         'HIGHSPEEDCLEAN' => GrinderDevState.highspeedClean,
+        'SETTING' => GrinderDevState.setting,
         _ => GrinderDevState.unknown,
       };
     }
@@ -452,6 +506,7 @@ class BookooGrinder implements Grinder {
       resetReason: _resetReason,
       releaseVer: _releaseVer,
       presets: _presets,
+      selectedPresetIndex: _selectedPresetIndex,
       grindSections: _grindSections,
     );
   }

--- a/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
+++ b/lib/src/models/device/impl/bookoo/bookoo_grinder.dart
@@ -55,7 +55,7 @@ class BookooGrinder implements Grinder {
   GrinderDevState _devState = GrinderDevState.unknown;
   int? _feedingRpm;
   int? _grindRpm;
-  int? _bladeGap;
+  int? _grindSetting;
   int? _humidity;
   int? _totalGrinds;
   bool? _cupDetect;
@@ -231,11 +231,11 @@ class BookooGrinder implements Grinder {
   }
 
   @override
-  Future<void> setBladeGap(int micrometers) async {
+  Future<void> setGrindSetting(int value) async {
     await _send({
       'geneSetting': {
         'op': 'set',
-        'data': {'bladeGap': micrometers},
+        'data': {'bladeGap': value},
       },
     });
   }
@@ -383,7 +383,7 @@ class BookooGrinder implements Grinder {
     _streamController.add(_snapshot());
     _log.fine(
       'Snapshot: ${_devState.name} rpm=$_grindRpm feeding=$_feedingRpm '
-      'gap=$_bladeGap presets=${_presets.length} sections=${_grindSections.length}',
+      'gap=$_grindSetting presets=${_presets.length} sections=${_grindSections.length}',
     );
   }
 
@@ -459,7 +459,7 @@ class BookooGrinder implements Grinder {
         : decoded;
     _feedingRpm = _asInt(source['feedingRpm']) ?? _feedingRpm;
     _grindRpm = _asInt(source['grindRpm']) ?? _grindRpm;
-    _bladeGap = _asInt(source['bladeGap']) ?? _bladeGap;
+    _grindSetting = _asInt(source['grindSetting']) ?? _grindSetting;
     _humidity = _asInt(source['humidity']) ?? _humidity;
     _totalGrinds = _asInt(source['totalGrinds']) ?? _totalGrinds;
     _cupDetect = _asBool(source['cupDetect']) ?? _cupDetect;
@@ -492,7 +492,7 @@ class BookooGrinder implements Grinder {
       devState: _devState,
       feedingRpm: _feedingRpm,
       grindRpm: _grindRpm,
-      bladeGap: _bladeGap,
+      grindSetting: _grindSetting,
       humidity: _humidity,
       totalGrinds: _totalGrinds,
       cupDetect: _cupDetect,

--- a/lib/src/models/device/impl/mock_grinder/mock_grinder.dart
+++ b/lib/src/models/device/impl/mock_grinder/mock_grinder.dart
@@ -17,7 +17,7 @@ class MockGrinder implements Grinder, SimulatedDevice {
   GrinderDevState _devState = GrinderDevState.idle;
   int _grindRpm = 750;
   int _feedingRpm = 30;
-  int _bladeGap = 400;
+  int _grindSetting = 400;
 
   @override
   Stream<ConnectionState> get connectionState => _connectionSubject.stream;
@@ -99,8 +99,8 @@ class MockGrinder implements Grinder, SimulatedDevice {
   }
 
   @override
-  Future<void> setBladeGap(int micrometers) async {
-    _bladeGap = micrometers;
+  Future<void> setGrindSetting(int value) async {
+    _grindSetting = value;
     _snapshotStream.add(_snapshot());
   }
 
@@ -128,7 +128,7 @@ class MockGrinder implements Grinder, SimulatedDevice {
       devState: _devState,
       feedingRpm: _feedingRpm,
       grindRpm: _grindRpm,
-      bladeGap: _bladeGap,
+      grindSetting: _grindSetting,
       presets: const [
         GrinderPreset(uid: 'mock-fine', name: 'Mock Fine'),
         GrinderPreset(uid: 'mock-coarse', name: 'Mock Coarse'),

--- a/lib/src/models/device/impl/mock_grinder/mock_grinder.dart
+++ b/lib/src/models/device/impl/mock_grinder/mock_grinder.dart
@@ -26,6 +26,9 @@ class MockGrinder implements Grinder, SimulatedDevice {
   Stream<GrinderSnapshot> get currentSnapshot => _snapshotStream.stream;
 
   @override
+  Stream<GrinderLogEntry> get logStream => const Stream.empty();
+
+  @override
   String get deviceId => 'MockGrinder';
 
   @override
@@ -70,6 +73,12 @@ class MockGrinder implements Grinder, SimulatedDevice {
     _devState = GrinderDevState.idle;
     _snapshotStream.add(_snapshot());
   }
+
+  @override
+  Future<void> querySections() async {}
+
+  @override
+  Future<void> queryPresets() async {}
 
   @override
   Future<void> setGrindSection({int? index, String? name}) async {}

--- a/lib/src/models/device/impl/mock_grinder/mock_grinder.dart
+++ b/lib/src/models/device/impl/mock_grinder/mock_grinder.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/grinder.dart';
+import 'package:reaprime/src/models/device/simulated_device.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:rxdart/subjects.dart';
+
+class MockGrinder implements Grinder, SimulatedDevice {
+  final BehaviorSubject<ConnectionState> _connectionSubject =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+  final StreamController<GrinderSnapshot> _snapshotStream =
+      StreamController.broadcast();
+
+  Timer? _broadcastTimer;
+  GrinderDevState _devState = GrinderDevState.idle;
+  int _grindRpm = 750;
+  int _feedingRpm = 30;
+  int _bladeGap = 400;
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionSubject.stream;
+
+  @override
+  Stream<GrinderSnapshot> get currentSnapshot => _snapshotStream.stream;
+
+  @override
+  String get deviceId => 'MockGrinder';
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.bookooGrinder;
+
+  @override
+  TransportType get transportType => TransportType.unknown;
+
+  @override
+  String get name => 'Mock Grinder';
+
+  @override
+  Future<void> onConnect() async {
+    _connectionSubject.add(ConnectionState.connected);
+    _broadcastTimer ??= Timer.periodic(const Duration(milliseconds: 200), (_) {
+      _snapshotStream.add(_snapshot());
+    });
+  }
+
+  @override
+  Future<void> disconnect() async {
+    simulateDisconnect();
+  }
+
+  @override
+  DeviceType get type => DeviceType.grinder;
+
+  void simulateDisconnect() {
+    _broadcastTimer?.cancel();
+    _broadcastTimer = null;
+    _connectionSubject.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<void> start() async {
+    _devState = GrinderDevState.grinding;
+    _snapshotStream.add(_snapshot());
+  }
+
+  @override
+  Future<void> stop() async {
+    _devState = GrinderDevState.idle;
+    _snapshotStream.add(_snapshot());
+  }
+
+  @override
+  Future<void> setGrindSection({int? index, String? name}) async {}
+
+  @override
+  Future<void> setPreset({String? uid, int? index}) async {}
+
+  @override
+  Future<void> setFeedingRpm(int rpm) async {
+    _feedingRpm = rpm;
+    _snapshotStream.add(_snapshot());
+  }
+
+  @override
+  Future<void> setGrindRpm(int rpm) async {
+    _grindRpm = rpm;
+    _snapshotStream.add(_snapshot());
+  }
+
+  @override
+  Future<void> setBladeGap(int micrometers) async {
+    _bladeGap = micrometers;
+    _snapshotStream.add(_snapshot());
+  }
+
+  @override
+  Future<void> setBrightness(int level) async {}
+
+  @override
+  Future<void> setStandbySec(int seconds) async {}
+
+  @override
+  Future<void> setCupDetect(bool enabled) async {}
+
+  @override
+  Future<void> setAutoStop(bool enabled) async {}
+
+  @override
+  Future<void> setFastClean(bool enabled) async {}
+
+  @override
+  Future<void> reboot() async {}
+
+  GrinderSnapshot _snapshot() {
+    return GrinderSnapshot(
+      timestamp: DateTime.now(),
+      devState: _devState,
+      feedingRpm: _feedingRpm,
+      grindRpm: _grindRpm,
+      bladeGap: _bladeGap,
+      presets: const [
+        GrinderPreset(uid: 'mock-fine', name: 'Mock Fine'),
+        GrinderPreset(uid: 'mock-coarse', name: 'Mock Coarse'),
+      ],
+      grindSections: const [
+        GrindSection(index: 0, name: 'Fine'),
+        GrindSection(index: 1, name: 'Coarse'),
+      ],
+    );
+  }
+}

--- a/lib/src/models/errors.dart
+++ b/lib/src/models/errors.dart
@@ -8,7 +8,7 @@ class PermissionDeniedException implements Exception {
       : 'PermissionDeniedException: $message';
 }
 
-enum DeviceKind { machine, scale, unknown }
+enum DeviceKind { machine, scale, grinder, unknown }
 
 class DeviceNotConnectedException implements Exception {
   final DeviceKind kind;
@@ -16,6 +16,7 @@ class DeviceNotConnectedException implements Exception {
   const DeviceNotConnectedException(this.kind);
   const DeviceNotConnectedException.machine() : kind = DeviceKind.machine;
   const DeviceNotConnectedException.scale() : kind = DeviceKind.scale;
+  const DeviceNotConnectedException.grinder() : kind = DeviceKind.grinder;
   const DeviceNotConnectedException.unknown() : kind = DeviceKind.unknown;
 
   @override

--- a/lib/src/services/device_factory.dart
+++ b/lib/src/services/device_factory.dart
@@ -4,6 +4,7 @@ import 'package:reaprime/src/models/device/impl/acaia/acaia_scale.dart';
 import 'package:reaprime/src/models/device/impl/atomheart/atomheart_scale.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/blackcoffee/blackcoffee_scale.dart';
+import 'package:reaprime/src/models/device/impl/bookoo/bookoo_grinder.dart';
 import 'package:reaprime/src/models/device/impl/bookoo/miniscale.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale.dart';
@@ -41,6 +42,7 @@ class DeviceFactory {
         transport: transport,
       ),
       DeviceImplementation.bookooScale => BookooScale(transport: transport),
+      DeviceImplementation.bookooGrinder => BookooGrinder(transport: transport),
       DeviceImplementation.eurekaScale => EurekaScale(transport: transport),
       DeviceImplementation.smartChefScale => SmartChefScale(
         transport: transport,

--- a/lib/src/services/device_matcher.dart
+++ b/lib/src/services/device_matcher.dart
@@ -4,6 +4,7 @@ import 'package:reaprime/src/models/device/impl/acaia/acaia_scale.dart';
 import 'package:reaprime/src/models/device/impl/atomheart/atomheart_scale.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/blackcoffee/blackcoffee_scale.dart';
+import 'package:reaprime/src/models/device/impl/bookoo/bookoo_grinder.dart';
 import 'package:reaprime/src/models/device/impl/bookoo/miniscale.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale.dart';
@@ -41,6 +42,7 @@ class DeviceMatcher {
       DecentTemp.serviceIdentifier.long,
       DifluidR2Sensor.serviceIdentifier.long,
     ],
+    DeviceType.grinder => [BookooGrinder.serviceIdentifier.long],
   };
 
   static DeviceImplementation? implementationForName(String advertisedName) {
@@ -99,6 +101,9 @@ class DeviceMatcher {
       return DeviceImplementation.atomheartScale;
     }
     if (nameLower.contains('bookoo')) return DeviceImplementation.bookooScale;
+    if (nameLower.contains('motto80')) {
+      return DeviceImplementation.bookooGrinder;
+    }
     if (nameLower.contains('decent temp')) {
       return DeviceImplementation.decentTemp;
     }
@@ -171,6 +176,9 @@ class DeviceMatcher {
     }
     if (nameLower.contains('bookoo')) {
       return BookooScale(transport: transport);
+    }
+    if (nameLower.contains('motto80')) {
+      return BookooGrinder(transport: transport);
     }
     if (nameLower.contains('decent temp')) {
       return DecentTemp(transport: transport);

--- a/lib/src/services/device_matcher.dart
+++ b/lib/src/services/device_matcher.dart
@@ -100,9 +100,11 @@ class DeviceMatcher {
     if (nameLower.contains('atomheart') || nameLower.contains('eclair')) {
       return DeviceImplementation.atomheartScale;
     }
-    if (nameLower.contains('bookoo')) return DeviceImplementation.bookooScale;
-    if (nameLower.contains('motto80')) {
+    if (nameLower.contains('motto80') || nameLower.contains('mt80')) {
       return DeviceImplementation.bookooGrinder;
+    }
+    if (nameLower.contains('bookoo') && !nameLower.contains('mt80')) {
+      return DeviceImplementation.bookooScale;
     }
     if (nameLower.contains('decent temp')) {
       return DeviceImplementation.decentTemp;
@@ -174,11 +176,11 @@ class DeviceMatcher {
     if (nameLower.contains('atomheart') || nameLower.contains('eclair')) {
       return AtomheartScale(transport: transport);
     }
-    if (nameLower.contains('bookoo')) {
-      return BookooScale(transport: transport);
-    }
-    if (nameLower.contains('motto80')) {
+    if (nameLower.contains('motto80') || nameLower.contains('mt80')) {
       return BookooGrinder(transport: transport);
+    }
+    if (nameLower.contains('bookoo') && !nameLower.contains('mt80')) {
+      return BookooScale(transport: transport);
     }
     if (nameLower.contains('decent temp')) {
       return DecentTemp(transport: transport);

--- a/lib/src/services/simulated_device_service.dart
+++ b/lib/src/services/simulated_device_service.dart
@@ -5,6 +5,7 @@ import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart';
 import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
 import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/models/device/impl/mock_grinder/mock_grinder.dart';
 import 'package:reaprime/src/models/device/impl/mock_scale/mock_scale.dart';
 import 'package:reaprime/src/models/device/impl/replay/mock_replay_de1.dart';
 import 'package:reaprime/src/models/device/impl/sensor/mock/mock_debug_port.dart';
@@ -77,6 +78,11 @@ class SimulatedDeviceService
       );
     } else {
       _devices.remove("MockReplayDe1");
+    }
+    if (enabledDevices.contains(SimulatedDevicesTypes.grinder)) {
+      _devices.putIfAbsent("MockGrinder", () => MockGrinder());
+    } else {
+      _devices.remove("MockGrinder");
     }
     final scale = _devices["MockScale"];
     if (scale is MockScale) {

--- a/lib/src/services/webserver/devices_handler.dart
+++ b/lib/src/services/webserver/devices_handler.dart
@@ -543,6 +543,8 @@ class DevicesHandler {
         } catch (e) {
           return ConnectionResult.failed(e.toString());
         }
+      case DeviceType.grinder:
+        return _connectionManager.connectGrinder(device as Grinder);
     }
   }
 
@@ -572,6 +574,7 @@ class DevicesHandler {
         DeviceType.machine => ConnectionErrorKind.machineConnectFailed,
         DeviceType.scale => ConnectionErrorKind.scaleConnectFailed,
         DeviceType.sensor => ConnectionErrorKind.sensorConnectFailed,
+        DeviceType.grinder => ConnectionErrorKind.grinderConnectFailed,
       },
       severity: ConnectionErrorSeverity.error,
       timestamp: DateTime.now().toUtc(),

--- a/lib/src/services/webserver/grinder_handler.dart
+++ b/lib/src/services/webserver/grinder_handler.dart
@@ -1,0 +1,127 @@
+part of '../webserver_service.dart';
+
+class GrinderHandler {
+  final GrinderController _controller;
+
+  final Logger _log = Logger("Grinder handler");
+
+  GrinderHandler({required GrinderController controller})
+      : _controller = controller;
+
+  StreamSubscription<GrinderSnapshot>? snapshotSub;
+
+  void addRoutes(RouterPlus app) {
+    app.get('/api/v1/grinder', (request) async {
+      final snapshot = _controller.latestSnapshot;
+      if (snapshot == null) {
+        return jsonOk({
+          'connected': _controller.currentConnectionState ==
+              ConnectionState.connected,
+          'snapshot': null,
+        });
+      }
+      return jsonOk({
+        'connected': _controller.currentConnectionState ==
+            ConnectionState.connected,
+        'snapshot': snapshot.toJson(),
+      });
+    });
+
+    app.put('/api/v1/grinder/settings', (request) async {
+      final grinder = _controller.connectedGrinder();
+      final payload = await readBoundedRequestBodyString(
+        request,
+        maxBytes: largeRequestBodyBytes,
+      );
+      final Map<String, dynamic> body;
+      try {
+        body = jsonDecode(payload) as Map<String, dynamic>;
+      } catch (e) {
+        return jsonBadRequest({'error': 'Invalid JSON: $e'});
+      }
+      try {
+        for (final entry in body.entries) {
+          switch (entry.key) {
+            case 'grindSetting':
+              await grinder.setGrindSetting((entry.value as num).toInt());
+            case 'feedingRpm':
+              await grinder.setFeedingRpm((entry.value as num).toInt());
+            case 'grindRpm':
+              await grinder.setGrindRpm((entry.value as num).toInt());
+            case 'brightness':
+              await grinder.setBrightness((entry.value as num).toInt());
+            case 'standbySec':
+              await grinder.setStandbySec((entry.value as num).toInt());
+            case 'cupDetect':
+              await grinder.setCupDetect(entry.value as bool);
+            case 'autoStop':
+              await grinder.setAutoStop(entry.value as bool);
+            case 'fastClean':
+              await grinder.setFastClean(entry.value as bool);
+          }
+        }
+      } catch (e) {
+        return jsonError({'error': e.toString()});
+      }
+      return jsonOk(null);
+    });
+
+    app.put('/api/v1/grinder/<command>', (request, command) async {
+      try {
+        final grinder = _controller.connectedGrinder();
+        switch (command) {
+          case 'start':
+            _log.fine("handling api grinder start");
+            await grinder.start();
+            return jsonOk(null);
+          case 'stop':
+            _log.fine("handling api grinder stop");
+            await grinder.stop();
+            return jsonOk(null);
+          case 'preset':
+            final payload = await readBoundedRequestBodyString(
+              request,
+              maxBytes: largeRequestBodyBytes,
+            );
+            final body = jsonDecode(payload) as Map<String, dynamic>;
+            await grinder.setPreset(uid: body['uid'] as String?);
+            return jsonOk(null);
+          case 'grindSection':
+            final payload = await readBoundedRequestBodyString(
+              request,
+              maxBytes: largeRequestBodyBytes,
+            );
+            final body = jsonDecode(payload) as Map<String, dynamic>;
+            await grinder.setGrindSection(index: body['index'] as int?);
+            return jsonOk(null);
+          case 'querySections':
+            await grinder.querySections();
+            return jsonOk(null);
+          case 'queryPresets':
+            await grinder.queryPresets();
+            return jsonOk(null);
+          default:
+            return jsonNotFound({'error': 'Unknown command: $command'});
+        }
+      } on DeviceNotConnectedException catch (e) {
+        return jsonError({'error': e.toString()});
+      }
+    });
+
+    app.get('/ws/v1/grinder/snapshot', admittedWebSocketHandler(_handleSnapshot));
+  }
+
+  Future<void> _handleSnapshot(
+    WebSocketChannel socket,
+    String? protocol,
+  ) async {
+    snapshotSub = _controller.grinderSnapshot.listen((snapshot) {
+      socket.sink.add(jsonEncode(snapshot.toJson()));
+    });
+    socket.stream.listen(
+      (msg) {},
+      onDone: () => snapshotSub?.cancel(),
+      onError: (e, _) => snapshotSub?.cancel(),
+    );
+  }
+}

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -429,6 +429,7 @@ Handler _init(
   de1Handler.addRoutes(app);
   firmwareHandler.addRoutes(app);
   scaleHandler.addRoutes(app);
+  grinderHandler.addRoutes(app);
   settingsHandler.addRoutes(app);
   sensorsHandler.addRoutes(app);
   workflowHandler.addRoutes(app);

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/controllers/remembered_devices_controller.dart';
 import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/controllers/profile_controller.dart';
+import 'package:reaprime/src/controllers/grinder_controller.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
 import 'package:reaprime/src/controllers/sensor_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
@@ -106,6 +107,7 @@ import 'webserver/feedback_handler.dart';
 
 part 'webserver/de1handler.dart';
 part 'webserver/scale_handler.dart';
+part 'webserver/grinder_handler.dart';
 part 'webserver/devices_handler.dart';
 part 'webserver/settings_handler.dart';
 part 'webserver/sensors_handler.dart';
@@ -177,6 +179,7 @@ Future<void> startWebServer(
     de1Controller: de1Controller,
     settingsController: settingsController,
   );
+  final grinderHandler = GrinderHandler(controller: connectionManager.grinderController);
   final deviceHandler = DevicesHandler(
     controller: deviceController,
     batteryController: batteryController,
@@ -347,6 +350,7 @@ Future<void> startWebServer(
       de1Handler,
       firmwareHandler,
       scaleHandler,
+      grinderHandler,
       settingsHandler,
       sensorsHandler,
       workflowHandler,
@@ -388,6 +392,7 @@ Handler _init(
   De1Handler de1Handler,
   FirmwareHandler firmwareHandler,
   ScaleHandler scaleHandler,
+  GrinderHandler grinderHandler,
   SettingsHandler settingsHandler,
   SensorsHandler sensorsHandler,
   WorkflowHandler workflowHandler,

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -18,6 +18,7 @@ import 'package:reaprime/src/models/data/profile_record.dart';
 import 'package:reaprime/src/models/data/shot_state_event.dart';
 import 'package:reaprime/src/models/data/utils.dart';
 import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/grinder.dart';
 import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/scale_calibration.dart';
 import 'package:reaprime/src/models/errors.dart';

--- a/lib/src/settings/device_management_page.dart
+++ b/lib/src/settings/device_management_page.dart
@@ -51,6 +51,9 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
   List<Device> get _scales =>
       _devices.where((d) => d.type == DeviceType.scale).toList();
 
+  List<Device> get _grinders =>
+      _devices.where((d) => d.type == DeviceType.grinder).toList();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -86,6 +89,17 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
                     emptyLabel: 'scales',
                     onSelected: (id) async {
                       await widget.settingsController.setPreferredScaleId(id);
+                      if (mounted) _showSavedSnackbar();
+                    },
+                  ),
+                  _buildSection(
+                    title: 'Auto-connect Grinder',
+                    icon: Icons.blender_outlined,
+                    devices: _grinders,
+                    selectedId: widget.settingsController.preferredGrinderId,
+                    emptyLabel: 'grinders',
+                    onSelected: (id) async {
+                      await widget.settingsController.setPreferredGrinderId(id);
                       if (mounted) _showSavedSnackbar();
                     },
                   ),

--- a/lib/src/settings/settings_controller.dart
+++ b/lib/src/settings/settings_controller.dart
@@ -42,6 +42,8 @@ class SettingsController with ChangeNotifier {
 
   String? _preferredScaleId;
 
+  String? _preferredGrinderId;
+
   String _defaultSkinId = 'streamline.js';
 
   bool _automaticUpdateCheck = true;
@@ -87,6 +89,7 @@ class SettingsController with ChangeNotifier {
   bool get stopHotWaterAtWeight => _stopHotWaterAtWeight;
   String? get preferredMachineId => _preferredMachineId;
   String? get preferredScaleId => _preferredScaleId;
+  String? get preferredGrinderId => _preferredGrinderId;
   String get defaultSkinId => _defaultSkinId;
   bool get automaticUpdateCheck => _automaticUpdateCheck;
   UpdateChannel get updateChannel => _updateChannel;
@@ -127,6 +130,7 @@ class SettingsController with ChangeNotifier {
     _stopHotWaterAtWeight = await _settingsService.stopHotWaterAtWeight();
     _preferredMachineId = await _settingsService.preferredMachineId();
     _preferredScaleId = await _settingsService.preferredScaleId();
+    _preferredGrinderId = await _settingsService.preferredGrinderId();
     _defaultSkinId = await _settingsService.defaultSkinId();
     _automaticUpdateCheck = await _settingsService.automaticUpdateCheck();
     _updateChannel = await _settingsService.updateChannel();
@@ -236,6 +240,9 @@ class SettingsController with ChangeNotifier {
     _preferredScaleId = devices.contains(SimulatedDevicesTypes.scale)
         ? 'MockScale'
         : null;
+    _preferredGrinderId = devices.contains(SimulatedDevicesTypes.grinder)
+        ? 'MockGrinder'
+        : null;
     notifyListeners();
   }
 
@@ -317,6 +324,15 @@ class SettingsController with ChangeNotifier {
     }
     _preferredScaleId = scaleId;
     await _settingsService.setPreferredScaleId(scaleId);
+    notifyListeners();
+  }
+
+  Future<void> setPreferredGrinderId(String? grinderId) async {
+    if (grinderId == _preferredGrinderId) {
+      return;
+    }
+    _preferredGrinderId = grinderId;
+    await _settingsService.setPreferredGrinderId(grinderId);
     notifyListeners();
   }
 

--- a/lib/src/settings/settings_service.dart
+++ b/lib/src/settings/settings_service.dart
@@ -34,6 +34,8 @@ abstract class SettingsService {
   Future<void> setPreferredMachineId(String? machineId);
   Future<String?> preferredScaleId();
   Future<void> setPreferredScaleId(String? scaleId);
+  Future<String?> preferredGrinderId();
+  Future<void> setPreferredGrinderId(String? grinderId);
   Future<String> defaultSkinId();
   Future<void> setDefaultSkinId(String skinId);
   Future<bool> automaticUpdateCheck();
@@ -248,6 +250,20 @@ class SharedPreferencesSettingsService extends SettingsService {
       await prefs.remove(SettingsKeys.preferredScaleId.name);
     } else {
       await prefs.setString(SettingsKeys.preferredScaleId.name, scaleId);
+    }
+  }
+
+  @override
+  Future<String?> preferredGrinderId() async {
+    return await prefs.getString(SettingsKeys.preferredGrinderId.name);
+  }
+
+  @override
+  Future<void> setPreferredGrinderId(String? grinderId) async {
+    if (grinderId == null) {
+      await prefs.remove(SettingsKeys.preferredGrinderId.name);
+    } else {
+      await prefs.setString(SettingsKeys.preferredGrinderId.name, grinderId);
     }
   }
 
@@ -536,6 +552,7 @@ enum SettingsKeys {
   stopHotWaterAtWeight,
   preferredMachineId,
   preferredScaleId,
+  preferredGrinderId,
   defaultSkinId,
   automaticUpdateCheck,
   updateChannel,
@@ -561,7 +578,7 @@ enum SettingsKeys {
   enableSimulatedWebViews,
 }
 
-enum SimulatedDevicesTypes { machine, scale, sensor, bengle, replay }
+enum SimulatedDevicesTypes { machine, scale, sensor, bengle, replay, grinder }
 
 extension SimulatedDevicesTypesFromString on SimulatedDevicesTypes {
   static SimulatedDevicesTypes? fromString(String value) {

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -2340,7 +2340,7 @@ void main() {
         );
         expect(
           connectionManager.currentStatus.conditions.single.affectedDeviceTypes,
-          {DeviceType.machine, DeviceType.scale},
+          {DeviceType.machine, DeviceType.scale, DeviceType.grinder},
         );
       });
 

--- a/test/controllers/de1_controller_test.dart
+++ b/test/controllers/de1_controller_test.dart
@@ -124,25 +124,31 @@ void main() {
   });
 
   group('initial shot settings', () {
-    test('missing initial settings do not block initialization', () async {
-      final deviceController = DeviceController([MockDeviceDiscoveryService()]);
-      await deviceController.initialize();
-      final de1Controller = De1Controller(controller: deviceController);
-      final testDe1 = TestDe1();
+    test(
+      'missing initial settings do not block initialization',
+      () async {
+        final deviceController = DeviceController([
+          MockDeviceDiscoveryService(),
+        ]);
+        await deviceController.initialize();
+        final de1Controller = De1Controller(controller: deviceController);
+        final testDe1 = TestDe1();
 
-      await de1Controller.connectToDe1(testDe1);
+        await de1Controller.connectToDe1(testDe1);
 
-      expect(
-        await de1Controller.initSettled
-            .firstWhere((generation) => generation != null)
-            .timeout(const Duration(seconds: 3)),
-        isNotNull,
-      );
-      expect(de1Controller.connectedDe1OrNull, same(testDe1));
+        expect(
+          await de1Controller.initSettled
+              .firstWhere((generation) => generation != null)
+              .timeout(const Duration(seconds: 3)),
+          isNotNull,
+        );
+        expect(de1Controller.connectedDe1OrNull, same(testDe1));
 
-      testDe1.dispose();
-      de1Controller.dispose();
-    }, timeout: const Timeout(Duration(seconds: 5)));
+        testDe1.dispose();
+        de1Controller.dispose();
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
   });
 
   group('shot-settings debounce race (comms-harden #5)', () {

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -1608,12 +1608,11 @@ void main() {
           [0.0, 0.0, 0.0, 18.0],
           reason: 'pre-tare frames are 0; real weight only after the pour tare',
         );
-        expect(recorded.map((s) => s.scale?.weightFlow).toList(), [
-          0.0,
-          0.0,
-          0.0,
-          2.0,
-        ], reason: 'flow off the un-tared cup must not leak either');
+        expect(
+          recorded.map((s) => s.scale?.weightFlow).toList(),
+          [0.0, 0.0, 0.0, 2.0],
+          reason: 'flow off the un-tared cup must not leak either',
+        );
 
         shotSequencer.dispose();
       });

--- a/test/controllers/workflow_device_sync_test.dart
+++ b/test/controllers/workflow_device_sync_test.dart
@@ -398,9 +398,11 @@ void main() {
 
         applyProfile('A');
         await Future<void>.delayed(const Duration(milliseconds: 10));
-        expect(gated.setProfileCalls.map((p) => p.title), [
-          'A',
-        ], reason: 'first change starts an upload immediately');
+        expect(
+          gated.setProfileCalls.map((p) => p.title),
+          ['A'],
+          reason: 'first change starts an upload immediately',
+        );
 
         applyProfile('B');
         applyProfile('C');
@@ -413,10 +415,11 @@ void main() {
 
         gated.completeNext();
         await Future<void>.delayed(const Duration(milliseconds: 10));
-        expect(gated.setProfileCalls.map((p) => p.title), [
-          'A',
-          'C',
-        ], reason: 'B was superseded by C before its upload started');
+        expect(
+          gated.setProfileCalls.map((p) => p.title),
+          ['A', 'C'],
+          reason: 'B was superseded by C before its upload started',
+        );
 
         gated.completeNext();
         await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -449,9 +452,11 @@ void main() {
         );
 
         await Future<void>.delayed(const Duration(milliseconds: 40));
-        expect(flaky.setProfileCalls.map((p) => p.title), [
-          'Cleaning',
-        ], reason: 'retry must fire without any further workflow change');
+        expect(
+          flaky.setProfileCalls.map((p) => p.title),
+          ['Cleaning'],
+          reason: 'retry must fire without any further workflow change',
+        );
       },
     );
 
@@ -468,9 +473,11 @@ void main() {
       applyProfile('B');
 
       await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(flaky.setProfileCalls.map((p) => p.title), [
-        'B',
-      ], reason: 'superseded profile A must never be uploaded');
+      expect(
+        flaky.setProfileCalls.map((p) => p.title),
+        ['B'],
+        reason: 'superseded profile A must never be uploaded',
+      );
     });
 
     test('backoff walks the delay list until the upload lands', () async {
@@ -568,11 +575,11 @@ void main() {
       gated.completeNext();
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      expect(gated.setProfileCalls.map((p) => p.title), [
-        'P1',
-        'P2',
-        'P1',
-      ], reason: 'device must converge to the workflow profile, not P2');
+      expect(
+        gated.setProfileCalls.map((p) => p.title),
+        ['P1', 'P2', 'P1'],
+        reason: 'device must converge to the workflow profile, not P2',
+      );
 
       gated.completeNext();
       await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -873,9 +880,11 @@ void main() {
       expect(steamEvents, hasLength(steamEventCountAfterBInit));
       expect(hotWaterEvents, hasLength(hotWaterEventCountAfterBInit));
       expect(rinseEvents, hasLength(rinseEventCountAfterBInit));
-      expect(de1B.setProfileCalls.map((p) => p.title), [
-        'Persisted',
-      ], reason: 'B should receive the profile via initSettled');
+      expect(
+        de1B.setProfileCalls.map((p) => p.title),
+        ['Persisted'],
+        reason: 'B should receive the profile via initSettled',
+      );
     });
 
     test('stale init does not emit B\'s generation', () async {

--- a/test/helpers/mock_settings_service.dart
+++ b/test/helpers/mock_settings_service.dart
@@ -20,6 +20,7 @@ class MockSettingsService extends SettingsService {
   bool _stopHotWaterAtWeight = true;
   String? _preferredMachineId;
   String? _preferredScaleId;
+  String? _preferredGrinderId;
   String _defaultSkinId = 'streamline.js';
   bool _automaticUpdateCheck = true;
   UpdateChannel _updateChannel = UpdateChannel.stable;
@@ -118,6 +119,11 @@ class MockSettingsService extends SettingsService {
   @override
   Future<void> setPreferredScaleId(String? scaleId) async =>
       _preferredScaleId = scaleId;
+  @override
+  Future<String?> preferredGrinderId() async => _preferredGrinderId;
+  @override
+  Future<void> setPreferredGrinderId(String? grinderId) async =>
+      _preferredGrinderId = grinderId;
   @override
   Future<String> defaultSkinId() async => _defaultSkinId;
   @override

--- a/test/profiles/default_profiles_migration_test.dart
+++ b/test/profiles/default_profiles_migration_test.dart
@@ -219,10 +219,11 @@ void main() {
       expect(storage.records[v3Id]!.parentId, v2Id);
 
       final lineage = await controller.getLineage(v3Id);
-      expect(lineage.map((r) => r.id).toList(), [
-        v2Id,
-        v3Id,
-      ], reason: 'lineage walks from v3 back to its v2 parent');
+      expect(
+        lineage.map((r) => r.id).toList(),
+        [v2Id, v3Id],
+        reason: 'lineage walks from v3 back to its v2 parent',
+      );
     },
   );
 }

--- a/test/rest_simulated_bengle_schema_test.dart
+++ b/test/rest_simulated_bengle_schema_test.dart
@@ -7,7 +7,7 @@ void main() {
     final spec = await File('assets/api/rest_v1.yml').readAsString();
     expect(
       RegExp(
-        r'enum: \[machine, scale, sensor, bengle\]',
+        r'enum: \[machine, scale, sensor, bengle, grinder\]',
       ).allMatches(spec).length,
       2,
     );

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -410,9 +410,11 @@ void main() {
         final prefixes = platform.startScanCalls
             .map((c) => c.filter?.withNamePrefix ?? const <String>[])
             .toList();
-        expect(prefixes.first, [
-          'Decent Scale',
-        ], reason: 'the raced watch start settles before the burst starts');
+        expect(
+          prefixes.first,
+          ['Decent Scale'],
+          reason: 'the raced watch start settles before the burst starts',
+        );
         expect(
           prefixes[1],
           isEmpty,

--- a/test/tools/generate_simulation_assets_test.dart
+++ b/test/tools/generate_simulation_assets_test.dart
@@ -206,101 +206,105 @@ void main() {
     );
   });
 
-  test('regenerate bundled simulation shots', () {
-    Directory(outputDir).createSync(recursive: true);
+  test(
+    'regenerate bundled simulation shots',
+    () {
+      Directory(outputDir).createSync(recursive: true);
 
-    (String, double) convert(File source) {
-      final stem = source.uri.pathSegments.last.replaceAll('.shot', '');
-      final content = source.readAsStringSync();
-      final map = TclParser.parse(content);
-      final parsed = TclShotParser.parse(content);
-      final framed = _withFrames(
-        parsed.shot.measurements,
-        map['espresso_state_change'],
-      );
-      final resampled = _resampleTo10Hz(framed);
-      final originalDuration = _durationSeconds(resampled);
-      final shot = parsed.shot.copyWith(
-        measurements: _extendTo(resampled, _targetDurationSeconds),
-      );
-
-      final json = shot.toJson();
-      json['id'] = 'sim-$stem';
-      final workflow = json['workflow'];
-      if (workflow is Map) {
-        workflow['id'] = 'sim-$stem-workflow';
-        final first = shot.measurements.first.machine;
-        final durationSeconds =
-            shot.measurements.last.machine.timestamp
-                .difference(first.timestamp)
-                .inMilliseconds /
-            1000.0;
-        final replayStep = ProfileStepPressure(
-          name: 'Replay',
-          transition: TransitionType.fast,
-          volume: 0,
-          seconds: durationSeconds,
-          temperature: first.targetGroupTemperature > 0
-              ? first.targetGroupTemperature
-              : 90,
-          sensor: TemperatureSensor.coffee,
-          pressure: first.targetPressure > 0 ? first.targetPressure : 9,
+      (String, double) convert(File source) {
+        final stem = source.uri.pathSegments.last.replaceAll('.shot', '');
+        final content = source.readAsStringSync();
+        final map = TclParser.parse(content);
+        final parsed = TclShotParser.parse(content);
+        final framed = _withFrames(
+          parsed.shot.measurements,
+          map['espresso_state_change'],
         );
-        final profile = workflow['profile'];
-        if (profile is Map) {
-          profile['steps'] = [replayStep.toJson()];
+        final resampled = _resampleTo10Hz(framed);
+        final originalDuration = _durationSeconds(resampled);
+        final shot = parsed.shot.copyWith(
+          measurements: _extendTo(resampled, _targetDurationSeconds),
+        );
+
+        final json = shot.toJson();
+        json['id'] = 'sim-$stem';
+        final workflow = json['workflow'];
+        if (workflow is Map) {
+          workflow['id'] = 'sim-$stem-workflow';
+          final first = shot.measurements.first.machine;
+          final durationSeconds =
+              shot.measurements.last.machine.timestamp
+                  .difference(first.timestamp)
+                  .inMilliseconds /
+              1000.0;
+          final replayStep = ProfileStepPressure(
+            name: 'Replay',
+            transition: TransitionType.fast,
+            volume: 0,
+            seconds: durationSeconds,
+            temperature: first.targetGroupTemperature > 0
+                ? first.targetGroupTemperature
+                : 90,
+            sensor: TemperatureSensor.coffee,
+            pressure: first.targetPressure > 0 ? first.targetPressure : 9,
+          );
+          final profile = workflow['profile'];
+          if (profile is Map) {
+            profile['steps'] = [replayStep.toJson()];
+          }
         }
+
+        final roundTripped = ShotRecord.fromJson(
+          jsonDecode(jsonEncode(json)) as Map<String, dynamic>,
+        );
+        expect(roundTripped.measurements, isNotEmpty);
+
+        // Compact (unindented) — these are generated, machine-read data files;
+        // indentation would roughly double the bundled size.
+        File('$outputDir/$stem.json').writeAsStringSync(jsonEncode(json));
+        return ('$stem.json', originalDuration);
       }
 
-      final roundTripped = ShotRecord.fromJson(
-        jsonDecode(jsonEncode(json)) as Map<String, dynamic>,
+      List<File> shotsIn(String dir) => Directory(dir).existsSync()
+          ? (Directory(dir)
+                .listSync()
+                .whereType<File>()
+                .where((f) => f.path.endsWith('.shot'))
+                .toList()
+              ..sort((a, b) => a.path.compareTo(b.path)))
+          : <File>[];
+
+      final fallbackSources = shotsIn(sourceDir);
+      expect(fallbackSources, isNotEmpty, reason: 'no fallback .shot sources');
+      final fallback = fallbackSources.map((s) {
+        final (file, original) = convert(s);
+        return {'file': file, 'originalDurationSeconds': original};
+      }).toList();
+
+      final profiles = <Map<String, dynamic>>[];
+      for (final source in shotsIn(profileDir)) {
+        final stem = source.uri.pathSegments.last.replaceAll('.shot', '');
+        final bundledProfile = File('assets/defaultProfiles/$stem.json');
+        final title = bundledProfile.existsSync()
+            ? (jsonDecode(bundledProfile.readAsStringSync())
+                      as Map<String, dynamic>)['title']
+                  as String
+            : TclShotParser.parse(source.readAsStringSync()).shot.workflow.name;
+        final (file, original) = convert(source);
+        profiles.add({
+          'file': file,
+          'profileTitle': title,
+          'profileFile': '$stem.json',
+          'originalDurationSeconds': original,
+        });
+      }
+
+      File('$outputDir/manifest.json').writeAsStringSync(
+        const JsonEncoder.withIndent(
+          '  ',
+        ).convert({'fallback': fallback, 'profiles': profiles}),
       );
-      expect(roundTripped.measurements, isNotEmpty);
-
-      // Compact (unindented) — these are generated, machine-read data files;
-      // indentation would roughly double the bundled size.
-      File('$outputDir/$stem.json').writeAsStringSync(jsonEncode(json));
-      return ('$stem.json', originalDuration);
-    }
-
-    List<File> shotsIn(String dir) => Directory(dir).existsSync()
-        ? (Directory(dir)
-              .listSync()
-              .whereType<File>()
-              .where((f) => f.path.endsWith('.shot'))
-              .toList()
-            ..sort((a, b) => a.path.compareTo(b.path)))
-        : <File>[];
-
-    final fallbackSources = shotsIn(sourceDir);
-    expect(fallbackSources, isNotEmpty, reason: 'no fallback .shot sources');
-    final fallback = fallbackSources.map((s) {
-      final (file, original) = convert(s);
-      return {'file': file, 'originalDurationSeconds': original};
-    }).toList();
-
-    final profiles = <Map<String, dynamic>>[];
-    for (final source in shotsIn(profileDir)) {
-      final stem = source.uri.pathSegments.last.replaceAll('.shot', '');
-      final bundledProfile = File('assets/defaultProfiles/$stem.json');
-      final title = bundledProfile.existsSync()
-          ? (jsonDecode(bundledProfile.readAsStringSync())
-                    as Map<String, dynamic>)['title']
-                as String
-          : TclShotParser.parse(source.readAsStringSync()).shot.workflow.name;
-      final (file, original) = convert(source);
-      profiles.add({
-        'file': file,
-        'profileTitle': title,
-        'profileFile': '$stem.json',
-        'originalDurationSeconds': original,
-      });
-    }
-
-    File('$outputDir/manifest.json').writeAsStringSync(
-      const JsonEncoder.withIndent(
-        '  ',
-      ).convert({'fallback': fallback, 'profiles': profiles}),
-    );
-  }, skip: regenerate ? false : 'set REGEN_SIM_ASSETS=1 to rebuild assets');
+    },
+    skip: regenerate ? false : 'set REGEN_SIM_ASSETS=1 to rebuild assets',
+  );
 }

--- a/test/unit/controllers/grinder_controller_test.dart
+++ b/test/unit/controllers/grinder_controller_test.dart
@@ -80,7 +80,7 @@ class _FakeGrinder implements Grinder {
   Future<void> setGrindRpm(int rpm) async {}
 
   @override
-  Future<void> setBladeGap(int micrometers) async {}
+  Future<void> setGrindSetting(int value) async {}
 
   @override
   Future<void> setBrightness(int level) async {}

--- a/test/unit/controllers/grinder_controller_test.dart
+++ b/test/unit/controllers/grinder_controller_test.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/grinder_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/grinder.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _FakeGrinder implements Grinder {
+  _FakeGrinder(this._id, {bool failConnect = false}) : _failConnect = failConnect;
+
+  final String _id;
+  final bool _failConnect;
+
+  final BehaviorSubject<ConnectionState> states = BehaviorSubject.seeded(
+    ConnectionState.discovered,
+  );
+  final StreamController<GrinderSnapshot> snapshots =
+      StreamController.broadcast();
+
+  @override
+  String get deviceId => _id;
+
+  @override
+  String get name => 'Fake Grinder';
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.bookooGrinder;
+
+  @override
+  TransportType get transportType => TransportType.ble;
+
+  @override
+  Stream<ConnectionState> get connectionState => states.stream;
+
+  @override
+  Stream<GrinderSnapshot> get currentSnapshot => snapshots.stream;
+
+  @override
+  DeviceType get type => DeviceType.grinder;
+
+  @override
+  Future<void> onConnect() async {
+    if (_failConnect) throw StateError('connect failed');
+    states.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async => states.add(ConnectionState.disconnected);
+
+  @override
+  Future<void> start() async {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> setGrindSection({int? index, String? name}) async {}
+
+  @override
+  Future<void> setPreset({String? uid, int? index}) async {}
+
+  @override
+  Future<void> setFeedingRpm(int rpm) async {}
+
+  @override
+  Future<void> setGrindRpm(int rpm) async {}
+
+  @override
+  Future<void> setBladeGap(int micrometers) async {}
+
+  @override
+  Future<void> setBrightness(int level) async {}
+
+  @override
+  Future<void> setStandbySec(int seconds) async {}
+
+  @override
+  Future<void> setCupDetect(bool enabled) async {}
+
+  @override
+  Future<void> setAutoStop(bool enabled) async {}
+
+  @override
+  Future<void> setFastClean(bool enabled) async {}
+
+  @override
+  Future<void> reboot() async {}
+}
+
+GrinderSnapshot _snapshot({GrinderDevState devState = GrinderDevState.idle}) {
+  return GrinderSnapshot(timestamp: DateTime.now(), devState: devState);
+}
+
+void main() {
+  test('connectToGrinder forwards snapshots and connection state', () async {
+    final controller = GrinderController();
+    final grinder = _FakeGrinder('grinder-1');
+    final snapshots = <GrinderSnapshot>[];
+    final states = <ConnectionState>[];
+    controller.grinderSnapshot.listen(snapshots.add);
+    controller.connectionState.listen(states.add);
+
+    await controller.connectToGrinder(grinder);
+    grinder.snapshots.add(_snapshot(devState: GrinderDevState.grinding));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.lastConnectedDeviceId, 'grinder-1');
+    expect(controller.connectedGrinder(), same(grinder));
+    expect(snapshots.single.devState, GrinderDevState.grinding);
+    expect(
+      controller.currentConnectionState,
+      ConnectionState.connected,
+    );
+
+    controller.dispose();
+    await grinder.snapshots.close();
+    await grinder.states.close();
+  });
+
+  test('connectToGrinder throws when onConnect fails', () async {
+    final controller = GrinderController();
+    final grinder = _FakeGrinder('grinder-2', failConnect: true);
+
+    await expectLater(
+      controller.connectToGrinder(grinder),
+      throwsStateError,
+    );
+    expect(controller.currentConnectionState, ConnectionState.disconnected);
+
+    controller.dispose();
+    await grinder.states.close();
+  });
+
+  test('connectedGrinder throws when no grinder is connected', () {
+    final controller = GrinderController();
+    expect(
+      () => controller.connectedGrinder(),
+      throwsA(isA<DeviceNotConnectedException>()),
+    );
+    controller.dispose();
+  });
+
+  test('adoptGrinder accepts an already-connected grinder', () async {
+    final controller = GrinderController();
+    final grinder = _FakeGrinder('grinder-3');
+    await grinder.onConnect();
+
+    await controller.adoptGrinder(grinder);
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.lastConnectedDeviceId, 'grinder-3');
+    expect(controller.currentConnectionState, ConnectionState.connected);
+
+    controller.dispose();
+    await grinder.states.close();
+  });
+}

--- a/test/unit/controllers/grinder_controller_test.dart
+++ b/test/unit/controllers/grinder_controller_test.dart
@@ -10,7 +10,8 @@ import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
 
 class _FakeGrinder implements Grinder {
-  _FakeGrinder(this._id, {bool failConnect = false}) : _failConnect = failConnect;
+  _FakeGrinder(this._id, {bool failConnect = false})
+    : _failConnect = failConnect;
 
   final String _id;
   final bool _failConnect;
@@ -52,10 +53,19 @@ class _FakeGrinder implements Grinder {
   Future<void> disconnect() async => states.add(ConnectionState.disconnected);
 
   @override
+  Stream<GrinderLogEntry> get logStream => const Stream.empty();
+
+  @override
   Future<void> start() async {}
 
   @override
   Future<void> stop() async {}
+
+  @override
+  Future<void> querySections() async {}
+
+  @override
+  Future<void> queryPresets() async {}
 
   @override
   Future<void> setGrindSection({int? index, String? name}) async {}
@@ -111,10 +121,7 @@ void main() {
     expect(controller.lastConnectedDeviceId, 'grinder-1');
     expect(controller.connectedGrinder(), same(grinder));
     expect(snapshots.single.devState, GrinderDevState.grinding);
-    expect(
-      controller.currentConnectionState,
-      ConnectionState.connected,
-    );
+    expect(controller.currentConnectionState, ConnectionState.connected);
 
     controller.dispose();
     await grinder.snapshots.close();
@@ -125,10 +132,7 @@ void main() {
     final controller = GrinderController();
     final grinder = _FakeGrinder('grinder-2', failConnect: true);
 
-    await expectLater(
-      controller.connectToGrinder(grinder),
-      throwsStateError,
-    );
+    await expectLater(controller.connectToGrinder(grinder), throwsStateError);
     expect(controller.currentConnectionState, ConnectionState.disconnected);
 
     controller.dispose();

--- a/test/unit/controllers/remembered_devices_controller_test.dart
+++ b/test/unit/controllers/remembered_devices_controller_test.dart
@@ -81,9 +81,11 @@ void main() {
     scale.add(null);
     await Future.delayed(Duration.zero);
 
-    expect(controller.remembered.map((d) => d.id), [
-      's',
-    ], reason: 'disconnect keeps it remembered');
+    expect(
+      controller.remembered.map((d) => d.id),
+      ['s'],
+      reason: 'disconnect keeps it remembered',
+    );
   });
 
   test('registry restores from settings on init', () async {
@@ -191,10 +193,11 @@ void main() {
       );
       await Future.delayed(Duration.zero);
 
-      expect(controller.remembered.map((d) => d.id).toSet(), {
-        'wifi:hds.local',
-        'AA:BB:CC:DD:EE:FF',
-      }, reason: 'same name, distinct ids → distinct entries');
+      expect(
+        controller.remembered.map((d) => d.id).toSet(),
+        {'wifi:hds.local', 'AA:BB:CC:DD:EE:FF'},
+        reason: 'same name, distinct ids → distinct entries',
+      );
     },
   );
 
@@ -233,9 +236,11 @@ void main() {
       throwsA(isA<StateError>()),
       reason: 'the awaitable forget path must not swallow a persist failure',
     );
-    expect(controller.remembered.map((d) => d.id), [
-      'a',
-    ], reason: 'a failed persist rolls back the removal (memory matches disk)');
+    expect(
+      controller.remembered.map((d) => d.id),
+      ['a'],
+      reason: 'a failed persist rolls back the removal (memory matches disk)',
+    );
   });
 
   test(
@@ -267,9 +272,11 @@ void main() {
       controller = build();
       await controller.initialize();
 
-      expect(controller.remembered.map((d) => d.id), [
-        'a',
-      ], reason: 'an unreadable record must not abort the whole load');
+      expect(
+        controller.remembered.map((d) => d.id),
+        ['a'],
+        reason: 'an unreadable record must not abort the whole load',
+      );
     },
   );
 

--- a/test/unit/models/bookoo_grinder_test.dart
+++ b/test/unit/models/bookoo_grinder_test.dart
@@ -1,0 +1,410 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/grinder.dart';
+import 'package:reaprime/src/models/device/impl/bookoo/bookoo_grinder.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _BookooTransport extends BLETransport {
+  final BehaviorSubject<ConnectionState> states = BehaviorSubject.seeded(
+    ConnectionState.discovered,
+  );
+  final List<List<int>> writes = [];
+  void Function(Uint8List)? notification;
+  Object? writeError;
+  bool failConnect = false;
+  List<String> discoverServicesOverride = [];
+
+  @override
+  Future<List<String>> discoverServices() async =>
+      discoverServicesOverride.isEmpty
+          ? [BookooGrinder.serviceIdentifier.long]
+          : discoverServicesOverride;
+
+  @override
+  String get id => 'motto80-test';
+
+  @override
+  String get name => 'MOTTO80 BLE';
+
+  @override
+  Stream<ConnectionState> get connectionState => states.stream;
+
+  @override
+  Future<ConnectionState> getConnectionState() async => states.value;
+
+  @override
+  Future<void> connect() async {
+    if (failConnect) throw StateError('connect failed');
+    states.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async => states.add(ConnectionState.disconnected);
+
+  @override
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) async => Uint8List(0);
+
+  @override
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) async {
+    notification = callback;
+  }
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {
+    writes.add(data.toList());
+    final error = writeError;
+    if (error != null) throw error;
+  }
+
+  void emit(List<int> data) => notification!(Uint8List.fromList(data));
+
+  @override
+  Future<void> setTransportPriority(bool prioritized) async {}
+
+  @override
+  Future<void> dispose() async => states.close();
+}
+
+Uint8List _frame(int seq, String jsonPayload) {
+  final payload = utf8.encode(jsonPayload);
+  final frame = Uint8List(8 + payload.length);
+  final view = ByteData.sublistView(frame);
+  frame[0] = 0xA5;
+  frame[1] = 0x01;
+  view.setUint16(2, seq & 0xffff, Endian.little);
+  view.setUint32(4, payload.length, Endian.little);
+  frame.setRange(8, 8 + payload.length, payload);
+  return frame;
+}
+
+BookooGrinder _grinder(_BookooTransport transport) => BookooGrinder(
+  transport: transport,
+  queryGap: Duration.zero,
+);
+
+void main() {
+  late _BookooTransport transport;
+  late BookooGrinder grinder;
+  late List<GrinderSnapshot> snapshots;
+
+  setUp(() async {
+    transport = _BookooTransport();
+    grinder = _grinder(transport);
+    snapshots = [];
+    await grinder.onConnect();
+    for (var i = 0; i < 3; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    grinder.currentSnapshot.listen(snapshots.add);
+  });
+
+  tearDown(() async {
+    await grinder.disconnect();
+    await transport.dispose();
+  });
+
+  test('onConnect subscribes and sends the startup query sequence', () {
+    final encoded = transport.writes.map(_decodeWrite).toList();
+    expect(encoded[0], {'request': {'appHello': {'op': 'handshake'}}});
+    expect(encoded[1], {
+      'request': {
+        'grindSection': {'op': 'get', 'selector': {'type': 'all'}},
+      },
+    });
+    expect(encoded[2], {
+      'request': {
+        'grindPreset': {'op': 'get', 'selector': {'type': 'all'}},
+      },
+    });
+  });
+
+  test('frames carry the A5 01 header, little-endian seq, and length', () {
+    final first = transport.writes[0];
+    expect(first[0], 0xA5);
+    expect(first[1], 0x01);
+    expect(first[2], 0x00); // seq 0
+    expect(first[3], 0x00);
+    final second = transport.writes[1];
+    expect(second[2], 0x01); // seq 1
+    final third = transport.writes[2];
+    expect(third[2], 0x02); // seq 2
+    final payloadLen = ByteData.sublistView(Uint8List.fromList(first))
+        .getUint32(4, Endian.little);
+    expect(payloadLen, first.length - 8);
+  });
+
+  test('decodes a broadcast frame into a snapshot', () async {
+    transport.emit(
+      _frame(
+        0x1001,
+        jsonEncode({
+          'fields': {
+            'devState': 'GRINDING',
+            'feedingRpm': 30,
+            'grindRpm': 800,
+            'bladeGap': 400,
+            'humidity': 55,
+            'totalGrinds': 1234,
+            'cupDetect': true,
+            'autoStop': false,
+            'fastClean': false,
+            'brightness': 5,
+            'standbySec': 300,
+            'snCode': 'M80-0001',
+            'releaseVer': '1.0.0',
+          },
+        }),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    final s = snapshots.single;
+    expect(s.devState, GrinderDevState.grinding);
+    expect(s.feedingRpm, 30);
+    expect(s.grindRpm, 800);
+    expect(s.bladeGap, 400);
+    expect(s.humidity, 55);
+    expect(s.totalGrinds, 1234);
+    expect(s.cupDetect, isTrue);
+    expect(s.autoStop, isFalse);
+    expect(s.snCode, 'M80-0001');
+  });
+
+  test('later broadcasts merge, retaining missing fields', () async {
+    transport.emit(_frame(0x2001, jsonEncode({'fields': {'devState': 'IDLE'}})));
+    await Future<void>.delayed(Duration.zero);
+    transport.emit(
+      _frame(0x2002, jsonEncode({'fields': {'grindRpm': 900}})),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(snapshots.last.devState, GrinderDevState.idle);
+    expect(snapshots.last.grindRpm, 900);
+  });
+
+  test('parses presets and sections from query responses', () async {
+    transport.emit(
+      _frame(
+        0x3001,
+        jsonEncode({
+          'request': {
+            'grindPreset': {
+              'op': 'get',
+              'response': [
+                {'uid': 'aabb', 'name': 'Espresso Fine'},
+                {'uid': 'ccdd', 'name': 'Pour Over'},
+              ],
+            },
+          },
+        }),
+      ),
+    );
+    transport.emit(
+      _frame(
+        0x3002,
+        jsonEncode({
+          'request': {
+            'grindSection': {
+              'op': 'get',
+              'response': [
+                {'index': 0, 'name': 'Fine'},
+                {'index': 1, 'name': 'Coarse'},
+              ],
+            },
+          },
+        }),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    final s = snapshots.last;
+    expect(s.presets.map((p) => p.name), ['Espresso Fine', 'Pour Over']);
+    expect(s.presets.first.uid, 'aabb');
+    expect(s.grindSections.map((g) => g.name), ['Fine', 'Coarse']);
+    expect(s.grindSections.first.index, 0);
+  });
+
+  test('reassembles a fragmented frame with repeated header', () async {
+    final full = _frame(
+      0x4001,
+      jsonEncode({
+        'fields': {'devState': 'GRINDING', 'grindRpm': 750},
+      }),
+    );
+    transport.emit(full.sublist(0, 10));
+    transport.emit([...full.sublist(0, 8), ...full.sublist(10, 20)]);
+    transport.emit(full.sublist(20));
+    await Future<void>.delayed(Duration.zero);
+    expect(snapshots.single.devState, GrinderDevState.grinding);
+    expect(snapshots.single.grindRpm, 750);
+  });
+
+  test('reassembles headerless continuation fragments', () async {
+    final full = _frame(
+      0x4002,
+      jsonEncode({
+        'fields': {'devState': 'IDLE', 'bladeGap': 300},
+      }),
+    );
+    transport.emit(full.sublist(0, 12));
+    transport.emit(full.sublist(12, 20));
+    transport.emit(full.sublist(20));
+    await Future<void>.delayed(Duration.zero);
+    expect(snapshots.single.devState, GrinderDevState.idle);
+    expect(snapshots.single.bladeGap, 300);
+  });
+
+  test('decodes UTF-8 split across fragment boundaries', () async {
+    final payload = utf8.encode(
+      jsonEncode({
+        'request': {
+          'grindPreset': {
+            'op': 'get',
+            'response': [
+              {'uid': 'aa', 'name': '意式中深'},
+            ],
+          },
+        },
+      }),
+    );
+    // Split inside the multibyte characters of 意式中深
+    final split = _findMultibyteSplit(payload);
+    final frame = Uint8List(8 + payload.length);
+    final view = ByteData.sublistView(frame);
+    frame[0] = 0xA5;
+    frame[1] = 0x01;
+    view.setUint32(4, payload.length, Endian.little);
+    frame.setRange(8, 8 + payload.length, payload);
+    transport.emit(frame.sublist(0, split));
+    transport.emit(frame.sublist(split));
+    await Future<void>.delayed(Duration.zero);
+    expect(snapshots.single.presets.single.name, '意式中深');
+  });
+
+  test('different-seq new frame drops stale pending', () async {
+    final first = _frame(
+      0x5001,
+      jsonEncode({
+        'fields': {'devState': 'GRINDING'},
+      }),
+    );
+    final second = _frame(
+      0x5002,
+      jsonEncode({
+        'fields': {'devState': 'IDLE'},
+      }),
+    );
+    transport.emit(first.sublist(0, 12));
+    transport.emit(second);
+    await Future<void>.delayed(Duration.zero);
+    expect(snapshots.single.devState, GrinderDevState.idle);
+  });
+
+  test('start and stop write the expected command frames', () async {
+    final before = transport.writes.length;
+    await grinder.start();
+    await grinder.stop();
+    final commands = transport.writes.sublist(before).map(_decodeWrite).toList();
+    expect(commands[0], {
+      'request': {'grind': {'op': 'start'}},
+    });
+    expect(commands[1], {
+      'request': {'grind': {'op': 'stop'}},
+    });
+  });
+
+  test('geneSetting setters write the expected payloads', () async {
+    final before = transport.writes.length;
+    await grinder.setBladeGap(400);
+    await grinder.setGrindRpm(850);
+    await grinder.setCupDetect(true);
+    final commands = transport.writes.sublist(before).map(_decodeWrite).toList();
+    expect(commands[0], {
+      'request': {
+        'geneSetting': {
+          'op': 'set',
+          'data': {'bladeGap': 400},
+        },
+      },
+    });
+    expect(commands[1], {
+      'request': {
+        'geneSetting': {
+          'op': 'set',
+          'data': {'grindRpm': 850},
+        },
+      },
+    });
+    expect(commands[2], {
+      'request': {
+        'geneSetting': {
+          'op': 'set',
+          'data': {'cupDetect': true},
+        },
+      },
+    });
+  });
+
+  test('disconnected command failure is ignored', () async {
+    transport.writeError = const DeviceNotConnectedException.grinder();
+    await expectLater(grinder.start(), completes);
+  });
+
+  test('unrelated command failure propagates', () async {
+    transport.writeError = StateError('write failed');
+    await expectLater(grinder.start(), throwsStateError);
+  });
+
+  test('connect failure emits disconnected', () async {
+    final failedTransport = _BookooTransport()..failConnect = true;
+    final failedGrinder = _grinder(failedTransport);
+    await failedGrinder.onConnect();
+    expect(
+      await failedGrinder.connectionState.first,
+      ConnectionState.disconnected,
+    );
+    await failedTransport.dispose();
+  });
+
+  test('missing service emits disconnected', () async {
+    final wrongTransport = _BookooTransport()
+      ..discoverServicesOverride = ['0000ffe0-0000-1000-8000-00805f9b34fb'];
+    final wrongGrinder = _grinder(wrongTransport);
+    await wrongGrinder.onConnect();
+    expect(
+      await wrongGrinder.connectionState.first,
+      ConnectionState.disconnected,
+    );
+    await wrongTransport.dispose();
+  });
+}
+
+Map<String, dynamic> _decodeWrite(List<int> bytes) {
+  final payload = bytes.sublist(8);
+  return jsonDecode(utf8.decode(payload)) as Map<String, dynamic>;
+}
+
+int _findMultibyteSplit(List<int> payload) {
+  for (var i = 8; i < payload.length - 1; i++) {
+    if (payload[i] > 0x7F && payload[i + 1] > 0x7F) {
+      return i;
+    }
+  }
+  return payload.length ~/ 2;
+}

--- a/test/unit/models/bookoo_grinder_test.dart
+++ b/test/unit/models/bookoo_grinder_test.dart
@@ -22,8 +22,8 @@ class _BookooTransport extends BLETransport {
   @override
   Future<List<String>> discoverServices() async =>
       discoverServicesOverride.isEmpty
-          ? [BookooGrinder.serviceIdentifier.long]
-          : discoverServicesOverride;
+      ? [BookooGrinder.serviceIdentifier.long]
+      : discoverServicesOverride;
 
   @override
   String get id => 'motto80-test';
@@ -96,10 +96,8 @@ Uint8List _frame(int seq, String jsonPayload) {
   return frame;
 }
 
-BookooGrinder _grinder(_BookooTransport transport) => BookooGrinder(
-  transport: transport,
-  queryGap: Duration.zero,
-);
+BookooGrinder _grinder(_BookooTransport transport) =>
+    BookooGrinder(transport: transport, queryGap: Duration.zero);
 
 void main() {
   late _BookooTransport transport;
@@ -124,15 +122,25 @@ void main() {
 
   test('onConnect subscribes and sends the startup query sequence', () {
     final encoded = transport.writes.map(_decodeWrite).toList();
-    expect(encoded[0], {'request': {'appHello': {'op': 'handshake'}}});
+    expect(encoded[0], {
+      'request': {
+        'appHello': {'op': 'handshake'},
+      },
+    });
     expect(encoded[1], {
       'request': {
-        'grindSection': {'op': 'get', 'selector': {'type': 'all'}},
+        'grindSection': {
+          'op': 'get',
+          'selector': {'type': 'all'},
+        },
       },
     });
     expect(encoded[2], {
       'request': {
-        'grindPreset': {'op': 'get', 'selector': {'type': 'all'}},
+        'grindPreset': {
+          'op': 'get',
+          'selector': {'type': 'all'},
+        },
       },
     });
   });
@@ -147,8 +155,9 @@ void main() {
     expect(second[2], 0x01); // seq 1
     final third = transport.writes[2];
     expect(third[2], 0x02); // seq 2
-    final payloadLen = ByteData.sublistView(Uint8List.fromList(first))
-        .getUint32(4, Endian.little);
+    final payloadLen = ByteData.sublistView(
+      Uint8List.fromList(first),
+    ).getUint32(4, Endian.little);
     expect(payloadLen, first.length - 8);
   });
 
@@ -189,10 +198,22 @@ void main() {
   });
 
   test('later broadcasts merge, retaining missing fields', () async {
-    transport.emit(_frame(0x2001, jsonEncode({'fields': {'devState': 'IDLE'}})));
+    transport.emit(
+      _frame(
+        0x2001,
+        jsonEncode({
+          'fields': {'devState': 'IDLE'},
+        }),
+      ),
+    );
     await Future<void>.delayed(Duration.zero);
     transport.emit(
-      _frame(0x2002, jsonEncode({'fields': {'grindRpm': 900}})),
+      _frame(
+        0x2002,
+        jsonEncode({
+          'fields': {'grindRpm': 900},
+        }),
+      ),
     );
     await Future<void>.delayed(Duration.zero);
     expect(snapshots.last.devState, GrinderDevState.idle);
@@ -320,12 +341,19 @@ void main() {
     final before = transport.writes.length;
     await grinder.start();
     await grinder.stop();
-    final commands = transport.writes.sublist(before).map(_decodeWrite).toList();
+    final commands = transport.writes
+        .sublist(before)
+        .map(_decodeWrite)
+        .toList();
     expect(commands[0], {
-      'request': {'grind': {'op': 'start'}},
+      'request': {
+        'grind': {'op': 'start'},
+      },
     });
     expect(commands[1], {
-      'request': {'grind': {'op': 'stop'}},
+      'request': {
+        'grind': {'op': 'stop'},
+      },
     });
   });
 
@@ -334,7 +362,10 @@ void main() {
     await grinder.setBladeGap(400);
     await grinder.setGrindRpm(850);
     await grinder.setCupDetect(true);
-    final commands = transport.writes.sublist(before).map(_decodeWrite).toList();
+    final commands = transport.writes
+        .sublist(before)
+        .map(_decodeWrite)
+        .toList();
     expect(commands[0], {
       'request': {
         'geneSetting': {

--- a/test/unit/models/bookoo_grinder_test.dart
+++ b/test/unit/models/bookoo_grinder_test.dart
@@ -161,7 +161,49 @@ void main() {
     expect(payloadLen, first.length - 8);
   });
 
-  test('decodes a broadcast frame into a snapshot', () async {
+  test('decodes a real broadcast.periodInfo frame into a snapshot', () async {
+    transport.emit(
+      _frame(
+        0x1001,
+        jsonEncode({
+          'broadcast': {
+            'periodInfo': {
+              'devState': 'SETTING',
+              'feedingRpm': 50,
+              'grindRpm': 750,
+              'bladeGap': 250,
+              'humidity': 35,
+              'totalGrinds': 26,
+              'cupDetect': true,
+              'autoStop': true,
+              'fastClean': true,
+              'brightness': 4,
+              'standbySec': 480,
+              'netState': 'CONNECTED',
+              'selectPreset': -1,
+            },
+          },
+        }),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    final s = snapshots.single;
+    expect(s.devState, GrinderDevState.setting);
+    expect(s.feedingRpm, 50);
+    expect(s.grindRpm, 750);
+    expect(s.bladeGap, 250);
+    expect(s.humidity, 35);
+    expect(s.totalGrinds, 26);
+    expect(s.cupDetect, isTrue);
+    expect(s.autoStop, isTrue);
+    expect(s.fastClean, isTrue);
+    expect(s.brightness, 4);
+    expect(s.standbySec, 480);
+    expect(s.netState, 'CONNECTED');
+    expect(s.selectedPresetIndex, -1);
+  });
+
+  test('decodes a legacy flat broadcast frame into a snapshot', () async {
     transport.emit(
       _frame(
         0x1001,

--- a/test/unit/models/bookoo_grinder_test.dart
+++ b/test/unit/models/bookoo_grinder_test.dart
@@ -171,7 +171,7 @@ void main() {
               'devState': 'SETTING',
               'feedingRpm': 50,
               'grindRpm': 750,
-              'bladeGap': 250,
+              'grindSetting': 250,
               'humidity': 35,
               'totalGrinds': 26,
               'cupDetect': true,
@@ -191,7 +191,7 @@ void main() {
     expect(s.devState, GrinderDevState.setting);
     expect(s.feedingRpm, 50);
     expect(s.grindRpm, 750);
-    expect(s.bladeGap, 250);
+    expect(s.grindSetting, 250);
     expect(s.humidity, 35);
     expect(s.totalGrinds, 26);
     expect(s.cupDetect, isTrue);
@@ -212,7 +212,7 @@ void main() {
             'devState': 'GRINDING',
             'feedingRpm': 30,
             'grindRpm': 800,
-            'bladeGap': 400,
+            'grindSetting': 400,
             'humidity': 55,
             'totalGrinds': 1234,
             'cupDetect': true,
@@ -231,7 +231,7 @@ void main() {
     expect(s.devState, GrinderDevState.grinding);
     expect(s.feedingRpm, 30);
     expect(s.grindRpm, 800);
-    expect(s.bladeGap, 400);
+    expect(s.grindSetting, 400);
     expect(s.humidity, 55);
     expect(s.totalGrinds, 1234);
     expect(s.cupDetect, isTrue);
@@ -322,7 +322,7 @@ void main() {
     final full = _frame(
       0x4002,
       jsonEncode({
-        'fields': {'devState': 'IDLE', 'bladeGap': 300},
+        'fields': {'devState': 'IDLE', 'grindSetting': 300},
       }),
     );
     transport.emit(full.sublist(0, 12));
@@ -330,7 +330,7 @@ void main() {
     transport.emit(full.sublist(20));
     await Future<void>.delayed(Duration.zero);
     expect(snapshots.single.devState, GrinderDevState.idle);
-    expect(snapshots.single.bladeGap, 300);
+    expect(snapshots.single.grindSetting, 300);
   });
 
   test('decodes UTF-8 split across fragment boundaries', () async {
@@ -401,7 +401,7 @@ void main() {
 
   test('geneSetting setters write the expected payloads', () async {
     final before = transport.writes.length;
-    await grinder.setBladeGap(400);
+    await grinder.setGrindSetting(400);
     await grinder.setGrindRpm(850);
     await grinder.setCupDetect(true);
     final commands = transport.writes

--- a/test/unit/models/device/impl/de1/unified_de1/firmware_mmr_exclusion_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/firmware_mmr_exclusion_test.dart
@@ -158,33 +158,37 @@ void main() {
     timeout: const Timeout(Duration(seconds: 10)),
   );
 
-  test('MMR issued during firmware follows final firmware traffic', () async {
-    transport.queueFirmwareMapResponse([0, 0, 0, 1, 0xff, 0xff, 0xff]);
-    transport.queueFirmwareMapResponse([0, 0, 0, 1, 0xff, 0xff, 0xfd]);
-    final eraseRequest = transport.nextWrite(Endpoint.fwMapRequest.uuid);
-    final update = de1.updateFirmware(
-      Uint8List.fromList(List<int>.filled(16, 0xab)),
-      onProgress: (_) {},
-    );
-    await eraseRequest;
+  test(
+    'MMR issued during firmware follows final firmware traffic',
+    () async {
+      transport.queueFirmwareMapResponse([0, 0, 0, 1, 0xff, 0xff, 0xff]);
+      transport.queueFirmwareMapResponse([0, 0, 0, 1, 0xff, 0xff, 0xfd]);
+      final eraseRequest = transport.nextWrite(Endpoint.fwMapRequest.uuid);
+      final update = de1.updateFirmware(
+        Uint8List.fromList(List<int>.filled(16, 0xab)),
+        onProgress: (_) {},
+      );
+      await eraseRequest;
 
-    transport.queueMmrResponseInt(MMRItem.targetSteamFlow, 100);
-    final read = de1.getSteamFlow();
-    await update;
-    await read;
+      transport.queueMmrResponseInt(MMRItem.targetSteamFlow, 100);
+      final read = de1.getSteamFlow();
+      await update;
+      await read;
 
-    final characteristics = transport.writes
-        .map((write) => write.characteristicUUID)
-        .toList();
-    expect(
-      characteristics.indexOf(Endpoint.readFromMMR.uuid),
-      greaterThan(characteristics.lastIndexOf(Endpoint.fwMapRequest.uuid)),
-    );
-    expect(
-      characteristics.indexOf(Endpoint.readFromMMR.uuid),
-      greaterThan(characteristics.lastIndexOf(Endpoint.writeToMMR.uuid)),
-    );
-  }, timeout: const Timeout(Duration(seconds: 15)));
+      final characteristics = transport.writes
+          .map((write) => write.characteristicUUID)
+          .toList();
+      expect(
+        characteristics.indexOf(Endpoint.readFromMMR.uuid),
+        greaterThan(characteristics.lastIndexOf(Endpoint.fwMapRequest.uuid)),
+      );
+      expect(
+        characteristics.indexOf(Endpoint.readFromMMR.uuid),
+        greaterThan(characteristics.lastIndexOf(Endpoint.writeToMMR.uuid)),
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 15)),
+  );
 }
 
 class _BarrierBleTransport extends BarrierBleTransport {

--- a/test/unit/models/device/impl/de1/unified_de1/serial_shot_settings_mirror_test.dart
+++ b/test/unit/models/device/impl/de1/unified_de1/serial_shot_settings_mirror_test.dart
@@ -73,17 +73,11 @@ void main() {
     final frame = await transport.shotSettings.first.timeout(
       const Duration(seconds: 1),
     );
-    expect(frame.buffer.asUint8List(), [
-      0x00,
-      0x96,
-      0x1e,
-      0x4b,
-      0x32,
-      0x1e,
-      0x24,
-      0x5e,
-      0x00,
-    ], reason: 'firmware defaults, since a serial machine never pushes K');
+    expect(
+      frame.buffer.asUint8List(),
+      [0x00, 0x96, 0x1e, 0x4b, 0x32, 0x1e, 0x24, 0x5e, 0x00],
+      reason: 'firmware defaults, since a serial machine never pushes K',
+    );
     expect(
       serial.writes.where((w) => w == '<-K>'),
       isEmpty,

--- a/test/unit/services/device_matcher_test.dart
+++ b/test/unit/services/device_matcher_test.dart
@@ -6,6 +6,7 @@ import 'package:reaprime/src/models/device/impl/acaia/acaia_scale.dart';
 import 'package:reaprime/src/models/device/impl/atomheart/atomheart_scale.dart';
 import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/blackcoffee/blackcoffee_scale.dart';
+import 'package:reaprime/src/models/device/impl/bookoo/bookoo_grinder.dart';
 import 'package:reaprime/src/models/device/impl/bookoo/miniscale.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale.dart';

--- a/test/unit/services/device_matcher_test.dart
+++ b/test/unit/services/device_matcher_test.dart
@@ -375,6 +375,30 @@ void main() {
       expect(device, isA<BookooScale>());
     });
 
+    test('BOOKOO MT80 matches the grinder, not the scale', () async {
+      final device = await DeviceMatcher.match(
+        transport: mockTransport,
+        advertisedName: 'BOOKOO MT80',
+      );
+
+      expect(device, isA<BookooGrinder>());
+    });
+
+    test('MOTTO80 BLE matches the grinder', () async {
+      final device = await DeviceMatcher.match(
+        transport: mockTransport,
+        advertisedName: 'MOTTO80 BLE',
+      );
+
+      expect(device, isA<BookooGrinder>());
+    });
+
+    test('serviceUuidsFor grinder contains the MT80 service', () {
+      final services = DeviceMatcher.serviceUuidsFor(DeviceType.grinder);
+
+      expect(services, contains('4d543830-0001-4b80-8f00-424f4f4b4f4f'));
+    });
+
     test('returns null for unknown name', () async {
       final device = await DeviceMatcher.match(
         transport: mockTransport,

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -647,12 +647,16 @@ void main() {
       await pump();
 
       for (var i = 0; i < chars.length; i++) {
-        expect(newReceived[i], [
-          (i + 1) * 10,
-        ], reason: 'new callback for ${chars[i]} must receive the push');
-        expect(oldReceived[i], [
-          i + 1,
-        ], reason: 'old callback for ${chars[i]} must NOT receive the push');
+        expect(
+          newReceived[i],
+          [(i + 1) * 10],
+          reason: 'new callback for ${chars[i]} must receive the push',
+        );
+        expect(
+          oldReceived[i],
+          [i + 1],
+          reason: 'old callback for ${chars[i]} must NOT receive the push',
+        );
       }
     });
 


### PR DESCRIPTION
## Summary

Add a new device kind to Decaid: the MOTTO80 (Bookoo) BLE grinder. The grinder advertises as "BOOKOO MT80" (service `4d543830-0001-4b80-8f00-424f4f4b4f4f`, command/status characteristics `...-0002`/`...-0003`, ~200ms JSON status broadcasts).

What this PR adds:

- `DeviceType.grinder` with a typed `Grinder` abstraction parallel to `Scale` — `GrinderSnapshot` DTO, start/stop, preset and grind-section selection, geneSetting adjustments (generic `grindSetting` mapped to the device's bladeGap wire key)
- `BookooGrinder` protocol driver: A5 01 framed JSON with seq counter, long-frame reassembly (repeated-header and headerless continuations, stale-pending drop, single UTF-8 decode), automatic handshake + grind-section/preset queries, broadcast field retention
- Registration: matcher (names containing `motto80`/`mt80`, with the Bookoo scale rule excluding `mt80`), factory, telemetry, webserver dispatch
- Auto-connect: `preferredGrinderId` setting, `ConnectionManager.connectGrinder`, preferred-grinder connect from scan results, remembered-devices wiring
- REST/WS API for skins: `GET /api/v1/grinder`, `PUT /api/v1/grinder/settings`, `PUT /api/v1/grinder/<command>`, `WS /ws/v1/grinder/snapshot`
- UI: devices list, debug view (live state, draggable settings, presets, per-kind logs, English/中文 toggle), auto-connect settings section
- `MockGrinder` simulated device (included in `simulate=1`)
- Docs: AI_BLE_NOTES protocol section, DeviceManagement matching/auto-connect, rest_v1.yml grinder enum + preferredGrinderId

## Linked Issue

Fixes #747

## Verification

- BookooGrinder fake-transport tests (frame codec, reassembly, UTF-8 splitting, broadcast parsing incl. the real `broadcast.periodInfo` shape), GrinderController tests, matcher/factory/schema updates — full suite 3737 tests passing, `flutter analyze` clean
- Hardware-verified against a physical MOTTO80: discovered by name, connects, live snapshots stream (feedingRpm/grindRpm/bladeGap/humidity/devState), and `feedingRpm`/`grindRpm` changes via the settings API take effect on the device (broadcasts confirm the new values)

## Impact

- New device kind only; no existing behavior or API changes (new endpoints are additive)
- Deferred follow-ups: grinder picker ambiguity, background reacquisition watch, quick-connect execution for remembered grinders, scan-flow column, ws/v1/grinder spec in websocket_v1.yml



## Protocol notes (pitfalls hit while porting, for future maintainers)

- The device advertises as **BOOKOO MT80**, not the "MOTTO80 BLE" name the reference GUI assumed; the matcher accepts both `mt80` and `motto80`, and the Bookoo *scale* rule excludes `mt80` so the grinder is not misclassified as a scale.
- Status broadcasts nest fields under `{"broadcast":{"periodInfo":{...}}}`; treating the frame as flat yields all-null snapshots.
- The generic `grindSetting` maps to the device wire key `bladeGap`; reading `grindSetting` from the broadcast misses every frame.
- A handshake (`appHello`) must precede the first queries — without it the grinder does not answer (the driver runs it automatically on connect).
- Grind start/stop and preset-select payloads are educated guesses; the debug view labels start/stop as not-yet-enabled.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work.
