### PR TITLE
feat(scale): add Timemore Link BLE scale support

### DIFF
--- a/lib/src/models/device/device_implementation.dart
+++ b/lib/src/models/device/device_implementation.dart
@@ -16,6 +16,7 @@ enum DeviceImplementation {
   hiroiaScale,
   atomheartScale,
   weighMasterScale,
+  timemoreScale,
   decentTemp,
   difluidR2Sensor,
   debugPort,

--- a/lib/src/models/device/impl/timemore/timemore_scale.dart
+++ b/lib/src/models/device/impl/timemore/timemore_scale.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/ble_service_identifier.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:rxdart/subjects.dart';
+
+import 'package:reaprime/src/models/device/device.dart';
+import '../../scale.dart';
+
+// Timemore Link scale BLE protocol.
+//
+// Service UUID  : 0000fff0-0000-1000-8000-00805f9b34fb
+// Notify char   : 0000fff1-0000-1000-8000-00805f9b34fb  (weight notifications)
+// Write char    : 0000fff2-0000-1000-8000-00805f9b34fb  (commands)
+//
+// Notify packet layout (type=0x01):
+//   [0] 0xA5  [1] 0x5A  [2] type  [3] stat
+//   [4..7] varies  [8] wHigh  [9] wLow  ...
+//   weight = signed_int16(bytes[8], bytes[9]) / 10.0  (grams)
+//
+// Commands use CRC-16/MODBUS appended as two big-endian bytes.
+// Advertising name prefix: "Basic3 Link"
+//
+// Protocol reverse-engineered from HCI snoop logs (12/12 verified).
+class TimemoreScale implements Scale {
+  final Logger _log = Logger('TimemoreScale');
+
+  static final BleServiceIdentifier serviceIdentifier =
+      BleServiceIdentifier.short('fff0');
+  static final BleServiceIdentifier _notifyCharacteristic =
+      BleServiceIdentifier.short('fff1');
+  static final BleServiceIdentifier _writeCharacteristic =
+      BleServiceIdentifier.short('fff2');
+
+  static const _packetHeader0 = 0xA5;
+  static const _packetHeader1 = 0x5A;
+  static const _typeWeight = 0x01;
+  static const _minPacketLength = 10;
+
+  final BLETransport _transport;
+  final StreamController<ScaleSnapshot> _streamController =
+      StreamController.broadcast();
+  final BehaviorSubject<ConnectionState> _connectionStateController =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+
+  TimemoreScale({required BLETransport transport}) : _transport = transport;
+
+  @override
+  String get deviceId => _transport.id;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.timemoreScale;
+
+  @override
+  TransportType get transportType => _transport.transportType;
+
+  @override
+  String get name => 'Timemore Link';
+
+  @override
+  DeviceType get type => DeviceType.scale;
+
+  @override
+  Stream<ScaleSnapshot> get currentSnapshot => _streamController.stream;
+
+  @override
+  Stream<ConnectionState> get connectionState =>
+      _connectionStateController.stream;
+
+  @override
+  Future<void> onConnect() async {
+    if (_connectionStateController.value == ConnectionState.connected &&
+        await _transport.connectionState.first == ConnectionState.connected) {
+      return;
+    }
+    _connectionStateController.add(ConnectionState.connecting);
+
+    StreamSubscription<ConnectionState>? disconnectSub;
+
+    try {
+      await _transport.connect();
+
+      disconnectSub = _transport.connectionState
+          .where((s) => s == ConnectionState.disconnected)
+          .listen((_) {
+            _connectionStateController.add(ConnectionState.disconnected);
+            disconnectSub?.cancel();
+          });
+
+      final services = await _transport.discoverServices();
+      if (!serviceIdentifier.matchesAny(services)) {
+        throw Exception(
+          'Expected service ${serviceIdentifier.long} not found. '
+          'Discovered: $services',
+        );
+      }
+
+      await _transport.subscribe(
+        serviceIdentifier.long,
+        _notifyCharacteristic.long,
+        _onNotification,
+      );
+
+      await _sendInitSequence();
+
+      _connectionStateController.add(ConnectionState.connected);
+    } catch (e) {
+      _log.warning('Connect failed: $e');
+      disconnectSub?.cancel();
+      _connectionStateController.add(ConnectionState.disconnected);
+      try {
+        await _transport.disconnect();
+      } catch (_) {}
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _transport.disconnect();
+  }
+
+  @override
+  Future<void> tare() async {
+    // Link tare: A5 5A 03 0D 00 02 00 00 + CRC16/MODBUS (2 bytes, big-endian)
+    // Precede with a 02-05 state query as observed in HCI snoop logs.
+    await _safeWrite(_linkQuery(0x05));
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    await _safeWrite(_withCrc([0xA5, 0x5A, 0x03, 0x0D, 0x00, 0x02, 0x00, 0x00]));
+  }
+
+  @override
+  Future<void> startTimer() async {
+    await _safeWrite(_withCrc([0xA5, 0x5A, 0x03, 0x02, 0x00, 0x01, 0x01]));
+  }
+
+  @override
+  Future<void> stopTimer() async {
+    await _safeWrite(_withCrc([0xA5, 0x5A, 0x03, 0x02, 0x00, 0x01, 0x02]));
+  }
+
+  @override
+  Future<void> resetTimer() async {
+    await _safeWrite(_withCrc([0xA5, 0x5A, 0x03, 0x02, 0x00, 0x01, 0x03]));
+  }
+
+  @override
+  Future<void> sleepDisplay() async {
+    await disconnect();
+  }
+
+  @override
+  Future<void> wakeDisplay() async {}
+
+  // Init sequence: query args 0x13, 0x08, 0x05, 0x02, 0x06, 0x0C
+  // Sent twice as observed in the reference implementation.
+  Future<void> _sendInitSequence() async {
+    const initArgs = [0x13, 0x08, 0x05, 0x02, 0x06, 0x0C];
+    for (final arg in initArgs) {
+      await _safeWrite(_linkQuery(arg));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    for (final arg in initArgs) {
+      await _safeWrite(_linkQuery(arg));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    // Follow-up 02-05 query observed after init in HCI logs.
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    await _safeWrite(_linkQuery(0x05));
+  }
+
+  void _onNotification(List<int> data) {
+    if (data.length < _minPacketLength) return;
+    if (data[0] != _packetHeader0 || data[1] != _packetHeader1) return;
+    if (data[2] != _typeWeight) return;
+
+    final rawWord = (data[8] << 8) | data[9];
+    // Treat as signed 16-bit.
+    final signed = rawWord > 32767 ? rawWord - 65536 : rawWord;
+    final weightGrams = signed / 10.0;
+
+    _streamController.add(
+      ScaleSnapshot(
+        timestamp: DateTime.now(),
+        weight: weightGrams,
+        batteryLevel: 0,
+      ),
+    );
+  }
+
+  Future<void> _safeWrite(List<int> bytes) async {
+    try {
+      await _transport.write(
+        serviceIdentifier.long,
+        _writeCharacteristic.long,
+        Uint8List.fromList(bytes),
+        withResponse: false,
+      );
+    } on DeviceNotConnectedException {
+      // Transport already emitted disconnected; nothing to do.
+    }
+  }
+
+  // Builds a Link query command: A5 5A 02 <arg> 00 00 + CRC16/MODBUS
+  List<int> _linkQuery(int arg) =>
+      _withCrc([0xA5, 0x5A, 0x02, arg, 0x00, 0x00]);
+
+  // Appends CRC-16/MODBUS checksum (big-endian) to payload.
+  List<int> _withCrc(List<int> payload) {
+    final crc = _crc16Modbus(payload);
+    return [...payload, (crc >> 8) & 0xFF, crc & 0xFF];
+  }
+
+  // CRC-16/MODBUS: poly 0xA001, init 0xFFFF, reflect in/out.
+  int _crc16Modbus(List<int> bytes) {
+    var crc = 0xFFFF;
+    for (final b in bytes) {
+      crc ^= b & 0xFF;
+      for (var i = 0; i < 8; i++) {
+        crc = (crc & 1) != 0 ? ((crc >> 1) ^ 0xA001) : (crc >> 1);
+      }
+    }
+    return crc & 0xFFFF;
+  }
+}

--- a/lib/src/models/device/impl/timemore/timemore_scale.dart
+++ b/lib/src/models/device/impl/timemore/timemore_scale.dart
@@ -11,21 +11,23 @@ import 'package:rxdart/subjects.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import '../../scale.dart';
 
-// Timemore Link scale BLE protocol.
+// Timemore scale BLE protocol (open-scale-protocol v1.0.3).
 //
 // Service UUID  : 0000fff0-0000-1000-8000-00805f9b34fb
-// Notify char   : 0000fff1-0000-1000-8000-00805f9b34fb  (weight notifications)
+// Notify char   : 0000fff1-0000-1000-8000-00805f9b34fb  (weight/flow/timer stream)
 // Write char    : 0000fff2-0000-1000-8000-00805f9b34fb  (commands)
 //
-// Notify packet layout (type=0x01):
-//   [0] 0xA5  [1] 0x5A  [2] type  [3] stat
-//   [4..7] varies  [8] wHigh  [9] wLow  ...
-//   weight = signed_int16(bytes[8], bytes[9]) / 10.0  (grams)
+// Frame layout:
+//   A5 5A | opcode | cmd | length(2, big-endian) | data | crc(2, big-endian)
+//   crc is CRC-16/MODBUS (poly 0x8005 reflected = 0xA001, init 0xFFFF).
 //
-// Commands use CRC-16/MODBUS appended as two big-endian bytes.
-// Advertising name prefix: "Basic3 Link"
+// Notify weight frame (opcode 0x01, cmd 0x01, length 0x0009):
+//   [6..9]   weight    Int32  BE  (divide by 10 -> grams)
+//   [10,11]  flow      Int16  BE  (divide by 10 -> grams/second)
+//   [12,13]  timer     UInt16 BE  (seconds)
+//   [14]     overload  UInt8      (1 = over limit)
 //
-// Protocol reverse-engineered from HCI snoop logs (12/12 verified).
+// Advertising name prefix: "Basic3 Link" (Link) or "TIMEMORE" (Dot family).
 class TimemoreScale implements Scale {
   final Logger _log = Logger('TimemoreScale');
 
@@ -36,16 +38,28 @@ class TimemoreScale implements Scale {
   static final BleServiceIdentifier _writeCharacteristic =
       BleServiceIdentifier.short('fff2');
 
-  static const _packetHeader0 = 0xA5;
-  static const _packetHeader1 = 0x5A;
-  static const _typeWeight = 0x01;
-  static const _minPacketLength = 10;
+  static const _header0 = 0xA5;
+  static const _header1 = 0x5A;
+
+  static const _opNotify = 0x01;
+  static const _opRead = 0x02;
+  static const _opWrite = 0x03;
+
+  static const _cmdWeightStream = 0x01;
+  static const _cmdTimer = 0x02;
+  static const _cmdBattery = 0x05;
+  static const _cmdTare = 0x0D;
+
+  static const _minFrameLength = 8;
+  static const _weightFrameLength = 17;
 
   final BLETransport _transport;
   final StreamController<ScaleSnapshot> _streamController =
       StreamController.broadcast();
   final BehaviorSubject<ConnectionState> _connectionStateController =
       BehaviorSubject.seeded(ConnectionState.discovered);
+
+  int _batteryLevel = 0;
 
   TimemoreScale({required BLETransport transport}) : _transport = transport;
 
@@ -125,26 +139,22 @@ class TimemoreScale implements Scale {
 
   @override
   Future<void> tare() async {
-    // Link tare: A5 5A 03 0D 00 02 00 00 + CRC16/MODBUS (2 bytes, big-endian)
-    // Precede with a 02-05 state query as observed in HCI snoop logs.
-    await _safeWrite(_linkQuery(0x05));
-    await Future<void>.delayed(const Duration(milliseconds: 150));
-    await _safeWrite(_withCrc([0xA5, 0x5A, 0x03, 0x0D, 0x00, 0x02, 0x00, 0x00]));
+    await _safeWrite(_frame(_opWrite, _cmdTare));
   }
 
   @override
   Future<void> startTimer() async {
-    await _safeWrite(_withCrc([0xA5, 0x5A, 0x03, 0x02, 0x00, 0x01, 0x01]));
+    await _safeWrite(_frame(_opWrite, _cmdTimer, const [0x01]));
   }
 
   @override
   Future<void> stopTimer() async {
-    await _safeWrite(_withCrc([0xA5, 0x5A, 0x03, 0x02, 0x00, 0x01, 0x02]));
+    await _safeWrite(_frame(_opWrite, _cmdTimer, const [0x02]));
   }
 
   @override
   Future<void> resetTimer() async {
-    await _safeWrite(_withCrc([0xA5, 0x5A, 0x03, 0x02, 0x00, 0x01, 0x03]));
+    await _safeWrite(_frame(_opWrite, _cmdTimer, const [0x03]));
   }
 
   @override
@@ -155,41 +165,45 @@ class TimemoreScale implements Scale {
   @override
   Future<void> wakeDisplay() async {}
 
-  // Init sequence: query args 0x13, 0x08, 0x05, 0x02, 0x06, 0x0C
-  // Sent twice as observed in the reference implementation.
+  // Query battery once on connect so snapshots carry a level.
   Future<void> _sendInitSequence() async {
-    const initArgs = [0x13, 0x08, 0x05, 0x02, 0x06, 0x0C];
-    for (final arg in initArgs) {
-      await _safeWrite(_linkQuery(arg));
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 200));
-    for (final arg in initArgs) {
-      await _safeWrite(_linkQuery(arg));
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-    }
-    // Follow-up 02-05 query observed after init in HCI logs.
-    await Future<void>.delayed(const Duration(milliseconds: 200));
-    await _safeWrite(_linkQuery(0x05));
+    await _safeWrite(_frame(_opRead, _cmdBattery));
   }
 
   void _onNotification(List<int> data) {
-    if (data.length < _minPacketLength) return;
-    if (data[0] != _packetHeader0 || data[1] != _packetHeader1) return;
-    if (data[2] != _typeWeight) return;
+    if (data.length < _minFrameLength) return;
+    if (data[0] != _header0 || data[1] != _header1) return;
 
-    final rawWord = (data[8] << 8) | data[9];
-    // Treat as signed 16-bit.
-    final signed = rawWord > 32767 ? rawWord - 65536 : rawWord;
-    final weightGrams = signed / 10.0;
+    final opcode = data[2];
+    final cmd = data[3];
 
-    _streamController.add(
-      ScaleSnapshot(
-        timestamp: DateTime.now(),
-        weight: weightGrams,
-        batteryLevel: 0,
-      ),
-    );
+    // Battery response: data = [bars, percent].
+    if (cmd == _cmdBattery && data.length >= 8) {
+      _batteryLevel = data[7];
+      return;
+    }
+
+    // Weight/flow/timer stream.
+    if (opcode == _opNotify &&
+        cmd == _cmdWeightStream &&
+        data.length >= _weightFrameLength) {
+      final bytes = Uint8List.fromList(data);
+      final view = ByteData.sublistView(bytes);
+
+      final weightGrams = view.getInt32(6, Endian.big) / 10.0;
+      final flowGramsPerSecond = view.getInt16(10, Endian.big) / 10.0;
+      final timerSeconds = view.getUint16(12, Endian.big);
+
+      _streamController.add(
+        ScaleSnapshot(
+          timestamp: DateTime.now(),
+          weight: weightGrams,
+          batteryLevel: _batteryLevel,
+          flow: flowGramsPerSecond,
+          timerValue: Duration(seconds: timerSeconds),
+        ),
+      );
+    }
   }
 
   Future<void> _safeWrite(List<int> bytes) async {
@@ -205,17 +219,22 @@ class TimemoreScale implements Scale {
     }
   }
 
-  // Builds a Link query command: A5 5A 02 <arg> 00 00 + CRC16/MODBUS
-  List<int> _linkQuery(int arg) =>
-      _withCrc([0xA5, 0x5A, 0x02, arg, 0x00, 0x00]);
-
-  // Appends CRC-16/MODBUS checksum (big-endian) to payload.
-  List<int> _withCrc(List<int> payload) {
+  // Builds a protocol frame with auto-computed length and CRC-16/MODBUS.
+  List<int> _frame(int opcode, int cmd, [List<int> data = const []]) {
+    final payload = <int>[
+      _header0,
+      _header1,
+      opcode,
+      cmd,
+      (data.length >> 8) & 0xFF,
+      data.length & 0xFF,
+      ...data,
+    ];
     final crc = _crc16Modbus(payload);
     return [...payload, (crc >> 8) & 0xFF, crc & 0xFF];
   }
 
-  // CRC-16/MODBUS: poly 0xA001, init 0xFFFF, reflect in/out.
+  // CRC-16/MODBUS: poly 0xA001 (reflected 0x8005), init 0xFFFF.
   int _crc16Modbus(List<int> bytes) {
     var crc = 0xFFFF;
     for (final b in bytes) {

--- a/lib/src/services/device_factory.dart
+++ b/lib/src/services/device_factory.dart
@@ -56,9 +56,7 @@ class DeviceFactory {
       DeviceImplementation.weighMasterScale => WeighMasterScale(
         transport: transport,
       ),
-      DeviceImplementation.timemoreScale => TimemoreScale(
-        transport: transport,
-      ),
+      DeviceImplementation.timemoreScale => TimemoreScale(transport: transport),
       DeviceImplementation.decentTemp => DecentTemp(transport: transport),
       DeviceImplementation.difluidR2Sensor => DifluidR2Sensor(
         transport: transport,

--- a/lib/src/services/device_factory.dart
+++ b/lib/src/services/device_factory.dart
@@ -20,6 +20,7 @@ import 'package:reaprime/src/models/device/impl/sensor/sensor_basket.dart';
 import 'package:reaprime/src/models/device/impl/skale/skale2_scale.dart';
 import 'package:reaprime/src/models/device/impl/smartchef/smartchef_scale.dart';
 import 'package:reaprime/src/models/device/impl/varia/varia_aku_scale.dart';
+import 'package:reaprime/src/models/device/impl/timemore/timemore_scale.dart';
 import 'package:reaprime/src/models/device/impl/weighmaster/weighmaster_scale.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/device/transport/serial_port.dart';
@@ -53,6 +54,9 @@ class DeviceFactory {
         transport: transport,
       ),
       DeviceImplementation.weighMasterScale => WeighMasterScale(
+        transport: transport,
+      ),
+      DeviceImplementation.timemoreScale => TimemoreScale(
         transport: transport,
       ),
       DeviceImplementation.decentTemp => DecentTemp(transport: transport),

--- a/lib/src/services/device_matcher.dart
+++ b/lib/src/services/device_matcher.dart
@@ -17,6 +17,7 @@ import 'package:reaprime/src/models/device/impl/skale/skale2_scale.dart';
 import 'package:reaprime/src/models/device/impl/smartchef/smartchef_scale.dart';
 import 'package:reaprime/src/models/device/impl/varia/varia_aku_scale.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/device/impl/timemore/timemore_scale.dart';
 import 'package:reaprime/src/models/device/impl/weighmaster/weighmaster_scale.dart';
 
 class DeviceMatcher {
@@ -34,6 +35,7 @@ class DeviceMatcher {
       HiroiaScale.serviceIdentifier.long,
       AtomheartScale.serviceIdentifier.long,
       WeighMasterScale.serviceIdentifier.long,
+      TimemoreScale.serviceIdentifier.long,
       ...AcaiaScale.advertisedServiceUuids,
     ],
     DeviceType.machine => [UnifiedDe1.advertisingIdentifier.long],
@@ -104,6 +106,10 @@ class DeviceMatcher {
     }
     if (name == 'WeighMaster Scale') {
       return DeviceImplementation.weighMasterScale;
+    }
+    if (nameLower.startsWith('basic3 link') ||
+        nameLower.startsWith('timemore')) {
+      return DeviceImplementation.timemoreScale;
     }
     return null;
   }
@@ -177,6 +183,10 @@ class DeviceMatcher {
     }
     if (name == 'WeighMaster Scale') {
       return WeighMasterScale(transport: transport);
+    }
+    if (nameLower.startsWith('basic3 link') ||
+        nameLower.startsWith('timemore')) {
+      return TimemoreScale(transport: transport);
     }
 
     return null;


### PR DESCRIPTION
## Summary

Adds support for the **Timemore Link** (Basic3 Link) BLE scale.

## Protocol Details

Protocol was reverse-engineered from HCI snoop logs (12/12 verified).

| | Value |
|---|---|
| BLE service UUID | \