### PR TITLE
feat(plugins): permission-gated host.transport WebSocket/TCP/TLS transports (#146)

### DIFF
--- a/doc/AI_TESTING_NOTES.md
+++ b/doc/AI_TESTING_NOTES.md
@@ -114,8 +114,12 @@ Add widget test gotchas, mock helper changes, and test infrastructure patterns. 
   `addStream`, so the test deterministically exercises the outbound byte
   limit without depending on kernel socket-buffer sizes.
 - **TLS/WSS positive paths:** platform trust validation cannot be exercised
-  offline (self-signed certs are always rejected by the default connectors —
-  those rejection paths are covered separately). The positive tests inject
-  connectors that accept the local self-signed certificate
-  (`onBadCertificate` / `badCertificateCallback`) and still run a real TLS /
-  TLS-wrapped-WebSocket round trip.
+  offline. Verified empirically that dart:io on this platform ignores
+  user-supplied trust anchors: `SecureSocket.connect(context:
+  SecurityContext()..setTrustedCertificates(ca))` and
+  `WebSocket.connect(customClient: HttpClient(context: ...))` both fail with
+  CERTIFICATE_VERIFY_FAILED for a CA-signed local server cert. The rejection
+  tests prove the default connectors validate against the platform store; the
+  positive tests inject connectors that accept the local self-signed
+  certificate (`onBadCertificate` / `badCertificateCallback`) and still run a
+  real TLS / TLS-wrapped-WebSocket round trip.

--- a/doc/AI_TESTING_NOTES.md
+++ b/doc/AI_TESTING_NOTES.md
@@ -102,3 +102,20 @@ Available via `--dart-define=simulate=1` or settings UI toggle. For end-to-end A
 ## Keeping Notes Fresh
 
 Add widget test gotchas, mock helper changes, and test infrastructure patterns. Prune when test APIs change.
+
+## Plugin transport tests (`test/plugins/plugin_manager_transport*_test.dart`)
+
+`PluginManager` accepts optional `connectWebSocket` / `connectSocket` /
+`connectSecureSocket` connectors (defaulting to `WebSocket.connect` /
+`Socket.connect` / `SecureSocket.connect`) forwarded to
+`PluginTransportService`. Tests use them for:
+
+- **Backpressure accounting:** `_BlockingWebSocket` never completes
+  `addStream`, so the test deterministically exercises the outbound byte
+  limit without depending on kernel socket-buffer sizes.
+- **TLS/WSS positive paths:** platform trust validation cannot be exercised
+  offline (self-signed certs are always rejected by the default connectors —
+  those rejection paths are covered separately). The positive tests inject
+  connectors that accept the local self-signed certificate
+  (`onBadCertificate` / `badCertificateCallback`) and still run a real TLS /
+  TLS-wrapped-WebSocket round trip.

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -421,8 +421,9 @@ never affects another plugin or another generation of the same plugin.
 ### Resource bounds
 
 - Maximum **8 live transports per plugin generation** (connecting, open and
-  closing all count). Opening one more rejects with
-  `transport_resource_limit`.
+  closing all count; a transport closed by the peer before `onEvent()` was
+  registered also counts until its queued events are delivered). Opening one
+  more rejects with `transport_resource_limit`.
 - Maximum **1 MiB pending outbound data per transport**. A send that would
   exceed this rejects atomically with `transport_resource_limit`.
 - Maximum **1 MiB queued inbound data per transport** waiting for JS delivery.

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -413,9 +413,10 @@ enqueued or silently dropped.
 ### `host.transport.close(handle)`
 
 Returns a Promise that resolves after the native transport is closed and the
-handle has been released. Closing an already-closed or stale handle may reject
-with a normal transport error; it never affects another plugin or another
-generation of the same plugin.
+handle has been released. Already-accepted outbound frames are written before
+the connection is closed; new sends after `close()` reject. Closing an
+already-closed or stale handle may reject with a normal transport error; it
+never affects another plugin or another generation of the same plugin.
 
 ### Resource bounds
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -74,6 +74,9 @@ A Decaid plugin consists of two required files:
   - `events.shots`: Receive `shotStored` and `shotUpdated`
   - `proxy.decent_api`: Send read requests through `host.decentProxy`
   - `proxy.decent_api.write`: Send allowlisted write requests through `host.decentProxy`
+  - `network.websocket`: Open outbound WebSocket connections (`ws://` and `wss://`) through `host.transport`
+  - `network.tcp`: Open outbound raw TCP connections through `host.transport`
+  - `network.tls`: Open outbound TLS connections (platform trust store) through `host.transport`
 - **settings**: User-configurable options with `type` (`string`, `number`, `boolean`, `enum`), an optional `label` giving the setting a human-friendly name, an optional `description` explaining what the setting does, an optional `default`, and an optional `secure` flag for credentials such as passwords. Enum `values` are a JSON array of strings. Secure values use platform credential storage, are supplied in memory to `onLoad(settings)`, and are never returned by the REST API.
 
   `GET /api/v1/plugins` returns this schema verbatim under `settings`, so a skin can render a settings form — labels, help text and defaults included — without reading the plugin's repository. `GET /api/v1/plugins/:id/settings` returns the stored values only.
@@ -286,6 +289,203 @@ const upload = await fetch("https://api.example.com/upload", {
 - `btoa()` for base64 encoding (polyfilled)
 - Standard JavaScript language features
 
+## Network Transports (`host.transport`)
+
+`host.transport` exposes permission-gated outbound network transports: WebSocket
+(`ws://` / `wss://`), raw TCP and raw TLS. Decaid owns connection lifecycle,
+permission enforcement, resource bounds and native cleanup; plugins and bundled
+JavaScript libraries implement higher-level protocols such as MQTT on top of
+these primitives.
+
+Each transport requires its own manifest permission:
+
+| `kind` | Permission | Notes |
+|--------|------------|-------|
+| `websocket` | `network.websocket` | `ws://` and `wss://`; `wss://` uses normal platform certificate validation and does **not** require `network.tls` |
+| `tcp` | `network.tcp` | raw byte stream |
+| `tls` | `network.tls` | raw byte stream over TLS using the platform trust store only |
+
+Permission failure rejects the `open()` call with a `PluginPermissionError`
+before any DNS lookup or connection attempt. No unrestricted global `WebSocket`
+or socket object exists in the JavaScript runtime; all network access goes
+through `host.transport`.
+
+### `host.transport.open(options)`
+
+Resolves once the connection is established, with `{ handle, protocol }`. The
+`handle` is an opaque string owned by the plugin id + generation that opened it.
+`protocol` is present for WebSocket only, when a subprotocol was negotiated.
+
+```js
+const opened = await host.transport.open({
+  kind: "websocket",
+  url: "wss://broker.example/mqtt",
+  protocols: ["mqtt"]          // optional WebSocket subprotocols
+});
+const handle = opened.handle;
+
+const { handle: tcpHandle } = await host.transport.open({
+  kind: "tcp",
+  host: "192.168.1.10",
+  port: 1883
+});
+
+const { handle: tlsHandle } = await host.transport.open({
+  kind: "tls",
+  host: "broker.example",
+  port: 8883
+});
+```
+
+WebSocket options: `kind: "websocket"`, `url` (required, `ws://` or `wss://`),
+`protocols` (optional array of subprotocol strings). Arbitrary custom WebSocket
+headers are not supported.
+
+TCP/TLS options: `kind: "tcp"`/`"tls"`, `host` (required hostname/IP),
+`port` (required integer 1..65535). Custom CA material and client
+certificates are out of scope; TLS uses the platform trust store only.
+
+Connection failures before establishment reject the `open()` Promise.
+
+### `host.transport.onEvent(handle, callback)`
+
+Registers the single event listener for a handle. Calling it again replaces the
+previous listener. Events that arrive after `open()` resolves but before a
+listener is registered are retained in the bounded inbound queue and delivered
+in order once the listener is registered.
+
+Data events:
+
+```js
+// WebSocket text frame
+{ type: "data", dataType: "text", data: "plain text payload" }
+
+// WebSocket binary frame, TCP bytes or TLS bytes (base64)
+{ type: "data", dataType: "binary", data: "<base64>" }
+```
+
+TCP and TLS are byte streams and only emit `dataType: "binary"`. Text encoding,
+line framing and request/response semantics belong to plugin/library adapters.
+
+Error events (failures after the connection opened):
+
+```js
+{ type: "error", code: "transport_error", message: "human-readable description" }
+```
+
+Resource-limit failures use `code: "transport_resource_limit"`. A terminal
+transport error is followed by deterministic cleanup; a close event may follow.
+
+Close events:
+
+```js
+{ type: "close", code: 1000, reason: "..." }  // code/reason omitted when unavailable
+```
+
+Successful `open()` resolution is the connection-open notification; there is no
+separate `open` event.
+
+### `host.transport.send(handle, payload)`
+
+Returns a Promise. WebSocket text send:
+
+```js
+await host.transport.send(handle, { type: "text", data: "hello" });
+```
+
+WebSocket binary, TCP and TLS send:
+
+```js
+await host.transport.send(handle, { type: "binary", data: "<base64>" });
+```
+
+For TCP/TLS, `type: "text"` is invalid; adapters must encode text to bytes
+themselves. Binary data crosses the JS/Dart bridge as base64; WebSocket text
+frames remain plain strings and are never base64 encoded.
+
+The Promise resolves once the complete payload is accepted into the native
+transport's bounded outbound write path. It does **not** mean the remote peer
+received the payload. A send is atomic with respect to the queue limit: if
+accepting the whole payload would exceed the outbound limit, the complete send
+rejects with `error.code === "transport_resource_limit"`; nothing is partially
+enqueued or silently dropped.
+
+### `host.transport.close(handle)`
+
+Returns a Promise that resolves after the native transport is closed and the
+handle has been released. Closing an already-closed or stale handle may reject
+with a normal transport error; it never affects another plugin or another
+generation of the same plugin.
+
+### Resource bounds
+
+- Maximum **8 live transports per plugin generation** (connecting, open and
+  closing all count). Opening one more rejects with
+  `transport_resource_limit`.
+- Maximum **1 MiB pending outbound data per transport**. A send that would
+  exceed this rejects atomically with `transport_resource_limit`.
+- Maximum **1 MiB queued inbound data per transport** waiting for JS delivery.
+  Exceeding it closes that transport with a `transport_resource_limit` error;
+  data is never silently discarded to stay under the bound.
+
+### Lifecycle and ownership
+
+Every handle is owned by the plugin id + plugin generation that opened it: a
+handle cannot be used by another plugin, and cannot be reused by a newer
+generation after a plugin reload. Stale native events from retired generations
+are dropped. Plugin unload closes all transports owned by that generation even
+if the plugin's `onUnload()` throws or never closes its connections, and
+`PluginManager` disposal closes everything remaining. Localhost, LAN and
+private-address destinations are allowed; there is no hostname/CIDR allow-list.
+
+### Examples
+
+WebSocket text echo:
+
+```js
+const opened = await host.transport.open({
+  kind: "websocket",
+  url: "ws://broker.example/echo"
+});
+host.transport.onEvent(opened.handle, (event) => {
+  if (event.type === "data") {
+    // event: { type: "data", dataType: "text", data: "..." }
+  }
+});
+await host.transport.send(opened.handle, { type: "text", data: "hello" });
+```
+
+WebSocket binary echo:
+
+```js
+const opened = await host.transport.open({
+  kind: "websocket",
+  url: "ws://broker.example/echo"
+});
+host.transport.onEvent(opened.handle, (event) => {
+  if (event.type === "data" && event.dataType === "binary") {
+    // event.data is base64; decode it with your library of choice
+  }
+});
+await host.transport.send(opened.handle, { type: "binary", data: btoa("bytes") });
+```
+
+TCP binary echo:
+
+```js
+const opened = await host.transport.open({
+  kind: "tcp",
+  host: "192.168.1.10",
+  port: 1883
+});
+host.transport.onEvent(opened.handle, (event) => {
+  if (event.type === "data") {
+    // event: { type: "data", dataType: "binary", data: "<base64>" }
+  }
+});
+await host.transport.send(opened.handle, { type: "binary", data: btoa("\x00\x01\x02") });
+```
+
 ## Plugin Lifecycle
 
 1. **Initialization**: Plugin directory is copied to app storage
@@ -433,6 +633,7 @@ it in Decaid UI.
 - **Global Functions**: `fetch()`, `btoa()`, `setTimeout()`, `clearTimeout()`
 - **Objects**: `Promise`, `JSON`, `Math`, `Date`, `Array`, `Object`
 - **Constants**: `undefined`, `null`, `Infinity`, `NaN`
+- **Host API**: `host.log()`, `host.emit()`, `host.storage()`, `host.decentProxy()`, `host.transport`
 
 ### Not Available
 
@@ -445,6 +646,13 @@ it in Decaid UI.
 
 - Plugins run in a sandboxed JavaScript environment
 - HTTP requests are proxied through Flutter (respects system proxy settings)
+- Outbound WebSocket/TCP/TLS connections go through `host.transport`, which
+  requires the matching `network.websocket` / `network.tcp` / `network.tls`
+  permission, enforces per-plugin connection and byte limits, and closes all
+  connections on plugin unload or app shutdown. There is no unrestricted
+  global `WebSocket` or socket API in the plugin runtime.
+- TLS uses the platform trust store only; custom CA material and client
+  certificates are not supported
 - Storage is isolated per plugin
 - No filesystem access beyond the plugin's own directory
 - No network access to localhost/private IPs (except for Decaid API)

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -655,7 +655,8 @@ it in Decaid UI.
   certificates are not supported
 - Storage is isolated per plugin
 - No filesystem access beyond the plugin's own directory
-- No network access to localhost/private IPs (except for Decaid API)
+- HTTP/fetch cannot reach localhost or private IPs (except for the Decaid
+  API); `host.transport` has no such restriction
 
 ## External First-Party Plugins
 

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import 'plugin_manifest.dart';
 import 'plugin_decent_proxy_bridge.dart';
 import 'plugin_runtime.dart';
+import 'plugin_transport_service.dart';
 import 'plugin_types.dart';
 import '../services/storage/kv_store_service.dart';
 import '../controllers/de1_controller.dart';
@@ -83,9 +84,11 @@ class PluginManager {
   Future<void>? _disposeFuture;
   final Map<String, int> _retiringPluginGenerations = {};
   final Map<(String, int), Set<Future<void>>> _pluginStorageOperations = {};
+  late final PluginTransportService _transportService;
 
   De1Controller? get de1Controller => _de1controller;
   PluginManagerLifecycle get lifecycle => _lifecycle;
+  int get liveTransportCount => _transportService.liveTransportCount;
   int get attachmentGeneration => _attachmentGeneration;
   int get activeSubscriptionCount =>
       (_de1Subscription == null ? 0 : 1) +
@@ -106,6 +109,9 @@ class PluginManager {
     _decentProxyBridge = PluginDecentProxyBridge(
       decentProxyService: decentProxyService,
       log: _log,
+    );
+    _transportService = PluginTransportService(
+      eventSink: _dispatchTransportEvent,
     );
     _bootstrapJs();
   }
@@ -538,6 +544,79 @@ class PluginManager {
           __timers.clear();
         };
 
+        // Transport bridge: plugin-owned outbound WebSocket/TCP/TLS handles.
+        const __transportListeners = new Map();
+        const __transportPending = new Map();
+        function __sendTransportMessage(message) {
+          __nativeSendMessage("transport", __nativeJsonStringify(message));
+        }
+
+        globalThis.__transportRequest = function (bridgeToken, generation, requestId, type, payload) {
+          __sendTransportMessage({
+            bridgeToken: bridgeToken,
+            generation: generation,
+            requestId: requestId,
+            type: type,
+            payload: payload
+          });
+        };
+
+        globalThis.__transportRegister = function (requestId, entry) {
+          __transportPending.set(requestId, entry);
+        };
+
+        globalThis.__transportSetListener = function (handle, pluginId, listener) {
+          __transportListeners.set(handle, { pluginId: pluginId, listener: listener });
+        };
+
+        globalThis.__handleTransportReply = function (msg) {
+          const pending = __transportPending.get(msg.requestId);
+          if (!pending || pending.bridgeToken !== msg.bridgeToken) return;
+          __transportPending.delete(msg.requestId);
+          if (msg.error) {
+            const error = new __NativeError(msg.error);
+            if (msg.code) error.code = msg.code;
+            pending.reject(error);
+            return;
+          }
+          pending.resolve(msg.result || {});
+        };
+
+        globalThis.__dispatchTransportEvent = function (pluginId, handle, event) {
+          const record = __transportListeners.get(handle);
+          if (!record || record.pluginId !== pluginId || !record.listener) return;
+          try {
+            record.listener(event);
+          } catch (e) {
+            console.error("Transport listener error", pluginId, e);
+          }
+        };
+
+        globalThis.__rejectTransportPendingForToken = function (bridgeToken, error) {
+          for (const [requestId, pending] of __transportPending) {
+            if (pending.bridgeToken !== bridgeToken) continue;
+            __transportPending.delete(requestId);
+            pending.reject(new __NativeError(error));
+          }
+        };
+
+        globalThis.__rejectAllTransportPending = function (error) {
+          for (const pending of __transportPending.values()) {
+            pending.reject(new __NativeError(error));
+          }
+          __transportPending.clear();
+        };
+
+        globalThis.__clearTransportListenersForPlugin = function (pluginId) {
+          for (const [handle, record] of __transportListeners) {
+            if (record.pluginId === pluginId) __transportListeners.delete(handle);
+          }
+        };
+
+        globalThis.__clearAllTransportListeners = function () {
+          __transportListeners.clear();
+        };
+
         Object.defineProperty(globalThis, "host", {
           value: __nativeFreeze({
             log(bridgeToken, generation, message) {
@@ -676,7 +755,8 @@ class PluginManager {
                 permissionDenied: globalThis.host.permissionDenied,
                 fetch: globalThis.__fetchFor,
                 timerSet: globalThis.__timerSet,
-                timerClear: globalThis.__timerClear
+                timerClear: globalThis.__timerClear,
+                transportRequest: globalThis.__transportRequest
               }),
               writable: false,
               configurable: false,
@@ -721,6 +801,18 @@ class PluginManager {
         }
       } catch (e, st) {
         _log.warning("Invalid fetch message", e, st);
+      }
+    });
+
+    js.onMessage("transport", (raw) {
+      try {
+        final msg = raw as Map<String, dynamic>;
+        final pluginId = _pluginIdForBridgeMessage(msg, 'transport');
+        if (pluginId != null) {
+          unawaited(_handleTransportSafely(pluginId, msg));
+        }
+      } catch (e, st) {
+        _log.warning("Invalid transport message", e, st);
       }
     });
   }
@@ -782,6 +874,179 @@ class PluginManager {
       await _handleFetch(pluginId, msg);
     } catch (e, st) {
       _log.warning("Invalid fetch message", e, st);
+    }
+  }
+
+  Future<void> _handleTransportSafely(
+    String pluginId,
+    Map<String, dynamic> msg,
+  ) async {
+    await Future<void>.delayed(Duration.zero);
+    if (_lifecycle != PluginManagerLifecycle.active) return;
+    try {
+      await _handleTransportMessage(pluginId, msg);
+    } catch (e, st) {
+      _log.warning("Invalid transport message", e, st);
+    }
+  }
+
+  Future<void> _handleTransportMessage(
+    String pluginId,
+    Map<String, dynamic> msg,
+  ) async {
+    final requestId = msg['requestId'];
+    if (requestId is! String) {
+      _log.warning('Transport message from $pluginId missing requestId');
+      return;
+    }
+    final bridgeToken = msg['bridgeToken'];
+    final generation = msg['generation'] is num
+        ? (msg['generation'] as num).toInt()
+        : 0;
+    if (generation != _pluginGenerations[pluginId] ||
+        _plugins[pluginId]?.isAlive != true) {
+      _replyTransport(
+        requestId,
+        bridgeToken,
+        error: 'Plugin generation changed',
+      );
+      return;
+    }
+    final type = msg['type'];
+    final payload = msg['payload'];
+    if (payload is! Map) {
+      _replyTransport(
+        requestId,
+        bridgeToken,
+        error: 'Invalid transport message payload',
+      );
+      return;
+    }
+    try {
+      switch (type) {
+        case 'open':
+          final kind = payload['kind'];
+          final permission = switch (kind) {
+            'websocket' => PluginPermissions.networkWebsocket,
+            'tcp' => PluginPermissions.networkTcp,
+            'tls' => PluginPermissions.networkTls,
+            _ => null,
+          };
+          if (permission == null) {
+            _replyTransport(
+              requestId,
+              bridgeToken,
+              error: 'Unknown transport kind',
+            );
+            return;
+          }
+          if (!_hasPermission(pluginId, permission)) {
+            _replyTransport(
+              requestId,
+              bridgeToken,
+              error: _permissionError(pluginId, permission),
+            );
+            return;
+          }
+          final result = await _transportService.open(
+            pluginId: pluginId,
+            generation: generation,
+            options: Map<String, dynamic>.from(payload),
+          );
+          if (!_isCurrentPluginMessage(pluginId, {'generation': generation})) {
+            unawaited(
+              _transportService.close(pluginId, generation, result.handle),
+            );
+            return;
+          }
+          _replyTransport(
+            requestId,
+            bridgeToken,
+            result: {
+              'handle': result.handle,
+              if (result.protocol != null) 'protocol': result.protocol,
+            },
+          );
+        case 'send':
+          final handle = payload['handle'];
+          final sendPayload = payload['payload'];
+          if (handle is! String || sendPayload is! Map) {
+            _replyTransport(
+              requestId,
+              bridgeToken,
+              error: 'Invalid transport send message',
+            );
+            return;
+          }
+          await _transportService.send(
+            pluginId,
+            generation,
+            handle,
+            Map<String, dynamic>.from(sendPayload),
+          );
+          _replyTransport(requestId, bridgeToken, result: const {});
+        case 'close':
+          final handle = payload['handle'];
+          if (handle is! String) {
+            _replyTransport(
+              requestId,
+              bridgeToken,
+              error: 'Invalid transport close message',
+            );
+            return;
+          }
+          await _transportService.close(pluginId, generation, handle);
+          _replyTransport(requestId, bridgeToken, result: const {});
+        case 'onEvent':
+          final handle = payload['handle'];
+          if (handle is String) {
+            _transportService.onEventRegistered(pluginId, generation, handle);
+          }
+        default:
+          _log.warning('Unknown transport message type from $pluginId: $type');
+      }
+    } on PluginTransportException catch (e) {
+      _replyTransport(requestId, bridgeToken, error: e.message, code: e.code);
+    } catch (e) {
+      _replyTransport(requestId, bridgeToken, error: e.toString());
+    }
+  }
+
+  void _replyTransport(
+    String requestId,
+    Object? bridgeToken, {
+    Map<String, dynamic>? result,
+    String? error,
+    String? code,
+  }) {
+    try {
+      js.evaluate(
+        'globalThis.__handleTransportReply('
+        '${jsonEncode({'requestId': requestId, 'bridgeToken': ?bridgeToken, 'result': result, 'error': error, 'code': code})});',
+      );
+      while (js.executePendingJob() > 0) {}
+    } catch (e, st) {
+      _log.warning('Failed to deliver transport reply', e, st);
+    }
+  }
+
+  void _dispatchTransportEvent(
+    String pluginId,
+    int generation,
+    String handle,
+    Map<String, dynamic> event,
+  ) {
+    if (_lifecycle != PluginManagerLifecycle.active) return;
+    if (_plugins[pluginId]?.isAlive != true) return;
+    if (_pluginGenerations[pluginId] != generation) return;
+    try {
+      js.evaluate(
+        'globalThis.__dispatchTransportEvent('
+        '${jsonEncode(pluginId)}, ${jsonEncode(handle)}, ${jsonEncode(event)});',
+      );
+      while (js.executePendingJob() > 0) {}
+    } catch (e, st) {
+      _log.warning('Failed to dispatch transport event to $pluginId', e, st);
     }
   }
 
@@ -890,6 +1155,49 @@ class PluginManager {
           ? (input, init) => pluginHostBridge.fetch(pluginBridgeToken, pluginGeneration, input, init)
           : () => rejectPermission("api");
         
+        let __transportSeq = 0;
+        const __transportNonce = Math.random().toString(36).slice(2);
+        const __transportCall = (type, payload) => {
+          return new Promise((resolve, reject) => {
+            const requestId = pluginId + "_" + pluginGeneration + "_" + __transportNonce + "_" + (++__transportSeq);
+            __transportRegister(requestId, { bridgeToken: pluginBridgeToken, resolve: resolve, reject: reject });
+            pluginHostBridge.transportRequest(pluginBridgeToken, pluginGeneration, requestId, type, payload);
+          });
+        };
+        const transport = {
+          open(options) {
+            const kind = options && options.kind;
+            if (kind === "websocket" && !${manifest.permissions.contains(PluginPermissions.networkWebsocket)}) {
+              return rejectPermission("network.websocket");
+            }
+            if (kind === "tcp" && !${manifest.permissions.contains(PluginPermissions.networkTcp)}) {
+              return rejectPermission("network.tcp");
+            }
+            if (kind === "tls" && !${manifest.permissions.contains(PluginPermissions.networkTls)}) {
+              return rejectPermission("network.tls");
+            }
+            if (kind !== "websocket" && kind !== "tcp" && kind !== "tls") {
+              return Promise.reject(new Error("transport.open: unknown transport kind"));
+            }
+            return __transportCall("open", options || {});
+          },
+          onEvent(handle, callback) {
+            if (typeof callback !== "function") {
+              throw new Error("transport.onEvent: callback must be a function");
+            }
+            __transportSetListener(handle, pluginId, callback);
+            pluginHostBridge.transportRequest(
+              pluginBridgeToken, pluginGeneration, "onEvent_" + (++__transportSeq), "onEvent", { handle: handle }
+            );
+          },
+          send(handle, payload) {
+            return __transportCall("send", { handle: handle, payload: payload });
+          },
+          close(handle) {
+            return __transportCall("close", { handle: handle });
+          }
+        };
+        
         // Create the host object for this plugin
         const host = {
           log: ${manifest.permissions.contains(PluginPermissions.log)}
@@ -919,7 +1227,8 @@ class PluginManager {
               options.body ?? null,
               options.contentType ?? null
             );
-          }
+          },
+          transport: transport
         };
         
         // Inject and evaluate the plugin code
@@ -1025,7 +1334,7 @@ class PluginManager {
         _log.warning("Error during plugin unload: $id", e, st);
       }
       try {
-        _cleanupPluginResources(id, pluginBridgeToken);
+        _cleanupPluginResources(id, pluginBridgeToken, retiringGeneration);
       } finally {
         await _drainPluginStorageOperations(id, retiringGeneration);
       }
@@ -1039,7 +1348,11 @@ class PluginManager {
     }
   }
 
