### PR TITLE
feat(workflow): add water-volume stop override

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -7642,6 +7642,16 @@ components:
           nullable: true
           description: Target output weight in grams (beverage)
           example: 36.0
+        targetWaterVolume:
+          type: number
+          format: double
+          nullable: true
+          description: |
+            DE1-integrated machine water volume in milliliters. Overrides the
+            profile targetVolume only for the existing volumetric fallback when
+            no usable scale stop is available. Null inherits the profile target;
+            0 disables volumetric stopping for this workflow.
+          example: 55.0
         grinderId:
           type: string
           nullable: true

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -8,6 +8,10 @@ REA supports loading profiles to the espresso machine either directly through th
 
 The REA Profile data object definition lives in `lib/src/models/data/profile.dart`.
 
+## Workflow Final Targets
+
+`WorkflowContext.targetYield` is beverage output weight in grams and drives scale-based stop-at-weight. `WorkflowContext.targetWaterVolume` is DE1-integrated machine water volume in milliliters and overrides `Profile.targetVolume` only for the existing volumetric fallback when no usable scale stop is available. A null workflow water target inherits the profile target; `0` disables volumetric stopping for that workflow. These quantities are never converted or used as fallbacks for each other.
+
 Step transitions can be owned by either the DE1 firmware or the app. Firmware
 owns pressure/flow `exit` conditions because they are encoded into the profile
 sent to the machine. The app owns per-step `weight` exits because only the

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -398,6 +398,11 @@ class _MyAppState extends State<MyApp> {
                                   .context
                                   ?.targetYield ??
                               0,
+                          targetWaterVolume: widget
+                              .workflowController
+                              .currentWorkflow
+                              .context
+                              ?.targetWaterVolume,
                           bypassSAW:
                               widget.settingsController.gatewayMode ==
                               GatewayMode.full,

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -814,6 +814,8 @@ class De1StateManager with WidgetsBindingObserver {
       targetProfile: _workflowController.currentWorkflow.profile,
       targetYield:
           _workflowController.currentWorkflow.context?.targetYield ?? 0,
+      targetWaterVolume:
+          _workflowController.currentWorkflow.context?.targetWaterVolume,
       bypassSAW: _settingsController.gatewayMode == GatewayMode.full,
       blockOnNoScale: _settingsController.blockOnNoScale && !scalelessBeverage,
       weightFlowMultiplier: _settingsController.weightFlowMultiplier,

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -63,12 +63,14 @@ class ShotSequencer {
     required this.persistenceController,
     required this.targetProfile,
     required this.targetYield,
+    double? targetWaterVolume,
     required bool bypassSAW,
     required bool blockOnNoScale,
     required double weightFlowMultiplier,
     required double volumeFlowMultiplier,
     required bool stepExitArbiterEnabled,
-  }) : _bypassSAW = bypassSAW,
+  }) : targetWaterVolume = targetWaterVolume ?? targetProfile.targetVolume,
+       _bypassSAW = bypassSAW,
        _blockOnNoScale = blockOnNoScale,
        _weightFlowMultiplier = weightFlowMultiplier,
        _volumeFlowMultiplier = volumeFlowMultiplier,
