### PR TITLE
chore(shots): track createdAt and updatedAt on shot records

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -6889,8 +6889,9 @@ components:
             ISO-8601 UTC instant of the last meaningful content change
             (always ends in `Z`). System-managed: rejected with 400 if
             supplied to PUT /api/v1/shots/{id}. Does not advance for writes
-            confined to the bookkeeping keys `uploaded_to_decent` and
-            `visualizerId` inside annotations.extras. Falls back to
+            confined to the bookkeeping keys `uploaded_to_decent`,
+            `decent_upload_rejected`, and `visualizerId` inside
+            annotations.extras. Falls back to
             `createdAt`, then `timestamp`, for legacy records.
         measurements:
           type: array
@@ -6931,8 +6932,9 @@ components:
         Partial-update payload for PUT /api/v1/shots/{id}. Only the fields
         included in the body are changed; all other fields are preserved from
         the existing record. `measurements`, `createdAt`, and `updatedAt` are
-        not editable and are rejected with 400. The `uploaded_to_decent` and
-        `visualizerId` keys inside annotations.extras are reserved bookkeeping:
+        not editable and are rejected with 400. The `uploaded_to_decent`,
+        `decent_upload_rejected`, and `visualizerId` keys inside
+        annotations.extras are reserved bookkeeping:
         writes confined to them persist without advancing `updatedAt`.
       properties:
         annotations:

--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1629,7 +1629,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ShotRecord"
+              $ref: "#/components/schemas/ShotUpdateRequest"
             examples:
               updateNotes:
                 summary: Update only espresso notes
@@ -1651,7 +1651,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/ShotRecord"
         "400":
-          description: Bad Request (ID mismatch)
+          description: |
+            Bad Request. Covers an ID in the body that does not match the
+            path ID, a body containing `measurements`, and a body containing
+            the system-managed fields `createdAt` or `updatedAt`.
           content:
             application/json:
               schema:
@@ -6871,6 +6874,24 @@ components:
           type: string
         timestamp:
           type: string
+        createdAt:
+          type: string
+          format: date-time
+          description: |
+            ISO-8601 UTC instant when the shot entered local storage
+            (always ends in `Z`). System-managed: rejected with 400 if
+            supplied to PUT /api/v1/shots/{id}. Falls back to `timestamp`
+            for legacy records that predate the field.
+        updatedAt:
+          type: string
+          format: date-time
+          description: |
+            ISO-8601 UTC instant of the last meaningful content change
+            (always ends in `Z`). System-managed: rejected with 400 if
+            supplied to PUT /api/v1/shots/{id}. Does not advance for writes
+            confined to the bookkeeping keys `uploaded_to_decent` and
+            `visualizerId` inside annotations.extras. Falls back to
+            `createdAt`, then `timestamp`, for legacy records.
         measurements:
           type: array
           items:
@@ -6904,6 +6925,34 @@ components:
           deprecated: true
           description: "Deprecated request alias for annotations.extras; response value mirrors the canonical field"
 
+    ShotUpdateRequest:
+      type: object
+      description: |
+        Partial-update payload for PUT /api/v1/shots/{id}. Only the fields
+        included in the body are changed; all other fields are preserved from
+        the existing record. `measurements`, `createdAt`, and `updatedAt` are
+        not editable and are rejected with 400. The `uploaded_to_decent` and
+        `visualizerId` keys inside annotations.extras are reserved bookkeeping:
+        writes confined to them persist without advancing `updatedAt`.
+      properties:
+        annotations:
+          $ref: "#/components/schemas/ShotAnnotations"
+        stopReason:
+          type: string
+          nullable: true
+          description: Why the shot ended (open set — tolerate unknown values). See ShotRecord.stopReason.
+        shotNotes:
+          type: string
+          nullable: true
+          deprecated: true
+          description: "Deprecated request alias for annotations.espressoNotes; response value mirrors the canonical field"
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties: true
+          deprecated: true
+          description: "Deprecated request alias for annotations.extras; response value mirrors the canonical field"
+
     ShotRecordSummary:
       type: object
       description: |
@@ -6914,6 +6963,18 @@ components:
           type: string
         timestamp:
           type: string
+        createdAt:
+          type: string
+          format: date-time
+          description: |
+            ISO-8601 UTC instant when the shot entered local storage
+            (always ends in `Z`). See ShotRecord.createdAt.
+        updatedAt:
+          type: string
+          format: date-time
+          description: |
+            ISO-8601 UTC instant of the last meaningful content change
+            (always ends in `Z`). See ShotRecord.updatedAt.
         workflow:
           $ref: "#/components/schemas/WorkflowRequest"
         annotations:

--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -71,6 +71,8 @@ Persistence uses Drift (SQLite) via `AppDatabase`. DAOs in `lib/src/daos/`, mapp
 
 **Schema migration:** The `@Database` annotation's `version` field is the schema version. Migrations run in `onUpgrade` callback. Each version bump needs a corresponding migration step.
 
+**Schema v5 (shot revision metadata):** `shot_records.createdAt`/`updatedAt` were added as nullable TEXT and backfilled from `timestamp` during the 4→5 migration, so pre-v5 rows carry a real DB-level revision instead of NULL. `ShotMapper.fromRow` still falls back to `timestamp` for any row with NULL fields (e.g. rows inserted without stamps). The revision contract (bookkeeping extras do not advance `updatedAt`, PUT cannot write the fields) is documented in `doc/Api.md` under Shots → Modification tracking.
+
 ## Profile Storage
 
 Content-based hash IDs for deduplication. `ProfileController` manages the profile library:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -175,6 +175,17 @@ Newly recorded shots snapshot `serialNumber`, `model`, `firmwareVersion`, and
 fields. Consumers must not infer missing capture-time identity from the machine
 that happens to be connected when a record is read.
 
+**Modification tracking.** Every shot carries `createdAt` and `updatedAt`
+(ISO-8601 UTC). `updatedAt` advances only when shot *content* changes:
+`PUT /api/v1/shots/:id` bumps it iff the merged record differs outside the
+bookkeeping area. The bookkeeping area is `annotations.extras` (plus its
+legacy alias `metadata`) — the reserved scratch space for plugin sync state
+such as `uploaded_to_decent` or `visualizerId`. Writes confined to that area
+persist without touching `updatedAt`, so consumers can reconcile edits by
+comparing `updatedAt` against their own sync marker without feedback loops.
+`measurements` is also excluded from the comparison; the PUT patch mechanism
+is not a measurements editing surface.
+
 ### Steams
 
 Recorded milk-steaming sessions. Each record is opened when the machine

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -183,10 +183,11 @@ for legacy records that predate the field. Both fields are system-managed: a
 clients cannot spoof revision metadata. `updatedAt` advances only when shot
 *content* changes: `PUT /api/v1/shots/:id` bumps it iff the merged record
 differs outside the bookkeeping keys. The bookkeeping keys are
-`uploaded_to_decent` and `visualizerId` inside `annotations.extras` (the
-reserved scratch space for plugin sync state). Writes confined to those keys
-persist without touching `updatedAt`, so consumers can reconcile edits by
-comparing `updatedAt` against their own sync marker without feedback loops.
+`uploaded_to_decent`, `decent_upload_rejected`, and `visualizerId` inside
+`annotations.extras` (the reserved scratch space for plugin sync state).
+Writes confined to those keys persist without touching `updatedAt`, so
+consumers can reconcile edits by comparing `updatedAt` against their own sync
+marker without feedback loops.
 An `extras` map emptied by that exclusion compares equal to no `extras`, and
 an `annotations` map emptied by it compares equal to no `annotations`, so the
 first-ever sync marker on a clean shot does not dirty it. All other `extras`

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -193,10 +193,11 @@ an `annotations` map emptied by it compares equal to no `annotations`, so the
 first-ever sync marker on a clean shot does not dirty it. All other `extras`
 keys count as content. `measurements` is not editable through this endpoint:
 a PUT body containing it is rejected with 400. Sync import with
-`onConflict: overwrite` follows the same rule: the existing `createdAt` is
-preserved, and `updatedAt` advances only when the imported content differs
-from the stored record, so a no-op re-import cannot move a consumer's cursor
-backwards.
+`onConflict: overwrite` replaces the whole record, so its comparison
+includes `measurements` (which overwrite can change, unlike PUT): the
+existing `createdAt` is preserved, and `updatedAt` advances whenever the
+imported record differs from the stored one, so a no-op re-import cannot
+move a consumer's cursor backwards.
 
 ### Steams
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -176,17 +176,26 @@ fields. Consumers must not infer missing capture-time identity from the machine
 that happens to be connected when a record is read.
 
 **Modification tracking.** Every shot carries `createdAt` and `updatedAt`
-(ISO-8601 UTC). `createdAt` is set when the shot enters local storage; the
-extraction `timestamp` is the fallback for legacy records that predate the
-field. `updatedAt` advances only when shot *content* changes:
-`PUT /api/v1/shots/:id` bumps it iff the merged record differs outside the
-bookkeeping keys. The bookkeeping keys are `uploaded_to_decent` and
-`visualizerId` inside `annotations.extras` (the reserved scratch space for
-plugin sync state). Writes confined to those keys persist without touching
-`updatedAt`, so consumers can reconcile edits by comparing `updatedAt`
-against their own sync marker without feedback loops. All other `extras`
+(ISO-8601 UTC, always serialized with a trailing `Z`). `createdAt` is set
+when the shot enters local storage; the extraction `timestamp` is the fallback
+for legacy records that predate the field. Both fields are system-managed: a
+`PUT /api/v1/shots/:id` body containing either is rejected with 400, so
+clients cannot spoof revision metadata. `updatedAt` advances only when shot
+*content* changes: `PUT /api/v1/shots/:id` bumps it iff the merged record
+differs outside the bookkeeping keys. The bookkeeping keys are
+`uploaded_to_decent` and `visualizerId` inside `annotations.extras` (the
+reserved scratch space for plugin sync state). Writes confined to those keys
+persist without touching `updatedAt`, so consumers can reconcile edits by
+comparing `updatedAt` against their own sync marker without feedback loops.
+An `extras` map emptied by that exclusion compares equal to no `extras`, and
+an `annotations` map emptied by it compares equal to no `annotations`, so the
+first-ever sync marker on a clean shot does not dirty it. All other `extras`
 keys count as content. `measurements` is not editable through this endpoint:
-a PUT body containing it is rejected with 400.
+a PUT body containing it is rejected with 400. Sync import with
+`onConflict: overwrite` follows the same rule: the existing `createdAt` is
+preserved, and `updatedAt` advances only when the imported content differs
+from the stored record, so a no-op re-import cannot move a consumer's cursor
+backwards.
 
 ### Steams
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -176,15 +176,17 @@ fields. Consumers must not infer missing capture-time identity from the machine
 that happens to be connected when a record is read.
 
 **Modification tracking.** Every shot carries `createdAt` and `updatedAt`
-(ISO-8601 UTC). `updatedAt` advances only when shot *content* changes:
+(ISO-8601 UTC). `createdAt` is set when the shot enters local storage; the
+extraction `timestamp` is the fallback for legacy records that predate the
+field. `updatedAt` advances only when shot *content* changes:
 `PUT /api/v1/shots/:id` bumps it iff the merged record differs outside the
-bookkeeping area. The bookkeeping area is `annotations.extras` (plus its
-legacy alias `metadata`) — the reserved scratch space for plugin sync state
-such as `uploaded_to_decent` or `visualizerId`. Writes confined to that area
-persist without touching `updatedAt`, so consumers can reconcile edits by
-comparing `updatedAt` against their own sync marker without feedback loops.
-`measurements` is also excluded from the comparison; the PUT patch mechanism
-is not a measurements editing surface.
+bookkeeping keys. The bookkeeping keys are `uploaded_to_decent` and
+`visualizerId` inside `annotations.extras` (the reserved scratch space for
+plugin sync state). Writes confined to those keys persist without touching
+`updatedAt`, so consumers can reconcile edits by comparing `updatedAt`
+against their own sync marker without feedback loops. All other `extras`
+keys count as content. `measurements` is not editable through this endpoint:
+a PUT body containing it is rejected with 400.
 
 ### Steams
 

--- a/lib/src/history_feature/history_feature.dart
+++ b/lib/src/history_feature/history_feature.dart
@@ -989,6 +989,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                     );
                 final updatedShot = record.copyWith(
                   annotations: updatedAnnotations,
+                  updatedAt: DateTime.now(),
                 );
                 await widget.persistenceController.updateShot(updatedShot);
                 if (!context.mounted) return;