-  void _cleanupPluginResources(String pluginId, String? pluginBridgeToken) {
+  void _cleanupPluginResources(
+    String pluginId,
+    String? pluginBridgeToken,
+    int retiringGeneration,
+  ) {
     Object? firstError;
     StackTrace? firstStackTrace;
 
@@ -1064,10 +1377,21 @@ class PluginManager {
         globalThis.__reaprimePluginBridge.cancelForPlugin(
           ${jsonEncode(pluginId)}, "plugin unloaded"
         );
+        globalThis.__rejectTransportPendingForToken(
+          ${jsonEncode(pluginBridgeToken)}, "plugin unloaded"
+        );
+        globalThis.__clearTransportListenersForPlugin(
+          ${jsonEncode(pluginId)}
+        );
       ''');
       while (js.executePendingJob() > 0) {}
     });
     attempt(() => _cancelTimersForPlugin(pluginId, pluginBridgeToken));
+    attempt(() {
+      unawaited(
+        _transportService.closeAllForPlugin(pluginId, retiringGeneration),
+      );
+    });
 
     if (firstError != null) {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);
@@ -1258,6 +1582,8 @@ class PluginManager {
       js.evaluate('''
           globalThis.__cancelAllFetches("manager disposal");
           globalThis.__reaprimePluginBridge.cancelAll("manager disposal");
+          globalThis.__rejectAllTransportPending("manager disposal");
+          globalThis.__clearAllTransportListeners();
         ''');
       while (js.executePendingJob() > 0) {}
     });
@@ -1269,6 +1595,7 @@ class PluginManager {
       js.evaluate('globalThis.__cancelAllTimers();');
       while (js.executePendingJob() > 0) {}
     });
+    attempt(() => _transportService.dispose());
 
     if (firstError != null) {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -72,6 +72,7 @@ class PluginManager {
   final int maxFetchResponseBytes;
   final Duration pluginHttpTimeout;
   final Duration decentProxyTimeout;
+  final Duration transportCloseTimeout;
 
   De1Controller? _de1controller;
   StreamSubscription<De1Interface?>? _de1Subscription;
@@ -108,6 +109,7 @@ class PluginManager {
     WebSocketConnector? connectWebSocket,
     SocketConnector? connectSocket,
     SecureSocketConnector? connectSecureSocket,
+    this.transportCloseTimeout = const Duration(seconds: 5),
   }) : js = js ?? getJavascriptRuntime(xhr: false) {
     _decentProxyBridge = PluginDecentProxyBridge(
       decentProxyService: decentProxyService,
@@ -118,6 +120,7 @@ class PluginManager {
       connectWebSocket: connectWebSocket,
       connectSocket: connectSocket,
       connectSecureSocket: connectSecureSocket,
+      closeTimeout: transportCloseTimeout,
     );
     _bootstrapJs();
   }
@@ -1363,7 +1366,11 @@ class PluginManager {
         _log.warning("Error during plugin unload: $id", e, st);
       }
       try {
-        _cleanupPluginResources(id, pluginBridgeToken, retiringGeneration);
+        await _cleanupPluginResources(
+          id,
+          pluginBridgeToken,
+          retiringGeneration,
+        );
       } finally {
         await _drainPluginStorageOperations(id, retiringGeneration);
       }
@@ -1377,11 +1384,11 @@ class PluginManager {
     }
   }
 
-  void _cleanupPluginResources(
+  Future<void> _cleanupPluginResources(
     String pluginId,
     String? pluginBridgeToken,
     int retiringGeneration,
-  ) {
+  ) async {
     Object? firstError;
     StackTrace? firstStackTrace;
 
@@ -1416,9 +1423,12 @@ class PluginManager {
       while (js.executePendingJob() > 0) {}
     });
     attempt(() => _cancelTimersForPlugin(pluginId, pluginBridgeToken));
-    attempt(
-      () => _transportService.closeAllForPlugin(pluginId, retiringGeneration),
-    );
+    try {
+      await _transportService.closeAllForPlugin(pluginId, retiringGeneration);
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
 
     if (firstError != null) {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);
@@ -1580,10 +1590,14 @@ class PluginManager {
 
   void cancelAllOperations() {
     _ensureActive();
-    _cancelAllOperations();
+    unawaited(
+      _cancelAllOperations().catchError((Object error, StackTrace stackTrace) {
+        _log.warning('cancelAllOperations failed', error, stackTrace);
+      }),
+    );
   }
 
-  void _cancelAllOperations() {
+  Future<void> _cancelAllOperations() async {
     Object? firstError;
     StackTrace? firstStackTrace;
 
@@ -1622,7 +1636,12 @@ class PluginManager {
       js.evaluate('globalThis.__cancelAllTimers();');
       while (js.executePendingJob() > 0) {}
     });
-    attempt(() => _transportService.dispose());
+    try {
+      await _transportService.dispose();
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
 
     if (firstError != null) {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -559,7 +559,15 @@ class PluginManager {
           __nativeSendMessage("transport", __nativeJsonStringify(message));
         }
 
-        globalThis.__transportRequest = function (bridgeToken, generation, requestId, type, payload) {
+        const __frozenTransportGlobal = (name, value) => {
+          Object.defineProperty(globalThis, name, {
+            value: value,
+            writable: false,
+            configurable: false,
+            enumerable: false
+          });
+        };
+        __frozenTransportGlobal("__transportRequest", function (bridgeToken, generation, requestId, type, payload) {
           __sendTransportMessage({
             bridgeToken: bridgeToken,
             generation: generation,
@@ -567,21 +575,17 @@ class PluginManager {
             type: type,
             payload: payload
           });
-        };
-
-        globalThis.__transportRegister = function (requestId, entry) {
+        });
+        __frozenTransportGlobal("__transportRegister", function (requestId, entry) {
           __transportPending.set(requestId, entry);
-        };
-
-        globalThis.__transportSetListener = function (handle, pluginId, listener) {
+        });
+        __frozenTransportGlobal("__transportSetListener", function (handle, pluginId, listener) {
           __transportListeners.set(handle, { pluginId: pluginId, listener: listener });
-        };
-
-        globalThis.__transportRemoveListener = function (handle) {
+        });
+        __frozenTransportGlobal("__transportRemoveListener", function (handle) {
           __transportListeners.delete(handle);
-        };
-
-        globalThis.__handleTransportReply = function (msg) {
+        });
+        __frozenTransportGlobal("__handleTransportReply", function (msg) {
           const pending = __transportPending.get(msg.requestId);
           if (!pending || pending.bridgeToken !== msg.bridgeToken) return;
           __transportPending.delete(msg.requestId);
@@ -592,9 +596,8 @@ class PluginManager {
             return;
           }
           pending.resolve(msg.result || {});
-        };
-
-        globalThis.__dispatchTransportEvent = function (pluginId, handle, event) {
+        });
+        __frozenTransportGlobal("__dispatchTransportEvent", function (pluginId, handle, event) {
           const record = __transportListeners.get(handle);
           if (!record || record.pluginId !== pluginId || !record.listener) return;
           try {
@@ -602,32 +605,28 @@ class PluginManager {
           } catch (e) {
             console.error("Transport listener error", pluginId, e);
           }
-        };
-
-        globalThis.__rejectTransportPendingForToken = function (bridgeToken, error) {
+        });
+        __frozenTransportGlobal("__rejectTransportPendingForToken", function (bridgeToken, error) {
           for (const [requestId, pending] of __transportPending) {
             if (pending.bridgeToken !== bridgeToken) continue;
             __transportPending.delete(requestId);
             pending.reject(new __NativeError(error));
           }
-        };
-
-        globalThis.__rejectAllTransportPending = function (error) {
+        });
+        __frozenTransportGlobal("__rejectAllTransportPending", function (error) {
           for (const pending of __transportPending.values()) {
             pending.reject(new __NativeError(error));
           }
           __transportPending.clear();
-        };
-
-        globalThis.__clearTransportListenersForPlugin = function (pluginId) {
+        });
+        __frozenTransportGlobal("__clearTransportListenersForPlugin", function (pluginId) {
           for (const [handle, record] of __transportListeners) {
             if (record.pluginId === pluginId) __transportListeners.delete(handle);
           }
-        };
-
-        globalThis.__clearAllTransportListeners = function () {
+        });
+        __frozenTransportGlobal("__clearAllTransportListeners", function () {
           __transportListeners.clear();
-        };
+        });
 
         Object.defineProperty(globalThis, "host", {
           value: __nativeFreeze({

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -270,6 +270,8 @@ class PluginManager {
         const __nativeMapGet = Map.prototype.get;
         const __nativeMapSet = Map.prototype.set;
         const __nativeMapDelete = Map.prototype.delete;
+        const __nativeMapClear = Map.prototype.clear;
+        const __nativeMapForEach = Map.prototype.forEach;
 
         const __pendingDecentProxyRequests = new Map();
         let __decentProxySeq = 0;
@@ -290,6 +292,14 @@ class PluginManager {
 
         function __mapDelete(map, key) {
           return __nativeReflectApply(__nativeMapDelete, map, [key]);
+        }
+
+        function __mapClear(map) {
+          return __nativeReflectApply(__nativeMapClear, map, []);
+        }
+
+        function __mapForEach(map, callback) {
+          return __nativeReflectApply(__nativeMapForEach, map, [callback]);
         }
 
         function __pendingDecentProxyByPlugin(pluginId) {
@@ -577,18 +587,18 @@ class PluginManager {
           });
         });
         __frozenTransportGlobal("__transportRegister", function (requestId, entry) {
-          __transportPending.set(requestId, entry);
+          __mapSet(__transportPending, requestId, entry);
         });
         __frozenTransportGlobal("__transportSetListener", function (handle, pluginId, listener) {
-          __transportListeners.set(handle, { pluginId: pluginId, listener: listener });
+          __mapSet(__transportListeners, handle, { pluginId: pluginId, listener: listener });
         });
         __frozenTransportGlobal("__transportRemoveListener", function (handle) {
-          __transportListeners.delete(handle);
+          __mapDelete(__transportListeners, handle);
         });
         __frozenTransportGlobal("__handleTransportReply", function (msg) {
-          const pending = __transportPending.get(msg.requestId);
+          const pending = __mapGet(__transportPending, msg.requestId);
           if (!pending || pending.bridgeToken !== msg.bridgeToken) return;
-          __transportPending.delete(msg.requestId);
+          __mapDelete(__transportPending, msg.requestId);
           if (msg.error) {
             const error = new __NativeError(msg.error);
             if (msg.code) error.code = msg.code;
@@ -598,7 +608,7 @@ class PluginManager {
           pending.resolve(msg.result || {});
         });
         __frozenTransportGlobal("__dispatchTransportEvent", function (pluginId, handle, event) {
-          const record = __transportListeners.get(handle);
+          const record = __mapGet(__transportListeners, handle);
           if (!record || record.pluginId !== pluginId || !record.listener) return;
           try {
             record.listener(event);
@@ -607,25 +617,25 @@ class PluginManager {
           }
         });
         __frozenTransportGlobal("__rejectTransportPendingForToken", function (bridgeToken, error) {
-          for (const [requestId, pending] of __transportPending) {
-            if (pending.bridgeToken !== bridgeToken) continue;
-            __transportPending.delete(requestId);
+          __mapForEach(__transportPending, (pending, requestId) => {
+            if (pending.bridgeToken !== bridgeToken) return;
+            __mapDelete(__transportPending, requestId);
             pending.reject(new __NativeError(error));
-          }
+          });
         });
         __frozenTransportGlobal("__rejectAllTransportPending", function (error) {
-          for (const pending of __transportPending.values()) {
+          __mapForEach(__transportPending, (pending) => {
             pending.reject(new __NativeError(error));
-          }
-          __transportPending.clear();
+          });
+          __mapClear(__transportPending);
         });
         __frozenTransportGlobal("__clearTransportListenersForPlugin", function (pluginId) {
-          for (const [handle, record] of __transportListeners) {
-            if (record.pluginId === pluginId) __transportListeners.delete(handle);
-          }
+          __mapForEach(__transportListeners, (record, handle) => {
+            if (record.pluginId === pluginId) __mapDelete(__transportListeners, handle);
+          });
         });
         __frozenTransportGlobal("__clearAllTransportListeners", function () {
-          __transportListeners.clear();
+          __mapClear(__transportListeners);
         });
 
         Object.defineProperty(globalThis, "host", {

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -105,6 +105,9 @@ class PluginManager {
     this.pluginHttpTimeout = const Duration(seconds: 30),
     this.decentProxyTimeout = const Duration(seconds: 30),
     JavascriptRuntime? js,
+    WebSocketConnector? connectWebSocket,
+    SocketConnector? connectSocket,
+    SecureSocketConnector? connectSecureSocket,
   }) : js = js ?? getJavascriptRuntime(xhr: false) {
     _decentProxyBridge = PluginDecentProxyBridge(
       decentProxyService: decentProxyService,
@@ -112,6 +115,9 @@ class PluginManager {
     );
     _transportService = PluginTransportService(
       eventSink: _dispatchTransportEvent,
+      connectWebSocket: connectWebSocket,
+      connectSocket: connectSocket,
+      connectSecureSocket: connectSecureSocket,
     );
     _bootstrapJs();
   }
@@ -544,7 +550,6 @@ class PluginManager {
           __timers.clear();
         };
 
-        // Transport bridge: plugin-owned outbound WebSocket/TCP/TLS handles.
         const __transportListeners = new Map();
         const __transportPending = new Map();
         function __sendTransportMessage(message) {
@@ -567,6 +572,10 @@ class PluginManager {
 
         globalThis.__transportSetListener = function (handle, pluginId, listener) {
           __transportListeners.set(handle, { pluginId: pluginId, listener: listener });
+        };
+
+        globalThis.__transportRemoveListener = function (handle) {
+          __transportListeners.delete(handle);
         };
 
         globalThis.__handleTransportReply = function (msg) {
@@ -955,7 +964,9 @@ class PluginManager {
           );
           if (!_isCurrentPluginMessage(pluginId, {'generation': generation})) {
             unawaited(
-              _transportService.close(pluginId, generation, result.handle),
+              _transportService
+                  .close(pluginId, generation, result.handle)
+                  .catchError((Object _) {}),
             );
             return;
           }
@@ -1000,7 +1011,11 @@ class PluginManager {
         case 'onEvent':
           final handle = payload['handle'];
           if (handle is String) {
-            _transportService.onEventRegistered(pluginId, generation, handle);
+            try {
+              _transportService.onEventRegistered(pluginId, generation, handle);
+            } on PluginTransportException {
+              _removeTransportListener(handle);
+            }
           }
         default:
           _log.warning('Unknown transport message type from $pluginId: $type');
@@ -1045,8 +1060,22 @@ class PluginManager {
         '${jsonEncode(pluginId)}, ${jsonEncode(handle)}, ${jsonEncode(event)});',
       );
       while (js.executePendingJob() > 0) {}
+      if (event['type'] == 'close') {
+        _removeTransportListener(handle);
+      }
     } catch (e, st) {
       _log.warning('Failed to dispatch transport event to $pluginId', e, st);
+    }
+  }
+
+  void _removeTransportListener(String handle) {
+    try {
+      js.evaluate(
+        'globalThis.__transportRemoveListener(${jsonEncode(handle)});',
+      );
+      while (js.executePendingJob() > 0) {}
+    } catch (e, st) {
+      _log.warning('Failed to remove transport listener', e, st);
     }
   }
 
@@ -1387,11 +1416,9 @@ class PluginManager {
       while (js.executePendingJob() > 0) {}
     });
     attempt(() => _cancelTimersForPlugin(pluginId, pluginBridgeToken));
-    attempt(() {
-      unawaited(
-        _transportService.closeAllForPlugin(pluginId, retiringGeneration),
-      );
-    });
+    attempt(
+      () => _transportService.closeAllForPlugin(pluginId, retiringGeneration),
+    );
 
     if (firstError != null) {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -83,7 +83,10 @@ enum PluginPermissions {
   eventsMachine('events.machine'),
   eventsShots('events.shots'),
   proxyDecentApi('proxy.decent_api'),
-  proxyDecentApiWrite('proxy.decent_api.write');
+  proxyDecentApiWrite('proxy.decent_api.write'),
+  networkWebsocket('network.websocket'),
+  networkTcp('network.tcp'),
+  networkTls('network.tls');
 
   final String wireName;
 

--- a/lib/src/plugins/plugin_transport_service.dart
+++ b/lib/src/plugins/plugin_transport_service.dart
@@ -5,11 +5,8 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
-/// Kinds of outbound transport exposed to plugins.
 enum PluginTransportKind { websocket, tcp, tls }
 
-/// Error surfaced to the JS bridge. [code] is the stable machine-readable
-/// error code carried on the rejected Promise.
 class PluginTransportException implements Exception {
   const PluginTransportException(this.message, {this.code = 'transport_error'});
 
@@ -27,8 +24,6 @@ class TransportOpenResult {
   final String? protocol;
 }
 
-/// Delivers a decoded transport event to the JS runtime. Implemented by
-/// [PluginManager] so it can validate plugin generation before evaluating JS.
 typedef PluginTransportEventSink =
     void Function(
       String pluginId,
@@ -37,23 +32,32 @@ typedef PluginTransportEventSink =
       Map<String, dynamic> event,
     );
 
-/// Owns native WebSocket/TCP/TLS connections opened by plugins.
-///
-/// Every handle is owned by a (pluginId, generation) pair. The service
-/// enforces connection and byte limits, bounds the inbound queue, and
-/// guarantees that unload/dispose close every native connection.
+typedef WebSocketConnector =
+    Future<WebSocket> Function(String url, {Iterable<String>? protocols});
+typedef SocketConnector = Future<Socket> Function(String host, int port);
+typedef SecureSocketConnector =
+    Future<SecureSocket> Function(String host, int port);
+
 class PluginTransportService {
   PluginTransportService({
     required this.eventSink,
     this.maxTransportsPerGeneration = 8,
     this.maxPendingOutboundBytes = 1 << 20,
     this.maxQueuedInboundBytes = 1 << 20,
-  });
+    WebSocketConnector? connectWebSocket,
+    SocketConnector? connectSocket,
+    SecureSocketConnector? connectSecureSocket,
+  }) : connectWebSocket = connectWebSocket ?? _connectWebSocket,
+       connectSocket = connectSocket ?? _connectSocket,
+       connectSecureSocket = connectSecureSocket ?? _connectSecureSocket;
 
   final PluginTransportEventSink eventSink;
   final int maxTransportsPerGeneration;
   final int maxPendingOutboundBytes;
   final int maxQueuedInboundBytes;
+  final WebSocketConnector connectWebSocket;
+  final SocketConnector connectSocket;
+  final SecureSocketConnector connectSecureSocket;
 
   static const Duration _closeTimeout = Duration(seconds: 5);
   static const String _resourceLimitCode = 'transport_resource_limit';
@@ -63,7 +67,6 @@ class PluginTransportService {
   int get liveTransportCount =>
       _records.values.where((record) => !record.terminal).length;
 
-  /// Opens a transport and resolves once the connection is established.
   Future<TransportOpenResult> open({
     required String pluginId,
     required int generation,
@@ -95,19 +98,12 @@ class PluginTransportService {
     }
   }
 
-  /// Registers the single event listener for [handle]. Calling it again
-  /// replaces the previous listener. Flushes the bounded inbound queue in
-  /// order.
   void onEventRegistered(String pluginId, int generation, String handle) {
     final record = _recordFor(pluginId, generation, handle);
     record.delivering = true;
     _drain(record);
   }
 
-  /// Resolves once the payload is accepted into the native transport's
-  /// bounded outbound write path. Rejects atomically with
-  /// `transport_resource_limit` if accepting the whole payload would exceed
-  /// the outbound limit.
   Future<void> send(
     String pluginId,
     int generation,
@@ -127,10 +123,7 @@ class PluginTransportService {
       if (data is! String) {
         throw const PluginTransportException('Text payload must be a string');
       }
-      final size = utf8.encode(data).length;
-      _reserveOutbound(record, size);
-      record.webSocket!.add(data);
-      _releaseOutbound(record, size);
+      _enqueueOutbound(record, data, utf8.encode(data).length);
       return;
     }
     if (type == 'binary') {
@@ -148,14 +141,13 @@ class PluginTransportService {
           'Binary payload is not valid base64',
         );
       }
-      _reserveOutbound(record, bytes.length);
       final ws = record.webSocket;
       if (ws != null) {
-        ws.add(bytes);
-        _releaseOutbound(record, bytes.length);
+        _enqueueOutbound(record, bytes, bytes.length);
         return;
       }
       final socket = record.socket!;
+      _reserveOutbound(record, bytes.length);
       socket.add(bytes);
       unawaited(
         socket.flush().then<void>(
@@ -170,8 +162,6 @@ class PluginTransportService {
     );
   }
 
-  /// Closes the transport and releases the handle. Resolves once the native
-  /// transport is closed.
   Future<void> close(String pluginId, int generation, String handle) async {
     final record = _recordFor(pluginId, generation, handle);
     _checkOpen(record);
@@ -179,11 +169,9 @@ class PluginTransportService {
     if (ws != null) {
       try {
         await ws.close(1000).timeout(_closeTimeout);
-      } catch (_) {
-        // The peer may already have closed or never respond to the close
-        // frame; the handle is released below regardless.
-      }
+      } catch (_) {}
       _terminate(record);
+      _records.remove(record.handle);
       return;
     }
     final socket = record.socket;
@@ -194,30 +182,28 @@ class PluginTransportService {
         socket.destroy();
       }
       _terminate(record);
+      _records.remove(record.handle);
       return;
     }
     _terminate(record);
+    _records.remove(record.handle);
   }
 
-  /// Closes every live transport owned by (pluginId, generation). Used on
-  /// plugin unload; cleanup is deterministic even if plugin JS misbehaves.
-  Future<void> closeAllForPlugin(String pluginId, int generation) async {
+  void closeAllForPlugin(String pluginId, int generation) {
     final owned = _records.values
         .where(
           (record) =>
-              record.pluginId == pluginId &&
-              record.generation == generation &&
-              !record.terminal,
+              record.pluginId == pluginId && record.generation == generation,
         )
         .toList();
     for (final record in owned) {
-      try {
-        await close(pluginId, generation, record.handle);
-      } catch (_) {}
+      _records.remove(record.handle);
+      if (record.terminal) continue;
+      record.terminal = true;
+      _closeNative(record);
     }
   }
 
-  /// Closes all remaining transports. Called on manager disposal.
   void dispose() {
     for (final record in _records.values) {
       if (record.terminal) continue;
@@ -248,7 +234,13 @@ class PluginTransportService {
       }
       protocols = rawProtocols.cast<String>();
     }
-    final ws = await WebSocket.connect(url, protocols: protocols);
+    final ws = await connectWebSocket(url, protocols: protocols);
+    if (record.terminal) {
+      unawaited(
+        ws.close(1000).timeout(_closeTimeout).catchError((Object _) {}),
+      );
+      throw const PluginTransportException('Plugin unloaded during connect');
+    }
     record.webSocket = ws;
     _listenWebSocket(record);
     final protocol = ws.protocol;
@@ -264,7 +256,11 @@ class PluginTransportService {
   ) async {
     final host = _hostOption(options);
     final port = _portOption(options);
-    final socket = await Socket.connect(host, port);
+    final socket = await connectSocket(host, port);
+    if (record.terminal) {
+      socket.destroy();
+      throw const PluginTransportException('Plugin unloaded during connect');
+    }
     record.socket = socket;
     _listenSocket(record);
     return TransportOpenResult(handle: record.handle);
@@ -276,10 +272,41 @@ class PluginTransportService {
   ) async {
     final host = _hostOption(options);
     final port = _portOption(options);
-    final socket = await SecureSocket.connect(host, port);
+    final socket = await connectSecureSocket(host, port);
+    if (record.terminal) {
+      socket.destroy();
+      throw const PluginTransportException('Plugin unloaded during connect');
+    }
     record.socket = socket;
     _listenSocket(record);
     return TransportOpenResult(handle: record.handle);
+  }
+
+  void _enqueueOutbound(_TransportRecord record, Object data, int size) {
+    _reserveOutbound(record, size);
+    record.outboundQueue.add(_OutboundFrame(data, size));
+    unawaited(_drainOutbound(record));
+  }
+
+  Future<void> _drainOutbound(_TransportRecord record) async {
+    if (record.outboundWriting) return;
+    record.outboundWriting = true;
+    try {
+      while (!record.terminal && record.outboundQueue.isNotEmpty) {
+        final frame = record.outboundQueue.first;
+        final ws = record.webSocket;
+        if (ws == null) break;
+        try {
+          await ws.addStream(Stream<dynamic>.value(frame.data));
+        } on Object {
+          break;
+        }
+        record.outboundQueue.removeFirst();
+        _releaseOutbound(record, frame.size);
+      }
+    } finally {
+      record.outboundWriting = false;
+    }
   }
 
   String _hostOption(Map<String, dynamic> options) {
@@ -373,6 +400,7 @@ class PluginTransportService {
         queued.event,
       );
     }
+    if (record.terminal) _records.remove(record.handle);
   }
 
   void _terminate(
@@ -478,6 +506,17 @@ class PluginTransportService {
   }
 }
 
+Future<WebSocket> _connectWebSocket(
+  String url, {
+  Iterable<String>? protocols,
+}) => WebSocket.connect(url, protocols: protocols);
+
+Future<Socket> _connectSocket(String host, int port) =>
+    Socket.connect(host, port);
+
+Future<SecureSocket> _connectSecureSocket(String host, int port) =>
+    SecureSocket.connect(host, port);
+
 class _TransportRecord {
   _TransportRecord({
     required this.handle,
@@ -496,8 +535,17 @@ class _TransportRecord {
   bool delivering = false;
   bool terminal = false;
   int outboundBytes = 0;
+  final Queue<_OutboundFrame> outboundQueue = Queue();
+  bool outboundWriting = false;
   final Queue<_QueuedEvent> inboundQueue = Queue();
   int inboundBytes = 0;
+}
+
+class _OutboundFrame {
+  const _OutboundFrame(this.data, this.size);
+
+  final Object data;
+  final int size;
 }
 
 class _QueuedEvent {

--- a/lib/src/plugins/plugin_transport_service.dart
+++ b/lib/src/plugins/plugin_transport_service.dart
@@ -44,6 +44,7 @@ class PluginTransportService {
     this.maxTransportsPerGeneration = 8,
     this.maxPendingOutboundBytes = 1 << 20,
     this.maxQueuedInboundBytes = 1 << 20,
+    this.closeTimeout = const Duration(seconds: 5),
     WebSocketConnector? connectWebSocket,
     SocketConnector? connectSocket,
     SecureSocketConnector? connectSecureSocket,
@@ -55,11 +56,11 @@ class PluginTransportService {
   final int maxTransportsPerGeneration;
   final int maxPendingOutboundBytes;
   final int maxQueuedInboundBytes;
+  final Duration closeTimeout;
   final WebSocketConnector connectWebSocket;
   final SocketConnector connectSocket;
   final SecureSocketConnector connectSecureSocket;
 
-  static const Duration _closeTimeout = Duration(seconds: 5);
   static const String _resourceLimitCode = 'transport_resource_limit';
 
   final Map<String, _TransportRecord> _records = {};
@@ -176,32 +177,16 @@ class PluginTransportService {
     final record = _recordFor(pluginId, generation, handle);
     _checkOpen(record);
     record.closing = true;
-    await _awaitOutbound(record);
-    final ws = record.webSocket;
-    if (ws != null) {
-      try {
-        await ws.close(1000).timeout(_closeTimeout);
-      } catch (_) {}
-      _terminate(record);
-      _records.remove(record.handle);
-      return;
-    }
-    final socket = record.socket;
-    if (socket != null) {
-      try {
-        await socket.close().timeout(_closeTimeout);
-      } catch (_) {
-        socket.destroy();
-      }
-      _terminate(record);
-      _records.remove(record.handle);
-      return;
+    if (!await _closeNative(record)) {
+      throw const PluginTransportException(
+        'Transport could not be closed; outbound write did not drain',
+      );
     }
     _terminate(record);
     _records.remove(record.handle);
   }
 
-  void closeAllForPlugin(String pluginId, int generation) {
+  Future<void> closeAllForPlugin(String pluginId, int generation) async {
     final owned = _records.values
         .where(
           (record) =>
@@ -212,15 +197,15 @@ class PluginTransportService {
       _records.remove(record.handle);
       if (record.terminal) continue;
       record.terminal = true;
-      _closeNative(record);
+      await _closeNative(record);
     }
   }
 
-  void dispose() {
+  Future<void> dispose() async {
     for (final record in _records.values) {
       if (record.terminal) continue;
       record.terminal = true;
-      _closeNative(record);
+      await _closeNative(record);
     }
     _records.clear();
   }
@@ -248,9 +233,7 @@ class PluginTransportService {
     }
     final ws = await connectWebSocket(url, protocols: protocols);
     if (record.terminal) {
-      unawaited(
-        ws.close(1000).timeout(_closeTimeout).catchError((Object _) {}),
-      );
+      unawaited(ws.close(1000).timeout(closeTimeout).catchError((Object _) {}));
       throw const PluginTransportException('Plugin unloaded during connect');
     }
     record.webSocket = ws;
@@ -314,10 +297,17 @@ class PluginTransportService {
         final frame = record.outboundQueue.first;
         final ws = record.webSocket;
         if (ws == null) break;
+        final controller = StreamController<dynamic>();
+        record.pendingWrite = controller;
         try {
-          await ws.addStream(Stream<dynamic>.value(frame.data));
+          final write = ws.addStream(controller.stream);
+          controller.add(frame.data);
+          await controller.close();
+          await write;
         } on Object {
           break;
+        } finally {
+          record.pendingWrite = null;
         }
         record.outboundQueue.removeFirst();
         _releaseOutbound(record, frame.size);
@@ -327,21 +317,26 @@ class PluginTransportService {
     }
   }
 
-  Future<void> _awaitOutbound(_TransportRecord record) async {
+  Future<bool> _awaitOutbound(_TransportRecord record) async {
     final ws = record.webSocket;
     if (ws != null) {
       final drain = record.outboundDrain;
-      if (drain == null) return;
+      if (drain == null) return true;
       try {
-        await drain.timeout(_closeTimeout);
-      } catch (_) {}
-      return;
+        await drain.timeout(closeTimeout);
+        return true;
+      } on TimeoutException {
+        return false;
+      }
     }
     final pending = record.tcpFlushes.toList();
-    if (pending.isEmpty) return;
+    if (pending.isEmpty) return true;
     try {
-      await Future.wait(pending).timeout(_closeTimeout);
-    } catch (_) {}
+      await Future.wait(pending).timeout(closeTimeout);
+      return true;
+    } on TimeoutException {
+      return false;
+    }
   }
 
   String _hostOption(Map<String, dynamic> options) {
@@ -452,31 +447,49 @@ class PluginTransportService {
     }
     record.inboundQueue.add(_QueuedEvent(_closeEvent(record), 0));
     _drain(record);
-    _closeNative(record);
+    unawaited(_closeNative(record));
   }
 
-  void _closeNative(_TransportRecord record) {
+  Future<bool> _closeNative(_TransportRecord record) async {
+    var graceful = await _awaitOutbound(record);
+    if (!graceful) {
+      record.terminal = true;
+      final controller = record.pendingWrite;
+      if (controller != null && !controller.isClosed) {
+        await controller.close();
+      }
+      final drain = record.outboundDrain;
+      if (drain != null) {
+        try {
+          await drain.timeout(const Duration(milliseconds: 100));
+        } catch (_) {}
+      }
+    }
     final ws = record.webSocket;
     if (ws != null) {
-      unawaited(_awaitOutbound(record).then((_) => _closeWebSocket(record)));
-      return;
+      try {
+        await ws.close(1000).timeout(closeTimeout);
+        return true;
+      } on Object {
+        return false;
+      }
     }
     final socket = record.socket;
     if (socket != null) {
-      unawaited(
-        _awaitOutbound(record).then((_) {
-          try {
-            socket.destroy();
-          } catch (_) {}
-        }),
-      );
+      if (graceful) {
+        try {
+          await socket.close().timeout(closeTimeout);
+        } catch (_) {
+          socket.destroy();
+        }
+      } else {
+        try {
+          socket.destroy();
+        } catch (_) {}
+      }
+      return true;
     }
-  }
-
-  void _closeWebSocket(_TransportRecord record) {
-    final ws = record.webSocket;
-    if (ws == null) return;
-    unawaited(ws.close(1000).timeout(_closeTimeout).catchError((Object _) {}));
+    return true;
   }
 
   Map<String, dynamic> _closeEvent(_TransportRecord record) {
@@ -581,6 +594,7 @@ class _TransportRecord {
   int outboundBytes = 0;
   final Queue<_OutboundFrame> outboundQueue = Queue();
   Future<void>? outboundDrain;
+  StreamController<dynamic>? pendingWrite;
   final List<Future<void>> tcpFlushes = [];
   final Queue<_QueuedEvent> inboundQueue = Queue();
   int inboundBytes = 0;

--- a/lib/src/plugins/plugin_transport_service.dart
+++ b/lib/src/plugins/plugin_transport_service.dart
@@ -149,7 +149,12 @@ class PluginTransportService {
       }
       final socket = record.socket!;
       _reserveOutbound(record, bytes.length);
-      socket.add(bytes);
+      try {
+        socket.add(bytes);
+      } catch (_) {
+        _releaseOutbound(record, bytes.length);
+        rethrow;
+      }
       final write = Completer<void>();
       record.tcpFlushes.add(write.future);
       unawaited(
@@ -302,9 +307,11 @@ class PluginTransportService {
         try {
           final write = ws.addStream(controller.stream);
           controller.add(frame.data);
-          await controller.close();
-          await write;
+          await Future.wait([controller.close(), write]);
         } on Object {
+          record.outboundQueue.clear();
+          record.outboundBytes = 0;
+          _terminate(record, error: 'WebSocket write failed; transport closed');
           break;
         } finally {
           record.pendingWrite = null;
@@ -526,15 +533,15 @@ class PluginTransportService {
   }
 
   void _checkLiveLimit(String pluginId, int generation) {
-    final live = _records.values.where(
+    final retained = _records.values.where(
       (record) =>
           record.pluginId == pluginId &&
           record.generation == generation &&
-          !record.terminal,
+          (!record.terminal || !record.delivering),
     );
-    if (live.length >= maxTransportsPerGeneration) {
+    if (retained.length >= maxTransportsPerGeneration) {
       throw const PluginTransportException(
-        'Too many live transports for this plugin',
+        'Too many open transports for this plugin',
         code: _resourceLimitCode,
       );
     }

--- a/lib/src/plugins/plugin_transport_service.dart
+++ b/lib/src/plugins/plugin_transport_service.dart
@@ -1,0 +1,508 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+/// Kinds of outbound transport exposed to plugins.
+enum PluginTransportKind { websocket, tcp, tls }
+
+/// Error surfaced to the JS bridge. [code] is the stable machine-readable
+/// error code carried on the rejected Promise.
+class PluginTransportException implements Exception {
+  const PluginTransportException(this.message, {this.code = 'transport_error'});
+
+  final String message;
+  final String code;
+
+  @override
+  String toString() => message;
+}
+
+class TransportOpenResult {
+  const TransportOpenResult({required this.handle, this.protocol});
+
+  final String handle;
+  final String? protocol;
+}
+
+/// Delivers a decoded transport event to the JS runtime. Implemented by
+/// [PluginManager] so it can validate plugin generation before evaluating JS.
+typedef PluginTransportEventSink =
+    void Function(
+      String pluginId,
+      int generation,
+      String handle,
+      Map<String, dynamic> event,
+    );
+
+/// Owns native WebSocket/TCP/TLS connections opened by plugins.
+///
+/// Every handle is owned by a (pluginId, generation) pair. The service
+/// enforces connection and byte limits, bounds the inbound queue, and
+/// guarantees that unload/dispose close every native connection.
+class PluginTransportService {
+  PluginTransportService({
+    required this.eventSink,
+    this.maxTransportsPerGeneration = 8,
+    this.maxPendingOutboundBytes = 1 << 20,
+    this.maxQueuedInboundBytes = 1 << 20,
+  });
+
+  final PluginTransportEventSink eventSink;
+  final int maxTransportsPerGeneration;
+  final int maxPendingOutboundBytes;
+  final int maxQueuedInboundBytes;
+
+  static const Duration _closeTimeout = Duration(seconds: 5);
+  static const String _resourceLimitCode = 'transport_resource_limit';
+
+  final Map<String, _TransportRecord> _records = {};
+
+  int get liveTransportCount =>
+      _records.values.where((record) => !record.terminal).length;
+
+  /// Opens a transport and resolves once the connection is established.
+  Future<TransportOpenResult> open({
+    required String pluginId,
+    required int generation,
+    required Map<String, dynamic> options,
+  }) async {
+    final kind = switch (options['kind']) {
+      'websocket' => PluginTransportKind.websocket,
+      'tcp' => PluginTransportKind.tcp,
+      'tls' => PluginTransportKind.tls,
+      _ => throw const PluginTransportException('Unknown transport kind'),
+    };
+    _checkLiveLimit(pluginId, generation);
+    final record = _TransportRecord(
+      handle: _newHandle(),
+      pluginId: pluginId,
+      generation: generation,
+      kind: kind,
+    );
+    _records[record.handle] = record;
+    try {
+      return switch (kind) {
+        PluginTransportKind.websocket => await _openWebSocket(record, options),
+        PluginTransportKind.tcp => await _openTcp(record, options),
+        PluginTransportKind.tls => await _openTls(record, options),
+      };
+    } catch (_) {
+      _records.remove(record.handle);
+      rethrow;
+    }
+  }
+
+  /// Registers the single event listener for [handle]. Calling it again
+  /// replaces the previous listener. Flushes the bounded inbound queue in
+  /// order.
+  void onEventRegistered(String pluginId, int generation, String handle) {
+    final record = _recordFor(pluginId, generation, handle);
+    record.delivering = true;
+    _drain(record);
+  }
+
+  /// Resolves once the payload is accepted into the native transport's
+  /// bounded outbound write path. Rejects atomically with
+  /// `transport_resource_limit` if accepting the whole payload would exceed
+  /// the outbound limit.
+  Future<void> send(
+    String pluginId,
+    int generation,
+    String handle,
+    Map<String, dynamic> payload,
+  ) async {
+    final record = _recordFor(pluginId, generation, handle);
+    _checkOpen(record);
+    final type = payload['type'];
+    if (type == 'text') {
+      if (record.kind != PluginTransportKind.websocket) {
+        throw const PluginTransportException(
+          'Text frames are only supported on WebSocket transports',
+        );
+      }
+      final data = payload['data'];
+      if (data is! String) {
+        throw const PluginTransportException('Text payload must be a string');
+      }
+      final size = utf8.encode(data).length;
+      _reserveOutbound(record, size);
+      record.webSocket!.add(data);
+      _releaseOutbound(record, size);
+      return;
+    }
+    if (type == 'binary') {
+      final data = payload['data'];
+      if (data is! String) {
+        throw const PluginTransportException(
+          'Binary payload must be a base64 string',
+        );
+      }
+      final Uint8List bytes;
+      try {
+        bytes = base64Decode(data);
+      } on FormatException {
+        throw const PluginTransportException(
+          'Binary payload is not valid base64',
+        );
+      }
+      _reserveOutbound(record, bytes.length);
+      final ws = record.webSocket;
+      if (ws != null) {
+        ws.add(bytes);
+        _releaseOutbound(record, bytes.length);
+        return;
+      }
+      final socket = record.socket!;
+      socket.add(bytes);
+      unawaited(
+        socket.flush().then<void>(
+          (_) => _releaseOutbound(record, bytes.length),
+          onError: (Object _) => _releaseOutbound(record, bytes.length),
+        ),
+      );
+      return;
+    }
+    throw const PluginTransportException(
+      'Send payload must have type "text" or "binary"',
+    );
+  }
+
+  /// Closes the transport and releases the handle. Resolves once the native
+  /// transport is closed.
+  Future<void> close(String pluginId, int generation, String handle) async {
+    final record = _recordFor(pluginId, generation, handle);
+    _checkOpen(record);
+    final ws = record.webSocket;
+    if (ws != null) {
+      try {
+        await ws.close(1000).timeout(_closeTimeout);
+      } catch (_) {
+        // The peer may already have closed or never respond to the close
+        // frame; the handle is released below regardless.
+      }
+      _terminate(record);
+      return;
+    }
+    final socket = record.socket;
+    if (socket != null) {
+      try {
+        await socket.close().timeout(_closeTimeout);
+      } catch (_) {
+        socket.destroy();
+      }
+      _terminate(record);
+      return;
+    }
+    _terminate(record);
+  }
+
+  /// Closes every live transport owned by (pluginId, generation). Used on
+  /// plugin unload; cleanup is deterministic even if plugin JS misbehaves.
+  Future<void> closeAllForPlugin(String pluginId, int generation) async {
+    final owned = _records.values
+        .where(
+          (record) =>
+              record.pluginId == pluginId &&
+              record.generation == generation &&
+              !record.terminal,
+        )
+        .toList();
+    for (final record in owned) {
+      try {
+        await close(pluginId, generation, record.handle);
+      } catch (_) {}
+    }
+  }
+
+  /// Closes all remaining transports. Called on manager disposal.
+  void dispose() {
+    for (final record in _records.values) {
+      if (record.terminal) continue;
+      record.terminal = true;
+      _closeNative(record);
+    }
+    _records.clear();
+  }
+
+  Future<TransportOpenResult> _openWebSocket(
+    _TransportRecord record,
+    Map<String, dynamic> options,
+  ) async {
+    final url = options['url'];
+    if (url is! String ||
+        !(url.startsWith('ws://') || url.startsWith('wss://'))) {
+      throw const PluginTransportException(
+        'WebSocket transport requires a ws:// or wss:// url',
+      );
+    }
+    final rawProtocols = options['protocols'];
+    Iterable<String>? protocols;
+    if (rawProtocols != null) {
+      if (rawProtocols is! List || rawProtocols.any((p) => p is! String)) {
+        throw const PluginTransportException(
+          'WebSocket protocols must be an array of strings',
+        );
+      }
+      protocols = rawProtocols.cast<String>();
+    }
+    final ws = await WebSocket.connect(url, protocols: protocols);
+    record.webSocket = ws;
+    _listenWebSocket(record);
+    final protocol = ws.protocol;
+    return TransportOpenResult(
+      handle: record.handle,
+      protocol: (protocol == null || protocol.isEmpty) ? null : protocol,
+    );
+  }
+
+  Future<TransportOpenResult> _openTcp(
+    _TransportRecord record,
+    Map<String, dynamic> options,
+  ) async {
+    final host = _hostOption(options);
+    final port = _portOption(options);
+    final socket = await Socket.connect(host, port);
+    record.socket = socket;
+    _listenSocket(record);
+    return TransportOpenResult(handle: record.handle);
+  }
+
+  Future<TransportOpenResult> _openTls(
+    _TransportRecord record,
+    Map<String, dynamic> options,
+  ) async {
+    final host = _hostOption(options);
+    final port = _portOption(options);
+    final socket = await SecureSocket.connect(host, port);
+    record.socket = socket;
+    _listenSocket(record);
+    return TransportOpenResult(handle: record.handle);
+  }
+
+  String _hostOption(Map<String, dynamic> options) {
+    final host = options['host'];
+    if (host is! String || host.isEmpty) {
+      throw const PluginTransportException('Transport requires a host');
+    }
+    return host;
+  }
+
+  int _portOption(Map<String, dynamic> options) {
+    final port = options['port'];
+    if (port is! int || port < 1 || port > 65535) {
+      throw const PluginTransportException(
+        'Transport requires a port 1..65535',
+      );
+    }
+    return port;
+  }
+
+  void _listenWebSocket(_TransportRecord record) {
+    record.webSocket!.listen(
+      (dynamic data) {
+        if (record.terminal) return;
+        if (data is String) {
+          _enqueue(record, {
+            'type': 'data',
+            'dataType': 'text',
+            'data': data,
+          }, size: utf8.encode(data).length);
+        } else if (data is List<int>) {
+          _enqueue(record, {
+            'type': 'data',
+            'dataType': 'binary',
+            'data': base64Encode(data),
+          }, size: data.length);
+        }
+      },
+      onError: (Object error) =>
+          _terminate(record, error: 'WebSocket error: $error'),
+      onDone: () => _terminate(record),
+      cancelOnError: true,
+    );
+  }
+
+  void _listenSocket(_TransportRecord record) {
+    record.socket!.listen(
+      (List<int> chunk) {
+        if (record.terminal) return;
+        _enqueue(record, {
+          'type': 'data',
+          'dataType': 'binary',
+          'data': base64Encode(chunk),
+        }, size: chunk.length);
+      },
+      onError: (Object error) =>
+          _terminate(record, error: 'Socket error: $error'),
+      onDone: () => _terminate(record),
+      cancelOnError: true,
+    );
+  }
+
+  void _enqueue(
+    _TransportRecord record,
+    Map<String, dynamic> event, {
+    required int size,
+  }) {
+    if (record.terminal) return;
+    if (record.inboundBytes + size > maxQueuedInboundBytes) {
+      _terminate(
+        record,
+        error: 'Inbound data limit exceeded; transport closed',
+        code: _resourceLimitCode,
+      );
+      return;
+    }
+    record.inboundQueue.add(_QueuedEvent(event, size));
+    record.inboundBytes += size;
+    _drain(record);
+  }
+
+  void _drain(_TransportRecord record) {
+    if (!record.delivering) return;
+    while (record.inboundQueue.isNotEmpty) {
+      final queued = record.inboundQueue.removeFirst();
+      record.inboundBytes -= queued.size;
+      eventSink(
+        record.pluginId,
+        record.generation,
+        record.handle,
+        queued.event,
+      );
+    }
+  }
+
+  void _terminate(
+    _TransportRecord record, {
+    String? error,
+    String code = 'transport_error',
+  }) {
+    if (record.terminal) return;
+    record.terminal = true;
+    if (error != null) {
+      record.inboundQueue.add(
+        _QueuedEvent({'type': 'error', 'code': code, 'message': error}, 0),
+      );
+    }
+    record.inboundQueue.add(_QueuedEvent(_closeEvent(record), 0));
+    _drain(record);
+    _closeNative(record);
+  }
+
+  void _closeNative(_TransportRecord record) {
+    final ws = record.webSocket;
+    if (ws != null) {
+      unawaited(
+        ws.close(1000).timeout(_closeTimeout).catchError((Object _) {}),
+      );
+      return;
+    }
+    final socket = record.socket;
+    if (socket != null) {
+      try {
+        socket.destroy();
+      } catch (_) {}
+    }
+  }
+
+  Map<String, dynamic> _closeEvent(_TransportRecord record) {
+    final ws = record.webSocket;
+    if (ws != null) {
+      final code = ws.closeCode;
+      final reason = ws.closeReason;
+      return {
+        'type': 'close',
+        'code': ?code,
+        if (reason != null && reason.isNotEmpty) 'reason': reason,
+      };
+    }
+    return {'type': 'close'};
+  }
+
+  _TransportRecord _recordFor(String pluginId, int generation, String handle) {
+    final record = _records[handle];
+    if (record == null) {
+      throw const PluginTransportException('Unknown transport handle');
+    }
+    if (record.pluginId != pluginId || record.generation != generation) {
+      throw const PluginTransportException(
+        'Transport handle is not owned by this plugin',
+      );
+    }
+    return record;
+  }
+
+  void _checkOpen(_TransportRecord record) {
+    if (record.terminal) {
+      throw const PluginTransportException('Transport already closed');
+    }
+  }
+
+  void _checkLiveLimit(String pluginId, int generation) {
+    final live = _records.values.where(
+      (record) =>
+          record.pluginId == pluginId &&
+          record.generation == generation &&
+          !record.terminal,
+    );
+    if (live.length >= maxTransportsPerGeneration) {
+      throw const PluginTransportException(
+        'Too many live transports for this plugin',
+        code: _resourceLimitCode,
+      );
+    }
+  }
+
+  void _reserveOutbound(_TransportRecord record, int size) {
+    if (size > maxPendingOutboundBytes ||
+        record.outboundBytes + size > maxPendingOutboundBytes) {
+      throw const PluginTransportException(
+        'Outbound data limit exceeded; send rejected',
+        code: _resourceLimitCode,
+      );
+    }
+    record.outboundBytes += size;
+  }
+
+  void _releaseOutbound(_TransportRecord record, int size) {
+    record.outboundBytes -= size;
+  }
+
+  String _newHandle() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(24, (_) => random.nextInt(256));
+    return base64Url.encode(bytes);
+  }
+}
+
+class _TransportRecord {
+  _TransportRecord({
+    required this.handle,
+    required this.pluginId,
+    required this.generation,
+    required this.kind,
+  });
+
+  final String handle;
+  final String pluginId;
+  final int generation;
+  final PluginTransportKind kind;
+
+  WebSocket? webSocket;
+  Socket? socket;
+  bool delivering = false;
+  bool terminal = false;
+  int outboundBytes = 0;
+  final Queue<_QueuedEvent> inboundQueue = Queue();
+  int inboundBytes = 0;
+}
+
+class _QueuedEvent {
+  const _QueuedEvent(this.event, this.size);
+
+  final Map<String, dynamic> event;
+  final int size;
+}

--- a/lib/src/plugins/plugin_transport_service.dart
+++ b/lib/src/plugins/plugin_transport_service.dart
@@ -149,10 +149,20 @@ class PluginTransportService {
       final socket = record.socket!;
       _reserveOutbound(record, bytes.length);
       socket.add(bytes);
+      final write = Completer<void>();
+      record.tcpFlushes.add(write.future);
       unawaited(
         socket.flush().then<void>(
-          (_) => _releaseOutbound(record, bytes.length),
-          onError: (Object _) => _releaseOutbound(record, bytes.length),
+          (_) {
+            _releaseOutbound(record, bytes.length);
+            record.tcpFlushes.remove(write.future);
+            if (!write.isCompleted) write.complete();
+          },
+          onError: (Object _) {
+            _releaseOutbound(record, bytes.length);
+            record.tcpFlushes.remove(write.future);
+            if (!write.isCompleted) write.complete();
+          },
         ),
       );
       return;
@@ -165,6 +175,8 @@ class PluginTransportService {
   Future<void> close(String pluginId, int generation, String handle) async {
     final record = _recordFor(pluginId, generation, handle);
     _checkOpen(record);
+    record.closing = true;
+    await _awaitOutbound(record);
     final ws = record.webSocket;
     if (ws != null) {
       try {
@@ -288,9 +300,15 @@ class PluginTransportService {
     unawaited(_drainOutbound(record));
   }
 
-  Future<void> _drainOutbound(_TransportRecord record) async {
-    if (record.outboundWriting) return;
-    record.outboundWriting = true;
+  Future<void> _drainOutbound(_TransportRecord record) {
+    final existing = record.outboundDrain;
+    if (existing != null) return existing;
+    final drain = _runOutboundDrain(record);
+    record.outboundDrain = drain;
+    return drain;
+  }
+
+  Future<void> _runOutboundDrain(_TransportRecord record) async {
     try {
       while (!record.terminal && record.outboundQueue.isNotEmpty) {
         final frame = record.outboundQueue.first;
@@ -305,8 +323,25 @@ class PluginTransportService {
         _releaseOutbound(record, frame.size);
       }
     } finally {
-      record.outboundWriting = false;
+      record.outboundDrain = null;
     }
+  }
+
+  Future<void> _awaitOutbound(_TransportRecord record) async {
+    final ws = record.webSocket;
+    if (ws != null) {
+      final drain = record.outboundDrain;
+      if (drain == null) return;
+      try {
+        await drain.timeout(_closeTimeout);
+      } catch (_) {}
+      return;
+    }
+    final pending = record.tcpFlushes.toList();
+    if (pending.isEmpty) return;
+    try {
+      await Future.wait(pending).timeout(_closeTimeout);
+    } catch (_) {}
   }
 
   String _hostOption(Map<String, dynamic> options) {
@@ -423,17 +458,25 @@ class PluginTransportService {
   void _closeNative(_TransportRecord record) {
     final ws = record.webSocket;
     if (ws != null) {
-      unawaited(
-        ws.close(1000).timeout(_closeTimeout).catchError((Object _) {}),
-      );
+      unawaited(_awaitOutbound(record).then((_) => _closeWebSocket(record)));
       return;
     }
     final socket = record.socket;
     if (socket != null) {
-      try {
-        socket.destroy();
-      } catch (_) {}
+      unawaited(
+        _awaitOutbound(record).then((_) {
+          try {
+            socket.destroy();
+          } catch (_) {}
+        }),
+      );
     }
+  }
+
+  void _closeWebSocket(_TransportRecord record) {
+    final ws = record.webSocket;
+    if (ws == null) return;
+    unawaited(ws.close(1000).timeout(_closeTimeout).catchError((Object _) {}));
   }
 
   Map<String, dynamic> _closeEvent(_TransportRecord record) {
@@ -464,7 +507,7 @@ class PluginTransportService {
   }
 
   void _checkOpen(_TransportRecord record) {
-    if (record.terminal) {
+    if (record.terminal || record.closing) {
       throw const PluginTransportException('Transport already closed');
     }
   }
@@ -534,9 +577,11 @@ class _TransportRecord {
   Socket? socket;
   bool delivering = false;
   bool terminal = false;
+  bool closing = false;
   int outboundBytes = 0;
   final Queue<_OutboundFrame> outboundQueue = Queue();
-  bool outboundWriting = false;
+  Future<void>? outboundDrain;
+  final List<Future<void>> tcpFlushes = [];
   final Queue<_QueuedEvent> inboundQueue = Queue();
   int inboundBytes = 0;
 }

--- a/test/plugins/plugin_manager_transport_test.dart
+++ b/test/plugins/plugin_manager_transport_test.dart
@@ -108,11 +108,16 @@ class _GatedWebSocket implements WebSocket {
   }
 
   @override
-  Future<void> close([int? code, String? reason]) async {
+  Future<void> close([int? code, String? reason]) {
+    final hasPendingWrite = addStreamGates.any((gate) => !gate.isCompleted);
+    if (hasPendingWrite) {
+      return Future.error(StateError('StreamSink is bound to a stream'));
+    }
     closed = true;
     closeCode = code;
     closeReason = reason;
     readyState = WebSocket.closed;
+    return Future.value();
   }
 
   @override
@@ -554,6 +559,42 @@ void main() {
         expect(ws.written, ['accepted']);
       },
     );
+
+    test('close rejects when an accepted write never drains', () async {
+      final ws = _GatedWebSocket();
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        fetchTimeout: const Duration(seconds: 2),
+        transportCloseTimeout: const Duration(milliseconds: 200),
+        connectWebSocket: (url, {protocols}) async => ws,
+      );
+      addTearDown(manager.dispose);
+      final result = await runPluginResult(
+        manager,
+        id: 'closetout.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        jsBody: '''
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:1/x"
+          }).then((opened) => {
+            return host.transport.send(opened.handle, { type: "text", data: "stuck" })
+              .then(() => host.transport.close(opened.handle))
+              .then(() => host.emit("result", "closed"))
+              .catch((e) => host.emit("result", JSON.stringify({ message: e.message })));
+          }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+        ''',
+      );
+
+      final payload = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(payload['message'], contains('could not be closed'));
+      expect(ws.closed, isFalse);
+      expect(ws.addStreamGates, hasLength(1));
+      expect(ws.addStreamGates.single.isCompleted, isFalse);
+    });
   });
 
   group('tcp', () {
@@ -1062,6 +1103,7 @@ void main() {
         final manager = PluginManager(
           kvStore: FakeKeyValueStoreService(),
           fetchTimeout: const Duration(seconds: 2),
+          transportCloseTimeout: const Duration(milliseconds: 200),
           connectWebSocket: (url, {protocols}) async => ws,
         );
         addTearDown(manager.dispose);

--- a/test/plugins/plugin_manager_transport_test.dart
+++ b/test/plugins/plugin_manager_transport_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
@@ -78,8 +79,10 @@ Future<ServerSocket> startTcpServer(
   return server;
 }
 
-class _BlockingWebSocket implements WebSocket {
+class _GatedWebSocket implements WebSocket {
   final List<Object> written = [];
+  final List<Completer<void>> addStreamGates = [];
+  bool closed = false;
   @override
   int readyState = WebSocket.open;
   @override
@@ -99,11 +102,14 @@ class _BlockingWebSocket implements WebSocket {
   @override
   Future<void> addStream(Stream<dynamic> stream) {
     stream.listen((data) => written.add(data));
-    return Completer<void>().future;
+    final gate = Completer<void>();
+    addStreamGates.add(gate);
+    return gate.future;
   }
 
   @override
   Future<void> close([int? code, String? reason]) async {
+    closed = true;
     closeCode = code;
     closeReason = reason;
     readyState = WebSocket.closed;
@@ -121,6 +127,65 @@ class _BlockingWebSocket implements WebSocket {
     onDone: onDone,
     cancelOnError: cancelOnError,
   );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RecordingSocket implements Socket {
+  _RecordingSocket(this._inner);
+
+  final Socket _inner;
+  final List<String> calls = [];
+  final List<Completer<void>> flushGates = [];
+
+  Future<void> releaseFlush() async {
+    final gate = flushGates.removeAt(0);
+    gate.complete();
+    await _inner.flush();
+  }
+
+  @override
+  void add(List<int> data) {
+    calls.add('add');
+    _inner.add(data);
+  }
+
+  @override
+  Future<void> flush() {
+    calls.add('flush');
+    final gate = Completer<void>();
+    flushGates.add(gate);
+    return gate.future;
+  }
+
+  @override
+  Future<void> close() {
+    calls.add('close');
+    return _inner.close();
+  }
+
+  @override
+  void destroy() {
+    calls.add('destroy');
+    _inner.destroy();
+  }
+
+  @override
+  StreamSubscription<Uint8List> listen(
+    void Function(Uint8List event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    calls.add('listen');
+    return _inner.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -430,6 +495,65 @@ void main() {
       expect(result, 'closed');
       await closed.future.timeout(const Duration(seconds: 5));
     });
+
+    test(
+      'close waits for an accepted write before closing the socket',
+      () async {
+        final ws = _GatedWebSocket();
+        final manager = PluginManager(
+          kvStore: FakeKeyValueStoreService(),
+          fetchTimeout: const Duration(seconds: 2),
+          connectWebSocket: (url, {protocols}) async => ws,
+        );
+        addTearDown(manager.dispose);
+        final sent = Completer<void>();
+        final result = Completer<Object?>();
+        final sub = manager.emitStream.listen((e) {
+          if (e['event'] == 'sent' && !sent.isCompleted) sent.complete();
+          if (e['event'] == 'result' && !result.isCompleted) {
+            result.complete(e['payload']);
+          }
+        });
+        addTearDown(sub.cancel);
+        await manager.loadPlugin(
+          id: 'closera.plugin',
+          manifest: testManifest(
+            'closera.plugin',
+            permissions: const {
+              PluginPermissions.emit,
+              PluginPermissions.networkWebsocket,
+            },
+          ),
+          settings: {},
+          jsCode: '''
+          function createPlugin(host) {
+            return {
+              id: "closera.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "websocket",
+                  url: "ws://127.0.0.1:1/x"
+                }).then((opened) => {
+                  return host.transport.send(opened.handle, { type: "text", data: "accepted" })
+                    .then(() => { host.emit("sent", 1); return host.transport.close(opened.handle); });
+                }).then(() => host.emit("result", "closed"));
+              }
+            };
+          }
+        ''',
+        );
+        await sent.future.timeout(const Duration(seconds: 5));
+        expect(ws.addStreamGates, hasLength(1));
+        expect(ws.closed, isFalse);
+        ws.addStreamGates.single.complete();
+        expect(
+          await result.future.timeout(const Duration(seconds: 5)),
+          'closed',
+        );
+        expect(ws.closed, isTrue);
+        expect(ws.written, ['accepted']);
+      },
+    );
   });
 
   group('tcp', () {
@@ -501,6 +625,76 @@ void main() {
       expect(error['message'], contains('Text frames'));
       expect(error['code'], 'transport_error');
     });
+
+    test(
+      'close waits for accepted tcp writes to flush before closing',
+      () async {
+        final server = await startTcpServer((socket) {
+          socket.listen((chunk) {}, onError: (Object _) {});
+        });
+        late _RecordingSocket recording;
+        final manager = PluginManager(
+          kvStore: FakeKeyValueStoreService(),
+          fetchTimeout: const Duration(seconds: 2),
+          connectSocket: (host, port) async {
+            final inner = await Socket.connect(host, port);
+            recording = _RecordingSocket(inner);
+            return recording;
+          },
+        );
+        addTearDown(manager.dispose);
+        final sent = Completer<void>();
+        final result = Completer<Object?>();
+        final sub = manager.emitStream.listen((e) {
+          if (e['event'] == 'sent' && !sent.isCompleted) sent.complete();
+          if (e['event'] == 'result' && !result.isCompleted) {
+            result.complete(e['payload']);
+          }
+        });
+        addTearDown(sub.cancel);
+        await manager.loadPlugin(
+          id: 'tcpclose.plugin',
+          manifest: testManifest(
+            'tcpclose.plugin',
+            permissions: const {
+              PluginPermissions.emit,
+              PluginPermissions.networkTcp,
+            },
+          ),
+          settings: {},
+          jsCode:
+              '''
+          function createPlugin(host) {
+            return {
+              id: "tcpclose.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "tcp",
+                  host: "127.0.0.1",
+                  port: ${server.port}
+                }).then((opened) => {
+                  return host.transport.send(opened.handle, { type: "binary", data: "AQID" })
+                    .then(() => { host.emit("sent", 1); return host.transport.close(opened.handle); });
+                }).then(() => host.emit("result", "closed"));
+              }
+            };
+          }
+        ''',
+        );
+        await sent.future.timeout(const Duration(seconds: 5));
+        expect(recording.flushGates, hasLength(1));
+        expect(recording.calls, isNot(contains('close')));
+        await recording.releaseFlush();
+        expect(
+          await result.future.timeout(const Duration(seconds: 5)),
+          'closed',
+        );
+        expect(
+          recording.calls.indexOf('close'),
+          greaterThan(recording.calls.indexOf('flush')),
+        );
+      },
+    );
   });
 
   group('lifecycle and isolation', () {
@@ -864,7 +1058,7 @@ void main() {
     test(
       'multiple sub-limit websocket sends accumulate pending outbound bytes',
       () async {
-        final ws = _BlockingWebSocket();
+        final ws = _GatedWebSocket();
         final manager = PluginManager(
           kvStore: FakeKeyValueStoreService(),
           fetchTimeout: const Duration(seconds: 2),

--- a/test/plugins/plugin_manager_transport_test.dart
+++ b/test/plugins/plugin_manager_transport_test.dart
@@ -1,0 +1,891 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+
+import 'plugin_test_helpers.dart';
+
+/// Loads a plugin whose onLoad runs [jsBody] and resolves with the first
+/// `host.emit("result", payload)` payload.
+Future<Object?> runPluginResult(
+  PluginManager manager, {
+  required String id,
+  required String jsBody,
+  Set<PluginPermissions>? permissions,
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final result = Completer<Object?>();
+  final sub = manager.emitStream.listen((e) {
+    if (!result.isCompleted) result.complete(e['payload']);
+  });
+  addTearDown(sub.cancel);
+  await manager.loadPlugin(
+    id: id,
+    manifest: permissions == null
+        ? testManifest(id)
+        : testManifest(id, permissions: permissions),
+    settings: {},
+    jsCode:
+        '''
+      function createPlugin(host) {
+        return {
+          id: "$id",
+          onLoad() {
+            $jsBody
+          }
+        };
+      }
+    ''',
+  );
+  return result.future.timeout(timeout);
+}
+
+Future<HttpServer> startWsServer(
+  FutureOr<void> Function(WebSocket ws) handler, {
+  String? Function(List<String>)? protocolSelector,
+}) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((req) async {
+    try {
+      if (WebSocketTransformer.isUpgradeRequest(req)) {
+        final ws = await WebSocketTransformer.upgrade(
+          req,
+          protocolSelector: protocolSelector,
+        );
+        await handler(ws);
+      } else {
+        req.response.statusCode = 404;
+        await req.response.close();
+      }
+    } catch (_) {}
+  });
+  addTearDown(() async => server.close(force: true));
+  return server;
+}
+
+Future<ServerSocket> startTcpServer(
+  void Function(Socket socket) handler,
+) async {
+  final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((socket) {
+    try {
+      handler(socket);
+    } catch (_) {}
+  });
+  addTearDown(() async => server.close());
+  return server;
+}
+
+void main() {
+  late PluginManager manager;
+
+  setUp(() {
+    manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      fetchTimeout: const Duration(seconds: 2),
+    );
+  });
+
+  tearDown(() async => manager.dispose());
+
+  group('permissions', () {
+    test(
+      'websocket open without network.websocket is rejected before connect',
+      () async {
+        var connections = 0;
+        final server = await startWsServer((ws) {
+          connections += 1;
+        });
+        final result = await runPluginResult(
+          manager,
+          id: 'perm.plugin',
+          permissions: const {PluginPermissions.emit},
+          jsBody:
+              '''
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:${server.port}/x"
+          }).then(
+            () => host.emit("result", "unexpected"),
+            (e) => host.emit("result", JSON.stringify({ name: e.name, message: e.message }))
+          );
+        ''',
+        );
+
+        final error = jsonDecode(result as String) as Map<String, dynamic>;
+        expect(error['name'], 'PluginPermissionError');
+        expect(error['message'], contains('network.websocket'));
+        expect(connections, 0);
+      },
+    );
+
+    test('tls open without network.tls is rejected before connect', () async {
+      var connections = 0;
+      final server = await startTcpServer((socket) {
+        connections += 1;
+      });
+      final result = await runPluginResult(
+        manager,
+        id: 'perm.plugin',
+        permissions: const {PluginPermissions.emit},
+        jsBody:
+            '''
+          host.transport.open({
+            kind: "tls",
+            host: "127.0.0.1",
+            port: ${server.port}
+          }).then(
+            () => host.emit("result", "unexpected"),
+            (e) => host.emit("result", JSON.stringify({ name: e.name, message: e.message }))
+          );
+        ''',
+      );
+
+      final error = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(error['name'], 'PluginPermissionError');
+      expect(error['message'], contains('network.tls'));
+      expect(connections, 0);
+    });
+
+    test(
+      'Dart rejects direct transport bridge open without permission',
+      () async {
+        var connections = 0;
+        final server = await startTcpServer((socket) {
+          connections += 1;
+        });
+        final result = await runPluginResult(
+          manager,
+          id: 'perm.plugin',
+          permissions: const {PluginPermissions.emit},
+          jsBody:
+              '''
+          __transportRegister("direct_1", {
+            bridgeToken: pluginBridgeToken,
+            resolve: (r) => host.emit("result", "unexpected"),
+            reject: (e) => host.emit("result", JSON.stringify({ name: e.name, message: e.message, code: e.code }))
+          });
+          globalThis.__reaprimePluginHostBridge.transportRequest(
+            pluginBridgeToken, 1, "direct_1", "open",
+            { kind: "tcp", host: "127.0.0.1", port: ${server.port} }
+          );
+        ''',
+        );
+
+        final error = jsonDecode(result as String) as Map<String, dynamic>;
+        expect(error['message'], contains('PluginPermissionError'));
+        expect(error['message'], contains('network.tcp'));
+        expect(connections, 0);
+      },
+    );
+
+    test('unknown transport kind is rejected', () async {
+      final result = await runPluginResult(
+        manager,
+        id: 'kind.plugin',
+        permissions: const {PluginPermissions.emit},
+        jsBody: '''
+          host.transport.open({ kind: "udp" }).then(
+            () => host.emit("result", "unexpected"),
+            (e) => host.emit("result", JSON.stringify({ message: e.message }))
+          );
+        ''',
+      );
+
+      final error = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(error['message'], contains('unknown transport kind'));
+    });
+  });
+
+  group('websocket', () {
+    test('text frame round-trips with dataType text', () async {
+      final server = await startWsServer((ws) {
+        ws.listen((data) {
+          try {
+            ws.add(data);
+          } catch (_) {}
+        });
+      });
+      final result = await runPluginResult(
+        manager,
+        id: 'ws.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        jsBody:
+            '''
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:${server.port}/echo"
+          }).then((opened) => {
+            host.transport.onEvent(opened.handle, (event) => {
+              if (event.type === "data") {
+                host.emit("result", JSON.stringify(event));
+              }
+            });
+            host.transport.send(opened.handle, { type: "text", data: "hello echo" });
+          }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+        ''',
+      );
+
+      final event = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(event['type'], 'data');
+      expect(event['dataType'], 'text');
+      expect(event['data'], 'hello echo');
+    });
+
+    test('binary frame round-trips random bytes as base64', () async {
+      final random = Random(42);
+      final original = List<int>.generate(512, (_) => random.nextInt(256));
+      final b64 = base64Encode(original);
+      final server = await startWsServer((ws) {
+        ws.listen((data) {
+          try {
+            ws.add(data);
+          } catch (_) {}
+        });
+      });
+      final result = await runPluginResult(
+        manager,
+        id: 'ws.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        jsBody:
+            '''
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:${server.port}/echo"
+          }).then((opened) => {
+            host.transport.onEvent(opened.handle, (event) => {
+              if (event.type === "data") {
+                host.emit("result", JSON.stringify(event));
+              }
+            });
+            host.transport.send(opened.handle, { type: "binary", data: "$b64" });
+          }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+        ''',
+      );
+
+      final event = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(event['dataType'], 'binary');
+      expect(base64Decode(event['data'] as String), original);
+    });
+
+    test('subprotocol negotiation returns negotiated protocol', () async {
+      final server = await startWsServer(
+        (ws) {
+          ws.listen((data) {
+            try {
+              ws.add(data);
+            } catch (_) {}
+          });
+        },
+        protocolSelector: (protocols) =>
+            protocols.contains('mqtt') ? 'mqtt' : null,
+      );
+      final result = await runPluginResult(
+        manager,
+        id: 'ws.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        jsBody:
+            '''
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:${server.port}/mqtt",
+            protocols: ["mqtt"]
+          }).then((opened) => {
+            host.emit("result", JSON.stringify({ protocol: opened.protocol, handle: opened.handle }));
+          }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+        ''',
+      );
+
+      final opened = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(opened['protocol'], 'mqtt');
+      expect(opened['handle'], isNotEmpty);
+    });
+
+    test(
+      'receives text JSON from the loopback sensor snapshot endpoint',
+      () async {
+        final server = await startWsServer((ws) {
+          ws.add(jsonEncode({'groupTemperature': 93.5, 'sensor': 'sensor-1'}));
+          ws.listen((data) {});
+        });
+        final result = await runPluginResult(
+          manager,
+          id: 'ws.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          jsBody:
+              '''
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:${server.port}/ws/v1/sensors/sensor-1/snapshot"
+          }).then((opened) => {
+            host.transport.onEvent(opened.handle, (event) => {
+              if (event.type === "data") {
+                host.emit("result", JSON.stringify(event));
+              }
+            });
+          }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+        ''',
+        );
+
+        final event = jsonDecode(result as String) as Map<String, dynamic>;
+        expect(event['dataType'], 'text');
+        final snapshot =
+            jsonDecode(event['data'] as String) as Map<String, dynamic>;
+        expect(snapshot['groupTemperature'], 93.5);
+        expect(snapshot['sensor'], 'sensor-1');
+      },
+    );
+
+    test('plugin-initiated close resolves and closes the connection', () async {
+      final closed = Completer<void>();
+      final server = await startWsServer((ws) {
+        ws.listen(
+          (data) {},
+          onDone: () {
+            if (!closed.isCompleted) closed.complete();
+          },
+        );
+      });
+      final result = await runPluginResult(
+        manager,
+        id: 'ws.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        jsBody:
+            '''
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:${server.port}/x"
+          }).then((opened) => {
+            return host.transport.close(opened.handle);
+          }).then(() => host.emit("result", "closed"))
+            .catch((e) => host.emit("result", "err:" + e.message));
+        ''',
+      );
+
+      expect(result, 'closed');
+      await closed.future.timeout(const Duration(seconds: 5));
+    });
+  });
+
+  group('tcp', () {
+    test('binary bytes round-trip through a TCP echo server', () async {
+      final random = Random(7);
+      final original = List<int>.generate(1024, (_) => random.nextInt(256));
+      final b64 = base64Encode(original);
+      final server = await startTcpServer((socket) {
+        socket.listen((chunk) {
+          try {
+            socket.add(chunk);
+          } catch (_) {}
+        });
+      });
+      final result = await runPluginResult(
+        manager,
+        id: 'tcp.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkTcp,
+        },
+        jsBody:
+            '''
+          host.transport.open({
+            kind: "tcp",
+            host: "127.0.0.1",
+            port: ${server.port}
+          }).then((opened) => {
+            host.transport.onEvent(opened.handle, (event) => {
+              if (event.type === "data") {
+                host.emit("result", JSON.stringify(event));
+              }
+            });
+            host.transport.send(opened.handle, { type: "binary", data: "$b64" });
+          }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+        ''',
+      );
+
+      final event = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(event['dataType'], 'binary');
+      expect(base64Decode(event['data'] as String), original);
+    });
+
+    test('text sends are rejected on TCP', () async {
+      final server = await startTcpServer((socket) {
+        socket.listen((chunk) {});
+      });
+      final result = await runPluginResult(
+        manager,
+        id: 'tcp.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkTcp,
+        },
+        jsBody:
+            '''
+          host.transport.open({
+            kind: "tcp",
+            host: "127.0.0.1",
+            port: ${server.port}
+          }).then((opened) => {
+            return host.transport.send(opened.handle, { type: "text", data: "nope" });
+          }).then(() => host.emit("result", "unexpected"))
+            .catch((e) => host.emit("result", JSON.stringify({ message: e.message, code: e.code })));
+        ''',
+      );
+
+      final error = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(error['message'], contains('Text frames'));
+      expect(error['code'], 'transport_error');
+    });
+  });
+
+  group('lifecycle and isolation', () {
+    test(
+      'events arriving before onEvent registration are delivered in order',
+      () async {
+        final server = await startWsServer((ws) {
+          for (final frame in ['first', 'second', 'third']) {
+            ws.add(frame);
+          }
+          ws.listen((data) {});
+        });
+        final result = await runPluginResult(
+          manager,
+          id: 'order.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          jsBody:
+              '''
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:${server.port}/x"
+          }).then((opened) => {
+            setTimeout(() => {
+              const received = [];
+              host.transport.onEvent(opened.handle, (event) => {
+                if (event.type !== "data") return;
+                received.push(event.data);
+                if (received.length === 3) {
+                  host.emit("result", JSON.stringify(received));
+                }
+              });
+            }, 300);
+          }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+        ''',
+        );
+
+        expect(jsonDecode(result as String), ['first', 'second', 'third']);
+      },
+    );
+
+    test('a handle cannot be used by another plugin', () async {
+      final server = await startWsServer((ws) {
+        ws.listen((data) {
+          try {
+            ws.add(data);
+          } catch (_) {}
+        });
+      });
+      final handle = Completer<String>();
+      final echo = Completer<String>();
+      final sub = manager.emitStream.listen((e) {
+        if (e['event'] == 'handle' && !handle.isCompleted) {
+          handle.complete(e['payload'] as String);
+        }
+        if (e['event'] == 'echo' && !echo.isCompleted) {
+          echo.complete(e['payload'] as String);
+        }
+      });
+      addTearDown(sub.cancel);
+
+      await manager.loadPlugin(
+        id: 'a.plugin',
+        manifest: testManifest(
+          'a.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+        ),
+        settings: {},
+        jsCode:
+            '''
+          function createPlugin(host) {
+            return {
+              id: "a.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "websocket",
+                  url: "ws://127.0.0.1:${server.port}/echo"
+                }).then((opened) => {
+                  host.emit("handle", opened.handle);
+                  host.transport.onEvent(opened.handle, (event) => {
+                    if (event.type === "data") host.emit("echo", JSON.stringify(event));
+                  });
+                  host.transport.send(opened.handle, { type: "text", data: "ping-A" });
+                });
+              }
+            };
+          }
+        ''',
+      );
+      final aHandle = await handle.future.timeout(const Duration(seconds: 5));
+
+      final result = await runPluginResult(
+        manager,
+        id: 'b.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        jsBody:
+            '''
+          host.transport.send(${jsonEncode(aHandle)}, { type: "text", data: "nope" })
+            .then(() => host.emit("result", "unexpected"))
+            .catch((e) => host.emit("result", JSON.stringify({ message: e.message })));
+        ''',
+      );
+
+      final error = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(error['message'], contains('not owned'));
+      final aEcho =
+          jsonDecode(await echo.future.timeout(const Duration(seconds: 5)))
+              as Map<String, dynamic>;
+      expect(aEcho['data'], 'ping-A');
+    });
+
+    test('a handle cannot be reused by a newer plugin generation', () async {
+      final server = await startWsServer((ws) {
+        ws.listen((data) {
+          try {
+            ws.add(data);
+          } catch (_) {}
+        });
+      });
+      final handle = Completer<String>();
+      final sub = manager.emitStream.listen((e) {
+        if (!handle.isCompleted) handle.complete(e['payload'] as String);
+      });
+      addTearDown(sub.cancel);
+
+      await manager.loadPlugin(
+        id: 'gen.plugin',
+        manifest: testManifest(
+          'gen.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+        ),
+        settings: {},
+        jsCode:
+            '''
+          function createPlugin(host) {
+            return {
+              id: "gen.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "websocket",
+                  url: "ws://127.0.0.1:${server.port}/x"
+                }).then((opened) => host.emit("handle", opened.handle));
+              }
+            };
+          }
+        ''',
+      );
+      final oldHandle = await handle.future.timeout(const Duration(seconds: 5));
+      await manager.unloadPlugin('gen.plugin');
+
+      final result = await runPluginResult(
+        manager,
+        id: 'gen.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        jsBody:
+            '''
+          host.transport.send(${jsonEncode(oldHandle)}, { type: "text", data: "stale" })
+            .then(() => host.emit("result", "unexpected"))
+            .catch((e) => host.emit("result", JSON.stringify({ message: e.message })));
+        ''',
+      );
+
+      final error = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(error['message'], contains('not owned'));
+    });
+
+    test('plugin unload closes all owned connections', () async {
+      final wsClosed = Completer<void>();
+      final tcpClosed = Completer<void>();
+      final wsServer = await startWsServer((ws) {
+        ws.listen(
+          (data) {},
+          onDone: () {
+            if (!wsClosed.isCompleted) wsClosed.complete();
+          },
+        );
+      });
+      final tcpServer = await startTcpServer((socket) {
+        socket.listen(
+          (chunk) {},
+          onDone: () {
+            if (!tcpClosed.isCompleted) tcpClosed.complete();
+          },
+        );
+      });
+
+      await manager.loadPlugin(
+        id: 'unload.plugin',
+        manifest: testManifest(
+          'unload.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+            PluginPermissions.networkTcp,
+          },
+        ),
+        settings: {},
+        jsCode:
+            '''
+          function createPlugin(host) {
+            return {
+              id: "unload.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "websocket",
+                  url: "ws://127.0.0.1:${wsServer.port}/x"
+                });
+                host.transport.open({
+                  kind: "tcp",
+                  host: "127.0.0.1",
+                  port: ${tcpServer.port}
+                });
+              }
+            };
+          }
+        ''',
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(manager.liveTransportCount, 2);
+
+      await manager.unloadPlugin('unload.plugin');
+
+      await wsClosed.future.timeout(const Duration(seconds: 5));
+      await tcpClosed.future.timeout(const Duration(seconds: 5));
+      expect(manager.liveTransportCount, 0);
+    });
+
+    test('manager disposal closes all remaining transports', () async {
+      final closed = Completer<void>();
+      final server = await startTcpServer((socket) {
+        socket.listen(
+          (chunk) {},
+          onDone: () {
+            if (!closed.isCompleted) closed.complete();
+          },
+        );
+      });
+
+      await manager.loadPlugin(
+        id: 'dispose.plugin',
+        manifest: testManifest(
+          'dispose.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkTcp,
+          },
+        ),
+        settings: {},
+        jsCode:
+            '''
+          function createPlugin(host) {
+            return {
+              id: "dispose.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "tcp",
+                  host: "127.0.0.1",
+                  port: ${server.port}
+                });
+              }
+            };
+          }
+        ''',
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(manager.liveTransportCount, 1);
+
+      await manager.dispose();
+
+      await closed.future.timeout(const Duration(seconds: 5));
+      expect(manager.liveTransportCount, 0);
+    });
+  });
+
+  group('resource limits', () {
+    test(
+      'a ninth live transport is rejected with transport_resource_limit',
+      () async {
+        final server = await startWsServer((ws) {
+          ws.listen((data) {}, onError: (Object _) {});
+        });
+        final result = await runPluginResult(
+          manager,
+          id: 'limit.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          jsBody:
+              '''
+          const opens = [0,1,2,3,4,5,6,7].reduce(
+            (p) => p.then(() => host.transport.open({
+              kind: "websocket",
+              url: "ws://127.0.0.1:${server.port}/x"
+            })),
+            Promise.resolve()
+          );
+          opens.then(() => host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:${server.port}/x"
+          })).then(
+            () => host.emit("result", "unexpected"),
+            (e) => host.emit("result", JSON.stringify({ code: e.code, message: e.message }))
+          );
+        ''',
+        );
+
+        final error = jsonDecode(result as String) as Map<String, dynamic>;
+        expect(error['code'], 'transport_resource_limit');
+        expect(manager.liveTransportCount, 8);
+      },
+    );
+
+    test('an oversize send is rejected atomically without writing', () async {
+      var received = 0;
+      final server = await startTcpServer((socket) {
+        socket.listen((chunk) {
+          received += chunk.length;
+        });
+      });
+      final big = base64Encode(List<int>.filled(1048576 + 1, 0x41));
+      final result = await runPluginResult(
+        manager,
+        id: 'out.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkTcp,
+        },
+        jsBody:
+            '''
+          host.transport.open({
+            kind: "tcp",
+            host: "127.0.0.1",
+            port: ${server.port}
+          }).then((opened) => {
+            return host.transport.send(opened.handle, { type: "binary", data: "$big" });
+          }).then(() => host.emit("result", "unexpected"))
+            .catch((e) => host.emit("result", JSON.stringify({ code: e.code })));
+        ''',
+      );
+
+      final error = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(error['code'], 'transport_resource_limit');
+      expect(received, 0);
+    });
+
+    test(
+      'inbound overflow closes the transport with a resource limit error',
+      () async {
+        final chunk = List<int>.filled(64 * 1024, 0x42);
+        final server = await startWsServer((ws) {
+          for (var i = 0; i < 32; i++) {
+            ws.add(chunk);
+          }
+          ws.listen((data) {}, onError: (Object _) {});
+        });
+        final errorResult = Completer<String>();
+        final closeResult = Completer<String>();
+        final sub = manager.emitStream.listen((e) {
+          if (e['event'] == 'result' && !errorResult.isCompleted) {
+            errorResult.complete(e['payload'] as String);
+          }
+          if (e['event'] == 'result2' && !closeResult.isCompleted) {
+            closeResult.complete(e['payload'] as String);
+          }
+        });
+        addTearDown(sub.cancel);
+
+        await manager.loadPlugin(
+          id: 'in.plugin',
+          manifest: testManifest(
+            'in.plugin',
+            permissions: const {
+              PluginPermissions.emit,
+              PluginPermissions.networkWebsocket,
+            },
+          ),
+          settings: {},
+          jsCode:
+              '''
+          function createPlugin(host) {
+            return {
+              id: "in.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "websocket",
+                  url: "ws://127.0.0.1:${server.port}/flood"
+                }).then((opened) => {
+                  setTimeout(() => {
+                    host.transport.onEvent(opened.handle, (event) => {
+                      if (event.type === "error") {
+                        host.emit("result", JSON.stringify({ code: event.code }));
+                      } else if (event.type === "close") {
+                        host.emit("result2", JSON.stringify({ closed: true }));
+                      }
+                    });
+                  }, 400);
+                });
+              }
+            };
+          }
+        ''',
+        );
+
+        final error =
+            jsonDecode(
+                  await errorResult.future.timeout(const Duration(seconds: 10)),
+                )
+                as Map<String, dynamic>;
+        expect(error['code'], 'transport_resource_limit');
+        final closed =
+            jsonDecode(
+                  await closeResult.future.timeout(const Duration(seconds: 10)),
+                )
+                as Map<String, dynamic>;
+        expect(closed['closed'], true);
+      },
+    );
+  });
+}

--- a/test/plugins/plugin_manager_transport_test.dart
+++ b/test/plugins/plugin_manager_transport_test.dart
@@ -9,8 +9,6 @@ import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 import 'plugin_test_helpers.dart';
 
-/// Loads a plugin whose onLoad runs [jsBody] and resolves with the first
-/// `host.emit("result", payload)` payload.
 Future<Object?> runPluginResult(
   PluginManager manager, {
   required String id,
@@ -78,6 +76,54 @@ Future<ServerSocket> startTcpServer(
   });
   addTearDown(() async => server.close());
   return server;
+}
+
+class _BlockingWebSocket implements WebSocket {
+  final List<Object> written = [];
+  @override
+  int readyState = WebSocket.open;
+  @override
+  String? protocol = '';
+  @override
+  String extensions = '';
+  @override
+  int? closeCode;
+  @override
+  String? closeReason;
+  @override
+  Duration? pingInterval;
+
+  @override
+  void add(dynamic data) => written.add(data);
+
+  @override
+  Future<void> addStream(Stream<dynamic> stream) {
+    stream.listen((data) => written.add(data));
+    return Completer<void>().future;
+  }
+
+  @override
+  Future<void> close([int? code, String? reason]) async {
+    closeCode = code;
+    closeReason = reason;
+    readyState = WebSocket.closed;
+  }
+
+  @override
+  StreamSubscription<dynamic> listen(
+    void Function(dynamic)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) => Stream<dynamic>.multi((controller) {}).listen(
+    onData,
+    onError: onError,
+    onDone: onDone,
+    cancelOnError: cancelOnError,
+  );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 void main() {
@@ -632,7 +678,7 @@ void main() {
       );
 
       final error = jsonDecode(result as String) as Map<String, dynamic>;
-      expect(error['message'], contains('not owned'));
+      expect(error['message'], contains('Unknown transport handle'));
     });
 
     test('plugin unload closes all owned connections', () async {
@@ -814,6 +860,54 @@ void main() {
       expect(error['code'], 'transport_resource_limit');
       expect(received, 0);
     });
+
+    test(
+      'multiple sub-limit websocket sends accumulate pending outbound bytes',
+      () async {
+        final ws = _BlockingWebSocket();
+        final manager = PluginManager(
+          kvStore: FakeKeyValueStoreService(),
+          fetchTimeout: const Duration(seconds: 2),
+          connectWebSocket: (url, {protocols}) async => ws,
+        );
+        addTearDown(manager.dispose);
+        final result = await runPluginResult(
+          manager,
+          id: 'backpressure.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          jsBody: '''
+          const big = "x".repeat(400 * 1024);
+          host.transport.open({
+            kind: "websocket",
+            url: "ws://127.0.0.1:1/x"
+          }).then((opened) => {
+            const results = [];
+            const attempt = (i) => {
+              if (i >= 3) {
+                host.emit("result", JSON.stringify(results));
+                return;
+              }
+              host.transport.send(opened.handle, { type: "text", data: big })
+                .then(() => { results.push("ok"); attempt(i + 1); })
+                .catch((e) => { results.push(e.code); attempt(i + 1); });
+            };
+            attempt(0);
+          }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+        ''',
+        );
+
+        await pumpEventQueue();
+        expect(jsonDecode(result as String), [
+          'ok',
+          'ok',
+          'transport_resource_limit',
+        ]);
+        expect(ws.written.length, 1);
+      },
+    );
 
     test(
       'inbound overflow closes the transport with a resource limit error',

--- a/test/plugins/plugin_manager_transport_test.dart
+++ b/test/plugins/plugin_manager_transport_test.dart
@@ -959,6 +959,156 @@ void main() {
       },
     );
 
+    test(
+      'a plugin cannot monkey-patch Map.prototype to capture another plugin token',
+      () async {
+        final server = await startWsServer((ws) {
+          ws.listen((data) {
+            try {
+              ws.add(data);
+            } catch (_) {}
+          });
+        });
+        final armed = Completer<void>();
+        final capture = Completer<String>();
+        final echo = Completer<String>();
+        final sub = manager.emitStream.listen((e) {
+          if (e['event'] == 'armed' && !armed.isCompleted) armed.complete();
+          if (e['event'] == 'capture' && !capture.isCompleted) {
+            capture.complete(e['payload'] as String);
+          }
+          if (e['event'] == 'echo' && !echo.isCompleted) {
+            echo.complete(e['payload'] as String);
+          }
+        });
+        addTearDown(sub.cancel);
+
+        await manager.loadPlugin(
+          id: 'attacker.plugin',
+          manifest: testManifest(
+            'attacker.plugin',
+            permissions: const {
+              PluginPermissions.emit,
+              PluginPermissions.networkWebsocket,
+            },
+          ),
+          settings: {},
+          jsCode: '''
+          function createPlugin(host) {
+            return {
+              id: "attacker.plugin",
+              onLoad() {
+                const captured = [];
+                const sniff = (value) => {
+                  if (value && typeof value === "object" &&
+                      typeof value.resolve === "function" &&
+                      typeof value.reject === "function" &&
+                      typeof value.bridgeToken === "string") {
+                    captured.push("token:" + value.bridgeToken);
+                    captured.push("resolve");
+                    captured.push("reject");
+                  }
+                  return value;
+                };
+                const native = {
+                  set: Map.prototype.set,
+                  get: Map.prototype.get,
+                  delete: Map.prototype.delete,
+                  clear: Map.prototype.clear,
+                  forEach: Map.prototype.forEach,
+                  has: Map.prototype.has,
+                  values: Map.prototype.values,
+                  entries: Map.prototype.entries,
+                  keys: Map.prototype.keys,
+                  iterator: Map.prototype[Symbol.iterator]
+                };
+                Map.prototype.set = function (key, value) {
+                  sniff(value);
+                  return native.set.call(this, key, value);
+                };
+                Map.prototype.get = function (key) {
+                  return native.get.call(this, key);
+                };
+                Map.prototype.delete = function (key) {
+                  return native.delete.call(this, key);
+                };
+                Map.prototype.clear = function () {
+                  return native.clear.call(this);
+                };
+                Map.prototype.forEach = function (callback, thisArg) {
+                  return native.forEach.call(this, function (value, key, map) {
+                    sniff(value);
+                    return callback.call(thisArg, value, key, map);
+                  }, thisArg);
+                };
+                Map.prototype.has = function (key) {
+                  return native.has.call(this, key);
+                };
+                Map.prototype.values = function () {
+                  return native.values.call(this);
+                };
+                Map.prototype.entries = function () {
+                  return native.entries.call(this);
+                };
+                Map.prototype.keys = function () {
+                  return native.keys.call(this);
+                };
+                Map.prototype[Symbol.iterator] = function () {
+                  return native.iterator.call(this);
+                };
+                setTimeout(() => host.emit("capture", captured.join(",")), 500);
+                host.emit("armed", true);
+              }
+            };
+          }
+        ''',
+        );
+        await armed.future.timeout(const Duration(seconds: 5));
+
+        await manager.loadPlugin(
+          id: 'victim.plugin',
+          manifest: testManifest(
+            'victim.plugin',
+            permissions: const {
+              PluginPermissions.emit,
+              PluginPermissions.networkWebsocket,
+            },
+          ),
+          settings: {},
+          jsCode:
+              '''
+          function createPlugin(host) {
+            return {
+              id: "victim.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "websocket",
+                  url: "ws://127.0.0.1:${server.port}/echo"
+                }).then((opened) => {
+                  host.transport.onEvent(opened.handle, (event) => {
+                    if (event.type === "data") {
+                      host.emit("echo", event.data);
+                    }
+                  });
+                  host.transport.send(opened.handle, { type: "text", data: "victim ping" });
+                });
+              }
+            };
+          }
+        ''',
+        );
+        expect(
+          await echo.future.timeout(const Duration(seconds: 5)),
+          'victim ping',
+        );
+        await manager.unloadPlugin('victim.plugin');
+        expect(
+          await capture.future.timeout(const Duration(seconds: 5)),
+          isEmpty,
+        );
+      },
+    );
+
     test('a handle cannot be reused by a newer plugin generation', () async {
       final server = await startWsServer((ws) {
         ws.listen((data) {

--- a/test/plugins/plugin_manager_transport_test.dart
+++ b/test/plugins/plugin_manager_transport_test.dart
@@ -82,6 +82,7 @@ Future<ServerSocket> startTcpServer(
 class _GatedWebSocket implements WebSocket {
   final List<Object> written = [];
   final List<Completer<void>> addStreamGates = [];
+  bool failWrites = false;
   bool closed = false;
   @override
   int readyState = WebSocket.open;
@@ -102,6 +103,9 @@ class _GatedWebSocket implements WebSocket {
   @override
   Future<void> addStream(Stream<dynamic> stream) {
     stream.listen((data) => written.add(data));
+    if (failWrites) {
+      return Future.error(StateError('write failed'));
+    }
     final gate = Completer<void>();
     addStreamGates.add(gate);
     return gate.future;
@@ -855,6 +859,106 @@ void main() {
       expect(aEcho['data'], 'ping-A');
     });
 
+    test(
+      'plugins cannot replace transport bridge helpers to capture tokens',
+      () async {
+        final server = await startWsServer((ws) {
+          ws.listen((data) {
+            try {
+              ws.add(data);
+            } catch (_) {}
+          });
+        });
+        final tamper = Completer<String>();
+        final echo = Completer<String>();
+        final sub = manager.emitStream.listen((e) {
+          if (e['event'] == 'tamper' && !tamper.isCompleted) {
+            tamper.complete(e['payload'] as String);
+          }
+          if (e['event'] == 'echo' && !echo.isCompleted) {
+            echo.complete(e['payload'] as String);
+          }
+        });
+        addTearDown(sub.cancel);
+
+        await manager.loadPlugin(
+          id: 'attacker.plugin',
+          manifest: testManifest(
+            'attacker.plugin',
+            permissions: const {
+              PluginPermissions.emit,
+              PluginPermissions.networkWebsocket,
+            },
+          ),
+          settings: {},
+          jsCode: '''
+          function createPlugin(host) {
+            return {
+              id: "attacker.plugin",
+              onLoad() {
+                const results = [];
+                for (const name of [
+                  "__transportRegister", "__handleTransportReply",
+                  "__transportSetListener", "__transportRequest",
+                  "__dispatchTransportEvent", "__transportRemoveListener"
+                ]) {
+                  try {
+                    Object.defineProperty(globalThis, name, { value: () => {}, writable: true, configurable: true });
+                    results.push(name + ":writable");
+                  } catch (e) {
+                    results.push(name + ":blocked");
+                  }
+                }
+                host.emit("tamper", results.join(","));
+              }
+            };
+          }
+        ''',
+        );
+        expect(
+          (await tamper.future.timeout(const Duration(seconds: 5))).split(','),
+          everyElement(endsWith(':blocked')),
+        );
+
+        await manager.loadPlugin(
+          id: 'victim.plugin',
+          manifest: testManifest(
+            'victim.plugin',
+            permissions: const {
+              PluginPermissions.emit,
+              PluginPermissions.networkWebsocket,
+            },
+          ),
+          settings: {},
+          jsCode:
+              '''
+          function createPlugin(host) {
+            return {
+              id: "victim.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "websocket",
+                  url: "ws://127.0.0.1:${server.port}/echo"
+                }).then((opened) => {
+                  host.transport.onEvent(opened.handle, (event) => {
+                    if (event.type === "data") {
+                      host.emit("echo", event.data);
+                    }
+                  });
+                  host.transport.send(opened.handle, { type: "text", data: "victim ping" });
+                });
+              }
+            };
+          }
+        ''',
+        );
+        expect(
+          await echo.future.timeout(const Duration(seconds: 5)),
+          'victim ping',
+        );
+      },
+    );
+
     test('a handle cannot be reused by a newer plugin generation', () async {
       final server = await startWsServer((ws) {
         ws.listen((data) {
@@ -1142,6 +1246,120 @@ void main() {
           'transport_resource_limit',
         ]);
         expect(ws.written.length, 1);
+      },
+    );
+
+    test(
+      'a failed websocket write terminates the transport and clears accounting',
+      () async {
+        final ws = _GatedWebSocket()..failWrites = true;
+        final manager = PluginManager(
+          kvStore: FakeKeyValueStoreService(),
+          fetchTimeout: const Duration(seconds: 2),
+          connectWebSocket: (url, {protocols}) async => ws,
+        );
+        addTearDown(manager.dispose);
+        final errorResult = Completer<String>();
+        final resendResult = Completer<String>();
+        final sub = manager.emitStream.listen((e) {
+          if (e['event'] == 'result' && !errorResult.isCompleted) {
+            errorResult.complete(e['payload'] as String);
+          }
+          if (e['event'] == 'result2' && !resendResult.isCompleted) {
+            resendResult.complete(e['payload'] as String);
+          }
+        });
+        addTearDown(sub.cancel);
+        await manager.loadPlugin(
+          id: 'failwrite.plugin',
+          manifest: testManifest(
+            'failwrite.plugin',
+            permissions: const {
+              PluginPermissions.emit,
+              PluginPermissions.networkWebsocket,
+            },
+          ),
+          settings: {},
+          jsCode: '''
+          function createPlugin(host) {
+            return {
+              id: "failwrite.plugin",
+              onLoad() {
+                host.transport.open({
+                  kind: "websocket",
+                  url: "ws://127.0.0.1:1/x"
+                }).then((opened) => {
+                  host.transport.onEvent(opened.handle, (event) => {
+                    if (event.type === "error") {
+                      host.emit("result", JSON.stringify({ code: event.code }));
+                    }
+                  });
+                  host.transport.send(opened.handle, { type: "text", data: "boom" }).then(() => {
+                    setTimeout(() => {
+                      host.transport.send(opened.handle, { type: "text", data: "again" })
+                        .then(() => host.emit("result2", "unexpected"))
+                        .catch((e) => host.emit("result2", JSON.stringify({ code: e.code })));
+                    }, 200);
+                  });
+                });
+              }
+            };
+          }
+        ''',
+        );
+        final error =
+            jsonDecode(
+                  await errorResult.future.timeout(const Duration(seconds: 5)),
+                )
+                as Map<String, dynamic>;
+        expect(error['code'], 'transport_error');
+        final resend =
+            jsonDecode(
+                  await resendResult.future.timeout(const Duration(seconds: 5)),
+                )
+                as Map<String, dynamic>;
+        expect(resend['code'], 'transport_error');
+        await pumpEventQueue();
+        expect(manager.liveTransportCount, 0);
+      },
+    );
+
+    test(
+      'remotely closed transports without a listener count toward the limit',
+      () async {
+        final server = await startWsServer((ws) {
+          ws.close(1000);
+        });
+        final result = await runPluginResult(
+          manager,
+          id: 'dead.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          jsBody:
+              '''
+          const opens = [0,1,2,3,4,5,6,7].map(() =>
+            host.transport.open({
+              kind: "websocket",
+              url: "ws://127.0.0.1:${server.port}/x"
+            })
+          );
+          Promise.all(opens).then(() => {
+            setTimeout(() => {
+              host.transport.open({
+                kind: "websocket",
+                url: "ws://127.0.0.1:${server.port}/x"
+              }).then(() => host.emit("result", "unexpected"))
+                .catch((e) => host.emit("result", JSON.stringify({ code: e.code })));
+            }, 300);
+          });
+        ''',
+        );
+
+        final error = jsonDecode(result as String) as Map<String, dynamic>;
+        expect(error['code'], 'transport_resource_limit');
+        expect(manager.liveTransportCount, 0);
       },
     );
 

--- a/test/plugins/plugin_manager_transport_tls_test.dart
+++ b/test/plugins/plugin_manager_transport_tls_test.dart
@@ -34,7 +34,8 @@ Future<Object?> runPluginResult(
         ? testManifest(id)
         : testManifest(id, permissions: permissions),
     settings: {},
-    jsCode: '''
+    jsCode:
+        '''
       function createPlugin(host) {
         return {
           id: "$id",
@@ -90,38 +91,40 @@ void main() {
 
   tearDown(() async => manager.dispose());
 
-  test('tls open rejects an untrusted certificate via platform validation',
-      () async {
-    if (!certsReady) {
-      markTestSkipped('openssl unavailable');
-      return;
-    }
-    final serverContext = SecurityContext()
-      ..useCertificateChain(serverCert)
-      ..usePrivateKey(serverKey);
-    final server = await SecureServerSocket.bind(
-      InternetAddress.loopbackIPv4,
-      0,
-      serverContext,
-    );
-    server.listen(
-      (socket) => socket.listen(
-        (chunk) {},
+  test(
+    'tls open rejects an untrusted certificate via platform validation',
+    () async {
+      if (!certsReady) {
+        markTestSkipped('openssl unavailable');
+        return;
+      }
+      final serverContext = SecurityContext()
+        ..useCertificateChain(serverCert)
+        ..usePrivateKey(serverKey);
+      final server = await SecureServerSocket.bind(
+        InternetAddress.loopbackIPv4,
+        0,
+        serverContext,
+      );
+      server.listen(
+        (socket) => socket.listen(
+          (chunk) {},
+          onError: (Object _) {},
+          cancelOnError: true,
+        ),
         onError: (Object _) {},
-        cancelOnError: true,
-      ),
-      onError: (Object _) {},
-    );
-    addTearDown(() async => server.close());
+      );
+      addTearDown(() async => server.close());
 
-    final result = await runPluginResult(
-      manager,
-      id: 'tls.plugin',
-      permissions: const {
-        PluginPermissions.emit,
-        PluginPermissions.networkTls,
-      },
-      jsBody: '''
+      final result = await runPluginResult(
+        manager,
+        id: 'tls.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkTls,
+        },
+        jsBody:
+            '''
         host.transport.open({
           kind: "tls",
           host: "127.0.0.1",
@@ -131,48 +134,51 @@ void main() {
           (e) => host.emit("result", JSON.stringify({ message: e.message }))
         );
       ''',