@@ -193,6 +195,7 @@ class ShotSequencer {
   DateTime get shotStartTime => _shotStartTime;
 
   final double targetYield;
+  final double? targetWaterVolume;
   ShotState _state = ShotState.idle;
   bool _scaleLost = false;
   bool _scaleConnected = false;
@@ -457,19 +460,19 @@ class ShotSequencer {
         if (!_bypassSAW &&
             !_machineHasAutonomousSAW &&
             (scale == null || _scaleLost) &&
-            (targetProfile.targetVolume ?? 0) > 0) {
+            (targetWaterVolume ?? 0) > 0) {
           final projectedVolume =
               _accumulatedVolume + (machine.flow * _volumeFlowMultiplier);
-          if (projectedVolume > targetProfile.targetVolume!) {
+          if (projectedVolume > targetWaterVolume!) {
             _finalStopReason = ShotDecisionReason.targetVolume;
             _emitDecision(
               ShotDecisionKind.stop,
               ShotDecisionReason.targetVolume,
               details:
-                  'Target volume ${targetProfile.targetVolume}ml reached '
+                  'Target volume ${targetWaterVolume}ml reached '
                   '(projected: $projectedVolume). Stopping shot.',
               data: {
-                'targetVolume': targetProfile.targetVolume,
+                'targetVolume': targetWaterVolume,
                 'projectedVolume': projectedVolume,
               },
             );

--- a/lib/src/models/data/workflow_context.dart
+++ b/lib/src/models/data/workflow_context.dart
@@ -3,6 +3,7 @@ import 'package:reaprime/src/models/data/utils.dart';
 class WorkflowContext {
   final double? targetDoseWeight;
   final double? targetYield;
+  final double? targetWaterVolume;
 
   final String? grinderId;
   final String? grinderModel;
@@ -22,6 +23,7 @@ class WorkflowContext {
   const WorkflowContext({
     this.targetDoseWeight,
     this.targetYield,
+    this.targetWaterVolume,
     this.grinderId,
     this.grinderModel,
     this.grinderSetting,
@@ -43,6 +45,7 @@ class WorkflowContext {
     return WorkflowContext(
       targetDoseWeight: parseOptionalDouble(json['targetDoseWeight']),
       targetYield: parseOptionalDouble(json['targetYield']),
+      targetWaterVolume: parseOptionalDouble(json['targetWaterVolume']),
       grinderId: parseOptionalString(json['grinderId']),
       grinderModel: parseOptionalString(json['grinderModel']),
       grinderSetting: parseOptionalString(json['grinderSetting']),
@@ -60,6 +63,7 @@ class WorkflowContext {
     return {
       if (targetDoseWeight != null) 'targetDoseWeight': targetDoseWeight,
       if (targetYield != null) 'targetYield': targetYield,
+      if (targetWaterVolume != null) 'targetWaterVolume': targetWaterVolume,
       if (grinderId != null) 'grinderId': grinderId,
       if (grinderModel != null) 'grinderModel': grinderModel,
       if (grinderSetting != null) 'grinderSetting': grinderSetting,
@@ -76,6 +80,7 @@ class WorkflowContext {
   WorkflowContext clearGrinder() => WorkflowContext(
     targetDoseWeight: targetDoseWeight,
     targetYield: targetYield,
+    targetWaterVolume: targetWaterVolume,
     grinderId: null,
     grinderModel: null,
     grinderSetting: grinderSetting,
@@ -91,6 +96,7 @@ class WorkflowContext {
   WorkflowContext clearBeanBatch() => WorkflowContext(
     targetDoseWeight: targetDoseWeight,
     targetYield: targetYield,
+    targetWaterVolume: targetWaterVolume,
     grinderId: grinderId,
     grinderModel: grinderModel,
     grinderSetting: grinderSetting,
@@ -106,6 +112,8 @@ class WorkflowContext {
   WorkflowContext copyWith({
     double? targetDoseWeight,
     double? targetYield,
+    double? targetWaterVolume,
+    bool clearTargetWaterVolume = false,
     String? grinderId,
     String? grinderModel,
     String? grinderSetting,
@@ -120,6 +128,9 @@ class WorkflowContext {
     return WorkflowContext(
       targetDoseWeight: targetDoseWeight ?? this.targetDoseWeight,
       targetYield: targetYield ?? this.targetYield,
+      targetWaterVolume: clearTargetWaterVolume
+          ? null
+          : targetWaterVolume ?? this.targetWaterVolume,
       grinderId: grinderId ?? this.grinderId,
       grinderModel: grinderModel ?? this.grinderModel,
       grinderSetting: grinderSetting ?? this.grinderSetting,
@@ -145,6 +156,7 @@ class WorkflowContext {
     if (other is! WorkflowContext) return false;
     return other.targetDoseWeight == targetDoseWeight &&
         other.targetYield == targetYield &&
+        other.targetWaterVolume == targetWaterVolume &&
         other.grinderId == grinderId &&
         other.grinderModel == grinderModel &&
         other.grinderSetting == grinderSetting &&
@@ -161,6 +173,7 @@ class WorkflowContext {
   int get hashCode => Object.hash(
     targetDoseWeight,
     targetYield,
+    targetWaterVolume,
     grinderId,
     grinderModel,
     grinderSetting,

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -1901,6 +1901,7 @@ void main() {
     ShotSequencer makeSequencer({
       Profile? profile,
       double targetYield = 36.0,
+      double? targetWaterVolume,
       double volumeFlowMultiplier = 0.0,
     }) {
       return ShotSequencer(
@@ -1909,6 +1910,7 @@ void main() {
         persistenceController: persistenceController,
         targetProfile: profile ?? _simpleProfile(),
         targetYield: targetYield,
+        targetWaterVolume: targetWaterVolume,
         bypassSAW: false,
         blockOnNoScale: false,
         weightFlowMultiplier: 0.0,
@@ -1916,6 +1918,29 @@ void main() {
         stepExitArbiterEnabled: true,
       );
     }
+
+    Profile volumeProfile() => Profile(
+      version: '2',
+      title: 'Volume Profile',
+      notes: '',
+      author: 'test',
+      beverageType: BeverageType.espresso,
+      targetVolumeCountStart: 0,
+      tankTemperature: 0,
+      targetWeight: 0,
+      targetVolume: 50,
+      steps: [
+        ProfileStepPressure(
+          name: 'step1',
+          transition: TransitionType.fast,
+          volume: 0,
+          seconds: 30,
+          temperature: 93,
+          sensor: TemperatureSensor.coffee,
+          pressure: 9,
+        ),
+      ],
+    );
 
     void driveToPouring() {
       testDe1.emitStateAndSubstate(
@@ -1977,30 +2002,8 @@ void main() {
         'the shot', () {
       fakeAsync((async) {
         scaleController.simulateDisconnect();
-        final profile = Profile(
-          version: '2',
-          title: 'Volume Profile',
-          notes: '',
-          author: 'test',
-          beverageType: BeverageType.espresso,
-          targetVolumeCountStart: 0,
-          tankTemperature: 0,
-          targetWeight: 0,
-          targetVolume: 50,
-          steps: [
-            ProfileStepPressure(
-              name: 'step1',
-              transition: TransitionType.fast,
-              volume: 0,
-              seconds: 30,
-              temperature: 93,
-              sensor: TemperatureSensor.coffee,
-              pressure: 9,
-            ),
-          ],
-        );
         final sequencer = makeSequencer(
-          profile: profile,
+          profile: volumeProfile(),
           volumeFlowMultiplier: 1.0,
         );
         final decisions = <ShotDecision>[];
@@ -2017,8 +2020,132 @@ void main() {
           (d) => d.reason == ShotDecisionReason.targetVolume,
         );
         expect(stop.kind, ShotDecisionKind.stop);
+        expect(stop.data?['targetVolume'], 50.0);
         expect(sequencer.finalStopReason, ShotDecisionReason.targetVolume);
         expect(testDe1.requestedStates, contains(MachineState.idle));
+
+        sequencer.dispose();
+      });
+    });
+
+    test('workflow water-volume override replaces the profile fallback', () {
+      fakeAsync((async) {
+        scaleController.simulateDisconnect();
+        final sequencer = makeSequencer(
+          profile: volumeProfile(),
+          targetWaterVolume: 75,
+          volumeFlowMultiplier: 1.0,
+        );
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+
+        emitPouringFrame(0, flow: 60);
+        async.elapse(Duration(milliseconds: 10));
+        expect(
+          decisions.where((d) => d.reason == ShotDecisionReason.targetVolume),
+          isEmpty,
+        );
+
+        emitPouringFrame(0, flow: 80);
+        async.elapse(Duration(milliseconds: 10));
+
+        final stop = decisions.singleWhere(
+          (d) => d.reason == ShotDecisionReason.targetVolume,
+        );
+        expect(stop.data?['targetVolume'], 75.0);
+
+        sequencer.dispose();
+      });
+    });
+
+    test('zero workflow water volume disables the profile fallback', () {
+      fakeAsync((async) {
+        scaleController.simulateDisconnect();
+        final sequencer = makeSequencer(
+          profile: volumeProfile(),
+          targetWaterVolume: 0,
+          volumeFlowMultiplier: 1.0,
+        );
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+        emitPouringFrame(0, flow: 100);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          decisions.where((d) => d.reason == ShotDecisionReason.targetVolume),
+          isEmpty,
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('target yield never becomes a volumetric fallback', () {
+      fakeAsync((async) {
+        scaleController.simulateDisconnect();
+        final sequencer = makeSequencer(
+          targetYield: 36,
+          volumeFlowMultiplier: 1.0,
+        );
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+        emitPouringFrame(0, flow: 100);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          decisions.where((d) => d.reason == ShotDecisionReason.targetVolume),
+          isEmpty,
+        );
+
+        sequencer.dispose();
+      });
+    });
+
+    test('workflow water volume activates only after scale loss', () {
+      fakeAsync((async) {
+        scaleController.emitWeight(0);
+        final sequencer = makeSequencer(
+          profile: volumeProfile(),
+          targetYield: 36,
+          targetWaterVolume: 55,
+          volumeFlowMultiplier: 1.0,
+        );
+        final decisions = <ShotDecision>[];
+        sequencer.decisions.listen(decisions.add);
+
+        async.elapse(Duration(milliseconds: 10));
+        driveToPouring();
+        async.elapse(Duration(milliseconds: 10));
+        emitPouringFrame(0, flow: 60);
+        async.elapse(Duration(milliseconds: 10));
+        expect(
+          decisions.where((d) => d.reason == ShotDecisionReason.targetVolume),
+          isEmpty,
+        );
+
+        scaleController.simulateDisconnect();
+        async.elapse(Duration(milliseconds: 10));
+        emitPouringFrame(0, flow: 60);
+        async.elapse(Duration(milliseconds: 10));
+
+        expect(
+          decisions
+              .singleWhere((d) => d.reason == ShotDecisionReason.targetVolume)
+              .data?['targetVolume'],
+          55.0,
+        );
 
         sequencer.dispose();
       });

--- a/test/models/workflow_context_test.dart
+++ b/test/models/workflow_context_test.dart
@@ -8,6 +8,7 @@ void main() {
       final ctx = WorkflowContext(
         targetDoseWeight: 18.0,
         targetYield: 36.0,
+        targetWaterVolume: 55.0,
         grinderId: 'grinder-123',
         grinderModel: 'Niche Zero',
         grinderSetting: '15',
@@ -27,6 +28,7 @@ void main() {
 
       expect(restored.targetDoseWeight, 18.0);
       expect(restored.targetYield, 36.0);
+      expect(restored.targetWaterVolume, 55.0);
       expect(restored.grinderId, 'grinder-123');
       expect(restored.grinderModel, 'Niche Zero');
       expect(restored.grinderSetting, '15');
@@ -47,6 +49,7 @@ void main() {
       final json = ctx.toJson();
       expect(json.containsKey('grinderId'), false);
       expect(json.containsKey('extras'), false);
+      expect(json.containsKey('targetWaterVolume'), false);
 
       final restored = WorkflowContext.fromJson(json);
       expect(restored.targetDoseWeight, 18.0);
@@ -72,6 +75,7 @@ void main() {
       final ctx = WorkflowContext(
         targetDoseWeight: 18.0,
         targetYield: 36.0,
+        targetWaterVolume: 55.0,
         coffeeName: 'Ethiopian',
       );
 
@@ -79,7 +83,29 @@ void main() {
 
       expect(updated.targetDoseWeight, 18.0);
       expect(updated.targetYield, 40.0);
+      expect(updated.targetWaterVolume, 55.0);
       expect(updated.coffeeName, 'Ethiopian');
+    });
+
+    test('copyWith changes and clears the water-volume override', () {
+      final ctx = WorkflowContext(targetWaterVolume: 55.0);
+
+      final updated = ctx.copyWith(targetWaterVolume: 60.0);
+      final cleared = updated.copyWith(clearTargetWaterVolume: true);
+
+      expect(updated.targetWaterVolume, 60.0);
+      expect(cleared.targetWaterVolume, isNull);
+    });
+
+    test('clear operations preserve the water-volume override', () {
+      final ctx = WorkflowContext(
+        targetWaterVolume: 55.0,
+        grinderId: 'grinder-123',
+        beanBatchId: 'batch-456',
+      );
+
+      expect(ctx.clearGrinder().targetWaterVolume, 55.0);
+      expect(ctx.clearBeanBatch().targetWaterVolume, 55.0);
     });
 
     group('fromJson non-string coercion (#106)', () {

--- a/test/models/workflow_equality_test.dart
+++ b/test/models/workflow_equality_test.dart
@@ -221,12 +221,14 @@ void main() {
       const a = WorkflowContext(
         targetDoseWeight: 18.0,
         targetYield: 36.0,
+        targetWaterVolume: 55.0,
         grinderId: 'g1',
         coffeeName: 'Illy',
       );
       const b = WorkflowContext(
         targetDoseWeight: 18.0,
         targetYield: 36.0,
+        targetWaterVolume: 55.0,
         grinderId: 'g1',
         coffeeName: 'Illy',
       );
@@ -237,6 +239,7 @@ void main() {
     test('differ when any field differs', () {
       const base = WorkflowContext(targetDoseWeight: 18.0, targetYield: 36.0);
       expect(base, isNot(equals(base.copyWith(targetDoseWeight: 18.5))));
+      expect(base, isNot(equals(base.copyWith(targetWaterVolume: 55.0))));
       expect(base, isNot(equals(base.copyWith(grinderId: 'g2'))));
     });
 
@@ -244,6 +247,7 @@ void main() {
       const original = WorkflowContext(
         targetDoseWeight: 18.0,
         targetYield: 36.0,
+        targetWaterVolume: 55.0,
         grinderId: '123',
         grinderSetting: '5',
         beanBatchId: '456',


### PR DESCRIPTION
## Summary

- Add optional `WorkflowContext.targetWaterVolume` JSON/API support.
- Apply it as the existing no-scale volumetric fallback override without changing weight-stop behavior.
- Define and test null inheritance, zero disablement, scale-loss behavior, and context reconstruction.

## Linked Issue

Fixes #579

## Verification

- `flutter test`: 3,847 passed, 1 skipped.
- Focused workflow, sequencer, and TLS suite: 91 passed.
- `flutter analyze --no-pub`: no issues.
- `git diff --check`: clean.

## Impact

- Adds the optional `targetWaterVolume` workflow field in milliliters.
- Existing workflows remain compatible: null inherits `Profile.targetVolume`; zero disables volumetric stopping for the workflow.
- `targetYield` remains beverage weight in grams and is never used as a volume fallback.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->