--- a/lib/src/history_feature/history_feature.dart
+++ b/lib/src/history_feature/history_feature.dart
@@ -989,7 +989,7 @@ class _HistoryFeatureState extends State<HistoryFeature> {
                     );
                 final updatedShot = record.copyWith(
                   annotations: updatedAnnotations,
-                  updatedAt: DateTime.now(),
+                  updatedAt: DateTime.now().toUtc(),
                 );
                 await widget.persistenceController.updateShot(updatedShot);
                 if (!context.mounted) return;

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -1,9 +1,15 @@
+import 'dart:convert';
+
 import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_snapshot.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 
 class ShotRecord {
+  /// Keys in `annotations.extras` reserved for plugin sync state. Writes
+  /// confined to these keys do not count as content changes.
+  static const bookkeepingExtrasKeys = {'uploaded_to_decent', 'visualizerId'};
+
   final String id;
   final DateTime timestamp;
   final DateTime? createdAt;
@@ -41,8 +47,8 @@ class ShotRecord {
     return {
       "id": id,
       "timestamp": timestamp.toIso8601String(),
-      "createdAt": createdAt?.toIso8601String(),
-      "updatedAt": updatedAt?.toIso8601String(),
+      "createdAt": createdAt?.toUtc().toIso8601String(),
+      "updatedAt": updatedAt?.toUtc().toIso8601String(),
       "measurements": measurements.map((e) => e.toJson()).toList(),
       "workflow": workflow.toJson(),
       if (annotations != null) "annotations": annotations!.toJson(),
@@ -56,8 +62,8 @@ class ShotRecord {
     return {
       "id": id,
       "timestamp": timestamp.toIso8601String(),
-      "createdAt": createdAt?.toIso8601String(),
-      "updatedAt": updatedAt?.toIso8601String(),
+      "createdAt": createdAt?.toUtc().toIso8601String(),
+      "updatedAt": updatedAt?.toUtc().toIso8601String(),
       "workflow": workflow.toJson(),
       if (annotations != null) "annotations": annotations!.toJson(),
       if (stopReason != null) "stopReason": stopReason,
@@ -79,17 +85,17 @@ class ShotRecord {
 
     final legacyTime = DateTime.parse(json["timestamp"]);
     final parsedCreatedAt = json["createdAt"] != null
-        ? DateTime.parse(json["createdAt"] as String)
+        ? DateTime.parse(json["createdAt"] as String).toUtc()
         : null;
     final parsedUpdatedAt = json["updatedAt"] != null
-        ? DateTime.parse(json["updatedAt"] as String)
+        ? DateTime.parse(json["updatedAt"] as String).toUtc()
         : null;
 
     return ShotRecord(
       id: json["id"],
       timestamp: legacyTime,
-      createdAt: parsedCreatedAt ?? legacyTime,
-      updatedAt: parsedUpdatedAt ?? parsedCreatedAt ?? legacyTime,
+      createdAt: parsedCreatedAt ?? legacyTime.toUtc(),
+      updatedAt: parsedUpdatedAt ?? parsedCreatedAt ?? legacyTime.toUtc(),
       measurements: (json["measurements"] as List)
           .map((e) => ShotSnapshot.fromJson(e))
           .toList(),
@@ -104,6 +110,45 @@ class ShotRecord {
           : json["metadata"] as Map<String, dynamic>?,
     );
   }
+
+  /// Canonical JSON of the user-meaningful content, used to decide whether a
+  /// write is a real content change. Excludes the system-managed timestamps,
+  /// measurements, and the deprecated `metadata` mirror; bookkeeping extras are
+  /// dropped, and an `extras` map emptied by that exclusion compares equal to
+  /// no `extras` (likewise for `annotations`).
+  Map<String, dynamic> contentSignature() {
+    final json = toJsonWithoutMeasurements()
+      ..remove('createdAt')
+      ..remove('updatedAt')
+      ..remove('metadata');
+    final annotations = json['annotations'];
+    if (annotations is Map<String, dynamic>) {
+      final normalized = Map<String, dynamic>.from(annotations);
+      final extras = normalized['extras'];
+      if (extras is Map<String, dynamic>) {
+        final cleaned = Map<String, dynamic>.from(extras)
+          ..removeWhere(
+            (key, _) => ShotRecord.bookkeepingExtrasKeys.contains(key),
+          );
+        if (cleaned.isEmpty) {
+          normalized.remove('extras');
+        } else {
+          normalized['extras'] = cleaned;
+        }
+      }
+      if (normalized.isEmpty) {
+        json.remove('annotations');
+      } else {
+        json['annotations'] = normalized;
+      }
+    }
+    return json;
+  }
+
+  /// True when both records carry identical user-meaningful content, ignoring
+  /// system-managed timestamps and bookkeeping extras.
+  bool sameContent(ShotRecord other) =>
+      jsonEncode(contentSignature()) == jsonEncode(other.contentSignature());
 
   String shotTime() {
     final dateFormat = DateFormat.yMd();

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -8,7 +8,11 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 class ShotRecord {
   /// Keys in `annotations.extras` reserved for plugin sync state. Writes
   /// confined to these keys do not count as content changes.
-  static const bookkeepingExtrasKeys = {'uploaded_to_decent', 'visualizerId'};
+  static const bookkeepingExtrasKeys = {
+    'uploaded_to_decent',
+    'decent_upload_rejected',
+    'visualizerId',
+  };
 
   final String id;
   final DateTime timestamp;

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -116,12 +116,13 @@ class ShotRecord {
   }
 
   /// Canonical JSON of the user-meaningful content, used to decide whether a
-  /// write is a real content change. Excludes the system-managed timestamps,
-  /// measurements, and the deprecated `metadata` mirror; bookkeeping extras are
-  /// dropped, and an `extras` map emptied by that exclusion compares equal to
-  /// no `extras` (likewise for `annotations`).
-  Map<String, dynamic> contentSignature() {
-    final json = toJsonWithoutMeasurements()
+  /// write is a real content change. Excludes the system-managed timestamps
+  /// and the deprecated `metadata` mirror; bookkeeping extras are dropped, and
+  /// an `extras` map emptied by that exclusion compares equal to no `extras`
+  /// (likewise for `annotations`). Measurements are excluded unless
+  /// [includeMeasurements] is set, matching callers that can edit them.
+  Map<String, dynamic> contentSignature({bool includeMeasurements = false}) {
+    final json = (includeMeasurements ? toJson() : toJsonWithoutMeasurements())
       ..remove('createdAt')
       ..remove('updatedAt')
       ..remove('metadata');
@@ -150,9 +151,13 @@ class ShotRecord {
   }
 
   /// True when both records carry identical user-meaningful content, ignoring
-  /// system-managed timestamps and bookkeeping extras.
-  bool sameContent(ShotRecord other) =>
-      jsonEncode(contentSignature()) == jsonEncode(other.contentSignature());
+  /// system-managed timestamps and bookkeeping extras. Measurements count as
+  /// content only when [includeMeasurements] is set.
+  bool sameContent(ShotRecord other, {bool includeMeasurements = false}) =>
+      jsonEncode(contentSignature(includeMeasurements: includeMeasurements)) ==
+      jsonEncode(
+        other.contentSignature(includeMeasurements: includeMeasurements),
+      );
 
   String shotTime() {
     final dateFormat = DateFormat.yMd();

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -6,8 +6,8 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 class ShotRecord {
   final String id;
   final DateTime timestamp;
-  final DateTime createdAt;
-  final DateTime updatedAt;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
   final List<ShotSnapshot> measurements;
   final Workflow workflow;
   final ShotAnnotations? annotations;
@@ -22,15 +22,13 @@ class ShotRecord {
     required this.timestamp,
     required this.measurements,
     required this.workflow,
-    DateTime? createdAt,
-    DateTime? updatedAt,
+    this.createdAt,
+    this.updatedAt,
     this.annotations,
     this.stopReason,
     String? shotNotes,
     Map<String, dynamic>? metadata,
-  }) : createdAt = createdAt ?? timestamp,
-       updatedAt = updatedAt ?? createdAt ?? timestamp,
-       _shotNotes = annotations != null ? annotations.espressoNotes : shotNotes,
+  }) : _shotNotes = annotations != null ? annotations.espressoNotes : shotNotes,
        _metadata = annotations != null ? annotations.extras : metadata;
 
   @Deprecated('Use annotations?.espressoNotes instead')
@@ -43,8 +41,8 @@ class ShotRecord {
     return {
       "id": id,
       "timestamp": timestamp.toIso8601String(),
-      "createdAt": createdAt.toIso8601String(),
-      "updatedAt": updatedAt.toIso8601String(),
+      "createdAt": createdAt?.toIso8601String(),
+      "updatedAt": updatedAt?.toIso8601String(),
       "measurements": measurements.map((e) => e.toJson()).toList(),
       "workflow": workflow.toJson(),
       if (annotations != null) "annotations": annotations!.toJson(),
@@ -58,8 +56,8 @@ class ShotRecord {
     return {
       "id": id,
       "timestamp": timestamp.toIso8601String(),
-      "createdAt": createdAt.toIso8601String(),
-      "updatedAt": updatedAt.toIso8601String(),
+      "createdAt": createdAt?.toIso8601String(),
+      "updatedAt": updatedAt?.toIso8601String(),
       "workflow": workflow.toJson(),
       if (annotations != null) "annotations": annotations!.toJson(),
       if (stopReason != null) "stopReason": stopReason,
@@ -79,15 +77,19 @@ class ShotRecord {
       ann = ShotAnnotations.fromLegacyJson(json);
     }
 
+    final legacyTime = DateTime.parse(json["timestamp"]);
+    final parsedCreatedAt = json["createdAt"] != null
+        ? DateTime.parse(json["createdAt"] as String)
+        : null;
+    final parsedUpdatedAt = json["updatedAt"] != null
+        ? DateTime.parse(json["updatedAt"] as String)
+        : null;
+
     return ShotRecord(
       id: json["id"],
-      timestamp: DateTime.parse(json["timestamp"]),
-      createdAt: json["createdAt"] != null
-          ? DateTime.parse(json["createdAt"] as String)
-          : DateTime.parse(json["timestamp"]),
-      updatedAt: json["updatedAt"] != null
-          ? DateTime.parse(json["updatedAt"] as String)
-          : null,
+      timestamp: legacyTime,
+      createdAt: parsedCreatedAt ?? legacyTime,
+      updatedAt: parsedUpdatedAt ?? parsedCreatedAt ?? legacyTime,
       measurements: (json["measurements"] as List)
           .map((e) => ShotSnapshot.fromJson(e))
           .toList(),

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -6,6 +6,8 @@ import 'package:shadcn_ui/shadcn_ui.dart';
 class ShotRecord {
   final String id;
   final DateTime timestamp;
+  final DateTime createdAt;
+  final DateTime updatedAt;
   final List<ShotSnapshot> measurements;
   final Workflow workflow;
   final ShotAnnotations? annotations;
@@ -20,11 +22,15 @@ class ShotRecord {
     required this.timestamp,
     required this.measurements,
     required this.workflow,
+    DateTime? createdAt,
+    DateTime? updatedAt,
     this.annotations,
     this.stopReason,
     String? shotNotes,
     Map<String, dynamic>? metadata,
-  }) : _shotNotes = annotations != null ? annotations.espressoNotes : shotNotes,
+  }) : createdAt = createdAt ?? timestamp,
+       updatedAt = updatedAt ?? createdAt ?? timestamp,
+       _shotNotes = annotations != null ? annotations.espressoNotes : shotNotes,
        _metadata = annotations != null ? annotations.extras : metadata;
 
   @Deprecated('Use annotations?.espressoNotes instead')
@@ -37,6 +43,8 @@ class ShotRecord {
     return {
       "id": id,
       "timestamp": timestamp.toIso8601String(),
+      "createdAt": createdAt.toIso8601String(),
+      "updatedAt": updatedAt.toIso8601String(),
       "measurements": measurements.map((e) => e.toJson()).toList(),
       "workflow": workflow.toJson(),
       if (annotations != null) "annotations": annotations!.toJson(),
@@ -50,6 +58,8 @@ class ShotRecord {
     return {
       "id": id,
       "timestamp": timestamp.toIso8601String(),
+      "createdAt": createdAt.toIso8601String(),
+      "updatedAt": updatedAt.toIso8601String(),
       "workflow": workflow.toJson(),
       if (annotations != null) "annotations": annotations!.toJson(),
       if (stopReason != null) "stopReason": stopReason,
@@ -72,6 +82,12 @@ class ShotRecord {
     return ShotRecord(
       id: json["id"],
       timestamp: DateTime.parse(json["timestamp"]),
+      createdAt: json["createdAt"] != null
+          ? DateTime.parse(json["createdAt"] as String)
+          : DateTime.parse(json["timestamp"]),
+      updatedAt: json["updatedAt"] != null
+          ? DateTime.parse(json["updatedAt"] as String)
+          : null,
       measurements: (json["measurements"] as List)
           .map((e) => ShotSnapshot.fromJson(e))
           .toList(),
@@ -96,6 +112,8 @@ class ShotRecord {
   ShotRecord copyWith({
     String? id,
     DateTime? timestamp,
+    DateTime? createdAt,
+    DateTime? updatedAt,
     List<ShotSnapshot>? measurements,
     Workflow? workflow,
     ShotAnnotations? annotations,
@@ -106,6 +124,8 @@ class ShotRecord {
     return ShotRecord(
       id: id ?? this.id,
       timestamp: timestamp ?? this.timestamp,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
       measurements: measurements ?? this.measurements,
       workflow: workflow ?? this.workflow,
       annotations: annotations ?? this.annotations,

--- a/lib/src/services/database/database.dart
+++ b/lib/src/services/database/database.dart
@@ -68,6 +68,10 @@ class AppDatabase extends _$AppDatabase {
         if (from < 5) {
           await m.addColumn(shotRecords, shotRecords.createdAt);
           await m.addColumn(shotRecords, shotRecords.updatedAt);
+          await customStatement(
+            'UPDATE shot_records SET created_at = timestamp, '
+            'updated_at = timestamp',
+          );
         }
       },
       beforeOpen: (details) async {

--- a/lib/src/services/database/database.dart
+++ b/lib/src/services/database/database.dart
@@ -44,7 +44,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration {
@@ -64,6 +64,10 @@ class AppDatabase extends _$AppDatabase {
         }
         if (from < 4) {
           await m.addColumn(shotRecords, shotRecords.stopReason);
+        }
+        if (from < 5) {
+          await m.addColumn(shotRecords, shotRecords.createdAt);
+          await m.addColumn(shotRecords, shotRecords.updatedAt);
         }
       },
       beforeOpen: (details) async {

--- a/lib/src/services/database/database.g.dart
+++ b/lib/src/services/database/database.g.dart
@@ -3229,6 +3229,28 @@ class $ShotRecordsTable extends ShotRecords
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
   @override
   late final GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
   workflowJson =
@@ -3280,6 +3302,8 @@ class $ShotRecordsTable extends ShotRecords
     enjoyment,
     espressoNotes,
     stopReason,
+    createdAt,
+    updatedAt,
     workflowJson,
     annotationsJson,
     measurementsJson,
@@ -3405,6 +3429,18 @@ class $ShotRecordsTable extends ShotRecords
         stopReason.isAcceptableOrUnknown(data['stop_reason']!, _stopReasonMeta),
       );
     }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
     if (data.containsKey('measurements_json')) {
       context.handle(
         _measurementsJsonMeta,
@@ -3481,6 +3517,14 @@ class $ShotRecordsTable extends ShotRecords
         DriftSqlType.string,
         data['${effectivePrefix}stop_reason'],
       ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      ),
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      ),
       workflowJson: $ShotRecordsTable.$converterworkflowJson.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.string,
@@ -3525,10 +3569,9 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
   final double? targetYield;
   final double? enjoyment;
   final String? espressoNotes;
-
-  /// Why the shot ended (ShotDecisionReason.name, open set). Added in schema
-  /// v4; null for shots recorded before then or not sequenced by the app.
   final String? stopReason;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
   final Map<String, dynamic> workflowJson;
   final Map<String, dynamic>? annotationsJson;
   final String measurementsJson;
@@ -3547,6 +3590,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     this.enjoyment,
     this.espressoNotes,
     this.stopReason,
+    this.createdAt,
+    this.updatedAt,
     required this.workflowJson,
     this.annotationsJson,
     required this.measurementsJson,
@@ -3591,6 +3636,12 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     }
     if (!nullToAbsent || stopReason != null) {
       map['stop_reason'] = Variable<String>(stopReason);
+    }
+    if (!nullToAbsent || createdAt != null) {
+      map['created_at'] = Variable<DateTime>(createdAt);
+    }
+    if (!nullToAbsent || updatedAt != null) {
+      map['updated_at'] = Variable<DateTime>(updatedAt);
     }
     {
       map['workflow_json'] = Variable<String>(
@@ -3646,6 +3697,12 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
       stopReason: stopReason == null && nullToAbsent
           ? const Value.absent()
           : Value(stopReason),
+      createdAt: createdAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(createdAt),
+      updatedAt: updatedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(updatedAt),
       workflowJson: Value(workflowJson),
       annotationsJson: annotationsJson == null && nullToAbsent
           ? const Value.absent()
@@ -3674,6 +3731,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
       enjoyment: serializer.fromJson<double?>(json['enjoyment']),
       espressoNotes: serializer.fromJson<String?>(json['espressoNotes']),
       stopReason: serializer.fromJson<String?>(json['stopReason']),
+      createdAt: serializer.fromJson<DateTime?>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime?>(json['updatedAt']),
       workflowJson: serializer.fromJson<Map<String, dynamic>>(
         json['workflowJson'],
       ),
@@ -3701,6 +3760,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
       'enjoyment': serializer.toJson<double?>(enjoyment),
       'espressoNotes': serializer.toJson<String?>(espressoNotes),
       'stopReason': serializer.toJson<String?>(stopReason),
+      'createdAt': serializer.toJson<DateTime?>(createdAt),
+      'updatedAt': serializer.toJson<DateTime?>(updatedAt),
       'workflowJson': serializer.toJson<Map<String, dynamic>>(workflowJson),
       'annotationsJson': serializer.toJson<Map<String, dynamic>?>(
         annotationsJson,
@@ -3724,6 +3785,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     Value<double?> enjoyment = const Value.absent(),
     Value<String?> espressoNotes = const Value.absent(),
     Value<String?> stopReason = const Value.absent(),
+    Value<DateTime?> createdAt = const Value.absent(),
+    Value<DateTime?> updatedAt = const Value.absent(),
     Map<String, dynamic>? workflowJson,
     Value<Map<String, dynamic>?> annotationsJson = const Value.absent(),
     String? measurementsJson,
@@ -3750,6 +3813,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
         ? espressoNotes.value
         : this.espressoNotes,
     stopReason: stopReason.present ? stopReason.value : this.stopReason,
+    createdAt: createdAt.present ? createdAt.value : this.createdAt,
+    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
     workflowJson: workflowJson ?? this.workflowJson,
     annotationsJson: annotationsJson.present
         ? annotationsJson.value
@@ -3792,6 +3857,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
       stopReason: data.stopReason.present
           ? data.stopReason.value
           : this.stopReason,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
       workflowJson: data.workflowJson.present
           ? data.workflowJson.value
           : this.workflowJson,
@@ -3821,6 +3888,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
           ..write('enjoyment: $enjoyment, ')
           ..write('espressoNotes: $espressoNotes, ')
           ..write('stopReason: $stopReason, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
           ..write('workflowJson: $workflowJson, ')
           ..write('annotationsJson: $annotationsJson, ')
           ..write('measurementsJson: $measurementsJson')
@@ -3844,6 +3913,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
     enjoyment,
     espressoNotes,
     stopReason,
+    createdAt,
+    updatedAt,
     workflowJson,
     annotationsJson,
     measurementsJson,
@@ -3866,6 +3937,8 @@ class ShotRecord extends DataClass implements Insertable<ShotRecord> {
           other.enjoyment == this.enjoyment &&
           other.espressoNotes == this.espressoNotes &&
           other.stopReason == this.stopReason &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
           other.workflowJson == this.workflowJson &&
           other.annotationsJson == this.annotationsJson &&
           other.measurementsJson == this.measurementsJson);
@@ -3886,6 +3959,8 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
   final Value<double?> enjoyment;
   final Value<String?> espressoNotes;
   final Value<String?> stopReason;
+  final Value<DateTime?> createdAt;
+  final Value<DateTime?> updatedAt;
   final Value<Map<String, dynamic>> workflowJson;
   final Value<Map<String, dynamic>?> annotationsJson;
   final Value<String> measurementsJson;
@@ -3905,6 +3980,8 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     this.enjoyment = const Value.absent(),
     this.espressoNotes = const Value.absent(),
     this.stopReason = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
     this.workflowJson = const Value.absent(),
     this.annotationsJson = const Value.absent(),
     this.measurementsJson = const Value.absent(),
@@ -3925,6 +4002,8 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     this.enjoyment = const Value.absent(),
     this.espressoNotes = const Value.absent(),
     this.stopReason = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
     required Map<String, dynamic> workflowJson,
     this.annotationsJson = const Value.absent(),
     required String measurementsJson,
@@ -3948,6 +4027,8 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     Expression<double>? enjoyment,
     Expression<String>? espressoNotes,
     Expression<String>? stopReason,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
     Expression<String>? workflowJson,
     Expression<String>? annotationsJson,
     Expression<String>? measurementsJson,
@@ -3968,6 +4049,8 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
       if (enjoyment != null) 'enjoyment': enjoyment,
       if (espressoNotes != null) 'espresso_notes': espressoNotes,
       if (stopReason != null) 'stop_reason': stopReason,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
       if (workflowJson != null) 'workflow_json': workflowJson,
       if (annotationsJson != null) 'annotations_json': annotationsJson,
       if (measurementsJson != null) 'measurements_json': measurementsJson,
@@ -3990,6 +4073,8 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     Value<double?>? enjoyment,
     Value<String?>? espressoNotes,
     Value<String?>? stopReason,
+    Value<DateTime?>? createdAt,
+    Value<DateTime?>? updatedAt,
     Value<Map<String, dynamic>>? workflowJson,
     Value<Map<String, dynamic>?>? annotationsJson,
     Value<String>? measurementsJson,
@@ -4010,6 +4095,8 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
       enjoyment: enjoyment ?? this.enjoyment,
       espressoNotes: espressoNotes ?? this.espressoNotes,
       stopReason: stopReason ?? this.stopReason,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
       workflowJson: workflowJson ?? this.workflowJson,
       annotationsJson: annotationsJson ?? this.annotationsJson,
       measurementsJson: measurementsJson ?? this.measurementsJson,
@@ -4062,6 +4149,12 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
     if (stopReason.present) {
       map['stop_reason'] = Variable<String>(stopReason.value);
     }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
     if (workflowJson.present) {
       map['workflow_json'] = Variable<String>(
         $ShotRecordsTable.$converterworkflowJson.toSql(workflowJson.value),
@@ -4100,6 +4193,8 @@ class ShotRecordsCompanion extends UpdateCompanion<ShotRecord> {
           ..write('enjoyment: $enjoyment, ')
           ..write('espressoNotes: $espressoNotes, ')
           ..write('stopReason: $stopReason, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
           ..write('workflowJson: $workflowJson, ')
           ..write('annotationsJson: $annotationsJson, ')
           ..write('measurementsJson: $measurementsJson, ')
@@ -7046,6 +7141,8 @@ typedef $$ShotRecordsTableCreateCompanionBuilder =
       Value<double?> enjoyment,
       Value<String?> espressoNotes,
       Value<String?> stopReason,
+      Value<DateTime?> createdAt,
+      Value<DateTime?> updatedAt,
       required Map<String, dynamic> workflowJson,
       Value<Map<String, dynamic>?> annotationsJson,
       required String measurementsJson,
@@ -7067,6 +7164,8 @@ typedef $$ShotRecordsTableUpdateCompanionBuilder =
       Value<double?> enjoyment,
       Value<String?> espressoNotes,
       Value<String?> stopReason,
+      Value<DateTime?> createdAt,
+      Value<DateTime?> updatedAt,
       Value<Map<String, dynamic>> workflowJson,
       Value<Map<String, dynamic>?> annotationsJson,
       Value<String> measurementsJson,
@@ -7149,6 +7248,16 @@ class $$ShotRecordsTableFilterComposer
 
   ColumnFilters<String> get stopReason => $composableBuilder(
     column: $table.stopReason,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -7257,6 +7366,16 @@ class $$ShotRecordsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get workflowJson => $composableBuilder(
     column: $table.workflowJson,
     builder: (column) => ColumnOrderings(column),
@@ -7344,6 +7463,12 @@ class $$ShotRecordsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
   GeneratedColumnWithTypeConverter<Map<String, dynamic>, String>
   get workflowJson => $composableBuilder(
     column: $table.workflowJson,
@@ -7407,6 +7532,8 @@ class $$ShotRecordsTableTableManager
                 Value<double?> enjoyment = const Value.absent(),
                 Value<String?> espressoNotes = const Value.absent(),
                 Value<String?> stopReason = const Value.absent(),
+                Value<DateTime?> createdAt = const Value.absent(),
+                Value<DateTime?> updatedAt = const Value.absent(),
                 Value<Map<String, dynamic>> workflowJson = const Value.absent(),
                 Value<Map<String, dynamic>?> annotationsJson =
                     const Value.absent(),
@@ -7427,6 +7554,8 @@ class $$ShotRecordsTableTableManager
                 enjoyment: enjoyment,
                 espressoNotes: espressoNotes,
                 stopReason: stopReason,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
                 workflowJson: workflowJson,
                 annotationsJson: annotationsJson,
                 measurementsJson: measurementsJson,
@@ -7448,6 +7577,8 @@ class $$ShotRecordsTableTableManager
                 Value<double?> enjoyment = const Value.absent(),
                 Value<String?> espressoNotes = const Value.absent(),
                 Value<String?> stopReason = const Value.absent(),
+                Value<DateTime?> createdAt = const Value.absent(),
+                Value<DateTime?> updatedAt = const Value.absent(),
                 required Map<String, dynamic> workflowJson,
                 Value<Map<String, dynamic>?> annotationsJson =
                     const Value.absent(),
@@ -7468,6 +7599,8 @@ class $$ShotRecordsTableTableManager
                 enjoyment: enjoyment,
                 espressoNotes: espressoNotes,
                 stopReason: stopReason,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
                 workflowJson: workflowJson,
                 annotationsJson: annotationsJson,
                 measurementsJson: measurementsJson,

--- a/lib/src/services/database/mappers/shot_mapper.dart
+++ b/lib/src/services/database/mappers/shot_mapper.dart
@@ -23,8 +23,8 @@ class ShotMapper {
     return domain.ShotRecord(
       id: row.id,
       timestamp: row.timestamp,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
+      createdAt: row.createdAt ?? row.timestamp,
+      updatedAt: row.updatedAt ?? row.createdAt ?? row.timestamp,
       measurements: measurements,
       workflow: workflow,
       annotations: annotations,

--- a/lib/src/services/database/mappers/shot_mapper.dart
+++ b/lib/src/services/database/mappers/shot_mapper.dart
@@ -38,7 +38,7 @@ class ShotMapper {
       id: Value(record.id),
       timestamp: Value(record.timestamp),
       createdAt: Value(record.createdAt),
-      updatedAt: Value(DateTime.now()),
+      updatedAt: Value(record.updatedAt),
 
       profileTitle: Value(record.workflow.profile.title),
       grinderId: Value(ctx?.grinderId),

--- a/lib/src/services/database/mappers/shot_mapper.dart
+++ b/lib/src/services/database/mappers/shot_mapper.dart
@@ -23,6 +23,8 @@ class ShotMapper {
     return domain.ShotRecord(
       id: row.id,
       timestamp: row.timestamp,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
       measurements: measurements,
       workflow: workflow,
       annotations: annotations,
@@ -35,6 +37,8 @@ class ShotMapper {
     return db.ShotRecordsCompanion(
       id: Value(record.id),
       timestamp: Value(record.timestamp),
+      createdAt: Value(record.createdAt),
+      updatedAt: Value(DateTime.now()),
 
       profileTitle: Value(record.workflow.profile.title),
       grinderId: Value(ctx?.grinderId),

--- a/lib/src/services/database/tables/shot_tables.dart
+++ b/lib/src/services/database/tables/shot_tables.dart
@@ -19,6 +19,9 @@ class ShotRecords extends Table {
 
   TextColumn get stopReason => text().nullable()();
 
+  DateTimeColumn get createdAt => dateTime().nullable()();
+  DateTimeColumn get updatedAt => dateTime().nullable()();
+
   TextColumn get workflowJson => text().map(const JsonMapConverter())();
   TextColumn get annotationsJson =>
       text().map(const NullableJsonMapConverter()).nullable()();

--- a/lib/src/services/storage/drift_storage_service.dart
+++ b/lib/src/services/storage/drift_storage_service.dart
@@ -14,7 +14,15 @@ class DriftStorageService implements StorageService {
 
   @override
   Future<void> storeShot(domain.ShotRecord record) {
-    return _db.shotDao.insertShot(ShotMapper.toCompanion(record));
+    final now = DateTime.now().toUtc();
+    return _db.shotDao.insertShot(
+      ShotMapper.toCompanion(
+        record.copyWith(
+          createdAt: record.createdAt ?? now,
+          updatedAt: record.updatedAt ?? now,
+        ),
+      ),
+    );
   }
 
   @override

--- a/lib/src/services/webserver/data_export/shot_export_section.dart
+++ b/lib/src/services/webserver/data_export/shot_export_section.dart
@@ -64,7 +64,10 @@ class ShotExportSection implements DataExportSection {
 
         if (existing != null) {
           if (strategy == ConflictStrategy.overwrite) {
-            final contentChanged = !existing.sameContent(record);
+            final contentChanged = !existing.sameContent(
+              record,
+              includeMeasurements: true,
+            );
             await _controller.storageService.updateShot(
               record.copyWith(
                 createdAt:

--- a/lib/src/services/webserver/data_export/shot_export_section.dart
+++ b/lib/src/services/webserver/data_export/shot_export_section.dart
@@ -64,7 +64,20 @@ class ShotExportSection implements DataExportSection {
 
         if (existing != null) {
           if (strategy == ConflictStrategy.overwrite) {
-            await _controller.storageService.updateShot(record);
+            final contentChanged = !existing.sameContent(record);
+            await _controller.storageService.updateShot(
+              record.copyWith(
+                createdAt:
+                    existing.createdAt ??
+                    record.createdAt ??
+                    existing.timestamp,
+                updatedAt: contentChanged
+                    ? DateTime.now().toUtc()
+                    : existing.updatedAt ??
+                          existing.createdAt ??
+                          existing.timestamp,
+              ),
+            );
             imported++;
           } else {
             skipped++;

--- a/lib/src/services/webserver/shots_handler.dart
+++ b/lib/src/services/webserver/shots_handler.dart
@@ -216,6 +216,14 @@ class ShotsHandler {
       _synchronizeLegacyAnnotationAliases(merged);
       merged['id'] = id;
 
+      final contentChanged = !_contentEquals(
+        merged,
+        existingShot.toJsonWithoutMeasurements(),
+      );
+      merged['updatedAt'] =
+          (contentChanged ? DateTime.now() : existingShot.updatedAt)
+              .toIso8601String();
+
       final updatedShot = ShotRecord.fromJson(merged);
       await _controller.updateShot(updatedShot);
       _log.info("Broadcasting shotUpdated for ${updatedShot.id}");
@@ -319,5 +327,26 @@ class ShotsHandler {
       }
     }
     return result;
+  }
+
+  bool _contentEquals(
+    Map<String, dynamic> merged,
+    Map<String, dynamic> existing,
+  ) {
+    return jsonEncode(_contentOnly(merged)) ==
+        jsonEncode(_contentOnly(existing));
+  }
+
+  Map<String, dynamic> _contentOnly(Map<String, dynamic> json) {
+    final copy = Map<String, dynamic>.from(json)
+      ..remove('updatedAt')
+      ..remove('measurements')
+      ..remove('metadata');
+    final annotations = copy['annotations'];
+    if (annotations is Map<String, dynamic>) {
+      copy['annotations'] = Map<String, dynamic>.from(annotations)
+        ..remove('extras');
+    }
+    return copy;
   }
 }

--- a/lib/src/services/webserver/shots_handler.dart
+++ b/lib/src/services/webserver/shots_handler.dart
@@ -9,6 +9,8 @@ import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
 class ShotsHandler {
+  static const _bookkeepingExtrasKeys = {'uploaded_to_decent', 'visualizerId'};
+
   final PersistenceController _controller;
   final BeanStorageService? _beanStorage;
   final PluginManager? _pluginManager;
@@ -204,6 +206,12 @@ class ShotsHandler {
         });
       }
 
+      if (json.containsKey('measurements')) {
+        return jsonBadRequest({
+          "error": "measurements is not editable via this endpoint",
+        });
+      }
+
       final existingShot = await _controller.storageService.getShot(id);
       if (existingShot == null) {
         return jsonNotFound({"error": "Shot not found"});
@@ -221,7 +229,11 @@ class ShotsHandler {
         existingShot.toJsonWithoutMeasurements(),
       );
       merged['updatedAt'] =
-          (contentChanged ? DateTime.now() : existingShot.updatedAt)
+          (contentChanged
+                  ? DateTime.now().toUtc()
+                  : existingShot.updatedAt ??
+                        existingShot.createdAt ??
+                        existingShot.timestamp)
               .toIso8601String();
 
       final updatedShot = ShotRecord.fromJson(merged);
@@ -344,8 +356,13 @@ class ShotsHandler {
       ..remove('metadata');
     final annotations = copy['annotations'];
     if (annotations is Map<String, dynamic>) {
-      copy['annotations'] = Map<String, dynamic>.from(annotations)
-        ..remove('extras');
+      final normalized = Map<String, dynamic>.from(annotations);
+      final extras = normalized['extras'];
+      if (extras is Map<String, dynamic>) {
+        normalized['extras'] = Map<String, dynamic>.from(extras)
+          ..removeWhere((key, _) => _bookkeepingExtrasKeys.contains(key));
+      }
+      copy['annotations'] = normalized;
     }
     return copy;
   }

--- a/lib/src/services/webserver/shots_handler.dart
+++ b/lib/src/services/webserver/shots_handler.dart
@@ -9,8 +9,6 @@ import 'package:reaprime/src/services/webserver/json_response.dart';
 import 'package:shelf_plus/shelf_plus.dart';
 
 class ShotsHandler {
-  static const _bookkeepingExtrasKeys = {'uploaded_to_decent', 'visualizerId'};
-
   final PersistenceController _controller;
   final BeanStorageService? _beanStorage;
   final PluginManager? _pluginManager;
@@ -212,6 +210,14 @@ class ShotsHandler {
         });
       }
 
+      if (json.containsKey('createdAt') || json.containsKey('updatedAt')) {
+        return jsonBadRequest({
+          "error":
+              "createdAt and updatedAt are system-managed and cannot be "
+              "modified via this endpoint",
+        });
+      }
+
       final existingShot = await _controller.storageService.getShot(id);
       if (existingShot == null) {
         return jsonNotFound({"error": "Shot not found"});
@@ -224,10 +230,9 @@ class ShotsHandler {
       _synchronizeLegacyAnnotationAliases(merged);
       merged['id'] = id;
 
-      final contentChanged = !_contentEquals(
+      final contentChanged = !ShotRecord.fromJson(
         merged,
-        existingShot.toJsonWithoutMeasurements(),
-      );
+      ).sameContent(existingShot);
       merged['updatedAt'] =
           (contentChanged
                   ? DateTime.now().toUtc()
@@ -339,31 +344,5 @@ class ShotsHandler {
       }
     }
     return result;
-  }
-
-  bool _contentEquals(
-    Map<String, dynamic> merged,
-    Map<String, dynamic> existing,
-  ) {
-    return jsonEncode(_contentOnly(merged)) ==
-        jsonEncode(_contentOnly(existing));
-  }
-
-  Map<String, dynamic> _contentOnly(Map<String, dynamic> json) {
-    final copy = Map<String, dynamic>.from(json)
-      ..remove('updatedAt')
-      ..remove('measurements')
-      ..remove('metadata');
-    final annotations = copy['annotations'];
-    if (annotations is Map<String, dynamic>) {
-      final normalized = Map<String, dynamic>.from(annotations);
-      final extras = normalized['extras'];
-      if (extras is Map<String, dynamic>) {
-        normalized['extras'] = Map<String, dynamic>.from(extras)
-          ..removeWhere((key, _) => _bookkeepingExtrasKeys.contains(key));
-      }
-      copy['annotations'] = normalized;
-    }
-    return copy;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1599,7 +1599,7 @@ packages:
     source: hosted
     version: "0.7.0+eol"
   sqlite3:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: sqlite3
       sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -166,6 +166,9 @@ dev_dependencies:
   drift_dev: ^2.24.0
   build_runner: ^2.4.0
   yaml: ^3.1.3
+  # Test-only: raw sqlite access for schema-migration fixtures. Already
+  # present transitively via drift's native implementation.
+  sqlite3: ^3.3.3
 
 flutter:
   uses-material-design: true

--- a/test/data_export/shot_export_section_test.dart
+++ b/test/data_export/shot_export_section_test.dart
@@ -4,9 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/shot_snapshot.dart';
 import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:reaprime/src/services/webserver/data_export/data_export_section.dart';
 import 'package:reaprime/src/services/webserver/data_export/shot_export_section.dart';
@@ -157,6 +159,27 @@ ShotRecord makeShot(int i) => ShotRecord.fromJson({
   'measurements': <Object?>[],
   'workflow': makeWorkflowJson(),
 });
+
+ShotSnapshot _snapshot() => ShotSnapshot(
+  machine: MachineSnapshot(
+    timestamp: DateTime.utc(2026, 5, 18, 12),
+    state: const MachineStateSnapshot(
+      state: MachineState.steam,
+      substate: MachineSubstate.pouring,
+    ),
+    flow: 0,
+    pressure: 0,
+    targetFlow: 0,
+    targetPressure: 0,
+    mixTemperature: 90,
+    groupTemperature: 90,
+    targetMixTemperature: 93,
+    targetGroupTemperature: 93,
+    profileFrame: 0,
+    steamTemperature: 140,
+  ),
+  volume: 0,
+);
 
 void main() {
   group('ShotExportSection', () {
@@ -371,6 +394,46 @@ void main() {
         expect(
           stored['updatedAt'],
           existing.updatedAt!.toUtc().toIso8601String(),
+        );
+      },
+    );
+
+    test(
+      'overwrite differing only in measurements advances updatedAt',
+      () async {
+        final storage = _TestShotStorage();
+        final existing = makeShot(1).copyWith(
+          createdAt: DateTime.utc(2024, 1, 1, 8),
+          updatedAt: DateTime.utc(2024, 1, 1, 8, 30),
+          measurements: [_snapshot().copyWith(volume: 36)],
+        );
+        storage.shots['shot-1'] = existing.toJson();
+        final section = ShotExportSection(
+          controller: PersistenceController(storageService: storage.service),
+          pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) async =>
+              [],
+        );
+
+        final reimported = makeShot(1).copyWith(
+          createdAt: DateTime.utc(2020, 1, 1),
+          updatedAt: DateTime.utc(2020, 1, 1),
+          measurements: [_snapshot().copyWith(volume: 42)],
+        );
+        final result = await importSectionJson(
+          section,
+          jsonEncode([reimported.toJson()]),
+          ConflictStrategy.overwrite,
+        );
+        expect(result.imported, 1);
+
+        final stored = storage.shots['shot-1']!;
+        expect((stored['measurements'] as List).single['volume'], 42);
+        expect(stored['updatedAt'], endsWith('Z'));
+        expect(
+          DateTime.parse(
+            stored['updatedAt'] as String,
+          ).isAfter(DateTime.utc(2024, 1, 1, 8, 30)),
+          isTrue,
         );
       },
     );

--- a/test/data_export/shot_export_section_test.dart
+++ b/test/data_export/shot_export_section_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
 import 'package:reaprime/src/models/data/steam_record.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
@@ -256,6 +257,123 @@ void main() {
       expect(result.imported, 1);
       expect(storage.updated, 1);
     });
+
+    test(
+      'overwrite preserves createdAt and bumps updatedAt on content change',
+      () async {
+        final storage = _TestShotStorage();
+        final existing = makeShot(1).copyWith(
+          createdAt: DateTime.utc(2024, 1, 1, 8),
+          updatedAt: DateTime.utc(2024, 1, 1, 8, 30),
+          annotations: const ShotAnnotations(espressoNotes: 'old'),
+        );
+        storage.shots['shot-1'] = existing.toJson();
+        final section = ShotExportSection(
+          controller: PersistenceController(storageService: storage.service),
+          pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) async =>
+              [],
+        );
+
+        final edited = makeShot(1).copyWith(
+          createdAt: DateTime.utc(2020, 1, 1),
+          updatedAt: DateTime.utc(2020, 1, 1),
+          annotations: const ShotAnnotations(espressoNotes: 'new'),
+        );
+        final result = await importSectionJson(
+          section,
+          jsonEncode([edited.toJson()]),
+          ConflictStrategy.overwrite,
+        );
+        expect(result.imported, 1);
+
+        final stored = storage.shots['shot-1']!;
+        expect(
+          stored['createdAt'],
+          existing.createdAt!.toUtc().toIso8601String(),
+        );
+        expect(stored['annotations']['espressoNotes'], 'new');
+        expect(stored['updatedAt'], endsWith('Z'));
+        expect(
+          DateTime.parse(
+            stored['updatedAt'] as String,
+          ).isAfter(DateTime.utc(2024, 1, 1, 8, 30)),
+          isTrue,
+        );
+      },
+    );
+
+    test('no-op overwrite preserves updatedAt', () async {
+      final storage = _TestShotStorage();
+      final existing = makeShot(1).copyWith(
+        createdAt: DateTime.utc(2024, 1, 1, 8),
+        updatedAt: DateTime.utc(2024, 1, 1, 8, 30),
+        annotations: const ShotAnnotations(espressoNotes: 'same'),
+      );
+      storage.shots['shot-1'] = existing.toJson();
+      final section = ShotExportSection(
+        controller: PersistenceController(storageService: storage.service),
+        pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) async =>
+            [],
+      );
+
+      final result = await importSectionJson(
+        section,
+        jsonEncode([existing.toJson()]),
+        ConflictStrategy.overwrite,
+      );
+      expect(result.imported, 1);
+
+      final stored = storage.shots['shot-1']!;
+      expect(
+        stored['createdAt'],
+        existing.createdAt!.toUtc().toIso8601String(),
+      );
+      expect(
+        stored['updatedAt'],
+        existing.updatedAt!.toUtc().toIso8601String(),
+      );
+    });
+
+    test(
+      'overwrite confined to bookkeeping extras does not advance updatedAt',
+      () async {
+        final storage = _TestShotStorage();
+        final existing = makeShot(1).copyWith(
+          createdAt: DateTime.utc(2024, 1, 1, 8),
+          updatedAt: DateTime.utc(2024, 1, 1, 8, 30),
+          annotations: const ShotAnnotations(
+            extras: {'favorite': true, 'uploaded_to_decent': 1},
+          ),
+        );
+        storage.shots['shot-1'] = existing.toJson();
+        final section = ShotExportSection(
+          controller: PersistenceController(storageService: storage.service),
+          pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) async =>
+              [],
+        );
+
+        final reimported = makeShot(1).copyWith(
+          createdAt: DateTime.utc(2020, 1, 1),
+          updatedAt: DateTime.utc(2020, 1, 1),
+          annotations: const ShotAnnotations(
+            extras: {'favorite': true, 'uploaded_to_decent': 2},
+          ),
+        );
+        final result = await importSectionJson(
+          section,
+          jsonEncode([reimported.toJson()]),
+          ConflictStrategy.overwrite,
+        );
+        expect(result.imported, 1);
+
+        final stored = storage.shots['shot-1']!;
+        expect(stored['annotations']['extras']['uploaded_to_decent'], 2);
+        expect(
+          stored['updatedAt'],
+          existing.updatedAt!.toUtc().toIso8601String(),
+        );
+      },
+    );
 
     test('individually invalid records keep partial-result behavior', () async {
       final storage = _TestShotStorage();

--- a/test/database/shot_schema_migration_test.dart
+++ b/test/database/shot_schema_migration_test.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/database/mappers/shot_mapper.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+// v4 shot_records DDL: the v5 CREATE TABLE minus the created_at/updated_at
+// columns added by the from<5 migration step.
+const _v4ShotTableDdl =
+    'CREATE TABLE "shot_records" ("id" TEXT NOT NULL, "timestamp" TEXT NOT '
+    'NULL, "profile_title" TEXT NULL, "grinder_id" TEXT NULL, '
+    '"grinder_model" TEXT NULL, "grinder_setting" TEXT NULL, '
+    '"bean_batch_id" TEXT NULL, "coffee_name" TEXT NULL, "coffee_roaster" '
+    'TEXT NULL, "target_dose_weight" REAL NULL, "target_yield" REAL NULL, '
+    '"enjoyment" REAL NULL, "espresso_notes" TEXT NULL, "stop_reason" TEXT '
+    'NULL, "workflow_json" TEXT NOT NULL, "annotations_json" TEXT NULL, '
+    '"measurements_json" TEXT NOT NULL, PRIMARY KEY ("id"))';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('reaprime_v4_migration');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test(
+    'migration from schema 4 backfills createdAt and updatedAt from timestamp',
+    () async {
+      final dbFile = File('${tempDir.path}/legacy.db');
+      final legacy = sqlite3.sqlite3.open(dbFile.path);
+      try {
+        legacy.execute(_v4ShotTableDdl);
+        legacy.execute('PRAGMA user_version = 4');
+        legacy.execute(
+          'INSERT INTO shot_records '
+          '(id, timestamp, workflow_json, measurements_json) '
+          'VALUES (?, ?, ?, ?)',
+          [
+            'legacy-1',
+            '2025-03-01T12:00:00.000Z',
+            jsonEncode(WorkflowController().currentWorkflow.toJson()),
+            '[]',
+          ],
+        );
+      } finally {
+        legacy.close();
+      }
+
+      final db = AppDatabase(NativeDatabase(dbFile));
+      try {
+        final version = (await db.customSelect('PRAGMA user_version').get())
+            .single
+            .data['user_version'];
+        expect(version, 5);
+
+        final raw =
+            (await db
+                    .customSelect(
+                      'SELECT created_at, updated_at FROM shot_records WHERE id = ?',
+                      variables: [const Variable('legacy-1')],
+                    )
+                    .get())
+                .single
+                .data;
+        expect(raw['created_at'], '2025-03-01T12:00:00.000Z');
+        expect(raw['updated_at'], '2025-03-01T12:00:00.000Z');
+
+        final shot = ShotMapper.fromRow(
+          (await db.shotDao.getShotById('legacy-1'))!,
+        );
+        expect(shot.createdAt, DateTime.utc(2025, 3, 1, 12));
+        expect(shot.updatedAt, DateTime.utc(2025, 3, 1, 12));
+      } finally {
+        await db.close();
+      }
+    },
+  );
+}

--- a/test/database/shot_stop_reason_persistence_test.dart
+++ b/test/database/shot_stop_reason_persistence_test.dart
@@ -70,9 +70,33 @@ void main() {
     expect(restored.updatedAt, isNotNull);
     expect(restored.createdAt!.isUtc, isTrue);
     expect(restored.updatedAt!.isUtc, isTrue);
+    expect(restored.createdAt, restored.updatedAt);
     expect(
       DateTime.now().toUtc().difference(restored.updatedAt!).inSeconds,
       lessThan(10),
     );
   });
+
+  test(
+    'legacy rows without timestamps expose the extraction-time fallback',
+    () async {
+      final workflow = WorkflowController().currentWorkflow;
+      await db
+          .into(db.shotRecords)
+          .insert(
+            ShotRecordsCompanion.insert(
+              id: 'legacy-1',
+              timestamp: DateTime.utc(2025, 3, 1, 12),
+              workflowJson: workflow.toJson(),
+              measurementsJson: '[]',
+            ),
+          );
+
+      final row = await db.shotDao.getShotById('legacy-1');
+      final restored = ShotMapper.fromRow(row!);
+
+      expect(restored.createdAt, DateTime.utc(2025, 3, 1, 12));
+      expect(restored.updatedAt, DateTime.utc(2025, 3, 1, 12));
+    },
+  );
 }

--- a/test/database/shot_stop_reason_persistence_test.dart
+++ b/test/database/shot_stop_reason_persistence_test.dart
@@ -43,4 +43,18 @@ void main() {
     final row = await db.shotDao.getShotById('shot-1');
     expect(ShotMapper.fromRow(row!).stopReason, isNull);
   });
+
+  test('updateShot persists the record updatedAt, not a fresh now()', () async {
+    await db.shotDao.insertShot(ShotMapper.toCompanion(makeRecord()));
+
+    final editedAt = DateTime.utc(2026, 6, 17, 10, 30);
+    await db.shotDao.updateShot(
+      ShotMapper.toCompanion(
+        makeRecord(stopReason: 'manual').copyWith(updatedAt: editedAt),
+      ),
+    );
+
+    final row = await db.shotDao.getShotById('shot-1');
+    expect(ShotMapper.fromRow(row!).updatedAt, editedAt);
+  });
 }

--- a/test/database/shot_stop_reason_persistence_test.dart
+++ b/test/database/shot_stop_reason_persistence_test.dart
@@ -4,6 +4,7 @@ import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/shot_record.dart' as domain;
 import 'package:reaprime/src/services/database/database.dart';
 import 'package:reaprime/src/services/database/mappers/shot_mapper.dart';
+import 'package:reaprime/src/services/storage/drift_storage_service.dart';
 
 void main() {
   late AppDatabase db;
@@ -56,5 +57,22 @@ void main() {
 
     final row = await db.shotDao.getShotById('shot-1');
     expect(ShotMapper.fromRow(row!).updatedAt, editedAt);
+  });
+
+  test('storeShot stamps createdAt and updatedAt at insertion', () async {
+    final storage = DriftStorageService(db);
+    await storage.storeShot(makeRecord());
+
+    final row = await db.shotDao.getShotById('shot-1');
+    final restored = ShotMapper.fromRow(row!);
+
+    expect(restored.createdAt, isNotNull);
+    expect(restored.updatedAt, isNotNull);
+    expect(restored.createdAt!.isUtc, isTrue);
+    expect(restored.updatedAt!.isUtc, isTrue);
+    expect(
+      DateTime.now().toUtc().difference(restored.updatedAt!).inSeconds,
+      lessThan(10),
+    );
   });
 }

--- a/test/models/shot_record_test.dart
+++ b/test/models/shot_record_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_record.dart';
+import 'package:reaprime/src/models/data/shot_snapshot.dart';
+import 'package:reaprime/src/models/device/machine.dart';
 
 void main() {
   test('canonical constructor annotations stay authoritative when null', () {
@@ -193,6 +195,43 @@ void main() {
 
       expect(a.sameContent(b), isTrue);
       expect(a.sameContent(c), isTrue);
+    });
+
+    test('measurements count as content only when requested', () {
+      ShotSnapshot snapshot(double volume) => ShotSnapshot(
+        machine: MachineSnapshot(
+          timestamp: DateTime.utc(2026, 7, 23, 10),
+          state: const MachineStateSnapshot(
+            state: MachineState.steam,
+            substate: MachineSubstate.pouring,
+          ),
+          flow: 0,
+          pressure: 0,
+          targetFlow: 0,
+          targetPressure: 0,
+          mixTemperature: 90,
+          groupTemperature: 90,
+          targetMixTemperature: 93,
+          targetGroupTemperature: 93,
+          profileFrame: 0,
+          steamTemperature: 140,
+        ),
+        volume: volume,
+      );
+
+      final plain = record();
+      final withFlow = ShotRecord(
+        id: 'shot-1',
+        timestamp: DateTime.utc(2026, 7, 23),
+        createdAt: DateTime.utc(2026, 7, 23, 9),
+        updatedAt: DateTime.utc(2026, 7, 23, 9, 30),
+        measurements: [snapshot(42)],
+        workflow: workflow,
+      );
+
+      expect(plain.sameContent(withFlow), isTrue);
+      expect(plain.sameContent(withFlow, includeMeasurements: true), isFalse);
+      expect(withFlow.sameContent(withFlow, includeMeasurements: true), isTrue);
     });
   });
 }

--- a/test/models/shot_record_test.dart
+++ b/test/models/shot_record_test.dart
@@ -131,10 +131,17 @@ void main() {
       final visualizerOnly = record(
         extras: {'favorite': true, 'visualizerId': 'viz-1'},
       );
+      final rejectedOnly = record(
+        extras: {
+          'favorite': true,
+          'decent_upload_rejected': {'status': 422},
+        },
+      );
 
       expect(base.sameContent(withMarker), isTrue);
       expect(base.sameContent(changedMarker), isTrue);
       expect(base.sameContent(visualizerOnly), isTrue);
+      expect(base.sameContent(rejectedOnly), isTrue);
     });
 
     test('empty extras compares equal to absent extras', () {

--- a/test/models/shot_record_test.dart
+++ b/test/models/shot_record_test.dart
@@ -71,6 +71,123 @@ void main() {
     expect(serialized.containsKey('shotNotes'), isFalse);
     expect(serialized.containsKey('metadata'), isFalse);
   });
+
+  test('serialization always emits UTC for createdAt and updatedAt', () {
+    final record = ShotRecord(
+      id: 'shot-1',
+      timestamp: DateTime.utc(2026, 7, 23),
+      createdAt: DateTime(2026, 7, 23, 10, 30),
+      updatedAt: DateTime(2026, 7, 23, 10, 31),
+      measurements: const [],
+      workflow: WorkflowController().currentWorkflow,
+    );
+
+    expect(record.toJson()['createdAt'], endsWith('Z'));
+    expect(record.toJson()['updatedAt'], endsWith('Z'));
+    expect(record.toJsonWithoutMeasurements()['createdAt'], endsWith('Z'));
+    expect(record.toJsonWithoutMeasurements()['updatedAt'], endsWith('Z'));
+  });
+
+  test('fromJson normalizes non-UTC and legacy-fallback timestamps to UTC', () {
+    final json = _baseJson()
+      ..['createdAt'] = '2026-07-23T10:30:00'
+      ..['updatedAt'] = '2026-07-23T10:31:00';
+
+    final record = ShotRecord.fromJson(json);
+    expect(record.createdAt!.isUtc, isTrue);
+    expect(record.updatedAt!.isUtc, isTrue);
+    expect(record.toJson()['createdAt'], endsWith('Z'));
+    expect(record.toJson()['updatedAt'], endsWith('Z'));
+
+    final legacy = ShotRecord.fromJson(_baseJson());
+    expect(legacy.createdAt!.isUtc, isTrue);
+    expect(legacy.updatedAt!.isUtc, isTrue);
+    expect(legacy.createdAt, legacy.timestamp.toUtc());
+    expect(legacy.updatedAt, legacy.timestamp.toUtc());
+  });
+
+  group('sameContent', () {
+    final workflow = WorkflowController().currentWorkflow;
+
+    ShotRecord record({Map<String, dynamic>? extras, String? notes}) =>
+        ShotRecord(
+          id: 'shot-1',
+          timestamp: DateTime.utc(2026, 7, 23),
+          createdAt: DateTime.utc(2026, 7, 23, 9),
+          updatedAt: DateTime.utc(2026, 7, 23, 9, 30),
+          measurements: const [],
+          workflow: workflow,
+          annotations: ShotAnnotations(espressoNotes: notes, extras: extras),
+        );
+
+    test('bookkeeping-only differences are not content', () {
+      final base = record(extras: {'favorite': true});
+      final withMarker = record(
+        extras: {'favorite': true, 'uploaded_to_decent': 1767230000},
+      );
+      final changedMarker = record(
+        extras: {'favorite': true, 'uploaded_to_decent': 1767230001},
+      );
+      final visualizerOnly = record(
+        extras: {'favorite': true, 'visualizerId': 'viz-1'},
+      );
+
+      expect(base.sameContent(withMarker), isTrue);
+      expect(base.sameContent(changedMarker), isTrue);
+      expect(base.sameContent(visualizerOnly), isTrue);
+    });
+
+    test('empty extras compares equal to absent extras', () {
+      final noExtras = record(notes: 'hi');
+      final emptyExtras = record(notes: 'hi', extras: {});
+      final markerOnly = record(notes: 'hi', extras: {'uploaded_to_decent': 1});
+
+      expect(noExtras.sameContent(emptyExtras), isTrue);
+      expect(noExtras.sameContent(markerOnly), isTrue);
+    });
+
+    test('empty annotations compares equal to absent annotations', () {
+      final bare = ShotRecord(
+        id: 'shot-1',
+        timestamp: DateTime.utc(2026, 7, 23),
+        measurements: const [],
+        workflow: workflow,
+      );
+      final markerOnly = record(extras: {'visualizerId': 'viz-1'});
+
+      expect(bare.sameContent(markerOnly), isTrue);
+    });
+
+    test('meaningful extras differences are content', () {
+      final base = record(extras: {'favorite': true});
+      final changed = record(extras: {'favorite': false});
+      final added = record(extras: {'favorite': true, 'origin': 'x'});
+
+      expect(base.sameContent(changed), isFalse);
+      expect(base.sameContent(added), isFalse);
+    });
+
+    test('notes differences are content', () {
+      expect(record(notes: 'a').sameContent(record(notes: 'b')), isFalse);
+    });
+
+    test('system-managed timestamps never count as content', () {
+      final a = record();
+      final b = record();
+      final c = ShotRecord(
+        id: 'shot-1',
+        timestamp: DateTime.utc(2026, 7, 23),
+        createdAt: DateTime.utc(2026, 7, 23, 8),
+        updatedAt: DateTime.utc(2026, 7, 23, 8, 45),
+        measurements: const [],
+        workflow: workflow,
+        annotations: const ShotAnnotations(),
+      );
+
+      expect(a.sameContent(b), isTrue);
+      expect(a.sameContent(c), isTrue);
+    });
+  });
 }
 
 Map<String, dynamic> _baseJson() => ShotRecord(

--- a/test/webserver/shots_handler_test.dart
+++ b/test/webserver/shots_handler_test.dart
@@ -376,6 +376,148 @@ void main() {
         );
       }
     });
+
+    test('first uploaded_to_decent write on a shot with no annotations '
+        'preserves updatedAt', () async {
+      await persistence.persistShot(makeShot(id: 'clean'));
+      final before = await decode(await sendGet('/api/v1/shots/clean'));
+
+      final (putJson, getJson) = await putAndGet('clean', {
+        'annotations': {
+          'extras': {'uploaded_to_decent': 1767230000},
+        },
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json['annotations']['extras'], {
+          'uploaded_to_decent': 1767230000,
+        });
+        expect(
+          DateTime.parse(json['updatedAt'] as String),
+          DateTime.parse(before['updatedAt'] as String),
+        );
+      }
+    });
+
+    test('first bookkeeping write on annotations with no extras '
+        'preserves updatedAt', () async {
+      await persistence.persistShot(
+        makeShot(
+          id: 'notes-only',
+          annotations: const ShotAnnotations(espressoNotes: 'hi'),
+        ),
+      );
+      final before = await decode(await sendGet('/api/v1/shots/notes-only'));
+
+      final (putJson, getJson) = await putAndGet('notes-only', {
+        'annotations': {
+          'extras': {'visualizerId': 'viz-1'},
+        },
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(json['annotations']['extras'], {'visualizerId': 'viz-1'});
+        expect(
+          DateTime.parse(json['updatedAt'] as String),
+          DateTime.parse(before['updatedAt'] as String),
+        );
+      }
+    });
+
+    test(
+      'changing an existing bookkeeping value preserves updatedAt',
+      () async {
+        await persistAnnotatedShot();
+        await putAndGet('annotated', {
+          'annotations': {
+            'extras': {'uploaded_to_decent': 100},
+          },
+        });
+        final before = await decode(await sendGet('/api/v1/shots/annotated'));
+
+        final (putJson, getJson) = await putAndGet('annotated', {
+          'annotations': {
+            'extras': {'uploaded_to_decent': 200},
+          },
+        });
+
+        for (final json in [putJson, getJson]) {
+          expect(json['annotations']['extras']['uploaded_to_decent'], 200);
+          expect(json['annotations']['extras']['favorite'], false);
+          expect(
+            DateTime.parse(json['updatedAt'] as String),
+            DateTime.parse(before['updatedAt'] as String),
+          );
+        }
+      },
+    );
+
+    test(
+      'visualizerId-only write on annotated shot preserves updatedAt',
+      () async {
+        await persistAnnotatedShot();
+        final before = await decode(await sendGet('/api/v1/shots/annotated'));
+
+        final (putJson, getJson) = await putAndGet('annotated', {
+          'annotations': {
+            'extras': {'visualizerId': 'viz-9'},
+          },
+        });
+
+        for (final json in [putJson, getJson]) {
+          expect(json['annotations']['extras']['visualizerId'], 'viz-9');
+          expect(
+            DateTime.parse(json['updatedAt'] as String),
+            DateTime.parse(before['updatedAt'] as String),
+          );
+        }
+      },
+    );
+
+    test(
+      'mixed bookkeeping plus meaningful extra advances updatedAt',
+      () async {
+        await persistAnnotatedShot();
+        final before = await decode(await sendGet('/api/v1/shots/annotated'));
+
+        final (putJson, getJson) = await putAndGet('annotated', {
+          'annotations': {
+            'extras': {'uploaded_to_decent': 1, 'favorite': true},
+          },
+        });
+
+        for (final json in [putJson, getJson]) {
+          expect(json['annotations']['extras']['uploaded_to_decent'], 1);
+          expect(json['annotations']['extras']['favorite'], true);
+          expect(
+            DateTime.parse(
+              json['updatedAt'],
+            ).isAfter(DateTime.parse(before['updatedAt'] as String)),
+            isTrue,
+          );
+        }
+      },
+    );
+
+    test(
+      'PUT with createdAt or updatedAt is rejected and leaves values intact',
+      () async {
+        await persistAnnotatedShot();
+        final before = await decode(await sendGet('/api/v1/shots/annotated'));
+
+        for (final field in ['createdAt', 'updatedAt']) {
+          final response = await sendPut('annotated', {
+            field: '2000-01-01T00:00:00Z',
+          });
+          expect(response.statusCode, 400);
+          expect((await decode(response))['error'], contains(field));
+        }
+
+        final after = await decode(await sendGet('/api/v1/shots/annotated'));
+        expect(after['createdAt'], before['createdAt']);
+        expect(after['updatedAt'], before['updatedAt']);
+      },
+    );
   });
 }
 

--- a/test/webserver/shots_handler_test.dart
+++ b/test/webserver/shots_handler_test.dart
@@ -328,6 +328,35 @@ void main() {
       }
     });
 
+    test('non-bookkeeping extras change advances updatedAt', () async {
+      await persistAnnotatedShot();
+
+      final before = await decode(await sendGet('/api/v1/shots/annotated'));
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'annotations': {
+          'extras': {'favorite': true},
+        },
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(
+          DateTime.parse(
+            json['updatedAt'],
+          ).isAfter(DateTime.parse(before['updatedAt'] as String)),
+          isTrue,
+        );
+      }
+    });
+
+    test('PUT with measurements is rejected', () async {
+      await persistAnnotatedShot();
+
+      final response = await sendPut('annotated', {'measurements': []});
+      expect(response.statusCode, 400);
+      expect((await decode(response))['error'], contains('measurements'));
+    });
+
     test('content patch advances updatedAt', () async {
       await persistAnnotatedShot();
 
@@ -338,6 +367,7 @@ void main() {
       });
 
       for (final json in [putJson, getJson]) {
+        expect(json['updatedAt'], endsWith('Z'));
         expect(
           DateTime.parse(
             json['updatedAt'],

--- a/test/webserver/shots_handler_test.dart
+++ b/test/webserver/shots_handler_test.dart
@@ -309,14 +309,16 @@ void main() {
       }
     });
 
-    test('bookkeeping-only patch preserves updatedAt', () async {
+    test('decent upload rejection marker preserves updatedAt', () async {
       await persistAnnotatedShot();
 
       final before = await decode(await sendGet('/api/v1/shots/annotated'));
 
       final (putJson, getJson) = await putAndGet('annotated', {
         'annotations': {
-          'extras': {'uploaded_to_decent': 1767230000},
+          'extras': {
+            'decent_upload_rejected': {'status': 422, 'timestamp': 1767230000},
+          },
         },
       });
 

--- a/test/webserver/shots_handler_test.dart
+++ b/test/webserver/shots_handler_test.dart
@@ -308,6 +308,44 @@ void main() {
         expect(json['metadata'], json['annotations']['extras']);
       }
     });
+
+    test('bookkeeping-only patch preserves updatedAt', () async {
+      await persistAnnotatedShot();
+
+      final before = await decode(await sendGet('/api/v1/shots/annotated'));
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'annotations': {
+          'extras': {'uploaded_to_decent': 1767230000},
+        },
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(
+          DateTime.parse(json['updatedAt']),
+          DateTime.parse(before['updatedAt'] as String),
+        );
+      }
+    });
+
+    test('content patch advances updatedAt', () async {
+      await persistAnnotatedShot();
+
+      final before = await decode(await sendGet('/api/v1/shots/annotated'));
+
+      final (putJson, getJson) = await putAndGet('annotated', {
+        'annotations': {'espressoNotes': 'edited'},
+      });
+
+      for (final json in [putJson, getJson]) {
+        expect(
+          DateTime.parse(
+            json['updatedAt'],
+          ).isAfter(DateTime.parse(before['updatedAt'] as String)),
+          isTrue,
+        );
+      }
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

What changed, and why?

- Adds `createdAt` and `updatedAt` timestamps to shot records (drift columns, generated code, mapper, model), defaulting to the existing shot timestamp for legacy records.
- Enables durable reconciliation for consumers like the shot-upload plugin: an already-seen shot that later gets edited (notes, bean/batch, annotations) can now be detected via `updatedAt` instead of being skipped on the `uploaded_to_decent` marker.
- Schema version bump 4 → 5 with a migration adding the two nullable columns.`n- Treats `decent_upload_rejected` as explicit sync bookkeeping so uploader rejection markers do not advance `updatedAt`.

## Linked Issue

Fixes #676

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `flutter analyze --no-pub` clean.`n- `flutter test --no-pub test/models/shot_record_test.dart test/webserver/shots_handler_test.dart`: 33 passed.
- `flutter test` on the touched suites (de1_controller, shot_sequencer, workflow_device_sync, universal_ble discovery/recovery, remembered_devices, firmware_mmr_exclusion, generate_simulation_assets): 151 passed, 1 skipped.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Drift schema migration (v4 → v5) adds two nullable columns; no data rewrite, legacy shots fall back to their extraction timestamp.
- API/spec documentation now lists `decent_upload_rejected` with the existing bookkeeping keys; no user-visible UI change.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