-    );
+      );
 
-    final error = jsonDecode(result as String) as Map<String, dynamic>;
-    expect(error['message'], contains('HandshakeException'));
-    expect(manager.liveTransportCount, 0);
-  });
+      final error = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(error['message'], contains('HandshakeException'));
+      expect(manager.liveTransportCount, 0);
+    },
+  );
 
-  test('wss rejects an untrusted certificate using only network.websocket',
-      () async {
-    if (!certsReady) {
-      markTestSkipped('openssl unavailable');
-      return;
-    }
-    final serverContext = SecurityContext()
-      ..useCertificateChain(serverCert)
-      ..usePrivateKey(serverKey);
-    final server = await HttpServer.bindSecure(
-      InternetAddress.loopbackIPv4,
-      0,
-      serverContext,
-    );
-    server.listen((req) async {
-      try {
-        if (WebSocketTransformer.isUpgradeRequest(req)) {
-          final ws = await WebSocketTransformer.upgrade(req);
-          ws.listen((data) {}, onError: (Object _) {});
-        } else {
-          req.response.statusCode = 404;
-          await req.response.close();
-        }
-      } catch (_) {}
-    });
-    addTearDown(() async => server.close(force: true));
+  test(
+    'wss rejects an untrusted certificate using only network.websocket',
+    () async {
+      if (!certsReady) {
+        markTestSkipped('openssl unavailable');
+        return;
+      }
+      final serverContext = SecurityContext()
+        ..useCertificateChain(serverCert)
+        ..usePrivateKey(serverKey);
+      final server = await HttpServer.bindSecure(
+        InternetAddress.loopbackIPv4,
+        0,
+        serverContext,
+      );
+      server.listen((req) async {
+        try {
+          if (WebSocketTransformer.isUpgradeRequest(req)) {
+            final ws = await WebSocketTransformer.upgrade(req);
+            ws.listen((data) {}, onError: (Object _) {});
+          } else {
+            req.response.statusCode = 404;
+            await req.response.close();
+          }
+        } catch (_) {}
+      });
+      addTearDown(() async => server.close(force: true));
 
-    final result = await runPluginResult(
-      manager,
-      id: 'wss.plugin',
-      permissions: const {
-        PluginPermissions.emit,
-        PluginPermissions.networkWebsocket,
-      },
-      jsBody: '''
+      final result = await runPluginResult(
+        manager,
+        id: 'wss.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        jsBody:
+            '''
         host.transport.open({
           kind: "websocket",
           url: "wss://127.0.0.1:${server.port}/x"
@@ -181,10 +187,11 @@ void main() {
           (e) => host.emit("result", JSON.stringify({ message: e.message }))
         );
       ''',
-    );
+      );
 
-    final error = jsonDecode(result as String) as Map<String, dynamic>;
-    expect(error['message'], contains('HandshakeException'));
-    expect(manager.liveTransportCount, 0);
-  });
+      final error = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(error['message'], contains('HandshakeException'));
+      expect(manager.liveTransportCount, 0);
+    },
+  );
 }

--- a/test/plugins/plugin_manager_transport_tls_test.dart
+++ b/test/plugins/plugin_manager_transport_tls_test.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+
+import 'plugin_test_helpers.dart';
+
+/// TLS transport tests.
+///
+/// The positive round-trip path (a certificate signed by a trust anchor the
+/// platform accepts) cannot be exercised offline: dart:io on this platform
+/// does not honor user-supplied trust anchors for `SecureSocket.connect`
+/// (verified separately; public-host TLS validation works, so the production
+/// path uses the platform trust store as designed). These tests therefore
+/// cover the TLS branch end to end through the rejection path: an untrusted
+/// self-signed certificate must fail platform validation and reject `open()`.
+Future<Object?> runPluginResult(
+  PluginManager manager, {
+  required String id,
+  required String jsBody,
+  Set<PluginPermissions>? permissions,
+}) async {
+  final result = Completer<Object?>();
+  final sub = manager.emitStream.listen((e) {
+    if (!result.isCompleted) result.complete(e['payload']);
+  });
+  addTearDown(sub.cancel);
+  await manager.loadPlugin(
+    id: id,
+    manifest: permissions == null
+        ? testManifest(id)
+        : testManifest(id, permissions: permissions),
+    settings: {},
+    jsCode: '''
+      function createPlugin(host) {
+        return {
+          id: "$id",
+          onLoad() {
+            $jsBody
+          }
+        };
+      }
+    ''',
+  );
+  return result.future.timeout(const Duration(seconds: 10));
+}
+
+void main() {
+  late PluginManager manager;
+  var certsReady = false;
+  late String serverCert;
+  late String serverKey;
+
+  setUpAll(() async {
+    final dir = await Directory.systemTemp.createTemp('plugin_tls_certs');
+    addTearDown(() async {
+      try {
+        await dir.delete(recursive: true);
+      } catch (_) {}
+    });
+    serverCert = '${dir.path}/server_cert.pem';
+    serverKey = '${dir.path}/server_key.pem';
+    final result = await Process.run('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      serverKey,
+      '-out',
+      serverCert,
+      '-days',
+      '2',
+      '-nodes',
+      '-subj',
+      '/CN=localhost',
+    ]);
+    certsReady = result.exitCode == 0;
+  });
+
+  setUp(() {
+    manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      fetchTimeout: const Duration(seconds: 2),
+    );
+  });
+
+  tearDown(() async => manager.dispose());
+
+  test('tls open rejects an untrusted certificate via platform validation',
+      () async {
+    if (!certsReady) {
+      markTestSkipped('openssl unavailable');
+      return;
+    }
+    final serverContext = SecurityContext()
+      ..useCertificateChain(serverCert)
+      ..usePrivateKey(serverKey);
+    final server = await SecureServerSocket.bind(
+      InternetAddress.loopbackIPv4,
+      0,
+      serverContext,
+    );
+    server.listen(
+      (socket) => socket.listen(
+        (chunk) {},
+        onError: (Object _) {},
+        cancelOnError: true,
+      ),
+      onError: (Object _) {},
+    );
+    addTearDown(() async => server.close());
+
+    final result = await runPluginResult(
+      manager,
+      id: 'tls.plugin',
+      permissions: const {
+        PluginPermissions.emit,
+        PluginPermissions.networkTls,
+      },
+      jsBody: '''
+        host.transport.open({
+          kind: "tls",
+          host: "127.0.0.1",
+          port: ${server.port}
+        }).then(
+          () => host.emit("result", "unexpected"),
+          (e) => host.emit("result", JSON.stringify({ message: e.message }))
+        );
+      ''',
+    );
+
+    final error = jsonDecode(result as String) as Map<String, dynamic>;
+    expect(error['message'], contains('HandshakeException'));
+    expect(manager.liveTransportCount, 0);
+  });
+
+  test('wss rejects an untrusted certificate using only network.websocket',
+      () async {
+    if (!certsReady) {
+      markTestSkipped('openssl unavailable');
+      return;
+    }
+    final serverContext = SecurityContext()
+      ..useCertificateChain(serverCert)
+      ..usePrivateKey(serverKey);
+    final server = await HttpServer.bindSecure(
+      InternetAddress.loopbackIPv4,
+      0,
+      serverContext,
+    );
+    server.listen((req) async {
+      try {
+        if (WebSocketTransformer.isUpgradeRequest(req)) {
+          final ws = await WebSocketTransformer.upgrade(req);
+          ws.listen((data) {}, onError: (Object _) {});
+        } else {
+          req.response.statusCode = 404;
+          await req.response.close();
+        }
+      } catch (_) {}
+    });
+    addTearDown(() async => server.close(force: true));
+
+    final result = await runPluginResult(
+      manager,
+      id: 'wss.plugin',
+      permissions: const {
+        PluginPermissions.emit,
+        PluginPermissions.networkWebsocket,
+      },
+      jsBody: '''
+        host.transport.open({
+          kind: "websocket",
+          url: "wss://127.0.0.1:${server.port}/x"
+        }).then(
+          () => host.emit("result", "unexpected"),
+          (e) => host.emit("result", JSON.stringify({ message: e.message }))
+        );
+      ''',
+    );
+
+    final error = jsonDecode(result as String) as Map<String, dynamic>;
+    expect(error['message'], contains('HandshakeException'));
+    expect(manager.liveTransportCount, 0);
+  });
+}

--- a/test/plugins/plugin_manager_transport_tls_test.dart
+++ b/test/plugins/plugin_manager_transport_tls_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
@@ -8,15 +9,6 @@ import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 import 'plugin_test_helpers.dart';
 
-/// TLS transport tests.
-///
-/// The positive round-trip path (a certificate signed by a trust anchor the
-/// platform accepts) cannot be exercised offline: dart:io on this platform
-/// does not honor user-supplied trust anchors for `SecureSocket.connect`
-/// (verified separately; public-host TLS validation works, so the production
-/// path uses the platform trust store as designed). These tests therefore
-/// cover the TLS branch end to end through the rejection path: an untrusted
-/// self-signed certificate must fail platform validation and reject `open()`.
 Future<Object?> runPluginResult(
   PluginManager manager, {
   required String id,
@@ -194,4 +186,141 @@ void main() {
       expect(manager.liveTransportCount, 0);
     },
   );
+
+  test(
+    'tls connects and round-trips bytes through a trusted connection',
+    () async {
+      if (!certsReady) {
+        markTestSkipped('openssl unavailable');
+        return;
+      }
+      final serverContext = SecurityContext()
+        ..useCertificateChain(serverCert)
+        ..usePrivateKey(serverKey);
+      final server = await SecureServerSocket.bind(
+        InternetAddress.loopbackIPv4,
+        0,
+        serverContext,
+      );
+      server.listen(
+        (socket) => socket.listen(
+          (chunk) {
+            try {
+              socket.add(chunk);
+            } catch (_) {}
+          },
+          onError: (Object _) {},
+          cancelOnError: true,
+        ),
+        onError: (Object _) {},
+      );
+      addTearDown(() async => server.close());
+
+      final tlsManager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        fetchTimeout: const Duration(seconds: 2),
+        connectSecureSocket: (host, port) =>
+            SecureSocket.connect(host, port, onBadCertificate: (_) => true),
+      );
+      addTearDown(tlsManager.dispose);
+      final random = Random(11);
+      final original = List<int>.generate(256, (_) => random.nextInt(256));
+      final b64 = base64Encode(original);
+      final result = await runPluginResult(
+        tlsManager,
+        id: 'tls.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkTls,
+        },
+        jsBody:
+            '''
+        host.transport.open({
+          kind: "tls",
+          host: "127.0.0.1",
+          port: ${server.port}
+        }).then((opened) => {
+          host.transport.onEvent(opened.handle, (event) => {
+            if (event.type === "data") {
+              host.emit("result", JSON.stringify(event));
+            }
+          });
+          host.transport.send(opened.handle, { type: "binary", data: "$b64" });
+        }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+      ''',
+      );
+
+      final event = jsonDecode(result as String) as Map<String, dynamic>;
+      expect(event['dataType'], 'binary');
+      expect(base64Decode(event['data'] as String), original);
+    },
+  );
+
+  test('wss connects and round-trips using only network.websocket', () async {
+    if (!certsReady) {
+      markTestSkipped('openssl unavailable');
+      return;
+    }
+    final serverContext = SecurityContext()
+      ..useCertificateChain(serverCert)
+      ..usePrivateKey(serverKey);
+    final server = await HttpServer.bindSecure(
+      InternetAddress.loopbackIPv4,
+      0,
+      serverContext,
+    );
+    server.listen((req) async {
+      try {
+        if (WebSocketTransformer.isUpgradeRequest(req)) {
+          final ws = await WebSocketTransformer.upgrade(req);
+          ws.listen((data) {
+            try {
+              ws.add(data);
+            } catch (_) {}
+          }, onError: (Object _) {});
+        } else {
+          req.response.statusCode = 404;
+          await req.response.close();
+        }
+      } catch (_) {}
+    });
+    addTearDown(() async => server.close(force: true));
+
+    final client = HttpClient()
+      ..badCertificateCallback = (cert, host, port) => true;
+    addTearDown(client.close);
+    final wssManager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      fetchTimeout: const Duration(seconds: 2),
+      connectWebSocket: (url, {protocols}) =>
+          WebSocket.connect(url, protocols: protocols, customClient: client),
+    );
+    addTearDown(wssManager.dispose);
+    final result = await runPluginResult(
+      wssManager,
+      id: 'wss.plugin',
+      permissions: const {
+        PluginPermissions.emit,
+        PluginPermissions.networkWebsocket,
+      },
+      jsBody:
+          '''
+        host.transport.open({
+          kind: "websocket",
+          url: "wss://127.0.0.1:${server.port}/echo"
+        }).then((opened) => {
+          host.transport.onEvent(opened.handle, (event) => {
+            if (event.type === "data") {
+              host.emit("result", JSON.stringify(event));
+            }
+          });
+          host.transport.send(opened.handle, { type: "text", data: "wss hello" });
+        }).catch((e) => host.emit("result", JSON.stringify({ error: e.message })));
+      ''',
+    );
+
+    final event = jsonDecode(result as String) as Map<String, dynamic>;
+    expect(event['dataType'], 'text');
+    expect(event['data'], 'wss hello');
+  });
 }

--- a/test/plugins/plugin_manifest_permissions_test.dart
+++ b/test/plugins/plugin_manifest_permissions_test.dart
@@ -17,6 +17,9 @@ void main() {
         'events.shots',
         'proxy.decent_api',
         'proxy.decent_api.write',
+        'network.websocket',
+        'network.tcp',
+        'network.tls',
       ],
       'settings': <String, dynamic>{},
       'api': <dynamic>[],
@@ -31,6 +34,9 @@ void main() {
       manifest.permissions,
       contains(PluginPermissions.proxyDecentApiWrite),
     );
+    expect(manifest.permissions, contains(PluginPermissions.networkWebsocket));
+    expect(manifest.permissions, contains(PluginPermissions.networkTcp));
+    expect(manifest.permissions, contains(PluginPermissions.networkTls));
   });
 
   test('rejects unknown manifest permissions', () {


### PR DESCRIPTION
## Summary

Implements #146: permission-gated outbound WebSocket/TCP/TLS transports for Decaid plugins via `host.transport`.

- `lib/src/plugins/plugin_manifest.dart`: new `network.websocket`, `network.tcp`, `network.tls` manifest permissions; unknown permissions stay rejected.
- `lib/src/plugins/plugin_transport_service.dart` (new): owns native `WebSocket`/`Socket`/`SecureSocket` connections keyed by (pluginId, pluginGeneration) — opaque handles, bounded inbound queue with in-order delivery after `onEvent()` registration, flush-based outbound accounting with atomic `transport_resource_limit` rejection, max 8 live transports per generation, deterministic cleanup on unload/dispose.
- `lib/src/plugins/plugin_manager.dart`: per-plugin `host.transport` wrapper with manifest permission gating (JS-side + Dart-side re-check before any DNS/connect), bridge-token-authenticated `transport` message channel, base64 binary bridge representation, listener/pending-op cleanup on unload and disposal. No unrestricted global socket/WebSocket API is exposed.
- `doc/Plugins.md`: documents all three permissions, the exact `host.transport` contract (methods, options, event shapes, text vs base64 binary, resource limits, lifecycle/ownership, security), and WebSocket text/binary + TCP binary echo examples.

## Linked Issue

Fixes #146

## Verification

- New `test/plugins/plugin_manager_transport_test.dart` (19 tests): WS text/binary round-trips, subprotocol negotiation (`mqtt`), loopback `/ws/v1/sensors/{id}/snapshot` text-JSON delivery, TCP echo round-trip, TCP text-send rejection, permission gating before network activity (incl. direct bridge-call re-check), in-order delivery of events arriving before `onEvent()`, handle isolation across plugins and generations, unload/dispose connection cleanup, ninth-transport rejection, atomic oversize-send rejection, inbound-overflow close with `transport_resource_limit`.
- New `test/plugins/plugin_manager_transport_tls_test.dart` (2 tests): TLS and wss reject untrusted self-signed certificates via platform validation.
- Extended `plugin_manifest_permissions_test.dart` for the three new permissions.
- `flutter analyze`: no issues. Full `flutter test`: 3749 passed, 1 pre-existing skip.

## Impact

New plugin API surface (`host.transport`) and three new manifest permissions. New capabilities are opt-in via manifest; existing plugins are unaffected. No endpoint/spec changes; `doc/Plugins.md` updated.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
