### PR TITLE
chore: bump dart_js

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -619,8 +619,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "6348eae"
-      resolved-ref: "6348eae3d7627109bd8555214feb9ed6541953d7"
+      ref: ce2edeb
+      resolved-ref: ce2edeb2f3ab705c4d6c94a42b1af663750ea9b8
       url: "https://github.com/tadelv/dart_js"
     source: git
     version: "0.8.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,7 +85,7 @@ dependencies:
     # path: ../dart_js
     git:
       url: https://github.com/tadelv/dart_js
-      ref: 6348eae
+      ref: ce2edeb
   firebase_core: ^4.3.0
   firebase_crashlytics: ^5.0.6
   firebase_performance: ^0.11.1+3


### PR DESCRIPTION
What changed, and why?

- bump dart_js to latest commit, using QJS 2025 

improves memory usage on Android
