### PR TITLE
feat(sensor): expose Bengle EBus tap as a raw Sensor

### DIFF
--- a/doc/AI_BUILD_NOTES.md
+++ b/doc/AI_BUILD_NOTES.md
@@ -153,6 +153,27 @@ temporary real-hardware tuning builds where debug endpoints must be reachable.
 
 **Fix:** Finite 500ms per-chunk write timeout + bail on zero-progress, `drainWithTimeout` polling `bytesToWrite`.
 
+## Bengle EBus tap (hardware verification)
+
+Decaid identifies the tap by VID `0x2e8a`, PID `0x000a`, and logical USB
+interface `2`; it never relies on unstable device paths. Interface `0` remains
+the Bengle machine with its existing stable ID. Discovery must not probe or
+write to the tap.
+
+The Sensor behavior contract — raw bytes, DTR, and single-reader ownership —
+lives in [`doc/DeviceManagement.md`](DeviceManagement.md#bengle-ebus-tap).
+
+**Hardware checks not covered by unit tests:**
+
+1. The machine and tap appear with distinct IDs and connect concurrently.
+2. Unplug removes only the detached physical device's logical entries; replug
+   rediscovers them.
+3. Android opens bulk-data interface `3` for logical interface `2`; devices
+   with duplicate USB descriptors receive distinct session IDs.
+4. Raw Sensor snapshots remain byte-exact and discovery performs no writes.
+
+Platform results must be observed independently on each claimed platform.
+
 ## Footgun #3: `codesign --deep` destroys Sparkle's Installer XPC
 
 **Symptom:** After a signed/notarized update, Sparkle's "Update failed" alert or a silent failure to relaunch. The app builds and notarizes fine.

--- a/doc/AI_BUILD_NOTES.md
+++ b/doc/AI_BUILD_NOTES.md
@@ -155,8 +155,10 @@ temporary real-hardware tuning builds where debug endpoints must be reachable.
 
 ## Bengle EBus tap (hardware verification)
 
-Decaid identifies the tap by VID `0x2e8a`, PID `0x000a`, and logical USB
-interface `2`; it never relies on unstable device paths. Interface `0` remains
+Decaid identifies the tap by VID `0x2e8a`, PID `0x000a`, the exact USB
+product name `Bengle`, and logical USB interface `2`; it never relies on
+unstable device paths. VID/PID are shared Pico SDK identifiers, so the product
+name is required to reject other Pico boards. Interface `0` remains
 the Bengle machine with its existing stable ID. Discovery must not probe or
 write to the tap.
 

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -371,6 +371,44 @@ same request prevent all fields from being stored (validation is atomic).
 | GET | `/api/v1/sensors/:id` | Get sensor manifest | |
 | POST | `/api/v1/sensors/:id/execute` | Execute sensor command | |
 
+#### `Bengle EBus Tap` sensor
+
+The Bengle EBus tap (USB interface `2` of a composite Bengle, VID `0x2e8a` /
+PID `0x000a`) is exposed through the generic Sensors surface — no new REST
+path. Manifest:
+
+```json
+{
+  "name": "Bengle EBus Tap",
+  "vendor": "Decent Espresso",
+  "data": [{"key": "bytes", "type": "string", "unit": "base64"}],
+  "commands": [{"id": "write", "paramsSchema": {"bytes": "string"}}]
+}
+```
+
+`GET /api/v1/sensors` lists the tap under its stable ID
+`usb-2e8a-a-<serial>-if02`. Each frame on `/ws/v1/sensors/<id>/snapshot` is one
+serial read chunk:
+
+```json
+{"timestamp": "2026-08-31T12:34:56.789Z", "bytes": "tp4..."}
+```
+
+`bytes` is standard base64; concatenating decoded chunks reproduces the exact
+serial byte stream. Chunk boundaries carry no protocol meaning.
+
+Raw write base64-decodes `bytes`, writes exactly those bytes to the tap, and
+returns the byte count written:
+
+```text
+POST /api/v1/sensors/usb-2e8a-a-<serial>-if02/execute
+{"commandId": "write", "params": {"bytes": "AO4A"}}
+→ {"status": "ok", "result": {"bytesWritten": 3}}
+```
+
+Malformed or missing base64 is rejected before any write. The tap is
+single-owner: no other reader may hold the port while Decaid owns it.
+
 ### Key-Value Store
 
 | Method | Path | Description | Handler |

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -749,9 +749,11 @@ Bengle composite devices (VID `0x2e8a`, PID `0x000a`) may expose a second CDC
 function as the `Bengle EBus Tap` Sensor
 (`lib/src/models/device/impl/sensor/bengle_debug_port.dart`).
 
-- **Identity.** The tap is identified by VID/PID and logical USB interface `2`,
-  never by unstable device paths. Its ID appends `-if02` to the machine's USB
-  stable ID; interface `0` retains the existing machine ID. Android opens the
+- **Identity.** The tap is identified by VID/PID, the exact USB product name
+  `Bengle`, and logical USB interface `2`, never by unstable device paths.
+  VID/PID alone are shared Pico SDK identifiers, so the product name is
+  required to reject other Pico boards. Its ID appends `-if02` to the
+  machine's USB stable ID; interface `0` retains the existing machine ID. Android opens the
   paired bulk-data interface `3` while preserving logical `if02` identity.
 - **Duplicate descriptors.** When multiple physical Bengle devices report the
   same USB descriptors, Android appends `UsbDevice.deviceId` to each tap ID for

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -743,6 +743,31 @@ sensor is connected, skins can call the `measure` command through the existing
 Sensors API and read TDS, temperature, refractive index, and status values from
 the sensor data stream.
 
+### Bengle EBus tap
+
+Bengle composite devices (VID `0x2e8a`, PID `0x000a`) may expose a second CDC
+function as the `Bengle EBus Tap` Sensor
+(`lib/src/models/device/impl/sensor/bengle_debug_port.dart`).
+
+- **Identity.** The tap is identified by VID/PID and logical USB interface `2`,
+  never by unstable device paths. Its ID appends `-if02` to the machine's USB
+  stable ID; interface `0` retains the existing machine ID. Android opens the
+  paired bulk-data interface `3` while preserving logical `if02` identity.
+- **Duplicate descriptors.** When multiple physical Bengle devices report the
+  same USB descriptors, Android appends `UsbDevice.deviceId` to each tap ID for
+  session-level disambiguation and emits at most one machine for the shared
+  stable ID.
+- **Raw tunnel.** Each serial read chunk becomes one snapshot with `bytes`
+  encoded as base64. Decoded chunks reproduce the serial stream exactly;
+  `write` sends the decoded bytes unchanged. ReaPrime adds no framing,
+  capture, compression, or upload behavior.
+- **Transport ownership.** The tap transport asserts DTR and permits one reader.
+  Transport errors leave the Sensor disconnected rather than reconnecting it
+  internally. Other serial-device DTR defaults are unchanged.
+
+Hardware verification steps:
+[`doc/AI_BUILD_NOTES.md`](AI_BUILD_NOTES.md#bengle-ebus-tap-hardware-verification).
+
 ### RememberedDevicesController
 
 **File:** `lib/src/controllers/remembered_devices_controller.dart`

--- a/lib/src/models/device/device_implementation.dart
+++ b/lib/src/models/device/device_implementation.dart
@@ -20,4 +20,5 @@ enum DeviceImplementation {
   difluidR2Sensor,
   debugPort,
   sensorBasket,
+  bengleDebugPort,
 }

--- a/lib/src/models/device/impl/sensor/bengle_debug_port.dart
+++ b/lib/src/models/device/impl/sensor/bengle_debug_port.dart
@@ -1,0 +1,150 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Lossless raw byte tunnel for the Bengle EBus tap (USB interface 2).
+///
+/// Each serial read chunk becomes one snapshot with the chunk base64-encoded
+/// under `bytes`; concatenating decoded chunks reproduces the exact serial
+/// byte stream. ReaPrime does not interpret or modify the stream.
+class BengleDebugPort implements Sensor {
+  late final Logger _log;
+  final SerialTransport _transport;
+
+  BengleDebugPort({required SerialTransport transport})
+    : _transport = transport {
+    _log = Logger("Bengle EBus Tap(${transport.name})");
+  }
+
+  final BehaviorSubject<ConnectionState> _connectionSubject =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      _connectionSubject.asBroadcastStream();
+
+  final StreamController<Map<String, dynamic>> _streamSubject =
+      StreamController<Map<String, dynamic>>.broadcast();
+
+  @override
+  Stream<Map<String, dynamic>> get data => _streamSubject.stream;
+
+  @override
+  String get deviceId => _transport.id;
+
+  @override
+  DeviceImplementation get implementation =>
+      DeviceImplementation.bengleDebugPort;
+
+  @override
+  TransportType get transportType => _transport.transportType;
+
+  StreamSubscription<Uint8List>? _transportSubscription;
+  bool _disconnected = false;
+
+  /// Shared in-flight connect so concurrent [onConnect] calls produce exactly
+  /// one raw subscription and one transport connect (one-reader ownership).
+  Future<void>? _inFlightConnect;
+
+  @override
+  Future<void> onConnect() => _ensureConnected();
+
+  Future<void> _ensureConnected() async {
+    if (await _connectionSubject.first == ConnectionState.connected) return;
+    await (_inFlightConnect ??= _doConnect());
+  }
+
+  Future<void> _doConnect() async {
+    _disconnected = false;
+    final subscription = _transport.rawStream.listen(
+      (chunk) {
+        _streamSubject.add({
+          'timestamp': DateTime.now().toIso8601String(),
+          'bytes': base64Encode(chunk),
+        });
+      },
+      onError: (Object error) {
+        _log.warning("transport error", error);
+        disconnect();
+      },
+      onDone: () {
+        disconnect();
+      },
+    );
+    try {
+      await _transport.connect();
+    } catch (e, st) {
+      _log.warning("connect failed", e, st);
+      await subscription.cancel();
+      _inFlightConnect = null;
+      rethrow;
+    }
+    if (_disconnected) {
+      // A disconnect raced the shared connect; the transport was already
+      // released by that disconnect.
+      await subscription.cancel();
+      _inFlightConnect = null;
+      return;
+    }
+    _transportSubscription = subscription;
+    _connectionSubject.add(ConnectionState.connected);
+    _inFlightConnect = null;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    if (_disconnected) return;
+    _disconnected = true;
+    _connectionSubject.add(ConnectionState.disconnected);
+    await _transportSubscription?.cancel();
+    _transportSubscription = null;
+    await _transport.disconnect();
+  }
+
+  @override
+  Future<Map<String, dynamic>> execute(
+    String commandId,
+    Map<String, dynamic>? parameters,
+  ) async {
+    if (commandId != "write") {
+      throw 'Invalid command: $commandId';
+    }
+    final encoded = parameters?["bytes"];
+    if (encoded is! String) {
+      throw 'Parameter "bytes" (base64 string) required';
+    }
+    final bytes = base64Decode(encoded);
+    await _transport.writeHexCommand(bytes);
+    return {'bytesWritten': bytes.length};
+  }
+
+  @override
+  SensorInfo get info => SensorInfo(
+    name: "Bengle EBus Tap",
+    vendor: "Decent Espresso",
+    dataChannels: [DataChannel(key: "bytes", type: "string", unit: "base64")],
+    commands: [
+      CommandDescriptor(
+        id: "write",
+        name: "write",
+        description: "Write raw bytes to the EBus tap",
+        paramsSchema: {"bytes": "string"},
+        resultsSchema: null,
+      ),
+    ],
+  );
+
+  @override
+  String get name => "Bengle EBus Tap";
+
+  @override
+  DeviceType get type => DeviceType.sensor;
+}

--- a/lib/src/services/device_factory.dart
+++ b/lib/src/services/device_factory.dart
@@ -14,6 +14,7 @@ import 'package:reaprime/src/models/device/impl/difluid/difluid_scale.dart';
 import 'package:reaprime/src/models/device/impl/eureka/eureka_scale.dart';
 import 'package:reaprime/src/models/device/impl/felicita/arc.dart';
 import 'package:reaprime/src/models/device/impl/hiroia/hiroia_scale.dart';
+import 'package:reaprime/src/models/device/impl/sensor/bengle_debug_port.dart';
 import 'package:reaprime/src/models/device/impl/sensor/debug_port.dart';
 import 'package:reaprime/src/models/device/impl/sensor/sensor_basket.dart';
 import 'package:reaprime/src/models/device/impl/skale/skale2_scale.dart';
@@ -62,6 +63,7 @@ class DeviceFactory {
       DeviceImplementation.hdsWifi => null,
       DeviceImplementation.debugPort => null,
       DeviceImplementation.sensorBasket => null,
+      DeviceImplementation.bengleDebugPort => null,
     };
   }
 
@@ -73,6 +75,9 @@ class DeviceFactory {
       DeviceImplementation.hdsSerial => HDSSerial(transport: transport),
       DeviceImplementation.debugPort => DebugPort(transport: transport),
       DeviceImplementation.sensorBasket => SensorBasket(transport: transport),
+      DeviceImplementation.bengleDebugPort => BengleDebugPort(
+        transport: transport,
+      ),
       DeviceImplementation.unifiedDe1 => UnifiedDe1(transport: transport),
       _ => null,
     };

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/device/device.dart';
@@ -13,6 +12,7 @@ import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
+import 'package:reaprime/src/models/device/impl/sensor/bengle_debug_port.dart';
 import 'package:reaprime/src/models/device/impl/sensor/debug_port.dart';
 import 'package:reaprime/src/models/device/impl/sensor/sensor_basket.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
@@ -33,6 +33,7 @@ class SerialServiceAndroid
   final Future<List<UsbDevice>> Function() _listDevices;
   final Stream<UsbEvent>? Function() _usbEventStream;
   final Future<Device?> Function(UsbDevice device)? _detectOverride;
+  final Future<UsbPort?> Function(UsbDevice device, int iface)? _createTapPort;
 
   final List<Device> _devices = [];
   StreamSubscription<UsbEvent>? _usbEventSubscription;
@@ -42,11 +43,20 @@ class SerialServiceAndroid
     Future<List<UsbDevice>> Function()? listDevices,
     Stream<UsbEvent>? Function()? usbEventStream,
     Future<Device?> Function(UsbDevice device)? detectDevice,
+    Future<UsbPort?> Function(UsbDevice device, int iface)? createTapPort,
   }) : _listDevices = listDevices ?? UsbSerial.listDevices,
        _usbEventStream = usbEventStream ?? (() => UsbSerial.usbEventStream),
