### PR TITLE
fix(skale2): accept nine-byte weight notifications

### DIFF
--- a/lib/src/models/device/impl/skale/skale2_scale.dart
+++ b/lib/src/models/device/impl/skale/skale2_scale.dart
@@ -224,16 +224,9 @@ class Skale2Scale implements Scale {
   }
 
   void _parseWeightNotification(List<int> data) {
-    double? weight;
-    if (data.length >= 5) {
-      var mantissa =
-          (data[1] & 0xFF) | ((data[2] & 0xFF) << 8) | ((data[3] & 0xFF) << 16);
-      if (mantissa & 0x800000 != 0) {
-        mantissa -= 0x1000000;
-      }
-      final rawExponent = data[4];
-      final exponent = rawExponent >= 0x80 ? rawExponent - 256 : rawExponent;
-      weight = mantissa * math.pow(10, exponent).toDouble();
+    double weight;
+    if (data.length == 5 || data.length == 9) {
+      weight = _decodeFirstWeightBlock(data);
     } else if (data.length == 4) {
       final byteData = ByteData(4);
       byteData.setUint8(0, data[0] & 0xFF);
@@ -252,6 +245,17 @@ class Skale2Scale implements Scale {
         batteryLevel: _batteryLevel,
       ),
     );
+  }
+
+  double _decodeFirstWeightBlock(List<int> data) {
+    var mantissa =
+        (data[1] & 0xFF) | ((data[2] & 0xFF) << 8) | ((data[3] & 0xFF) << 16);
+    if (mantissa & 0x800000 != 0) {
+      mantissa -= 0x1000000;
+    }
+    final rawExponent = data[4];
+    final exponent = rawExponent >= 0x80 ? rawExponent - 256 : rawExponent;
+    return mantissa * math.pow(10, exponent).toDouble();
   }
 
   void _parseButtonNotification(List<int> data) {}

--- a/lib/src/models/device/impl/skale/skale2_scale.dart
+++ b/lib/src/models/device/impl/skale/skale2_scale.dart
@@ -225,7 +225,7 @@ class Skale2Scale implements Scale {
 
   void _parseWeightNotification(List<int> data) {
     double? weight;
-    if (data.length == 5) {
+    if (data.length >= 5) {
       var mantissa =
           (data[1] & 0xFF) | ((data[2] & 0xFF) << 8) | ((data[3] & 0xFF) << 16);
       if (mantissa & 0x800000 != 0) {

--- a/test/unit/models/skale2_scale_test.dart
+++ b/test/unit/models/skale2_scale_test.dart
@@ -511,7 +511,7 @@ void main() {
       await sub.cancel();
     });
 
-    test('parses nine-byte weight notification', () async {
+    test('uses first weight block from nine-byte notification', () async {
       final completer = Completer<ScaleSnapshot>();
       final sub = scale.currentSnapshot.listen((snapshot) {
         if (!completer.isCompleted) completer.complete(snapshot);
@@ -523,16 +523,35 @@ void main() {
         0x03,
         0x00,
         0xFF,
-        0xE8,
-        0x03,
+        0xD2,
+        0x04,
         0x00,
-        0xFF,
+        0xFE,
       ]);
 
       final snapshot = await completer.future.timeout(
         const Duration(seconds: 1),
       );
       expect(snapshot.weight, closeTo(100.0, 0.001));
+
+      await sub.cancel();
+    });
+
+    test('ignores unsupported six-byte frame', () async {
+      var emissions = 0;
+      final sub = scale.currentSnapshot.listen((_) => emissions++);
+
+      transport.simulateWeightNotification([
+        0x00,
+        0xE8,
+        0x03,
+        0x00,
+        0xFF,
+        0x00,
+      ]);
+
+      await Future.delayed(const Duration(milliseconds: 100));
+      expect(emissions, 0);
 
       await sub.cancel();
     });

--- a/test/unit/models/skale2_scale_test.dart
+++ b/test/unit/models/skale2_scale_test.dart
@@ -511,9 +511,11 @@ void main() {
       await sub.cancel();
     });
 
-    test('ignores oversized six-byte frame (no snapshot)', () async {
-      var emissions = 0;
-      final sub = scale.currentSnapshot.listen((_) => emissions++);
+    test('parses nine-byte weight notification', () async {
+      final completer = Completer<ScaleSnapshot>();
+      final sub = scale.currentSnapshot.listen((snapshot) {
+        if (!completer.isCompleted) completer.complete(snapshot);
+      });
 
       transport.simulateWeightNotification([
         0x00,
@@ -521,11 +523,16 @@ void main() {
         0x03,
         0x00,
         0xFF,
+        0xE8,
+        0x03,
         0x00,
+        0xFF,
       ]);
 
-      await Future.delayed(const Duration(milliseconds: 100));
-      expect(emissions, 0);
+      final snapshot = await completer.future.timeout(
+        const Duration(seconds: 1),
+      );
+      expect(snapshot.weight, closeTo(100.0, 0.001));
 
       await sub.cancel();
     });


### PR DESCRIPTION
## Summary

What changed, and why?

- Accept only the known 4-, 5-, and 9-byte Skale EF81 notification layouts.
- Decode the first mantissa/exponent weight block as the canonical reported value for both SDK-format layouts; leave the second 9-byte block unused.
- Restore weight snapshots that PR #722 accidentally suppressed while preserving its signed mantissa/exponent decoding and the legacy 4-byte decoder.
- Cover first-block precedence with differing 9-byte blocks and reject unsupported 6-byte frames.

## Linked Issue

Fixes #752

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- Pre-#755 regression: `flutter test test/unit/models/skale2_scale_test.dart --plain-name 'uses first weight block from nine-byte notification'` timed out because no snapshot was emitted.
- Post-fix regression: the same focused test passed and emitted `100.0 g`, not the second block's `12.34 g`.
- Pre-tightening malformed-frame regression: the 6-byte test observed one emission; the explicit framing fix reduced it to zero.
- `flutter test test/unit/models/skale2_scale_test.dart` — 22 tests passed.
- `dart format lib test` — 782 files checked, 0 changed.
- `flutter analyze` — no issues found.
- `flutter test` — 3,728 tests passed, 1 skipped.
- No real-device test was performed in this implementation run.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Restores live Skale 2 weight readings for affected 0.8.4 users. Tare, timer, display, battery, connection behavior, and API contracts are unchanged.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