-       _detectOverride = detectDevice;
+       _detectOverride = detectDevice,
+       _createTapPort = createTapPort;
 
   final Map<String, AndroidSerialPort> _transportForDeviceId = {};
+
+  /// Logical device ID -> physical `UsbDevice.deviceId` it was created from.
+  ///
+  /// Identical-serial Bengle boards share VID/PID/serial, so stable IDs
+  /// cannot distinguish them; detach and cleanup follow physical-instance
+  /// ownership instead.
+  final Map<String, int> _logicalToPhysicalDeviceId = {};
 
   bool _isScanning = false;
   Future<void>? _currentScan;
@@ -83,7 +93,7 @@ class SerialServiceAndroid
   }
 
   @visibleForTesting
-  void handleUsbEvent(UsbEvent data) {
+  Future<void> handleUsbEvent(UsbEvent data) async {
     if (_disposed) return;
     switch (data.event) {
       case UsbEvent.ACTION_USB_DETACHED:
@@ -99,25 +109,31 @@ class SerialServiceAndroid
             pid: pid,
             serial: data.device!.serial,
           );
-          final vidPidPrefix = (vid != null && pid != null)
-              ? 'usb-${vid.toRadixString(16)}-${pid.toRadixString(16)}-'
-              : null;
           _log.info(
             "USB_DETACHED: stableId=${detachedStableId ?? 'none'}, "
-            "prefix=$vidPidPrefix",
+            "physical=${data.device!.deviceId}",
           );
-          final match = _devices.firstWhereOrNull(
-            (d) =>
-                d.deviceId == detachedStableId ||
-                (vidPidPrefix != null && d.deviceId.startsWith(vidPidPrefix)) ||
-                d.deviceId == "${data.device!.deviceId}",
-          );
-          if (match != null) {
-            _log.info(
-              "USB_DETACHED: disconnecting ${match.name}(${match.deviceId})",
-            );
-            match.disconnect();
-            _devices.remove(match);
+          final detachedPhysicalId = data.device!.deviceId;
+          final matches = _devices.where((d) {
+            if (detachedPhysicalId != null) {
+              return _logicalToPhysicalDeviceId[d.deviceId] ==
+                      detachedPhysicalId ||
+                  d.deviceId == "$detachedPhysicalId";
+            }
+            // No physical ID on the detach event: fall back to the stable
+            // machine ID. Indistinguishable same-serial devices without a
+            // physical ID cannot be separated.
+            return withoutUsbInterfaceSuffix(d.deviceId) == detachedStableId;
+          }).toList();
+          if (matches.isNotEmpty) {
+            for (final match in matches) {
+              _log.info(
+                "USB_DETACHED: disconnecting ${match.name}(${match.deviceId})",
+              );
+              await match.disconnect();
+              _devices.remove(match);
+            }
+            await _releaseDisconnected(matches);
           } else {
             _log.warning("USB_DETACHED: no matching device in $_devices");
           }
@@ -247,10 +263,12 @@ class SerialServiceAndroid
       );
     }
     _devices.add(machine);
+    _recordPhysicalOwnership(machine.deviceId, device);
     machine.connectionState.listen((state) {
       if (state == ConnectionState.disconnected) {
         _devices.remove(machine);
         _machineSubject.add(_devices);
+        _logicalToPhysicalDeviceId.remove(machine.deviceId);
         final t = _transportForDeviceId.remove(machine.deviceId);
         try {
           t?.dispose();
@@ -323,10 +341,12 @@ class SerialServiceAndroid
         await device.onConnect().timeout(const Duration(seconds: 10));
         final connected = device;
         _devices.add(connected);
+        _recordPhysicalOwnership(connected.deviceId, d);
         connected.connectionState.listen((state) {
           if (state == ConnectionState.disconnected) {
             _devices.remove(connected);
             _machineSubject.add(_devices);
+            _logicalToPhysicalDeviceId.remove(connected.deviceId);
             final t = _transportForDeviceId.remove(connected.deviceId);
             try {
               t?.dispose();
@@ -369,6 +389,28 @@ class SerialServiceAndroid
     }
   }
 
+  void _recordPhysicalOwnership(String logicalDeviceId, UsbDevice physical) {
+    final physicalId = physical.deviceId;
+    if (physicalId != null) {
+      _logicalToPhysicalDeviceId[logicalDeviceId] = physicalId;
+    }
+  }
+
+  /// Removes ownership and transport mappings for [devices] that left the
+  /// registry and disposes their adapters, so a later redetection does not
+  /// overwrite the map entry and leak the old `UsbDeviceConnection`.
+  Future<void> _releaseDisconnected(List<Device> devices) async {
+    for (final d in devices) {
+      _logicalToPhysicalDeviceId.remove(d.deviceId);
+      final t = _transportForDeviceId.remove(d.deviceId);
+      try {
+        await t?.dispose();
+      } catch (e, st) {
+        _log.fine('transport dispose failed for ${d.deviceId}', e, st);
+      }
+    }
+  }
+
   Future<void> _performScan() async {
     List<Device> connected = [];
     final devicesCopy = List<Device>.from(_devices);
@@ -387,6 +429,7 @@ class SerialServiceAndroid
       );
     }
     _devices.removeWhere((d) => connected.contains(d) == false);
+    await _releaseDisconnected(removed);
     if (connected.isNotEmpty) {
       _log.fine(
         "Keeping ${connected.length} connected: "
@@ -400,17 +443,34 @@ class SerialServiceAndroid
       "(${devices.map((d) => '${d.productName ?? d.deviceName}[${computeUsbStableId(vid: d.vid, pid: d.pid, serial: d.serial) ?? d.deviceId}]').join(', ')})",
     );
 
-    final enumeratedIds = devices
+    final enumeratedPhysicalIds = devices
+        .map((d) => d.deviceId)
+        .whereType<int>()
+        .toSet();
+    final enumeratedStableIds = devices
         .map(
           (d) =>
               computeUsbStableId(vid: d.vid, pid: d.pid, serial: d.serial) ??
               "${d.deviceId}",
         )
         .toSet();
-    final orphans = connected
-        .where((d) => !enumeratedIds.contains(d.deviceId))
-        .toList();
-    for (final orphan in orphans) {
+
+    // Devices with recorded physical ownership are reconciled against the
+    // enumerated physical IDs — identical-serial boards reduce to the same
+    // stable base, so only physical ownership can tell them apart. Devices
+    // without ownership fall back to the stable base ID.
+    bool isOrphan(Device d) {
+      final physicalId = _logicalToPhysicalDeviceId[d.deviceId];
+      if (physicalId != null) {
+        return !enumeratedPhysicalIds.contains(physicalId);
+      }
+      return !enumeratedStableIds.contains(
+        withoutUsbInterfaceSuffix(d.deviceId),
+      );
+    }
+
+    final orphan = connected.where(isOrphan).toList();
+    for (final orphan in orphan) {
       _log.warning(
         "Orphan GC: ${orphan.name}(${orphan.deviceId}) not in USB enumeration, forcing disconnect",
       );
@@ -418,41 +478,103 @@ class SerialServiceAndroid
       connected.remove(orphan);
       _devices.remove(orphan);
     }
-
-    devices.removeWhere((d) {
-      final usbStableId = computeUsbStableId(
-        vid: d.vid,
-        pid: d.pid,
-        serial: d.serial,
-      );
-      final isDuplicate = usbStableId != null
-          ? _devices.any((t) => t.deviceId == usbStableId)
-          : _devices.any((t) => t.deviceId == "${d.deviceId}");
-      if (isDuplicate) {
-        _log.fine(
-          "Skipping ${d.productName ?? d.deviceName}: "
-          "already connected as ${usbStableId ?? d.deviceId}",
-        );
-      }
-      return isDuplicate;
-    });
+    await _releaseDisconnected(orphan);
 
     _log.info("${devices.length} new devices to detect");
+    final seenMachineIds = <String>{};
     final results = await Future.wait(
       devices.map((d) async {
+        final found = <Device>[];
         try {
-          final device = await _runDetection(d);
-          _log.info("Port $d -> ${device ?? 'no device'}");
-          return device;
+          final machineId =
+              computeUsbStableId(vid: d.vid, pid: d.pid, serial: d.serial) ??
+              '${d.deviceId}';
+          if (!_devices.any((t) => t.deviceId == machineId) &&
+              seenMachineIds.add(machineId)) {
+            final device = await _runDetection(d);
+            if (device != null) {
+              found.add(device);
+              _recordPhysicalOwnership(device.deviceId, d);
+            }
+          }
         } catch (e, st) {
           _log.warning("Error detecting device on $d", e, st);
-          return null;
         }
+        try {
+          final tap = await _detectTap(d);
+          if (tap != null) found.add(tap);
+        } catch (e, st) {
+          _log.warning("Error detecting Bengle tap on $d", e, st);
+        }
+        return found;
       }),
     );
-    _devices.addAll(results.whereType<Device>());
+    _devices.addAll(results.expand((e) => e));
     _machineSubject.add(_devices);
   }
+
+  /// Detects the Bengle EBus tap on a composite Bengle device.
+  ///
+  /// Gated only on VID/PID plus interface count — never on product name and
+  /// never by probing or writing to the interface. The tap is opened through
+  /// the Android bulk-data interface 3 (the usb_serial fork derives the
+  /// control interface as `iface - 1`), while the logical identity and ID
+  /// keep denoting interface 2 (`-if02`). Identical-serial boards are
+  /// disambiguated by the physical `UsbDevice.deviceId` in the tap ID.
+  Future<Device?> _detectTap(UsbDevice device) async {
+    if (!isBengleCompositeWithTap(
+      vid: device.vid,
+      pid: device.pid,
+      interfaceCount: device.interfaceCount,
+    )) {
+      return null;
+    }
+    final tapStableId = computeUsbStableId(
+      vid: device.vid,
+      pid: device.pid,
+      serial: device.serial,
+      interfaceNumber: bengleEbusTapInterface,
+    );
+    final physicalId = device.deviceId;
+    final tapId = tapStableId == null
+        ? null
+        : physicalId == null
+        ? tapStableId
+        : '$tapStableId-$physicalId';
+    if (tapId != null && _devices.any((d) => d.deviceId == tapId)) {
+      return null;
+    }
+    final port = await (_createTapPort ?? _defaultCreateTapPort)(
+      device,
+      bengleEbusAndroidDataInterface,
+    );
+    if (port == null) {
+      _log.warning(
+        "failed to open Bengle tap data interface "
+        "$bengleEbusAndroidDataInterface on $device",
+      );
+      return null;
+    }
+    final transport = AndroidSerialPort(
+      device: device,
+      port: port,
+      interfaceNumber: bengleEbusTapInterface,
+      physicalInstanceId: physicalId,
+      dtrOn: true,
+      // The tap is binary-only: never enter the UTF-8/text log path.
+      decodeUtf8Text: false,
+    );
+    _transportForDeviceId[transport.id] = transport;
+    _recordPhysicalOwnership(transport.id, device);
+    _log.info(
+      "Bengle EBus tap on interface $bengleEbusTapInterface"
+      " (${transport.id})",
+    );
+    return BengleDebugPort(transport: transport);
+  }
+
+  static Future<UsbPort?> _defaultCreateTapPort(UsbDevice device, int iface) =>
+      device.create(UsbSerial.CDC, iface);
 
   Future<Device?> _detectDevice(UsbDevice device) async {
     _log.info("device name: ${device.productName}");
@@ -606,6 +728,7 @@ class SerialServiceAndroid
       await transport.dispose();
     }
     _transportForDeviceId.clear();
+    _logicalToPhysicalDeviceId.clear();
     await _attachedSubject.close();
     await _machineSubject.close();
   }
@@ -614,7 +737,12 @@ class SerialServiceAndroid
 class AndroidSerialPort implements SerialTransport {
   final UsbDevice _device;
   final UsbPort _port;
+  final int? _interfaceNumber;
+  final int? _physicalInstanceId;
+  final bool _dtrOn;
+  final bool _decodeUtf8Text;
   late Logger _log;
+  bool _disposed = false;
   final BehaviorSubject<ConnectionState> _open = BehaviorSubject.seeded(
     ConnectionState.discovered,
   );
@@ -622,15 +750,26 @@ class AndroidSerialPort implements SerialTransport {
   @override
   Stream<ConnectionState> get connectionState => _open.asBroadcastStream();
 
-  AndroidSerialPort({required UsbDevice device, required UsbPort port})
-    : _device = device,
-      _port = port {
+  AndroidSerialPort({
+    required UsbDevice device,
+    required UsbPort port,
+    int? interfaceNumber,
+    int? physicalInstanceId,
+    bool dtrOn = false,
+    bool decodeUtf8Text = true,
+  }) : _device = device,
+       _port = port,
+       _interfaceNumber = interfaceNumber,
+       _physicalInstanceId = physicalInstanceId,
+       _dtrOn = dtrOn,
+       _decodeUtf8Text = decodeUtf8Text {
     _log = Logger("Serial:${_device.deviceName}");
   }
   @override
   Future<void> disconnect() async {
+    if (_disposed) return;
     _log.info("disconnecting (id=$id, path=${_device.deviceName})");
-    _open.add(ConnectionState.disconnected);
+    if (!_open.isClosed) _open.add(ConnectionState.disconnected);
     _portSubscription?.cancel();
     await _port.close();
   }
@@ -641,8 +780,11 @@ class AndroidSerialPort implements SerialTransport {
       vid: _device.vid,
       pid: _device.pid,
       serial: _device.serial,
+      interfaceNumber: _interfaceNumber,
     );
-    return stable ?? "${_device.deviceId}";
+    final base = stable ?? "${_device.deviceId}";
+    final instance = _physicalInstanceId;
+    return instance == null ? base : "$base-$instance";
   }
 
   @override
@@ -662,7 +804,7 @@ class AndroidSerialPort implements SerialTransport {
       throw "Failed to open port";
     }
 
-    await _port.setDTR(false);
+    await _port.setDTR(_dtrOn);
     await _port.setRTS(false);
 
     _port.setPortParameters(
@@ -679,6 +821,7 @@ class AndroidSerialPort implements SerialTransport {
     _portSubscription = inputStream?.listen(
       (Uint8List event) {
         _rawController.add(event);
+        if (!_decodeUtf8Text) return;
         try {
           final input = utf8.decode(event);
           _log.finest("received serial input: $input");
@@ -727,8 +870,15 @@ class AndroidSerialPort implements SerialTransport {
 
   @override
   Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
     await _portSubscription?.cancel();
     _portSubscription = null;
+    try {
+      await _port.close();
+    } catch (e, st) {
+      _log.warning("dispose: _port.close failed", e, st);
+    }
     if (!_open.isClosed) _open.close();
     if (!_rawController.isClosed) _rawController.close();
     if (!_outputController.isClosed) _outputController.close();

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -515,9 +515,9 @@ class SerialServiceAndroid
 
   /// Detects the Bengle EBus tap on a composite Bengle device.
   ///
-  /// Gated only on VID/PID plus interface count — never on product name and
-  /// never by probing or writing to the interface. The tap is opened through
-  /// the Android bulk-data interface 3 (the usb_serial fork derives the
+  /// Gated on VID/PID, interface count, and the exact product name — never
+  /// by probing or writing to the interface. The tap is opened through the
+  /// Android bulk-data interface 3 (the usb_serial fork derives the
   /// control interface as `iface - 1`), while the logical identity and ID
   /// keep denoting interface 2 (`-if02`). Identical-serial boards are
   /// disambiguated by the physical `UsbDevice.deviceId` in the tap ID.
@@ -526,6 +526,7 @@ class SerialServiceAndroid
       vid: device.vid,
       pid: device.pid,
       interfaceCount: device.interfaceCount,
+      productName: device.productName,
     )) {
       return null;
     }

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -384,6 +384,7 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
     int? vid;
     int? pid;
     int? interfaceNumber;
+    String? productName;
     try {
       vid = port.vendorId;
     } catch (_) {}
@@ -393,12 +394,24 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
     try {
       interfaceNumber = port.interfaceNumber;
     } catch (_) {}
-    if (isBengleEbusTap(vid: vid, pid: pid, interfaceNumber: interfaceNumber)) {
+    try {
+      productName = port.productName;
+    } catch (_) {}
+    if (isBengleEbusTap(
+      vid: vid,
+      pid: pid,
+      interfaceNumber: interfaceNumber,
+      productName: productName,
+    )) {
       _log.info(
         "Bengle EBus tap on interface $interfaceNumber ($id)"
         " — no protocol probe",
       );
-      final transport = _DesktopSerialPort(port: port, dtrOn: true);
+      final transport = _DesktopSerialPort(
+        port: port,
+        dtrOn: true,
+        decodeUtf8Text: false,
+      );
       _portPathToTransport[id] = transport;
       final device = BengleDebugPort(transport: transport);
       _portPathToDeviceId[id] = device.deviceId;
@@ -559,6 +572,7 @@ const int _serialWriteTimeoutMs = 500;
 class _DesktopSerialPort implements SerialTransport {
   final SerialPort _port;
   final bool _dtrOn;
+  final bool _decodeUtf8Text;
   late Logger _log;
   final BehaviorSubject<ConnectionState> _open = BehaviorSubject.seeded(
     ConnectionState.discovered,
@@ -570,9 +584,13 @@ class _DesktopSerialPort implements SerialTransport {
   late final String _cachedId = _computeId();
   late final String _cachedName = _safePortName() ?? "Unknown port";
 
-  _DesktopSerialPort({required SerialPort port, bool dtrOn = false})
-    : _port = port,
-      _dtrOn = dtrOn {
+  _DesktopSerialPort({
+    required SerialPort port,
+    bool dtrOn = false,
+    bool decodeUtf8Text = true,
+  }) : _port = port,
+       _dtrOn = dtrOn,
+       _decodeUtf8Text = decodeUtf8Text {
     _log = Logger("SerialPort:${port.name}");
     _cachedId;
     _cachedName;
@@ -729,6 +747,7 @@ class _DesktopSerialPort implements SerialTransport {
       _portSubscription = reader.stream.listen(
         (data) {
           _rawStreamController.add(data);
+          if (!_decodeUtf8Text) return;
           try {
             final input = utf8.decode(data);
             _log.finest("received serial input: $input");

--- a/lib/src/services/serial/serial_service_desktop.dart
+++ b/lib/src/services/serial/serial_service_desktop.dart
@@ -11,6 +11,7 @@ import 'package:reaprime/src/models/device/impl/bengle/bengle.dart';
 import 'package:reaprime/src/models/device/impl/de1/de1.models.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/unified_de1.dart';
 import 'package:reaprime/src/models/device/impl/decent_scale/scale_serial.dart';
+import 'package:reaprime/src/models/device/impl/sensor/bengle_debug_port.dart';
 import 'package:reaprime/src/models/device/impl/sensor/debug_port.dart';
 import 'package:reaprime/src/models/device/impl/sensor/sensor_basket.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
@@ -333,6 +334,7 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
     int? vid;
     int? pid;
     String? serial;
+    int? interfaceNumber;
     try {
       name = port.name ?? path;
     } catch (_) {}
@@ -351,12 +353,21 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
     try {
       serial = port.serialNumber;
     } catch (_) {}
-    final stableId = computeUsbStableId(vid: vid, pid: pid, serial: serial);
+    try {
+      interfaceNumber = port.interfaceNumber;
+    } catch (_) {}
+    final stableId = computeUsbStableId(
+      vid: vid,
+      pid: pid,
+      serial: serial,
+      interfaceNumber: interfaceNumber,
+    );
     return _PortMetadata(
       name: name,
       transport: transport,
       productName: productName,
       stableId: stableId,
+      interfaceNumber: interfaceNumber,
     );
   }
 
@@ -368,6 +379,30 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
     if (port.transport.toTransport() == "Bluetooth") {
       port.dispose();
       return null;
+    }
+
+    int? vid;
+    int? pid;
+    int? interfaceNumber;
+    try {
+      vid = port.vendorId;
+    } catch (_) {}
+    try {
+      pid = port.productId;
+    } catch (_) {}
+    try {
+      interfaceNumber = port.interfaceNumber;
+    } catch (_) {}
+    if (isBengleEbusTap(vid: vid, pid: pid, interfaceNumber: interfaceNumber)) {
+      _log.info(
+        "Bengle EBus tap on interface $interfaceNumber ($id)"
+        " — no protocol probe",
+      );
+      final transport = _DesktopSerialPort(port: port, dtrOn: true);
+      _portPathToTransport[id] = transport;
+      final device = BengleDebugPort(transport: transport);
+      _portPathToDeviceId[id] = device.deviceId;
+      return device;
     }
 
     final transport = _DesktopSerialPort(port: port);
@@ -391,14 +426,6 @@ class SerialServiceDesktop implements DeviceDiscoveryService {
       return device;
     }
 
-    int? vid;
-    int? pid;
-    try {
-      vid = port.vendorId;
-    } catch (_) {}
-    try {
-      pid = port.productId;
-    } catch (_) {}
     final usbModel = matchUsbDevice(usbDeviceTable, vid: vid, pid: pid);
     if (usbModel != null) {
       final device = UnifiedDe1(transport: transport);
@@ -531,6 +558,7 @@ const int _serialWriteTimeoutMs = 500;
 
 class _DesktopSerialPort implements SerialTransport {
   final SerialPort _port;
+  final bool _dtrOn;
   late Logger _log;
   final BehaviorSubject<ConnectionState> _open = BehaviorSubject.seeded(
     ConnectionState.discovered,
@@ -542,7 +570,9 @@ class _DesktopSerialPort implements SerialTransport {
   late final String _cachedId = _computeId();
   late final String _cachedName = _safePortName() ?? "Unknown port";
 
-  _DesktopSerialPort({required SerialPort port}) : _port = port {
+  _DesktopSerialPort({required SerialPort port, bool dtrOn = false})
+    : _port = port,
+      _dtrOn = dtrOn {
     _log = Logger("SerialPort:${port.name}");
     _cachedId;
     _cachedName;
@@ -560,6 +590,7 @@ class _DesktopSerialPort implements SerialTransport {
     int? vid;
     int? pid;
     String? serial;
+    int? interfaceNumber;
     try {
       vid = _port.vendorId;
     } catch (_) {}
@@ -569,7 +600,15 @@ class _DesktopSerialPort implements SerialTransport {
     try {
       serial = _port.serialNumber;
     } catch (_) {}
-    final stable = computeUsbStableId(vid: vid, pid: pid, serial: serial);
+    try {
+      interfaceNumber = _port.interfaceNumber;
+    } catch (_) {}
+    final stable = computeUsbStableId(
+      vid: vid,
+      pid: pid,
+      serial: serial,
+      interfaceNumber: interfaceNumber,
+    );
     if (stable != null) return stable;
     final portName = _safePortName();
     if (portName != null) {
@@ -673,7 +712,7 @@ class _DesktopSerialPort implements SerialTransport {
       cfg.stopBits = 1;
       cfg.rts = 0;
       cfg.cts = 0;
-      cfg.dtr = 0;
+      cfg.dtr = _dtrOn ? 1 : 0;
       cfg.dsr = 0;
       cfg.xonXoff = 0;
       cfg.setFlowControl(0);
@@ -776,11 +815,13 @@ class _PortMetadata {
   final String transport;
   final String? productName;
   final String? stableId;
+  final int? interfaceNumber;
   _PortMetadata({
     required this.name,
     required this.transport,
     required this.productName,
     required this.stableId,
+    required this.interfaceNumber,
   });
 }
 

--- a/lib/src/services/serial/usb_ids.dart
+++ b/lib/src/services/serial/usb_ids.dart
@@ -27,6 +27,13 @@ UsbDeviceModel? matchUsbDevice(
 const int bengleEbusTapVid = 0x2e8a;
 const int bengleEbusTapPid = 0x000a;
 
+/// USB product name string of the Bengle machine and its EBus tap.
+///
+/// VID/PID are shared Pico SDK identifiers, so the exact product name is
+/// required in addition to the IDs and interface before anything is treated
+/// as the tap.
+const String bengleUsbProductName = 'Bengle';
+
 /// Logical USB interface of the Bengle EBus tap (Linux CDC control
 /// interface). ReaPrime's identity, stable ID, and docs all use `if02`.
 const int bengleEbusTapInterface = 2;
@@ -40,22 +47,35 @@ const int bengleEbusTapInterface = 2;
 /// interface, which has no bulk endpoints and makes `UsbPort.open()` fail.
 const int bengleEbusAndroidDataInterface = 3;
 
-/// True only for the Bengle EBus tap: VID 0x2e8a, PID 0x000a, interface 2.
-/// Everything else — interface 0, missing metadata, and devices without
-/// interface 2 — is false.
-bool isBengleEbusTap({int? vid, int? pid, int? interfaceNumber}) {
+/// True only for the Bengle EBus tap: VID 0x2e8a, PID 0x000a, interface 2,
+/// and the exact product name `Bengle`. Everything else — interface 0,
+/// missing metadata, other products, and devices without interface 2 — is
+/// false.
+bool isBengleEbusTap({
+  int? vid,
+  int? pid,
+  int? interfaceNumber,
+  required String? productName,
+}) {
   return vid == bengleEbusTapVid &&
       pid == bengleEbusTapPid &&
-      interfaceNumber == bengleEbusTapInterface;
+      interfaceNumber == bengleEbusTapInterface &&
+      productName == bengleUsbProductName;
 }
 
 /// True when a Bengle composite device reports enough interfaces to contain
-/// the EBus tap. Android exposes the interface count, not a per-interface
-/// number, so presence of the tap's bulk-data interface 3 is inferred from
-/// `interfaceCount > 3`.
-bool isBengleCompositeWithTap({int? vid, int? pid, int? interfaceCount}) {
+/// the EBus tap and carries the exact product name `Bengle`. Android exposes
+/// the interface count, not a per-interface number, so presence of the tap's
+/// bulk-data interface 3 is inferred from `interfaceCount > 3`.
+bool isBengleCompositeWithTap({
+  int? vid,
+  int? pid,
+  int? interfaceCount,
+  required String? productName,
+}) {
   return vid == bengleEbusTapVid &&
       pid == bengleEbusTapPid &&
       interfaceCount != null &&
-      interfaceCount > bengleEbusAndroidDataInterface;
+      interfaceCount > bengleEbusAndroidDataInterface &&
+      productName == bengleUsbProductName;
 }

--- a/lib/src/services/serial/usb_ids.dart
+++ b/lib/src/services/serial/usb_ids.dart
@@ -23,3 +23,39 @@ UsbDeviceModel? matchUsbDevice(
   }
   return null;
 }
+
+const int bengleEbusTapVid = 0x2e8a;
+const int bengleEbusTapPid = 0x000a;
+
+/// Logical USB interface of the Bengle EBus tap (Linux CDC control
+/// interface). ReaPrime's identity, stable ID, and docs all use `if02`.
+const int bengleEbusTapInterface = 2;
+
+/// Android bulk-data interface for the Bengle EBus tap.
+///
+/// The installed usb_serial fork treats the requested interface as the CDC
+/// bulk-data interface and derives the control interface as `iface - 1`.
+/// The tap's Android bulk-data interface is therefore 3 (Linux control
+/// interface 2). Do NOT change this back to 2 — interface 2 is the control
+/// interface, which has no bulk endpoints and makes `UsbPort.open()` fail.
+const int bengleEbusAndroidDataInterface = 3;
+
+/// True only for the Bengle EBus tap: VID 0x2e8a, PID 0x000a, interface 2.
+/// Everything else — interface 0, missing metadata, and devices without
+/// interface 2 — is false.
+bool isBengleEbusTap({int? vid, int? pid, int? interfaceNumber}) {
+  return vid == bengleEbusTapVid &&
+      pid == bengleEbusTapPid &&
+      interfaceNumber == bengleEbusTapInterface;
+}
+
+/// True when a Bengle composite device reports enough interfaces to contain
+/// the EBus tap. Android exposes the interface count, not a per-interface
+/// number, so presence of the tap's bulk-data interface 3 is inferred from
+/// `interfaceCount > 3`.
+bool isBengleCompositeWithTap({int? vid, int? pid, int? interfaceCount}) {
+  return vid == bengleEbusTapVid &&
+      pid == bengleEbusTapPid &&
+      interfaceCount != null &&
+      interfaceCount > bengleEbusAndroidDataInterface;
+}

--- a/lib/src/services/serial/utils.dart
+++ b/lib/src/services/serial/utils.dart
@@ -51,8 +51,24 @@ Future<void> drainWithTimeout({
   }
 }
 
-String? computeUsbStableId({int? vid, int? pid, String? serial}) {
+String? computeUsbStableId({
+  int? vid,
+  int? pid,
+  String? serial,
+  int? interfaceNumber,
+}) {
   if (vid == null || pid == null) return null;
   final s = (serial != null && serial.isNotEmpty) ? serial : 'unknown';
-  return 'usb-${vid.toRadixString(16)}-${pid.toRadixString(16)}-$s';
+  final id = 'usb-${vid.toRadixString(16)}-${pid.toRadixString(16)}-$s';
+  if (interfaceNumber == null || interfaceNumber <= 0) return id;
+  return '$id-if${interfaceNumber.toRadixString(16).padLeft(2, '0')}';
+}
+
+/// Strips a trailing `-ifNN` (optionally followed by a physical-instance
+/// `-<deviceId>`) suffix from a USB stable ID, so a composite device's
+/// machine and tap logical IDs map back to one physical device. IDs without
+/// a suffix are returned unchanged.
+String withoutUsbInterfaceSuffix(String stableId) {
+  final match = RegExp(r'-if[0-9a-fA-F]+(?:-[0-9]+)?$').firstMatch(stableId);
+  return match == null ? stableId : stableId.substring(0, match.start);
 }

--- a/test/services/serial/bengle_debug_port_android_test.dart
+++ b/test/services/serial/bengle_debug_port_android_test.dart
@@ -1,0 +1,532 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/services/serial/serial_service_android.dart';
+import 'package:reaprime/src/services/serial/utils.dart';
+
+// ignore: depend_on_referenced_packages
+import 'package:usb_serial/usb_serial.dart';
+
+const _serial = 'TEST-SERIAL';
+const _machineId = 'usb-2e8a-a-$_serial';
+const _tapId = 'usb-2e8a-a-$_serial-if02';
+
+UsbDevice _composite({
+  int? vid = 0x2e8a,
+  int? pid = 0x000a,
+  String? serial = _serial,
+  int? deviceId = 1002,
+  int? interfaceCount = 4,
+}) {
+  return UsbDevice(
+    '/dev/bus/usb/001/002',
+    vid,
+    pid,
+    'Bengle',
+    'Decent Espresso',
+    deviceId,
+    serial,
+    interfaceCount,
+  );
+}
+
+class _FakeMachine implements Device {
+  _FakeMachine(this.deviceId);
+
+  @override
+  final String deviceId;
+
+  @override
+  String get name => 'Bengle';
+
+  @override
+  DeviceType get type => DeviceType.machine;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.bengle;
+
+  @override
+  TransportType get transportType => TransportType.serial;
+
+  int disconnectCalls = 0;
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+
+  @override
+  Future<void> onConnect() async {}
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<UsbDevice> listed;
+  late SerialServiceAndroid service;
+  int? requestedInterface;
+  late List<String> channelCalls;
+  late List<bool> dtrValues;
+
+  String machineIdOf(UsbDevice d) =>
+      computeUsbStableId(vid: d.vid, pid: d.pid, serial: d.serial) ??
+      '${d.deviceId}';
+
+  SerialServiceAndroid build({Future<Device?> Function(UsbDevice)? detect}) {
+    requestedInterface = null;
+    return SerialServiceAndroid(
+      listDevices: () async => listed,
+      usbEventStream: () => null,
+      detectDevice: detect ?? (d) async => _FakeMachine(machineIdOf(d)),
+      createTapPort: (device, iface) async {
+        requestedInterface = iface;
+        return UsbPort('test-tap-port');
+      },
+    );
+  }
+
+  setUp(() {
+    listed = [];
+    channelCalls = [];
+    dtrValues = [];
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(const MethodChannel('test-tap-port'), (
+      call,
+    ) async {
+      channelCalls.add(call.method);
+      if (call.method == 'setDTR') {
+        dtrValues.add(call.arguments['value'] as bool);
+      }
+      if (call.method == 'open' || call.method == 'close') return true;
+      return null;
+    });
+    messenger.setMockStreamHandler(
+      const EventChannel('test-tap-port/stream'),
+      MockStreamHandler.inline(onListen: (_, _) {}, onCancel: (_) {}),
+    );
+    service = build(detect: (_) async => _FakeMachine(_machineId));
+  });
+
+  tearDown(() async {
+    await service.dispose();
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('test-tap-port'),
+      null,
+    );
+    messenger.setMockStreamHandler(
+      const EventChannel('test-tap-port/stream'),
+      null,
+    );
+  });
+
+  test('composite Bengle exposes machine and tap with distinct IDs', () async {
+    listed = [_composite()];
+    await service.scanForDevices();
+
+    final devices = await service.devices.first;
+    expect(devices, hasLength(2));
+    final ids = devices.map((d) => d.deviceId).toSet();
+    expect(ids, contains(_machineId));
+    expect(ids, contains('$_tapId-1002'));
+
+    final tap = devices.singleWhere((d) => d is Sensor);
+    expect(tap.name, 'Bengle EBus Tap');
+    expect(tap.implementation, DeviceImplementation.bengleDebugPort);
+  });
+
+  test('Android opens the tap data interface 3, identity keeps if02', () async {
+    listed = [_composite(), _composite(deviceId: 1003)];
+    service = build();
+    await service.scanForDevices();
+
+    // The usb_serial fork derives the control interface as iface - 1, so the
+    // tap's Android bulk-data interface is 3 even though the logical identity
+    // and ID keep denoting interface 2.
+    expect(requestedInterface, 3);
+    final taps = (await service.devices.first).whereType<Sensor>().toList();
+    expect(taps, hasLength(2));
+    for (final tap in taps) {
+      expect(tap.deviceId, contains('-if02-'), reason: tap.deviceId);
+    }
+  });
+
+  test('tap discovery is independent of machine detection', () async {
+    listed = [_composite()];
+    service = build(detect: (_) async => null);
+    await service.scanForDevices();
+
+    final devices = await service.devices.first;
+    expect(devices.map((d) => d.deviceId), ['$_tapId-1002']);
+  });
+
+  test('device without the tap data interface yields no tap', () async {
+    listed = [_composite(interfaceCount: 1)];
+    await service.scanForDevices();
+
+    final devices = await service.devices.first;
+    expect(devices.map((d) => d.deviceId), [_machineId]);
+    expect(requestedInterface, isNull);
+  });
+
+  test('unrelated interface-2 composite yields no tap', () async {
+    listed = [_composite(vid: 0x046d, pid: 0xc31c, serial: 'kbd-1')];
+    service = build(detect: (_) async => null);
+    await service.scanForDevices();
+
+    final devices = await service.devices.first;
+    expect(devices, isEmpty);
+    expect(requestedInterface, isNull);
+  });
+
+  test('rescan keeps both logical IDs without duplicates', () async {
+    listed = [_composite()];
+    await service.scanForDevices();
+    final tap = (await service.devices.first).singleWhere(
+      (d) => d.deviceId == '$_tapId-1002',
+    );
+    await tap.onConnect();
+
+    await service.scanForDevices();
+
+    final devices = await service.devices.first;
+    expect(devices, hasLength(2));
+    expect(devices.map((d) => d.deviceId).toSet(), {
+      _machineId,
+      '$_tapId-1002',
+    });
+  });
+
+  test(
+    'connected machine does not block rediscovery of a missing tap',
+    () async {
+      listed = [_composite()];
+      await service.scanForDevices();
+      // The machine stays connected (fake); the tap is left disconnected and is
+      // dropped from the registry between scans.
+      await service.scanForDevices();
+
+      final devices = await service.devices.first;
+      expect(devices.map((d) => d.deviceId).toSet(), {
+        _machineId,
+        '$_tapId-1002',
+      });
+    },
+  );
+
+  test(
+    'two same-serial boards yield one machine and two unique taps',
+    () async {
+      listed = [_composite(), _composite(deviceId: 1003)];
+      service = build();
+      await service.scanForDevices();
+
+      final devices = await service.devices.first;
+      final ids = devices.map((d) => d.deviceId).toSet();
+      expect(ids, {_machineId, '$_tapId-1002', '$_tapId-1003'});
+      expect(ids.length, devices.length, reason: 'no duplicate logical IDs');
+    },
+  );
+
+  test('rescan of two same-serial boards adds no duplicates', () async {
+    listed = [_composite(), _composite(deviceId: 1003)];
+    service = build();
+    await service.scanForDevices();
+    await service.scanForDevices();
+
+    final devices = await service.devices.first;
+    final ids = devices.map((d) => d.deviceId).toSet();
+    expect(ids, {_machineId, '$_tapId-1002', '$_tapId-1003'});
+    expect(ids.length, devices.length, reason: 'no duplicate logical IDs');
+  });
+
+  test(
+    'detaching one same-serial board removes only its physical tap',
+    () async {
+      listed = [_composite(), _composite(deviceId: 1003)];
+      service = build();
+      await service.scanForDevices();
+
+      // Board 1002 owns the machine (first in enumeration); detaching it takes
+      // the machine and its tap, leaving the other board's tap untouched.
+      await service.handleUsbEvent(
+        UsbEvent()
+          ..event = UsbEvent.ACTION_USB_DETACHED
+          ..device = _composite(),
+      );
+
+      final devices = await service.devices.first;
+      expect(devices.map((d) => d.deviceId).toSet(), {'$_tapId-1003'});
+    },
+  );
+
+  test('detaching a non-owner board preserves the machine', () async {
+    listed = [_composite(), _composite(deviceId: 1003)];
+    service = build();
+    await service.scanForDevices();
+
+    // Board 1003 does not own the machine; detaching it removes only its tap.
+    await service.handleUsbEvent(
+      UsbEvent()
+        ..event = UsbEvent.ACTION_USB_DETACHED
+        ..device = _composite(deviceId: 1003),
+    );
+
+    final devices = await service.devices.first;
+    expect(devices.map((d) => d.deviceId).toSet(), {
+      _machineId,
+      '$_tapId-1002',
+    });
+  });
+
+  test('physical detach removes both logical devices', () async {
+    listed = [_composite()];
+    await service.scanForDevices();
+    final tap = (await service.devices.first).singleWhere(
+      (d) => d.deviceId == '$_tapId-1002',
+    );
+    final machine = (await service.devices.first).singleWhere(
+      (d) => d.deviceId == _machineId,
+    );
+    final machineDisconnectCalls = (machine as _FakeMachine).disconnectCalls;
+
+    await service.handleUsbEvent(
+      UsbEvent()
+        ..event = UsbEvent.ACTION_USB_DETACHED
+        ..device = _composite(),
+    );
+
+    final devices = await service.devices.first;
+    expect(devices, isEmpty);
+    expect(machine.disconnectCalls, machineDisconnectCalls + 1);
+    expect(await tap.connectionState.first, ConnectionState.disconnected);
+  });
+
+  test('physical orphan GC removes only the vanished board tap', () async {
+    listed = [_composite(), _composite(deviceId: 1003)];
+    service = build();
+    await service.scanForDevices();
+    for (final tap in (await service.devices.first).whereType<Sensor>()) {
+      await tap.onConnect();
+    }
+
+    // Board 1003 vanishes from enumeration without a detach event; both taps
+    // reduce to the same stable base, so only physical ownership can tell
+    // the surviving tap apart.
+    listed = [_composite()];
+    await service.scanForDevices();
+
+    final devices = await service.devices.first;
+    expect(devices.map((d) => d.deviceId).toSet(), {
+      _machineId,
+      '$_tapId-1002',
+    });
+  });
+
+  test(
+    'scan cleanup disposes the old tap adapter before replacement',
+    () async {
+      listed = [_composite()];
+      service = build();
+      await service.scanForDevices();
+      final tap = (await service.devices.first).singleWhere(
+        (d) => d.deviceId == '$_tapId-1002',
+      );
+      await tap.onConnect();
+      await tap.disconnect();
+      channelCalls.clear();
+
+      await service.scanForDevices();
+
+      expect(channelCalls, contains('close'));
+      final devices = await service.devices.first;
+      final replacement = devices.singleWhere(
+        (d) => d.deviceId == '$_tapId-1002',
+      );
+      expect(replacement, isNot(same(tap)));
+    },
+  );
+
+  test(
+    'detach without a physical ID does not remove unrelated devices',
+    () async {
+      listed = [
+        _composite(deviceId: null), // serial SERIAL, no physical ID
+        _composite(serial: 'OTHER-SERIAL', deviceId: null),
+      ];
+      service = build();
+      await service.scanForDevices();
+      expect(await service.devices.first, hasLength(4));
+
+      // The detach event carries no physical ID; the stable-ID fallback must
+      // only remove the detached serial's logical devices. Devices without
+      // physical ownership must not all match a null physical ID.
+      await service.handleUsbEvent(
+        UsbEvent()
+          ..event = UsbEvent.ACTION_USB_DETACHED
+          ..device = _composite(deviceId: null),
+      );
+
+      final devices = await service.devices.first;
+      expect(devices.map((d) => d.deviceId).toSet(), {
+        'usb-2e8a-a-OTHER-SERIAL',
+        'usb-2e8a-a-OTHER-SERIAL-if02',
+      });
+    },
+  );
+
+  test('tap transport asserts DTR on connect', () async {
+    listed = [_composite()];
+    await service.scanForDevices();
+    final tap = (await service.devices.first).singleWhere(
+      (d) => d.deviceId == '$_tapId-1002',
+    );
+
+    await tap.onConnect();
+
+    expect(channelCalls, contains('setDTR'));
+    expect(dtrValues, [true]);
+  });
+
+  test('service disposal closes the tap port and is idempotent', () async {
+    listed = [_composite()];
+    await service.scanForDevices();
+    final tap = (await service.devices.first).singleWhere(
+      (d) => d.deviceId == '$_tapId-1002',
+    );
+    await tap.onConnect();
+    channelCalls.clear();
+
+    await service.dispose();
+    expect(channelCalls, contains('close'));
+
+    await service.dispose();
+  });
+
+  test('stable ID helper matches the emitted tap ID', () {
+    expect(
+      computeUsbStableId(
+        vid: 0x2e8a,
+        pid: 0x000a,
+        serial: _serial,
+        interfaceNumber: 2,
+      ),
+      _tapId,
+    );
+  });
+
+  group('AndroidSerialPort text vs binary paths', () {
+    late List<MockStreamHandlerEventSink> sinks;
+    late AndroidSerialPort port;
+
+    setUp(() {
+      sinks = [];
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(const MethodChannel('test-port'), (
+        call,
+      ) async {
+        if (call.method == 'open' || call.method == 'close') return true;
+        return null;
+      });
+      messenger.setMockStreamHandler(
+        const EventChannel('test-port/stream'),
+        MockStreamHandler.inline(
+          onListen: (_, events) => sinks.add(events),
+          onCancel: (_) {},
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await port.dispose();
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(
+        const MethodChannel('test-port'),
+        null,
+      );
+      messenger.setMockStreamHandler(
+        const EventChannel('test-port/stream'),
+        null,
+      );
+    });
+
+    test(
+      'binary tap chunk reaches rawStream unchanged and skips text',
+      () async {
+        port = AndroidSerialPort(
+          device: _composite(),
+          port: UsbPort('test-port'),
+          decodeUtf8Text: false,
+        );
+        await port.connect();
+
+        // Capture the per-chunk decode-failure log the old tap path emitted.
+        final previousRootLevel = Logger.root.level;
+        Logger.root.level = Level.ALL;
+        addTearDown(() => Logger.root.level = previousRootLevel);
+        final records = <LogRecord>[];
+        final logSub = Logger.root.onRecord.listen(records.add);
+
+        final raw = <Uint8List>[];
+        final text = <String>[];
+        final rawSub = port.rawStream.listen(raw.add);
+        final textSub = port.readStream.listen(text.add);
+
+        final chunk = Uint8List.fromList([0x00, 0xFF, 0x0A, 0x12, 0x80]);
+        sinks.single.success(chunk);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(raw, [chunk]);
+        expect(text, isEmpty);
+        expect(
+          records.where(
+            (r) =>
+                r.loggerName.startsWith('Serial:') &&
+                r.error is FormatException,
+          ),
+          isEmpty,
+          reason: 'binary tap must never enter the UTF-8 decode/log path',
+        );
+        await logSub.cancel();
+        await rawSub.cancel();
+        await textSub.cancel();
+      },
+    );
+
+    test('default transport still decodes UTF-8 to readStream', () async {
+      port = AndroidSerialPort(
+        device: _composite(),
+        port: UsbPort('test-port'),
+      );
+      await port.connect();
+
+      final raw = <Uint8List>[];
+      final text = <String>[];
+      final rawSub = port.rawStream.listen(raw.add);
+      final textSub = port.readStream.listen(text.add);
+
+      final chunk = utf8.encode('Bengle machine ping\n');
+      sinks.single.success(chunk);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(raw, [chunk]);
+      expect(text, ['Bengle machine ping\n']);
+      await rawSub.cancel();
+      await textSub.cancel();
+    });
+  });
+}

--- a/test/services/serial/bengle_debug_port_android_test.dart
+++ b/test/services/serial/bengle_debug_port_android_test.dart
@@ -23,12 +23,13 @@ UsbDevice _composite({
   String? serial = _serial,
   int? deviceId = 1002,
   int? interfaceCount = 4,
+  String? productName = 'Bengle',
 }) {
   return UsbDevice(
     '/dev/bus/usb/001/002',
     vid,
     pid,
-    'Bengle',
+    productName,
     'Decent Espresso',
     deviceId,
     serial,
@@ -188,6 +189,30 @@ void main() {
 
     final devices = await service.devices.first;
     expect(devices, isEmpty);
+    expect(requestedInterface, isNull);
+  });
+
+  test(
+    'matching vid/pid/interface but wrong product name yields no tap',
+    () async {
+      // VID/PID are shared Pico SDK identifiers; only the exact product name
+      // `Bengle` exposes the tap. A Pico board with the same IDs and interface
+      // layout must not open the tap data interface.
+      listed = [_composite(productName: 'Pico')];
+      await service.scanForDevices();
+
+      final devices = await service.devices.first;
+      expect(devices.map((d) => d.deviceId), [_machineId]);
+      expect(requestedInterface, isNull);
+    },
+  );
+
+  test('null product name yields no tap', () async {
+    listed = [_composite(productName: null)];
+    await service.scanForDevices();
+
+    final devices = await service.devices.first;
+    expect(devices.map((d) => d.deviceId), [_machineId]);
     expect(requestedInterface, isNull);
   });
 

--- a/test/services/serial/usb_attach_event_test.dart
+++ b/test/services/serial/usb_attach_event_test.dart
@@ -47,7 +47,7 @@ void main() {
 
   test('attach emits a non-replaying hint with available metadata', () async {
     final event = service.deviceAttached.first;
-    service.handleUsbEvent(
+    await service.handleUsbEvent(
       _event(UsbEvent.ACTION_USB_ATTACHED, device: _device()),
     );
 
@@ -68,16 +68,16 @@ void main() {
       final events = <DeviceAttachedEvent>[];
       final subscription = service.deviceAttached.listen(events.add);
 
-      service.handleUsbEvent(
+      await service.handleUsbEvent(
         _event(UsbEvent.ACTION_USB_ATTACHED, device: _device(serial: null)),
       );
-      service.handleUsbEvent(
+      await service.handleUsbEvent(
         _event(
           UsbEvent.ACTION_USB_ATTACHED,
           device: _device(vid: null, pid: null, serial: null),
         ),
       );
-      service.handleUsbEvent(_event(UsbEvent.ACTION_USB_ATTACHED));
+      await service.handleUsbEvent(_event(UsbEvent.ACTION_USB_ATTACHED));
       await Future<void>.delayed(Duration.zero);
 
       expect(events, hasLength(3));
@@ -89,7 +89,7 @@ void main() {
 
   test('device support is not filtered by the attach notifier', () async {
     final event = service.deviceAttached.first;
-    service.handleUsbEvent(
+    await service.handleUsbEvent(
       _event(
         UsbEvent.ACTION_USB_ATTACHED,
         device: UsbDevice(
@@ -112,10 +112,10 @@ void main() {
     final events = <DeviceAttachedEvent>[];
     final subscription = service.deviceAttached.listen(events.add);
 
-    service.handleUsbEvent(
+    await service.handleUsbEvent(
       _event(UsbEvent.ACTION_USB_DETACHED, device: _device()),
     );
-    service.handleUsbEvent(_event('unknown'));
+    await service.handleUsbEvent(_event('unknown'));
     await Future<void>.delayed(Duration.zero);
 
     expect(events, isEmpty);

--- a/test/unit/models/device/impl/sensor/bengle_debug_port_test.dart
+++ b/test/unit/models/device/impl/sensor/bengle_debug_port_test.dart
@@ -1,0 +1,324 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/impl/sensor/bengle_debug_port.dart';
+import 'package:reaprime/src/models/device/transport/serial_port.dart';
+import 'package:rxdart/rxdart.dart';
+
+class _FakeSerialTransport extends SerialTransport {
+  final BehaviorSubject<ConnectionState> _connection = BehaviorSubject.seeded(
+    ConnectionState.discovered,
+  );
+  final BehaviorSubject<Uint8List> _raw = BehaviorSubject<Uint8List>();
+  final List<Uint8List> writes = [];
+  List<Uint8List> emitDuringConnect = const [];
+  int connectCalls = 0;
+  int disconnectCalls = 0;
+  bool failConnect = false;
+
+  @override
+  String get id => 'usb-2e8a-a-SERIAL-if02';
+
+  @override
+  String get name => 'tap';
+
+  @override
+  Stream<ConnectionState> get connectionState => _connection.stream;
+
+  @override
+  Stream<Uint8List> get rawStream => _raw.stream;
+
+  @override
+  Stream<String> get readStream => const Stream.empty();
+
+  @override
+  Future<void> connect() async {
+    connectCalls++;
+    if (failConnect) throw Exception('connect failed');
+    for (final chunk in emitDuringConnect) {
+      _raw.add(chunk);
+    }
+    _connection.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+    _connection.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> writeCommand(String command) async {
+    fail('writeCommand must never be called on the EBus tap');
+  }
+
+  @override
+  Future<void> writeHexCommand(Uint8List command) async {
+    writes.add(Uint8List.fromList(command));
+  }
+}
+
+void main() {
+  late _FakeSerialTransport transport;
+  late BengleDebugPort sensor;
+
+  setUp(() {
+    transport = _FakeSerialTransport();
+    sensor = BengleDebugPort(transport: transport);
+  });
+
+  group('raw byte preservation', () {
+    test('arbitrary binary chunks round-trip exactly through base64', () async {
+      final chunks = <Uint8List>[
+        Uint8List.fromList([0x00, 0xFF, 0x0A, 0x12]), // NUL, invalid UTF-8, LF
+        Uint8List.fromList([0x34]),
+        Uint8List.fromList([0x56, 0x78, 0x00, 0x80, 0x81]), // split part 2
+        Uint8List.fromList([0x0D, 0x0A, 0x00]),
+      ];
+      await sensor.onConnect();
+
+      final snapshots = <Map<String, dynamic>>[];
+      final sub = sensor.data.listen(snapshots.add);
+      for (final chunk in chunks) {
+        transport._raw.add(chunk);
+      }
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(snapshots, hasLength(chunks.length));
+      for (var i = 0; i < chunks.length; i++) {
+        final bytes = base64Decode(snapshots[i]['bytes'] as String);
+        expect(bytes, chunks[i], reason: 'chunk $i must be preserved');
+        expect(snapshots[i]['timestamp'], isA<String>());
+      }
+    });
+
+    test('chunks stay separate events in arrival order', () async {
+      await sensor.onConnect();
+      final snapshots = <Map<String, dynamic>>[];
+      final sub = sensor.data.listen(snapshots.add);
+      transport._raw.add(Uint8List.fromList([0x01]));
+      transport._raw.add(Uint8List.fromList([0x02, 0x03]));
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(
+        snapshots.map((s) => base64Decode(s['bytes'] as String)).toList(),
+        [
+          Uint8List.fromList([0x01]),
+          Uint8List.fromList([0x02, 0x03]),
+        ],
+      );
+    });
+
+    test('new subscribers do not receive previously emitted chunks', () async {
+      await sensor.onConnect();
+      transport._raw.add(Uint8List.fromList([0x01]));
+      await Future<void>.delayed(Duration.zero);
+
+      final lateSnapshots = <Map<String, dynamic>>[];
+      final sub = sensor.data.listen(lateSnapshots.add);
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(
+        lateSnapshots,
+        isEmpty,
+        reason: 'raw chunks are events, not state',
+      );
+    });
+  });
+
+  group('write command', () {
+    test('writes decoded bytes unchanged', () async {
+      final bytes = Uint8List.fromList([0x00, 0xDE, 0xAD, 0x0A, 0xFF]);
+      final result = await sensor.execute('write', {
+        'bytes': base64Encode(bytes),
+      });
+
+      expect(transport.writes, hasLength(1));
+      expect(transport.writes.single, bytes);
+      expect(result, {'bytesWritten': bytes.length});
+    });
+
+    test('invalid command id writes nothing', () async {
+      await expectLater(
+        sensor.execute('input', {
+          'bytes': base64Encode([0x01]),
+        }),
+        throwsA(anything),
+      );
+      expect(transport.writes, isEmpty);
+    });
+
+    test('invalid base64 writes nothing', () async {
+      await expectLater(
+        sensor.execute('write', {'bytes': 'not base64 !!!'}),
+        throwsA(isA<FormatException>()),
+      );
+      expect(transport.writes, isEmpty);
+    });
+
+    test('missing or non-string bytes writes nothing', () async {
+      await expectLater(sensor.execute('write', {}), throwsA(anything));
+      await expectLater(
+        sensor.execute('write', {'bytes': 42}),
+        throwsA(anything),
+      );
+      expect(transport.writes, isEmpty);
+    });
+  });
+
+  group('lifecycle', () {
+    test('chunks emitted synchronously during connect are not lost', () async {
+      transport.emitDuringConnect = [
+        Uint8List.fromList([0x42]),
+      ];
+      final snapshots = <Map<String, dynamic>>[];
+      final sub = sensor.data.listen(snapshots.add);
+
+      await sensor.onConnect();
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(snapshots, hasLength(1));
+      expect(base64Decode(snapshots.single['bytes'] as String), [0x42]);
+    });
+
+    test('connect failure cancels the subscription and rethrows', () async {
+      transport.failConnect = true;
+      await expectLater(sensor.onConnect(), throwsA(isA<Exception>()));
+
+      final snapshots = <Map<String, dynamic>>[];
+      final sub = sensor.data.listen(snapshots.add);
+      transport._raw.add(Uint8List.fromList([0x01]));
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+      expect(snapshots, isEmpty, reason: 'subscription must be cancelled');
+    });
+
+    test('concurrent onConnect calls share one transport connect', () async {
+      final first = sensor.onConnect();
+      final second = sensor.onConnect();
+      await Future.wait([first, second]);
+
+      expect(transport.connectCalls, 1);
+      expect(await sensor.connectionState.first, ConnectionState.connected);
+    });
+
+    test(
+      'one raw chunk after concurrent connects yields one snapshot',
+      () async {
+        final first = sensor.onConnect();
+        final second = sensor.onConnect();
+        await Future.wait([first, second]);
+
+        final snapshots = <Map<String, dynamic>>[];
+        final sub = sensor.data.listen(snapshots.add);
+        final chunk = Uint8List.fromList([0x00, 0xFF, 0x0A, 0x42]);
+        transport._raw.add(chunk);
+        await Future<void>.delayed(Duration.zero);
+        await sub.cancel();
+
+        expect(snapshots, hasLength(1));
+        expect(base64Decode(snapshots.single['bytes'] as String), chunk);
+      },
+    );
+
+    test(
+      'failed shared connect clears in-flight state and retry succeeds',
+      () async {
+        transport.failConnect = true;
+        final first = sensor.onConnect();
+        final second = sensor.onConnect();
+        await expectLater(
+          Future.wait([first, second]),
+          throwsA(isA<Exception>()),
+        );
+        expect(transport.connectCalls, 1);
+
+        transport.failConnect = false;
+        await sensor.onConnect();
+        expect(transport.connectCalls, 2);
+
+        // No leaked duplicate subscriptions from the failed attempt.
+        final snapshots = <Map<String, dynamic>>[];
+        final sub = sensor.data.listen(snapshots.add);
+        transport._raw.add(Uint8List.fromList([0x01]));
+        await Future<void>.delayed(Duration.zero);
+        await sub.cancel();
+        expect(snapshots, hasLength(1));
+      },
+    );
+
+    test('onConnect is idempotent', () async {
+      await sensor.onConnect();
+      await sensor.onConnect();
+      expect(transport.connectCalls, 1);
+      expect(await sensor.connectionState.first, ConnectionState.connected);
+    });
+
+    test('disconnect is idempotent and cancels the subscription', () async {
+      await sensor.onConnect();
+      final snapshots = <Map<String, dynamic>>[];
+      final sub = sensor.data.listen(snapshots.add);
+      await Future<void>.delayed(Duration.zero);
+
+      await sensor.disconnect();
+      await sensor.disconnect();
+      expect(transport.disconnectCalls, 1);
+      expect(await sensor.connectionState.first, ConnectionState.disconnected);
+
+      transport._raw.add(Uint8List.fromList([0x01]));
+      await Future<void>.delayed(Duration.zero);
+      expect(snapshots, isEmpty, reason: 'no events after disconnect');
+      await sub.cancel();
+    });
+
+    test('reconnects after disconnect', () async {
+      await sensor.onConnect();
+      await sensor.disconnect();
+      await sensor.onConnect();
+      expect(transport.connectCalls, 2);
+      expect(await sensor.connectionState.first, ConnectionState.connected);
+    });
+
+    test('transport error surfaces as disconnected', () async {
+      await sensor.onConnect();
+      transport._raw.addError(Exception('port died'));
+      await Future<void>.delayed(Duration.zero);
+      expect(await sensor.connectionState.first, ConnectionState.disconnected);
+    });
+
+    test('transport onDone surfaces as disconnected', () async {
+      await sensor.onConnect();
+      await transport._raw.close();
+      await Future<void>.delayed(Duration.zero);
+      expect(await sensor.connectionState.first, ConnectionState.disconnected);
+    });
+  });
+
+  group('contract', () {
+    test('exposes the Bengle EBus Tap manifest', () {
+      expect(sensor.deviceId, 'usb-2e8a-a-SERIAL-if02');
+      expect(sensor.name, 'Bengle EBus Tap');
+      expect(sensor.implementation, DeviceImplementation.bengleDebugPort);
+      expect(sensor.type, DeviceType.sensor);
+
+      final info = sensor.info.toJson();
+      expect(info['name'], 'Bengle EBus Tap');
+      expect(info['vendor'], 'Decent Espresso');
+      expect(info['data'], [
+        {'key': 'bytes', 'type': 'string', 'unit': 'base64'},
+      ]);
+      expect((info['commands'] as List).single['id'], 'write');
+    });
+  });
+}

--- a/test/unit/services/device_factory_test.dart
+++ b/test/unit/services/device_factory_test.dart
@@ -271,6 +271,13 @@ void main() {
         DeviceFactory.createBle(DeviceImplementation.sensorBasket, transport),
         isNull,
       );
+      expect(
+        DeviceFactory.createBle(
+          DeviceImplementation.bengleDebugPort,
+          transport,
+        ),
+        isNull,
+      );
     });
   });
 
@@ -303,6 +310,16 @@ void main() {
       );
       expect(device, isNotNull);
       expect(device!.implementation, DeviceImplementation.sensorBasket);
+    });
+
+    test('bengleDebugPort returns BengleDebugPort', () {
+      final device = DeviceFactory.createSerial(
+        DeviceImplementation.bengleDebugPort,
+        transport,
+      );
+      expect(device, isNotNull);
+      expect(device!.implementation, DeviceImplementation.bengleDebugPort);
+      expect(device.transportType, TransportType.serial);
     });
 
     test('unifiedDe1 returns UnifiedDe1 (serial DE1)', () {

--- a/test/unit/services/serial/bengle_ebus_tap_identity_test.dart
+++ b/test/unit/services/serial/bengle_ebus_tap_identity_test.dart
@@ -6,44 +6,126 @@ void main() {
   group('isBengleEbusTap', () {
     test('exact tap identity is accepted', () {
       expect(
-        isBengleEbusTap(vid: 0x2e8a, pid: 0x000a, interfaceNumber: 2),
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceNumber: 2,
+          productName: 'Bengle',
+        ),
         isTrue,
       );
     });
 
     test('interface 0 (machine) is rejected and keeps its identity', () {
       expect(
-        isBengleEbusTap(vid: 0x2e8a, pid: 0x000a, interfaceNumber: 0),
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceNumber: 0,
+          productName: 'Bengle',
+        ),
         isFalse,
       );
       expect(
-        isBengleEbusTap(vid: 0x2e8a, pid: 0x000a, interfaceNumber: 1),
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceNumber: 1,
+          productName: 'Bengle',
+        ),
         isFalse,
       );
     });
 
     test('missing metadata is rejected', () {
       expect(
-        isBengleEbusTap(vid: null, pid: 0x000a, interfaceNumber: 2),
+        isBengleEbusTap(
+          vid: null,
+          pid: 0x000a,
+          interfaceNumber: 2,
+          productName: 'Bengle',
+        ),
         isFalse,
       );
       expect(
-        isBengleEbusTap(vid: 0x2e8a, pid: null, interfaceNumber: 2),
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: null,
+          interfaceNumber: 2,
+          productName: 'Bengle',
+        ),
         isFalse,
       );
       expect(
-        isBengleEbusTap(vid: 0x2e8a, pid: 0x000a, interfaceNumber: null),
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceNumber: null,
+          productName: 'Bengle',
+        ),
+        isFalse,
+      );
+      expect(
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceNumber: 2,
+          productName: null,
+        ),
         isFalse,
       );
     });
 
     test('wrong vid or pid is rejected', () {
       expect(
-        isBengleEbusTap(vid: 0x1a86, pid: 0x000a, interfaceNumber: 2),
+        isBengleEbusTap(
+          vid: 0x1a86,
+          pid: 0x000a,
+          interfaceNumber: 2,
+          productName: 'Bengle',
+        ),
         isFalse,
       );
       expect(
-        isBengleEbusTap(vid: 0x2e8a, pid: 0x7522, interfaceNumber: 2),
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x7522,
+          interfaceNumber: 2,
+          productName: 'Bengle',
+        ),
+        isFalse,
+      );
+    });
+
+    test('matching vid/pid/interface but wrong product name is rejected', () {
+      // VID/PID are shared Pico SDK identifiers; a Pico board with the same
+      // IDs and a tap-like interface layout must not be treated as the tap.
+      expect(
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceNumber: 2,
+          productName: 'Pico',
+        ),
+        isFalse,
+      );
+      expect(
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceNumber: 2,
+          productName: 'DE1',
+        ),
+        isFalse,
+      );
+      // Product matching is exact: no case-insensitive fallback.
+      expect(
+        isBengleEbusTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceNumber: 2,
+          productName: 'bengle',
+        ),
         isFalse,
       );
     });
@@ -52,20 +134,35 @@ void main() {
   group('isBengleCompositeWithTap', () {
     test('composite with the tap data interface present exposes the tap', () {
       expect(
-        isBengleCompositeWithTap(vid: 0x2e8a, pid: 0x000a, interfaceCount: 4),
+        isBengleCompositeWithTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceCount: 4,
+          productName: 'Bengle',
+        ),
         isTrue,
       );
     });
 
     test('device without the tap data interface yields no tap', () {
       expect(
-        isBengleCompositeWithTap(vid: 0x2e8a, pid: 0x000a, interfaceCount: 1),
+        isBengleCompositeWithTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceCount: 1,
+          productName: 'Bengle',
+        ),
         isFalse,
       );
       // Interfaces 0..2 only: the Linux tap control interface exists but the
       // Android bulk-data interface 3 does not, so the tap cannot open.
       expect(
-        isBengleCompositeWithTap(vid: 0x2e8a, pid: 0x000a, interfaceCount: 3),
+        isBengleCompositeWithTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceCount: 3,
+          productName: 'Bengle',
+        ),
         isFalse,
       );
       expect(
@@ -73,6 +170,7 @@ void main() {
           vid: 0x2e8a,
           pid: 0x000a,
           interfaceCount: null,
+          productName: 'Bengle',
         ),
         isFalse,
       );
@@ -80,10 +178,48 @@ void main() {
 
     test('unrelated composite devices yield no tap', () {
       expect(
-        isBengleCompositeWithTap(vid: 0x046d, pid: 0xc31c, interfaceCount: 4),
+        isBengleCompositeWithTap(
+          vid: 0x046d,
+          pid: 0xc31c,
+          interfaceCount: 4,
+          productName: 'Bengle',
+        ),
         isFalse,
       );
     });
+
+    test(
+      'matching vid/pid/interface count but wrong product name is rejected',
+      () {
+        expect(
+          isBengleCompositeWithTap(
+            vid: 0x2e8a,
+            pid: 0x000a,
+            interfaceCount: 4,
+            productName: 'Pico',
+          ),
+          isFalse,
+        );
+        expect(
+          isBengleCompositeWithTap(
+            vid: 0x2e8a,
+            pid: 0x000a,
+            interfaceCount: 4,
+            productName: 'Other',
+          ),
+          isFalse,
+        );
+        expect(
+          isBengleCompositeWithTap(
+            vid: 0x2e8a,
+            pid: 0x000a,
+            interfaceCount: 4,
+            productName: null,
+          ),
+          isFalse,
+        );
+      },
+    );
   });
 
   group('computeUsbStableId with interface', () {

--- a/test/unit/services/serial/bengle_ebus_tap_identity_test.dart
+++ b/test/unit/services/serial/bengle_ebus_tap_identity_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/serial/usb_ids.dart';
+import 'package:reaprime/src/services/serial/utils.dart';
+
+void main() {
+  group('isBengleEbusTap', () {
+    test('exact tap identity is accepted', () {
+      expect(
+        isBengleEbusTap(vid: 0x2e8a, pid: 0x000a, interfaceNumber: 2),
+        isTrue,
+      );
+    });
+
+    test('interface 0 (machine) is rejected and keeps its identity', () {
+      expect(
+        isBengleEbusTap(vid: 0x2e8a, pid: 0x000a, interfaceNumber: 0),
+        isFalse,
+      );
+      expect(
+        isBengleEbusTap(vid: 0x2e8a, pid: 0x000a, interfaceNumber: 1),
+        isFalse,
+      );
+    });
+
+    test('missing metadata is rejected', () {
+      expect(
+        isBengleEbusTap(vid: null, pid: 0x000a, interfaceNumber: 2),
+        isFalse,
+      );
+      expect(
+        isBengleEbusTap(vid: 0x2e8a, pid: null, interfaceNumber: 2),
+        isFalse,
+      );
+      expect(
+        isBengleEbusTap(vid: 0x2e8a, pid: 0x000a, interfaceNumber: null),
+        isFalse,
+      );
+    });
+
+    test('wrong vid or pid is rejected', () {
+      expect(
+        isBengleEbusTap(vid: 0x1a86, pid: 0x000a, interfaceNumber: 2),
+        isFalse,
+      );
+      expect(
+        isBengleEbusTap(vid: 0x2e8a, pid: 0x7522, interfaceNumber: 2),
+        isFalse,
+      );
+    });
+  });
+
+  group('isBengleCompositeWithTap', () {
+    test('composite with the tap data interface present exposes the tap', () {
+      expect(
+        isBengleCompositeWithTap(vid: 0x2e8a, pid: 0x000a, interfaceCount: 4),
+        isTrue,
+      );
+    });
+
+    test('device without the tap data interface yields no tap', () {
+      expect(
+        isBengleCompositeWithTap(vid: 0x2e8a, pid: 0x000a, interfaceCount: 1),
+        isFalse,
+      );
+      // Interfaces 0..2 only: the Linux tap control interface exists but the
+      // Android bulk-data interface 3 does not, so the tap cannot open.
+      expect(
+        isBengleCompositeWithTap(vid: 0x2e8a, pid: 0x000a, interfaceCount: 3),
+        isFalse,
+      );
+      expect(
+        isBengleCompositeWithTap(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          interfaceCount: null,
+        ),
+        isFalse,
+      );
+    });
+
+    test('unrelated composite devices yield no tap', () {
+      expect(
+        isBengleCompositeWithTap(vid: 0x046d, pid: 0xc31c, interfaceCount: 4),
+        isFalse,
+      );
+    });
+  });
+
+  group('computeUsbStableId with interface', () {
+    test('interface 2 appends a zero-padded -if02 suffix', () {
+      expect(
+        computeUsbStableId(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          serial: 'ABC123',
+          interfaceNumber: 2,
+        ),
+        equals('usb-2e8a-a-ABC123-if02'),
+      );
+    });
+
+    test('interface 0 and absent interface preserve existing IDs', () {
+      expect(
+        computeUsbStableId(
+          vid: 0x2e8a,
+          pid: 0x000a,
+          serial: 'ABC123',
+          interfaceNumber: 0,
+        ),
+        equals('usb-2e8a-a-ABC123'),
+      );
+      expect(
+        computeUsbStableId(vid: 0x2e8a, pid: 0x000a, serial: 'ABC123'),
+        equals('usb-2e8a-a-ABC123'),
+      );
+    });
+  });
+
+  group('withoutUsbInterfaceSuffix', () {
+    test('strips the tap suffix back to the physical device ID', () {
+      expect(
+        withoutUsbInterfaceSuffix('usb-2e8a-a-ABC123-if02'),
+        equals('usb-2e8a-a-ABC123'),
+      );
+      expect(
+        withoutUsbInterfaceSuffix('usb-2e8a-a-ABC123-if02-1003'),
+        equals('usb-2e8a-a-ABC123'),
+      );
+    });
+
+    test('returns suffix-free IDs unchanged', () {
+      expect(
+        withoutUsbInterfaceSuffix('usb-2e8a-a-ABC123'),
+        equals('usb-2e8a-a-ABC123'),
+      );
+      expect(
+        withoutUsbInterfaceSuffix('serial-ttyACM0'),
+        equals('serial-ttyACM0'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- expose the supported Bengle USB tap through the existing Sensor API
- preserve raw bytes for snapshot and write operations
- support desktop and Android discovery while preserving existing machine identity
- handle duplicate USB descriptors using physical ownership

## Safety

- discovery uses explicit USB identity and does not actively probe the tap
- binary transport has single-reader connection semantics and skips text decoding
- no protocol parsing, capture, compression, or upload behavior is included

## Validation

- `flutter analyze`
- focused Sensor, serial discovery, identity, and factory tests
- full `flutter test`: 3777 passed, 1 skipped
- Android hardware validated; additional hardware details available out of band
