### PR TITLE
feat(plugins): register sensor-backed devices

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -6671,7 +6671,7 @@ components:
                 type: string
                 enum: ["quick", "full"]
             required: ["mode"]
-        resultSchema:
+        resultsSchema:
           type: object
           additionalProperties: true
           example:
@@ -7123,7 +7123,21 @@ components:
           type: array
           items:
             type: string
-            enum: [log, api, emit, pluginStorage, events.machine, events.shots, proxy.decent_api, proxy.decent_api.write]
+            enum: [log, api, emit, pluginStorage, events.machine, events.shots, proxy.decent_api, proxy.decent_api.write, network.websocket, network.tcp, network.tls]
+        drivers:
+          type: array
+          maxItems: 8
+          description: Device classes this plugin may register. Driver declarations do not grant transport permissions.
+          items:
+            type: object
+            required: [id, type]
+            properties:
+              id:
+                type: string
+                pattern: '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'
+              type:
+                type: string
+                enum: [sensor]
         settings:
           type: object
           description: >

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -395,6 +395,12 @@ same request prevent all fields from being stored (validation is atomic).
 | GET | `/api/v1/sensors/:id` | Get sensor manifest | |
 | POST | `/api/v1/sensors/:id/execute` | Execute sensor command | |
 
+Plugin-backed sensors registered through `host.devices` use this same API and
+the device inventory. Their stable IDs have the form
+`plugin:<pluginId>:<driverId>:<instanceId>`. Sensor manifests expose command
+result schemas as `resultsSchema`. See `Plugins.md` for registration and
+lifecycle rules.
+
 #### `Bengle EBus Tap` sensor
 
 The Bengle EBus tap (USB interface `2` of a composite Bengle, VID `0x2e8a` /

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -743,6 +743,15 @@ sensor is connected, skins can call the `measure` command through the existing
 Sensors API and read TDS, temperature, refractive index, and status values from
 the sensor data stream.
 
+`PluginDeviceService` is a `DeviceDiscoveryService` that contributes sensors
+registered by plugin generations. This keeps plugin-backed sensors on the same
+`DeviceController` → `SensorController` path as native sensors. Public identity
+comes from plugin id, declared driver id, and plugin-local instance id; unload
+removes the retiring generation without changing that identity for a later
+reload. Plugin connection handlers must complete protocol initialization before
+the sensor reports `connected`. Registrations are runtime-only and are not added
+to remembered-device selection.
+
 ### Bengle EBus tap
 
 Bengle composite devices (VID `0x2e8a`, PID `0x000a`) may expose a second CDC

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -582,16 +582,21 @@ handle with:
 
 All three handlers are required. Decaid calls `connect()` when the sensor joins
 the sensor registry; resolving means the driver is ready to serve commands, not
-merely that its transport opened. `disconnect()` performs normal driver cleanup.
-`execute({ commandId, params })` handles a declared command and returns an object.
-Handler failures propagate through the existing sensor command API. Calls time
-out after 10 seconds.
+merely that its transport opened. `disconnect()` performs normal driver cleanup
+and is run before a device is removed: on explicit `unregister()` and on plugin
+unload, so the driver can release its transport or other resources. A failing or
+timed-out `disconnect()` still removes the device and rejects in-flight
+commands; the failure is surfaced to the caller.
+`execute({ commandId, params })` handles a declared command and returns an
+object. Handler failures propagate through the existing sensor command API.
+Calls time out after 10 seconds.
 
 Definitions, snapshots, command parameters and command results are limited to
 64 KiB of JSON. A plugin generation can register at most 8 devices. Registration
-is not remembered across app restarts. On plugin unload, Decaid removes every
-device and rejects in-flight commands owned by the retiring generation, even if
-`onUnload()` fails. Late publications and command results from older generations
+is not remembered across app restarts. On plugin unload, Decaid runs each
+device's `disconnect()` handler, removes every device, and rejects in-flight
+commands owned by the retiring generation, even if `onUnload()` fails. Late
+publications and command results from older generations
 are ignored. BLE-backed drivers, discovery, probing and grinder registration are
 not supported by this first sensor registration contract.
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -32,6 +32,12 @@ A Decaid plugin consists of two required files:
     "pluginStorage",
     "events.machine"
   ],
+  "drivers": [
+    {
+      "id": "humidity",
+      "type": "sensor"
+    }
+  ],
   "settings": {
     "SettingName": {
       "type": "string",
@@ -77,6 +83,7 @@ A Decaid plugin consists of two required files:
   - `network.websocket`: Open outbound WebSocket connections (`ws://` and `wss://`) through `host.transport`
   - `network.tcp`: Open outbound raw TCP connections through `host.transport`
   - `network.tls`: Open outbound TLS connections (platform trust store) through `host.transport`
+- **drivers**: Device classes the plugin may register. Each declaration has a plugin-local `id` and a `type`. The only currently supported type is `sensor`. A manifest may declare at most 8 drivers. Driver declarations authorize registration; they do not grant transport access. For example, a WebSocket-backed sensor also needs `network.websocket`.
 - **settings**: User-configurable options with `type` (`string`, `number`, `boolean`, `enum`), an optional `label` giving the setting a human-friendly name, an optional `description` explaining what the setting does, an optional `default`, and an optional `secure` flag for credentials such as passwords. Enum `values` are a JSON array of strings. Secure values use platform credential storage, are supplied in memory to `onLoad(settings)`, and are never returned by the REST API.
 
   `GET /api/v1/plugins` returns this schema verbatim under `settings`, so a skin can render a settings form — labels, help text and defaults included — without reading the plugin's repository. `GET /api/v1/plugins/:id/settings` returns the stored values only.
@@ -488,6 +495,106 @@ host.transport.onEvent(opened.handle, (event) => {
 await host.transport.send(opened.handle, { type: "binary", data: btoa("\x00\x01\x02") });
 ```
 
+## Device Registration (`host.devices`)
+
+A plugin with a declared sensor driver can register runtime sensor instances.
+Registered sensors join Decaid's normal device inventory and sensor registry; no
+plugin-specific endpoint is created. They are available through:
+
+- `GET /api/v1/devices`
+- `GET /api/v1/sensors`
+- `GET /api/v1/sensors/:id`
+- `POST /api/v1/sensors/:id/execute`
+- `/ws/v1/sensors/:id/snapshot`
+
+Registration and transport authorization are independent. The manifest below
+allows a sensor registration and an outbound WebSocket connection:
+
+```json
+{
+  "drivers": [{ "id": "humidity", "type": "sensor" }],
+  "permissions": ["network.websocket"]
+}
+```
+
+Register the sensor from `onLoad()`:
+
+```js
+let sensor;
+let transportHandle;
+
+async function registerSensor() {
+  sensor = await host.devices.register({
+    driverId: "humidity",
+    instanceId: "office",
+    name: "Office humidity",
+    vendor: "Example",
+    dataChannels: [
+      { key: "relativeHumidity", type: "number", unit: "%RH" }
+    ],
+    commands: [
+      {
+        id: "sampleNow",
+        name: "Sample now",
+        paramsSchema: { type: "object" },
+        resultsSchema: {
+          type: "object",
+          properties: { relativeHumidity: { type: "number" } }
+        }
+      }
+    ]
+  }, {
+    async connect() {
+      const opened = await host.transport.open({
+        kind: "websocket",
+        url: "ws://sensor.local/readings"
+      });
+      transportHandle = opened.handle;
+    },
+    async disconnect() {
+      if (transportHandle) await host.transport.close(transportHandle);
+    },
+    async execute(command) {
+      if (command.commandId === "sampleNow") {
+        return { relativeHumidity: 52.4 };
+      }
+      throw new Error("unknown command");
+    }
+  });
+
+  await sensor.publish({ relativeHumidity: 52.4 });
+}
+```
+
+Call `registerSensor()` from the plugin's `onLoad()` method.
+
+`host.devices.register(definition, handlers)` returns a Promise for a device
+handle with:
+
+- `deviceId`: stable public identity derived from plugin id, driver id, and
+  instance id; plugin generation is not part of the identity.
+- `publish(snapshot)`: publishes one complete snapshot. Every declared channel
+  must be present, values must match their declared JSON type, and undeclared
+  channels are rejected.
+- `reportDisconnected()`: marks the sensor disconnected after an unexpected
+  transport or protocol failure.
+- `unregister()`: removes the sensor from the device inventory.
+
+All three handlers are required. Decaid calls `connect()` when the sensor joins
+the sensor registry; resolving means the driver is ready to serve commands, not
+merely that its transport opened. `disconnect()` performs normal driver cleanup.
+`execute({ commandId, params })` handles a declared command and returns an object.
+Handler failures propagate through the existing sensor command API. Calls time
+out after 10 seconds.
+
+Definitions, snapshots, command parameters and command results are limited to
+64 KiB of JSON. A plugin generation can register at most 8 devices. Registration
+is not remembered across app restarts. On plugin unload, Decaid removes every
+device and rejects in-flight commands owned by the retiring generation, even if
+`onUnload()` fails. Late publications and command results from older generations
+are ignored. BLE-backed drivers, discovery, probing and grinder registration are
+not supported by this first sensor registration contract.
+
 ## Plugin Lifecycle
 
 1. **Initialization**: Plugin directory is copied to app storage
@@ -635,7 +742,7 @@ it in Decaid UI.
 - **Global Functions**: `fetch()`, `btoa()`, `setTimeout()`, `clearTimeout()`
 - **Objects**: `Promise`, `JSON`, `Math`, `Date`, `Array`, `Object`
 - **Constants**: `undefined`, `null`, `Infinity`, `NaN`
-- **Host API**: `host.log()`, `host.emit()`, `host.storage()`, `host.decentProxy()`, `host.transport`
+- **Host API**: `host.log()`, `host.emit()`, `host.storage()`, `host.decentProxy()`, `host.transport`, `host.devices`
 
 ### Not Available
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -544,8 +544,8 @@ async function registerSensor() {
       }
     ]
   }, {
-    async connect() {
-      const opened = await host.transport.open({
+    async connect(transport) {
+      const opened = await transport.open({
         kind: "websocket",
         url: "ws://sensor.local/readings"
       });
@@ -580,9 +580,12 @@ handle with:
   transport or protocol failure.
 - `unregister()`: removes the sensor from the device inventory.
 
-All three handlers are required. Decaid calls `connect()` when the sensor joins
-the sensor registry; resolving means the driver is ready to serve commands, not
-merely that its transport opened. `disconnect()` performs normal driver cleanup
+All three handlers are required. Decaid calls `connect(transport)` when the
+sensor joins the sensor registry. The invocation-bound `transport` has the same
+methods as `host.transport`; connections opened through it belong to that
+connect attempt across Promise continuations. Resolving means the driver is
+ready to serve commands, not merely that its transport opened. `disconnect()`
+performs normal driver cleanup
 and is run before a device is removed: on explicit `unregister()` and on plugin
 unload, so the driver can release its transport or other resources. A failing or
 timed-out `disconnect()` still removes the device and rejects in-flight

--- a/doc/plans/archive/plugin-backed-sensor-driver/design.md
+++ b/doc/plans/archive/plugin-backed-sensor-driver/design.md
@@ -1,0 +1,57 @@
+# Plugin-backed sensor driver
+
+**Date:** 2026-09-03
+**Discussion:** [#749](https://github.com/decentespresso/decaid/discussions/749)
+
+## Goal
+
+Prove the plugin device boundary with a humidity sensor whose protocol runs in JavaScript over the existing permission-gated WebSocket transport.
+
+## Decisions
+
+- Add static `drivers` contributions to plugin manifests; they are not permissions.
+- The first supported driver type is `sensor`.
+- A plugin may register only instances of drivers declared by its manifest.
+- Device identity is stable across reloads and derived from plugin id, driver id, and plugin-local instance id; generation is ownership metadata, not identity.
+- `ConnectionState.connected` means the plugin's connect handler completed protocol initialization and the sensor is ready.
+- Decaid invokes plugin connect, disconnect, and command handlers. Plugins own protocol framing, handshakes, and transport use.
+- Registered devices enter `DeviceController` through a plugin-backed `DeviceDiscoveryService`, so existing device inventory and Sensor APIs see them without new REST or WebSocket routes.
+- Registration definitions are immutable. State publications are complete, bounded snapshots.
+- Registrations, callbacks, and pending commands are owned by plugin id plus generation and are removed or rejected during unload even when `onUnload()` fails.
+
+## Public seams
+
+1. `PluginManifest.fromJson()` validates `drivers`.
+2. `host.devices.register(definition, handlers)` registers a declared sensor.
+3. The returned device publishes snapshots and reports unsolicited disconnects.
+4. Existing `/api/v1/devices`, `/api/v1/sensors`, `/api/v1/sensors/{id}/execute`, and `/ws/v1/sensors/{id}/snapshot` expose the device.
+5. Plugin unload/reload/disposal removes stale registrations and closes associated transports.
+
+## Tracer fixture
+
+A test-local WebSocket server:
+
+- sends `{"relativeHumidity":52.4}`;
+- accepts `{"command":"sampleNow"}`;
+- replies with a fresh humidity sample.
+
+The test plugin declares `network.websocket` plus one `sensor` driver, connects through `host.transport`, registers the sensor, publishes readings, and translates `sampleNow` commands.
+
+## Implementation order
+
+1. Manifest driver parsing and rejection tests.
+2. Plugin device service and DeviceController inventory test.
+3. `host.devices` registration/publication/command tests.
+4. End-to-end fake-WebSocket humidity sensor test through existing Sensor APIs.
+5. Generation, unload, malformed input, timeout, and resource-bound tests.
+6. Update `doc/Plugins.md`, `doc/DeviceManagement.md`, and correct affected REST schema mismatches.
+
+## Out of scope
+
+- Grinder semantics or `DeviceType.grinder`.
+- BLE scanning, matching, GATT access, or probing.
+- Migrating existing native devices.
+- Remembered/preferred plugin devices.
+- Generic device settings/debug UI.
+- New generic REST or WebSocket endpoints.
+- Shared JavaScript runtime isolation hardening.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ import 'package:reaprime/src/controllers/workflow_device_sync.dart';
 import 'package:reaprime/src/models/data/workflow.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/simulated_device.dart';
+import 'package:reaprime/src/plugins/plugin_device_service.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_source_service.dart';
 import 'package:reaprime/src/services/android_updater.dart';
@@ -278,6 +279,8 @@ void main(List<String> args) async {
   });
 
   final List<DeviceDiscoveryService> services = [];
+  final pluginDeviceService = PluginDeviceService();
+  services.add(pluginDeviceService);
 
   final bleDiscoveryService = UniversalBleDiscoveryService();
   if (!cliArgs.serial) {
@@ -503,6 +506,7 @@ void main(List<String> args) async {
     kvStore: HiveStoreService(defaultNamespace: "plugins")..initialize(),
     decentProxyService: decentProxyService,
     credentialStore: credentialStore,
+    deviceService: pluginDeviceService,
   );
   await pluginService.pluginManager.attachDe1Controller(de1Controller);
   persistenceController.onShotStored = (shotId) =>

--- a/lib/src/models/device/device_implementation.dart
+++ b/lib/src/models/device/device_implementation.dart
@@ -21,4 +21,5 @@ enum DeviceImplementation {
   debugPort,
   sensorBasket,
   bengleDebugPort,
+  plugin,
 }

--- a/lib/src/plugins/plugin_device_service.dart
+++ b/lib/src/plugins/plugin_device_service.dart
@@ -257,7 +257,9 @@ class _PluginSensor implements Sensor {
       StreamController.broadcast();
   Future<void>? _connecting;
   Future<void>? _disconnectCleanup;
+  int? _disconnectCleanupEpoch;
   int _connectionEpoch = 0;
+  int _connectionFence = 0;
   bool _disposed = false;
 
   @override
@@ -289,19 +291,38 @@ class _PluginSensor implements Sensor {
     if (_disposed || _connectionState.value == ConnectionState.connected) {
       return Future.value();
     }
-    return _connecting ??= _connect().whenComplete(() => _connecting = null);
+    return _connecting ??= _connectAfterCleanup().whenComplete(
+      () => _connecting = null,
+    );
+  }
+
+  Future<void> _connectAfterCleanup() async {
+    final cleanup = _disconnectCleanup;
+    final cleanupFence = _connectionFence;
+    if (cleanup != null) {
+      try {
+        await cleanup;
+      } catch (_) {}
+      if (cleanupFence != _connectionFence) return;
+      if (identical(_disconnectCleanup, cleanup)) {
+        _disconnectCleanup = null;
+        _disconnectCleanupEpoch = null;
+      }
+    }
+    await _connect();
   }
 
   Future<void> _connect() async {
-    final epoch = ++_connectionEpoch;
+    ++_connectionEpoch;
+    final fence = ++_connectionFence;
     _connectionState.add(ConnectionState.connecting);
     try {
       await _invoke(PluginDeviceOperation.connect, const {});
-      if (!_disposed && epoch == _connectionEpoch) {
+      if (!_disposed && fence == _connectionFence) {
         _connectionState.add(ConnectionState.connected);
       }
     } catch (_) {
-      if (!_disposed && epoch == _connectionEpoch) {
+      if (!_disposed && fence == _connectionFence) {
         _connectionState.add(ConnectionState.disconnected);
       }
       rethrow;
@@ -311,18 +332,35 @@ class _PluginSensor implements Sensor {
   @override
   Future<void> disconnect() {
     if (_disposed) return Future.value();
-    return _disconnectCleanup ??= _runDisconnectCleanup();
+    final epoch = _connectionEpoch;
+    final existing = _disconnectCleanup;
+    if (existing != null && _disconnectCleanupEpoch == epoch) {
+      if (_connecting != null) _connectionFence += 1;
+      return existing;
+    }
+    final cleanup = _runDisconnectCleanup(epoch);
+    _disconnectCleanup = cleanup;
+    _disconnectCleanupEpoch = epoch;
+    return cleanup;
   }
 
-  Future<void> _runDisconnectCleanup() async {
-    _connectionEpoch += 1;
+  Future<void> _runDisconnectCleanup(int epoch) async {
+    final connecting = _connecting;
+    _connectionFence += 1;
     if (_connectionState.value != ConnectionState.disconnected) {
       _connectionState.add(ConnectionState.disconnecting);
+    }
+    if (connecting != null) {
+      try {
+        await connecting;
+      } catch (_) {}
     }
     try {
       await _invoke(PluginDeviceOperation.disconnect, const {});
     } finally {
-      if (!_disposed) _connectionState.add(ConnectionState.disconnected);
+      if (!_disposed && epoch == _connectionEpoch) {
+        _connectionState.add(ConnectionState.disconnected);
+      }
     }
   }
 
@@ -370,14 +408,14 @@ class _PluginSensor implements Sensor {
 
   void reportDisconnected() {
     if (_disposed) return;
-    _connectionEpoch += 1;
+    _connectionFence += 1;
     _connectionState.add(ConnectionState.disconnected);
   }
 
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
-    _connectionEpoch += 1;
+    _connectionFence += 1;
     await _data.close();
     await _connectionState.close();
   }

--- a/lib/src/plugins/plugin_device_service.dart
+++ b/lib/src/plugins/plugin_device_service.dart
@@ -1,0 +1,449 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/remembered_device.dart';
+import 'package:reaprime/src/models/device/scan_filter.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:rxdart/rxdart.dart';
+
+const _maxPluginDevices = 8;
+const _maxPluginDevicePayloadBytes = 64 * 1024;
+final _safeId = RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$');
+const _dataTypes = {
+  'number',
+  'integer',
+  'string',
+  'boolean',
+  'object',
+  'array',
+};
+
+enum PluginDeviceOperation { connect, disconnect, execute }
+
+typedef PluginDeviceInvoker =
+    Future<Map<String, dynamic>> Function(
+      PluginDeviceOperation operation,
+      Map<String, dynamic> payload,
+    );
+
+class PluginDeviceException implements Exception {
+  final String message;
+
+  const PluginDeviceException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+class PluginDeviceRegistration {
+  final String deviceId;
+
+  const PluginDeviceRegistration({required this.deviceId});
+}
+
+class PluginDeviceService implements DeviceDiscoveryService {
+  final BehaviorSubject<List<Device>> _devices = BehaviorSubject.seeded(
+    const [],
+  );
+  final Map<(String, int, String), _PluginSensor> _registrations = {};
+  bool _disposed = false;
+
+  @override
+  Stream<List<Device>> get devices => _devices.stream;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> scanForDevices({ScanFilter? filter}) async {}
+
+  @override
+  void stopScan() {}
+
+  @override
+  Future<Device?> tryQuickConnect(RememberedDevice remembered) async => null;
+
+  Future<PluginDeviceRegistration> register({
+    required String pluginId,
+    required int generation,
+    required String registrationHandle,
+    required Map<String, dynamic> definition,
+    required PluginDeviceInvoker invoke,
+  }) async {
+    _ensureActive();
+    _checkPayloadSize(definition, 'Plugin device definition');
+    if (!_safeId.hasMatch(registrationHandle)) {
+      throw const PluginDeviceException('Invalid registration handle');
+    }
+    final driverId = _requiredSafeString(definition, 'driverId');
+    final instanceId = _requiredSafeString(definition, 'instanceId');
+    final name = _requiredString(definition, 'name');
+    final vendor = _requiredString(definition, 'vendor');
+    final key = (pluginId, generation, registrationHandle);
+    if (_registrations.containsKey(key)) {
+      throw const PluginDeviceException('Registration handle already exists');
+    }
+    if (_registrations.keys
+            .where((key) => key.$1 == pluginId && key.$2 == generation)
+            .length >=
+        _maxPluginDevices) {
+      throw const PluginDeviceException(
+        'A plugin generation may register at most 8 devices',
+      );
+    }
+
+    final deviceId = 'plugin:$pluginId:$driverId:$instanceId';
+    if (_registrations.values.any((sensor) => sensor.deviceId == deviceId)) {
+      throw PluginDeviceException('Device already registered: $deviceId');
+    }
+    final sensor = _PluginSensor(
+      deviceId: deviceId,
+      name: name,
+      vendor: vendor,
+      dataChannels: _parseDataChannels(definition['dataChannels']),
+      commands: _parseCommands(definition['commands']),
+      invoke: invoke,
+    );
+    _registrations[key] = sensor;
+    _publishDevices();
+    return PluginDeviceRegistration(deviceId: deviceId);
+  }
+
+  void publish({
+    required String pluginId,
+    required int generation,
+    required String registrationHandle,
+    required Map<String, dynamic> snapshot,
+  }) {
+    _ensureActive();
+    _checkPayloadSize(snapshot, 'Plugin device snapshot');
+    _registration(pluginId, generation, registrationHandle).publish(snapshot);
+  }
+
+  void reportDisconnected({
+    required String pluginId,
+    required int generation,
+    required String registrationHandle,
+  }) {
+    _ensureActive();
+    _registration(
+      pluginId,
+      generation,
+      registrationHandle,
+    ).reportDisconnected();
+  }
+
+  Future<void> unregister({
+    required String pluginId,
+    required int generation,
+    required String registrationHandle,
+  }) async {
+    _ensureActive();
+    final sensor = _registrations.remove((
+      pluginId,
+      generation,
+      registrationHandle,
+    ));
+    if (sensor == null) {
+      throw const PluginDeviceException('Unknown plugin device registration');
+    }
+    await sensor.dispose();
+    _publishDevices();
+  }
+
+  Future<void> removeAllForPlugin(String pluginId, int generation) async {
+    final keys = _registrations.keys
+        .where((key) => key.$1 == pluginId && key.$2 == generation)
+        .toList();
+    final removed = keys
+        .map((key) => _registrations.remove(key))
+        .whereType<_PluginSensor>()
+        .toList();
+    if (removed.isEmpty) return;
+    await Future.wait(removed.map((sensor) => sensor.dispose()));
+    if (!_devices.isClosed) _publishDevices();
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    final sensors = _registrations.values.toList();
+    _registrations.clear();
+    await Future.wait(sensors.map((sensor) => sensor.dispose()));
+    await _devices.close();
+  }
+
+  _PluginSensor _registration(
+    String pluginId,
+    int generation,
+    String registrationHandle,
+  ) {
+    final sensor = _registrations[(pluginId, generation, registrationHandle)];
+    if (sensor == null) {
+      throw const PluginDeviceException('Unknown plugin device registration');
+    }
+    return sensor;
+  }
+
+  void _publishDevices() {
+    _devices.add(List.unmodifiable(_registrations.values));
+  }
+
+  void _ensureActive() {
+    if (_disposed) throw StateError('PluginDeviceService is disposed');
+  }
+}
+
+class _PluginSensor implements Sensor {
+  _PluginSensor({
+    required this.deviceId,
+    required this.name,
+    required String vendor,
+    required List<DataChannel> dataChannels,
+    required List<CommandDescriptor> commands,
+    required PluginDeviceInvoker invoke,
+  }) : _invoke = invoke,
+       info = SensorInfo(
+         name: name,
+         vendor: vendor,
+         dataChannels: dataChannels,
+         commands: commands,
+       ),
+       _dataChannels = {
+         for (final channel in dataChannels) channel.key: channel,
+       };
+
+  final PluginDeviceInvoker _invoke;
+  final Map<String, DataChannel> _dataChannels;
+  final BehaviorSubject<ConnectionState> _connectionState =
+      BehaviorSubject.seeded(ConnectionState.discovered);
+  final StreamController<Map<String, dynamic>> _data =
+      StreamController.broadcast();
+  Future<void>? _connecting;
+  int _connectionEpoch = 0;
+  bool _disposed = false;
+
+  @override
+  final String deviceId;
+
+  @override
+  final String name;
+
+  @override
+  final SensorInfo info;
+
+  @override
+  DeviceType get type => DeviceType.sensor;
+
+  @override
+  DeviceImplementation get implementation => DeviceImplementation.plugin;
+
+  @override
+  TransportType get transportType => TransportType.unknown;
+
+  @override
+  Stream<ConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  Stream<Map<String, dynamic>> get data => _data.stream;
+
+  @override
+  Future<void> onConnect() {
+    if (_disposed || _connectionState.value == ConnectionState.connected) {
+      return Future.value();
+    }
+    return _connecting ??= _connect().whenComplete(() => _connecting = null);
+  }
+
+  Future<void> _connect() async {
+    final epoch = ++_connectionEpoch;
+    _connectionState.add(ConnectionState.connecting);
+    try {
+      await _invoke(PluginDeviceOperation.connect, const {});
+      if (!_disposed && epoch == _connectionEpoch) {
+        _connectionState.add(ConnectionState.connected);
+      }
+    } catch (_) {
+      if (!_disposed && epoch == _connectionEpoch) {
+        _connectionState.add(ConnectionState.disconnected);
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    if (_disposed || _connectionState.value == ConnectionState.disconnected) {
+      return;
+    }
+    _connectionEpoch += 1;
+    _connectionState.add(ConnectionState.disconnecting);
+    try {
+      await _invoke(PluginDeviceOperation.disconnect, const {});
+    } finally {
+      if (!_disposed) _connectionState.add(ConnectionState.disconnected);
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>> execute(
+    String commandId,
+    Map<String, dynamic>? parameters,
+  ) async {
+    if (_disposed || _connectionState.value != ConnectionState.connected) {
+      throw const PluginDeviceException('Plugin device is not connected');
+    }
+    if (info.commands?.any((command) => command.id == commandId) != true) {
+      throw PluginDeviceException('Unknown sensor command: $commandId');
+    }
+    _checkPayloadSize(
+      parameters ?? const {},
+      'Plugin device command parameters',
+    );
+    final result = await _invoke(PluginDeviceOperation.execute, {
+      'commandId': commandId,
+      'params': parameters,
+    });
+    _checkPayloadSize(result, 'Plugin device command result');
+    return result;
+  }
+
+  void publish(Map<String, dynamic> snapshot) {
+    if (_disposed) throw const PluginDeviceException('Plugin device is closed');
+    if (snapshot.length != _dataChannels.length ||
+        !_dataChannels.keys.every(snapshot.containsKey)) {
+      throw const PluginDeviceException(
+        'Plugin device snapshot must contain every declared data channel',
+      );
+    }
+    for (final entry in snapshot.entries) {
+      final channel = _dataChannels[entry.key];
+      if (channel == null || !_matchesType(entry.value, channel.type)) {
+        throw PluginDeviceException(
+          'Invalid value for plugin device channel ${entry.key}',
+        );
+      }
+    }
+    _data.add(Map.unmodifiable(snapshot));
+  }
+
+  void reportDisconnected() {
+    if (_disposed) return;
+    _connectionEpoch += 1;
+    _connectionState.add(ConnectionState.disconnected);
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _connectionEpoch += 1;
+    await _data.close();
+    await _connectionState.close();
+  }
+}
+
+String _requiredSafeString(Map<String, dynamic> json, String key) {
+  final value = _requiredString(json, key);
+  if (!_safeId.hasMatch(value)) {
+    throw PluginDeviceException('Invalid plugin device $key');
+  }
+  return value;
+}
+
+String _requiredString(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is! String || value.isEmpty || value.length > 128) {
+    throw PluginDeviceException('Invalid plugin device $key');
+  }
+  return value;
+}
+
+List<DataChannel> _parseDataChannels(dynamic json) {
+  if (json is! List || json.isEmpty || json.length > 64) {
+    throw const PluginDeviceException('Invalid plugin device dataChannels');
+  }
+  final channels = <DataChannel>[];
+  final ids = <String>{};
+  for (final value in json) {
+    if (value is! Map) {
+      throw const PluginDeviceException('Invalid plugin device data channel');
+    }
+    final map = Map<String, dynamic>.from(value);
+    final key = _requiredSafeString(map, 'key');
+    final type = map['type'];
+    final unit = map['unit'];
+    if (type is! String ||
+        !_dataTypes.contains(type) ||
+        (unit != null && unit is! String) ||
+        !ids.add(key)) {
+      throw const PluginDeviceException('Invalid plugin device data channel');
+    }
+    channels.add(DataChannel(key: key, type: type, unit: unit as String?));
+  }
+  return List.unmodifiable(channels);
+}
+
+List<CommandDescriptor> _parseCommands(dynamic json) {
+  if (json == null) return const [];
+  if (json is! List || json.length > 64) {
+    throw const PluginDeviceException('Invalid plugin device commands');
+  }
+  final commands = <CommandDescriptor>[];
+  final ids = <String>{};
+  for (final value in json) {
+    if (value is! Map) {
+      throw const PluginDeviceException('Invalid plugin device command');
+    }
+    final map = Map<String, dynamic>.from(value);
+    final id = _requiredSafeString(map, 'id');
+    final name = map['name'];
+    final description = map['description'];
+    final paramsSchema = map['paramsSchema'];
+    final resultsSchema = map['resultsSchema'];
+    if (!ids.add(id) ||
+        (name != null && name is! String) ||
+        (description != null && description is! String) ||
+        (paramsSchema != null && paramsSchema is! Map) ||
+        (resultsSchema != null && resultsSchema is! Map)) {
+      throw const PluginDeviceException('Invalid plugin device command');
+    }
+    commands.add(
+      CommandDescriptor(
+        id: id,
+        name: name as String?,
+        description: description as String?,
+        paramsSchema: paramsSchema == null
+            ? null
+            : Map<String, dynamic>.from(paramsSchema as Map),
+        resultsSchema: resultsSchema == null
+            ? null
+            : Map<String, dynamic>.from(resultsSchema as Map),
+      ),
+    );
+  }
+  return List.unmodifiable(commands);
+}
+
+bool _matchesType(Object? value, String type) => switch (type) {
+  'number' => value is num,
+  'integer' => value is int,
+  'string' => value is String,
+  'boolean' => value is bool,
+  'object' => value is Map,
+  'array' => value is List,
+  _ => false,
+};
+
+void _checkPayloadSize(Object payload, String name) {
+  try {
+    if (utf8.encode(jsonEncode(payload)).length >
+        _maxPluginDevicePayloadBytes) {
+      throw PluginDeviceException('$name exceeds 64 KiB');
+    }
+  } on JsonUnsupportedObjectError {
+    throw PluginDeviceException('$name must be JSON encodable');
+  }
+}

--- a/lib/src/plugins/plugin_device_service.dart
+++ b/lib/src/plugins/plugin_device_service.dart
@@ -256,6 +256,7 @@ class _PluginSensor implements Sensor {
   final StreamController<Map<String, dynamic>> _data =
       StreamController.broadcast();
   Future<void>? _connecting;
+  Future<void>? _disconnectCleanup;
   int _connectionEpoch = 0;
   bool _disposed = false;
 
@@ -308,12 +309,16 @@ class _PluginSensor implements Sensor {
   }
 
   @override
-  Future<void> disconnect() async {
-    if (_disposed || _connectionState.value == ConnectionState.disconnected) {
-      return;
-    }
+  Future<void> disconnect() {
+    if (_disposed) return Future.value();
+    return _disconnectCleanup ??= _runDisconnectCleanup();
+  }
+
+  Future<void> _runDisconnectCleanup() async {
     _connectionEpoch += 1;
-    _connectionState.add(ConnectionState.disconnecting);
+    if (_connectionState.value != ConnectionState.disconnected) {
+      _connectionState.add(ConnectionState.disconnecting);
+    }
     try {
       await _invoke(PluginDeviceOperation.disconnect, const {});
     } finally {

--- a/lib/src/plugins/plugin_device_service.dart
+++ b/lib/src/plugins/plugin_device_service.dart
@@ -325,6 +325,7 @@ class _PluginSensor implements Sensor {
       if (!_disposed && fence == _connectionFence) {
         _connectionState.add(ConnectionState.disconnected);
       }
+      if (_disposed || fence != _connectionFence) return;
       rethrow;
     }
   }

--- a/lib/src/plugins/plugin_device_service.dart
+++ b/lib/src/plugins/plugin_device_service.dart
@@ -58,7 +58,10 @@ class PluginDeviceService implements DeviceDiscoveryService {
   Future<void> initialize() async {}
 
   @override
-  Future<void> scanForDevices({ScanFilter? filter}) async {}
+  Future<void> scanForDevices({ScanFilter? filter}) async {
+    if (_disposed) return;
+    _publishDevices();
+  }
 
   @override
   void stopScan() {}
@@ -142,29 +145,59 @@ class PluginDeviceService implements DeviceDiscoveryService {
     required String registrationHandle,
   }) async {
     _ensureActive();
-    final sensor = _registrations.remove((
-      pluginId,
-      generation,
-      registrationHandle,
-    ));
+    final key = (pluginId, generation, registrationHandle);
+    final sensor = _registrations[key];
     if (sensor == null) {
       throw const PluginDeviceException('Unknown plugin device registration');
     }
+    Object? disconnectError;
+    try {
+      await sensor.disconnect();
+    } catch (error) {
+      disconnectError = error;
+    }
+    _registrations.remove(key);
     await sensor.dispose();
     _publishDevices();
+    if (disconnectError != null) {
+      throw PluginDeviceException('Device disconnect failed: $disconnectError');
+    }
   }
 
-  Future<void> removeAllForPlugin(String pluginId, int generation) async {
+  Future<void> removeAllForPlugin(
+    String pluginId,
+    int generation, {
+    bool runDisconnect = true,
+  }) async {
     final keys = _registrations.keys
         .where((key) => key.$1 == pluginId && key.$2 == generation)
         .toList();
+    if (keys.isEmpty) return;
+    Object? firstError;
+    StackTrace? firstStackTrace;
+    if (runDisconnect) {
+      await Future.wait(
+        keys.map((key) async {
+          final sensor = _registrations[key];
+          if (sensor == null) return;
+          try {
+            await sensor.disconnect();
+          } catch (error, stackTrace) {
+            firstError ??= error;
+            firstStackTrace ??= stackTrace;
+          }
+        }),
+      );
+    }
     final removed = keys
         .map((key) => _registrations.remove(key))
         .whereType<_PluginSensor>()
         .toList();
-    if (removed.isEmpty) return;
     await Future.wait(removed.map((sensor) => sensor.dispose()));
     if (!_devices.isClosed) _publishDevices();
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStackTrace!);
+    }
   }
 
   Future<void> dispose() async {
@@ -189,7 +222,7 @@ class PluginDeviceService implements DeviceDiscoveryService {
   }
 
   void _publishDevices() {
-    _devices.add(List.unmodifiable(_registrations.values));
+    _devices.add(List<Device>.of(_registrations.values));
   }
 
   void _ensureActive() {

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:reaprime/src/services/storage/app_directories.dart';
 import 'package:reaprime/src/services/storage/kv_store_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:reaprime/src/plugins/plugin_device_service.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_package.dart';
@@ -63,10 +64,12 @@ class PluginLoaderService {
     required KeyValueStoreService kvStore,
     DecentProxyService? decentProxyService,
     CredentialStore? credentialStore,
+    PluginDeviceService? deviceService,
   }) : _credentialStore = credentialStore,
        pluginManager = PluginManager(
          kvStore: kvStore,
          decentProxyService: decentProxyService,
+         deviceService: deviceService,
        );
 
   bool _initialized = false;

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -46,6 +46,7 @@ class _PendingDeviceInvocation {
   _PendingDeviceInvocation({
     required this.pluginId,
     required this.generation,
+    required this.registrationHandle,
     required this.operation,
     required this.completer,
     required this.timer,
@@ -53,6 +54,7 @@ class _PendingDeviceInvocation {
 
   final String pluginId;
   final int generation;
+  final String registrationHandle;
   final PluginDeviceOperation operation;
   final Completer<Map<String, dynamic>> completer;
   final Timer timer;
@@ -1159,6 +1161,13 @@ class PluginManager {
           );
           _replyDevice(requestId, bridgeToken, result: const {});
         case 'unregister':
+          _rejectDeviceInvocations(
+            pluginId,
+            generation,
+            'Plugin device unregistered',
+            registrationHandle: registrationHandle,
+            excludeOperation: PluginDeviceOperation.disconnect,
+          );
           await deviceService.unregister(
             pluginId: pluginId,
             generation: generation,
@@ -1230,6 +1239,7 @@ class PluginManager {
     _pendingDeviceInvocations[invocationId] = _PendingDeviceInvocation(
       pluginId: pluginId,
       generation: generation,
+      registrationHandle: registrationHandle,
       operation: operation,
       completer: completer,
       timer: timer,
@@ -1287,13 +1297,19 @@ class PluginManager {
   void _rejectDeviceInvocations(
     String pluginId,
     int generation,
-    String reason,
-  ) {
+    String reason, {
+    String? registrationHandle,
+    PluginDeviceOperation? excludeOperation,
+  }) {
     final ids = _pendingDeviceInvocations.entries
         .where(
           (entry) =>
               entry.value.pluginId == pluginId &&
-              entry.value.generation == generation,
+              entry.value.generation == generation &&
+              (registrationHandle == null ||
+                  entry.value.registrationHandle == registrationHandle) &&
+              (excludeOperation == null ||
+                  entry.value.operation != excludeOperation),
         )
         .map((entry) => entry.key)
         .toList();

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -114,6 +114,7 @@ class PluginManager {
   >
   _deviceConnectAttempts = {};
   final Map<(String, int, String), Set<String>> _timedOutDeviceConnects = {};
+  final Map<(String, int), Set<String>> _retiredDeviceConnectInvocations = {};
   int _deviceInvocationSequence = 0;
 
   final Set<(String, int)> _deviceDisconnectCleanup = {};
@@ -227,6 +228,7 @@ class PluginManager {
       _deviceDisconnectCleanup.clear();
       _deviceConnectAttempts.clear();
       _timedOutDeviceConnects.clear();
+      _retiredDeviceConnectInvocations.clear();
       _pluginStorageOperations.clear();
       _pluginBridgeTokens.clear();
       _pluginIdsByBridgeToken.clear();
@@ -739,23 +741,15 @@ class PluginManager {
             });
             return;
           }
-          const previousDeviceConnect = __activeDeviceConnect;
-          const connectContext = operation === "connect"
-            ? { registrationHandle: handle, invocationId: invocationId }
-            : null;
           try {
+            const previousDeviceConnect = __activeDeviceConnect;
             let handlerResult;
             try {
-              __activeDeviceConnect = connectContext;
+              __activeDeviceConnect = operation === "connect"
+                ? { registrationHandle: handle, invocationId: invocationId }
+                : null;
               handlerResult = handler(payload);
-            } catch (error) {
-              __activeDeviceConnect = previousDeviceConnect;
-              throw error;
-            }
-            const keepsDeviceConnectContext =
-              connectContext && handlerResult &&
-              typeof handlerResult.then === "function";
-            if (!keepsDeviceConnectContext) {
+            } finally {
               __activeDeviceConnect = previousDeviceConnect;
             }
             const promise = __nativeReflectApply(
@@ -764,36 +758,20 @@ class PluginManager {
               [handlerResult]
             );
             __nativeReflectApply(__nativePromiseThen, promise, [
-              (result) => {
-                if (keepsDeviceConnectContext &&
-                    __activeDeviceConnect === connectContext) {
-                  __activeDeviceConnect = previousDeviceConnect;
-                }
-                __sendDeviceMessage({
-                  bridgeToken: entry.bridgeToken,
-                  generation: generation,
-                  type: "invocationResult",
-                  payload: { invocationId: invocationId, result: result }
-                });
-              },
-              (error) => {
-                if (keepsDeviceConnectContext &&
-                    __activeDeviceConnect === connectContext) {
-                  __activeDeviceConnect = previousDeviceConnect;
-                }
-                __sendDeviceMessage({
-                  bridgeToken: entry.bridgeToken,
-                  generation: generation,
-                  type: "invocationResult",
-                  payload: { invocationId: invocationId, error: String(error) }
-                });
-              }
+              (result) => __sendDeviceMessage({
+                bridgeToken: entry.bridgeToken,
+                generation: generation,
+                type: "invocationResult",
+                payload: { invocationId: invocationId, result: result }
+              }),
+              (error) => __sendDeviceMessage({
+                bridgeToken: entry.bridgeToken,
+                generation: generation,
+                type: "invocationResult",
+                payload: { invocationId: invocationId, error: String(error) }
+              })
             ]);
-            return;
           } catch (error) {
-            if (__activeDeviceConnect === connectContext) {
-              __activeDeviceConnect = previousDeviceConnect;
-            }
             __sendDeviceMessage({
               bridgeToken: entry.bridgeToken,
               generation: generation,
@@ -1143,6 +1121,19 @@ class PluginManager {
       return;
     }
     if (type == 'invocationResult') {
+      if (invocationId is String) {
+        _timedOutDeviceConnects.removeWhere(
+          (_, ids) => ids.remove(invocationId) && ids.isEmpty,
+        );
+        final retired =
+            _retiredDeviceConnectInvocations[(pluginId, generation)];
+        if (retired != null) {
+          retired.remove(invocationId);
+          if (retired.isEmpty) {
+            _retiredDeviceConnectInvocations.remove((pluginId, generation));
+          }
+        }
+      }
       if ((generation != _pluginGenerations[pluginId] ||
               _plugins[pluginId]?.isAlive != true) &&
           !cleanupInvocation) {
@@ -1304,6 +1295,9 @@ class PluginManager {
           registrationHandle,
           connectInvocationId,
         );
+        _retiredDeviceConnectInvocations
+            .putIfAbsent((pluginId, generation), () => <String>{})
+            .add(connectInvocationId);
       }
     }
     final invocationId =
@@ -1536,6 +1530,17 @@ class PluginManager {
               requestId,
               bridgeToken,
               error: _permissionError(pluginId, permission),
+            );
+            return;
+          }
+          if (!ownsDeviceConnect &&
+              _retiredDeviceConnectInvocations[(pluginId, generation)]
+                      ?.isNotEmpty ==
+                  true) {
+            _replyTransport(
+              requestId,
+              bridgeToken,
+              error: 'Plugin device connect retired',
             );
             return;
           }
@@ -2041,6 +2046,9 @@ class PluginManager {
             attempt.pluginId == id && attempt.generation == retiringGeneration,
       );
       _timedOutDeviceConnects.removeWhere(
+        (key, _) => key.$1 == id && key.$2 == retiringGeneration,
+      );
+      _retiredDeviceConnectInvocations.removeWhere(
         (key, _) => key.$1 == id && key.$2 == retiringGeneration,
       );
       _removePluginBridgeToken(id);

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -1319,8 +1319,16 @@ class PluginManager {
     final generation = msg['generation'] is num
         ? (msg['generation'] as num).toInt()
         : 0;
-    if (generation != _pluginGenerations[pluginId] ||
-        _plugins[pluginId]?.isAlive != true) {
+    final type = msg['type'];
+    final current =
+        generation == _pluginGenerations[pluginId] &&
+        _plugins[pluginId]?.isAlive == true;
+    final cleanupTransportClose =
+        type == 'close' &&
+        _lifecycle == PluginManagerLifecycle.active &&
+        _plugins[pluginId]?.state == PluginRuntimeState.stopping &&
+        _deviceDisconnectCleanup.contains((pluginId, generation));
+    if (!current && !cleanupTransportClose) {
       _replyTransport(
         requestId,
         bridgeToken,
@@ -1328,7 +1336,6 @@ class PluginManager {
       );
       return;
     }
-    final type = msg['type'];
     final payload = msg['payload'];
     if (payload is! Map) {
       _replyTransport(

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -108,6 +108,12 @@ class PluginManager {
   final Map<(String, int), Set<Future<void>>> _pluginStorageOperations = {};
   late final PluginTransportService _transportService;
   final Map<String, _PendingDeviceInvocation> _pendingDeviceInvocations = {};
+  final Map<
+    String,
+    ({String pluginId, int generation, String registrationHandle})
+  >
+  _deviceConnectAttempts = {};
+  final Map<(String, int, String), Set<String>> _timedOutDeviceConnects = {};
   int _deviceInvocationSequence = 0;
 
   final Set<(String, int)> _deviceDisconnectCleanup = {};
@@ -219,6 +225,8 @@ class PluginManager {
       _pluginGenerations.clear();
       _retiringPluginGenerations.clear();
       _deviceDisconnectCleanup.clear();
+      _deviceConnectAttempts.clear();
+      _timedOutDeviceConnects.clear();
       _pluginStorageOperations.clear();
       _pluginBridgeTokens.clear();
       _pluginIdsByBridgeToken.clear();
@@ -603,6 +611,7 @@ class PluginManager {
 
         const __transportListeners = new Map();
         const __transportPending = new Map();
+        let __activeDeviceConnect = null;
         function __sendTransportMessage(message) {
           __nativeSendMessage("transport", __nativeJsonStringify(message));
         }
@@ -616,13 +625,19 @@ class PluginManager {
           });
         };
         __frozenTransportGlobal("__transportRequest", function (bridgeToken, generation, requestId, type, payload) {
-          __sendTransportMessage({
+          const message = {
             bridgeToken: bridgeToken,
             generation: generation,
             requestId: requestId,
             type: type,
             payload: payload
-          });
+          };
+          if (__activeDeviceConnect) {
+            message.deviceRegistrationHandle =
+              __activeDeviceConnect.registrationHandle;
+            message.deviceInvocationId = __activeDeviceConnect.invocationId;
+          }
+          __sendTransportMessage(message);
         });
         __frozenTransportGlobal("__transportRegister", function (requestId, entry) {
           __mapSet(__transportPending, requestId, entry);
@@ -725,10 +740,20 @@ class PluginManager {
             return;
           }
           try {
+            const previousDeviceConnect = __activeDeviceConnect;
+            let handlerResult;
+            try {
+              __activeDeviceConnect = operation === "connect"
+                ? { registrationHandle: handle, invocationId: invocationId }
+                : null;
+              handlerResult = handler(payload);
+            } finally {
+              __activeDeviceConnect = previousDeviceConnect;
+            }
             const promise = __nativeReflectApply(
               __nativePromiseResolve,
               __NativePromise,
-              [handler(payload)]
+              [handlerResult]
             );
             __nativeReflectApply(__nativePromiseThen, promise, [
               (result) => __sendDeviceMessage({
@@ -1084,17 +1109,19 @@ class PluginManager {
     final pending = invocationId is String
         ? _pendingDeviceInvocations[invocationId]
         : null;
-    final cleanupDisconnect =
+    final cleanupInvocation =
         type == 'invocationResult' &&
-        pending?.operation == PluginDeviceOperation.disconnect &&
+        pending != null &&
+        (pending.operation == PluginDeviceOperation.connect ||
+            pending.operation == PluginDeviceOperation.disconnect) &&
         _isDeviceDisconnectCleanup(pluginId, generation);
-    if (_lifecycle != PluginManagerLifecycle.active && !cleanupDisconnect) {
+    if (_lifecycle != PluginManagerLifecycle.active && !cleanupInvocation) {
       return;
     }
     if (type == 'invocationResult') {
       if ((generation != _pluginGenerations[pluginId] ||
               _plugins[pluginId]?.isAlive != true) &&
-          !cleanupDisconnect) {
+          !cleanupInvocation) {
         return;
       }
       _completeDeviceInvocation(pluginId, generation, data);
@@ -1240,11 +1267,36 @@ class PluginManager {
         const PluginDeviceException('Plugin generation changed'),
       );
     }
+    final retiredConnectInvocations = <String>[];
+    if (operation == PluginDeviceOperation.disconnect) {
+      final key = (pluginId, generation, registrationHandle);
+      retiredConnectInvocations.addAll(
+        _timedOutDeviceConnects.remove(key) ?? const <String>{},
+      );
+      for (final connectInvocationId in retiredConnectInvocations) {
+        _transportService.retireDeviceConnect(
+          pluginId,
+          generation,
+          registrationHandle,
+          connectInvocationId,
+        );
+      }
+    }
     final invocationId =
         '${pluginId}_${generation}_device_${++_deviceInvocationSequence}';
     final completer = Completer<Map<String, dynamic>>();
     final timer = Timer(deviceInvocationTimeout, () {
       final pending = _pendingDeviceInvocations.remove(invocationId);
+      if (pending?.operation == PluginDeviceOperation.connect) {
+        final key = (
+          pending!.pluginId,
+          pending.generation,
+          pending.registrationHandle,
+        );
+        _timedOutDeviceConnects
+            .putIfAbsent(key, () => <String>{})
+            .add(invocationId);
+      }
       pending?.completer.completeError(
         const PluginDeviceException('Plugin device invocation timed out'),
       );
@@ -1257,6 +1309,13 @@ class PluginManager {
       completer: completer,
       timer: timer,
     );
+    if (operation == PluginDeviceOperation.connect) {
+      _deviceConnectAttempts[invocationId] = (
+        pluginId: pluginId,
+        generation: generation,
+        registrationHandle: registrationHandle,
+      );
+    }
     try {
       js.evaluate(
         'globalThis.__dispatchDeviceInvocation('
@@ -1268,9 +1327,49 @@ class PluginManager {
     } catch (error) {
       final pending = _pendingDeviceInvocations.remove(invocationId);
       pending?.timer.cancel();
+      if (operation == PluginDeviceOperation.connect) {
+        _deviceConnectAttempts.remove(invocationId);
+      }
       pending?.completer.completeError(error);
     }
-    return completer.future;
+    if (retiredConnectInvocations.isEmpty) return completer.future;
+    return _awaitRetiredDeviceConnects(
+      completer.future,
+      pluginId,
+      generation,
+      registrationHandle,
+      retiredConnectInvocations,
+    );
+  }
+
+  Future<Map<String, dynamic>> _awaitRetiredDeviceConnects(
+    Future<Map<String, dynamic>> invocation,
+    String pluginId,
+    int generation,
+    String registrationHandle,
+    List<String> invocationIds,
+  ) async {
+    Future<void> closeTransports() => Future.wait(
+      invocationIds.map(
+        (invocationId) => _transportService.closeDeviceConnect(
+          pluginId,
+          generation,
+          registrationHandle,
+          invocationId,
+        ),
+      ),
+    );
+
+    try {
+      final result = await invocation;
+      await closeTransports();
+      return result;
+    } catch (error, stackTrace) {
+      try {
+        await closeTransports();
+      } catch (_) {}
+      Error.throwWithStackTrace(error, stackTrace);
+    }
   }
 
   void _completeDeviceInvocation(
@@ -1288,6 +1387,9 @@ class PluginManager {
     }
     _pendingDeviceInvocations.remove(invocationId);
     pending.timer.cancel();
+    if (pending.operation == PluginDeviceOperation.connect) {
+      _deviceConnectAttempts.remove(invocationId);
+    }
     final error = payload['error'];
     if (error != null) {
       pending.completer.completeError(PluginDeviceException(error.toString()));
@@ -1351,6 +1453,18 @@ class PluginManager {
         ? (msg['generation'] as num).toInt()
         : 0;
     final type = msg['type'];
+    final deviceRegistrationHandle = msg['deviceRegistrationHandle'];
+    final deviceInvocationId = msg['deviceInvocationId'];
+    final connectAttempt = deviceInvocationId is String
+        ? _deviceConnectAttempts[deviceInvocationId]
+        : null;
+    final ownsDeviceConnect =
+        type == 'open' &&
+        deviceRegistrationHandle is String &&
+        deviceInvocationId is String &&
+        connectAttempt?.pluginId == pluginId &&
+        connectAttempt?.generation == generation &&
+        connectAttempt?.registrationHandle == deviceRegistrationHandle;
     final current =
         generation == _pluginGenerations[pluginId] &&
         _plugins[pluginId]?.isAlive == true;
@@ -1405,6 +1519,10 @@ class PluginManager {
             pluginId: pluginId,
             generation: generation,
             options: Map<String, dynamic>.from(payload),
+            deviceRegistrationHandle: ownsDeviceConnect
+                ? deviceRegistrationHandle
+                : null,
+            deviceInvocationId: ownsDeviceConnect ? deviceInvocationId : null,
           );
           if (!_isCurrentPluginMessage(pluginId, {'generation': generation})) {
             unawaited(
@@ -1894,6 +2012,13 @@ class PluginManager {
       runtime.markDisposed();
       _plugins.remove(id);
       _closingPluginPermissions.remove(id);
+      _deviceConnectAttempts.removeWhere(
+        (_, attempt) =>
+            attempt.pluginId == id && attempt.generation == retiringGeneration,
+      );
+      _timedOutDeviceConnects.removeWhere(
+        (key, _) => key.$1 == id && key.$2 == retiringGeneration,
+      );
       _removePluginBridgeToken(id);
       _log.info("unloaded: $id");
     }

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -114,7 +114,6 @@ class PluginManager {
   >
   _deviceConnectAttempts = {};
   final Map<(String, int, String), Set<String>> _timedOutDeviceConnects = {};
-  final Map<(String, int), Set<String>> _retiredDeviceConnectInvocations = {};
   int _deviceInvocationSequence = 0;
 
   final Set<(String, int)> _deviceDisconnectCleanup = {};
@@ -228,7 +227,6 @@ class PluginManager {
       _deviceDisconnectCleanup.clear();
       _deviceConnectAttempts.clear();
       _timedOutDeviceConnects.clear();
-      _retiredDeviceConnectInvocations.clear();
       _pluginStorageOperations.clear();
       _pluginBridgeTokens.clear();
       _pluginIdsByBridgeToken.clear();
@@ -613,7 +611,6 @@ class PluginManager {
 
         const __transportListeners = new Map();
         const __transportPending = new Map();
-        let __activeDeviceConnect = null;
         function __sendTransportMessage(message) {
           __nativeSendMessage("transport", __nativeJsonStringify(message));
         }
@@ -626,7 +623,15 @@ class PluginManager {
             enumerable: false
           });
         };
-        __frozenTransportGlobal("__transportRequest", function (bridgeToken, generation, requestId, type, payload) {
+        __frozenTransportGlobal("__transportRequest", function (
+          bridgeToken,
+          generation,
+          requestId,
+          type,
+          payload,
+          deviceRegistrationHandle,
+          deviceInvocationId
+        ) {
           const message = {
             bridgeToken: bridgeToken,
             generation: generation,
@@ -634,10 +639,10 @@ class PluginManager {
             type: type,
             payload: payload
           };
-          if (__activeDeviceConnect) {
-            message.deviceRegistrationHandle =
-              __activeDeviceConnect.registrationHandle;
-            message.deviceInvocationId = __activeDeviceConnect.invocationId;
+          if (typeof deviceRegistrationHandle === "string" &&
+              typeof deviceInvocationId === "string") {
+            message.deviceRegistrationHandle = deviceRegistrationHandle;
+            message.deviceInvocationId = deviceInvocationId;
           }
           __sendTransportMessage(message);
         });
@@ -742,16 +747,9 @@ class PluginManager {
             return;
           }
           try {
-            const previousDeviceConnect = __activeDeviceConnect;
-            let handlerResult;
-            try {
-              __activeDeviceConnect = operation === "connect"
-                ? { registrationHandle: handle, invocationId: invocationId }
-                : null;
-              handlerResult = handler(payload);
-            } finally {
-              __activeDeviceConnect = previousDeviceConnect;
-            }
+            const handlerResult = operation === "connect"
+              ? handler(entry.connectTransport(invocationId))
+              : handler(payload);
             const promise = __nativeReflectApply(
               __nativePromiseResolve,
               __NativePromise,
@@ -1125,17 +1123,17 @@ class PluginManager {
         _timedOutDeviceConnects.removeWhere(
           (_, ids) => ids.remove(invocationId) && ids.isEmpty,
         );
-        final retired =
-            _retiredDeviceConnectInvocations[(pluginId, generation)];
-        if (retired != null) {
-          retired.remove(invocationId);
-          if (retired.isEmpty) {
-            _retiredDeviceConnectInvocations.remove((pluginId, generation));
-            await _transportService.closeRetiredConnectCandidates(
-              pluginId,
-              generation,
-            );
-          }
+        final attempt = _deviceConnectAttempts[invocationId];
+        if (attempt != null &&
+            attempt.pluginId == pluginId &&
+            attempt.generation == generation) {
+          _deviceConnectAttempts.remove(invocationId);
+          _transportService.finishDeviceConnect(
+            attempt.pluginId,
+            attempt.generation,
+            attempt.registrationHandle,
+            invocationId,
+          );
         }
       }
       if ((generation != _pluginGenerations[pluginId] ||
@@ -1299,9 +1297,6 @@ class PluginManager {
           registrationHandle,
           connectInvocationId,
         );
-        _retiredDeviceConnectInvocations
-            .putIfAbsent((pluginId, generation), () => <String>{})
-            .add(connectInvocationId);
       }
     }
     final invocationId =
@@ -1318,6 +1313,12 @@ class PluginManager {
         _timedOutDeviceConnects
             .putIfAbsent(key, () => <String>{})
             .add(invocationId);
+        _transportService.retireDeviceConnect(
+          pending.pluginId,
+          pending.generation,
+          pending.registrationHandle,
+          invocationId,
+        );
       }
       pending?.completer.completeError(
         const PluginDeviceException('Plugin device invocation timed out'),
@@ -1409,9 +1410,6 @@ class PluginManager {
     }
     _pendingDeviceInvocations.remove(invocationId);
     pending.timer.cancel();
-    if (pending.operation == PluginDeviceOperation.connect) {
-      _deviceConnectAttempts.remove(invocationId);
-    }
     final error = payload['error'];
     if (error != null) {
       pending.completer.completeError(PluginDeviceException(error.toString()));
@@ -1480,10 +1478,14 @@ class PluginManager {
     final connectAttempt = deviceInvocationId is String
         ? _deviceConnectAttempts[deviceInvocationId]
         : null;
+    final hasDeviceConnectClaim =
+        type == 'open' &&
+        (deviceRegistrationHandle != null || deviceInvocationId != null);
+    final validDeviceConnectClaim =
+        deviceRegistrationHandle is String && deviceInvocationId is String;
     final ownsDeviceConnect =
         type == 'open' &&
-        deviceRegistrationHandle is String &&
-        deviceInvocationId is String &&
+        validDeviceConnectClaim &&
         connectAttempt?.pluginId == pluginId &&
         connectAttempt?.generation == generation &&
         connectAttempt?.registrationHandle == deviceRegistrationHandle;
@@ -1499,6 +1501,14 @@ class PluginManager {
         requestId,
         bridgeToken,
         error: 'Plugin generation changed',
+      );
+      return;
+    }
+    if (hasDeviceConnectClaim && !ownsDeviceConnect) {
+      _replyTransport(
+        requestId,
+        bridgeToken,
+        error: 'Plugin device connect retired',
       );
       return;
     }
@@ -1545,17 +1555,6 @@ class PluginManager {
                 ? deviceRegistrationHandle
                 : null,
             deviceInvocationId: ownsDeviceConnect ? deviceInvocationId : null,
-            retiredConnectCandidate:
-                !ownsDeviceConnect &&
-                _retiredDeviceConnectInvocations[(pluginId, generation)]
-                        ?.isNotEmpty ==
-                    true &&
-                !_pendingDeviceInvocations.values.any(
-                  (pending) =>
-                      pending.pluginId == pluginId &&
-                      pending.generation == generation &&
-                      pending.operation == PluginDeviceOperation.connect,
-                ),
           );
           if (!_isCurrentPluginMessage(pluginId, {'generation': generation})) {
             unawaited(
@@ -1786,46 +1785,67 @@ class PluginManager {
         
         let __transportSeq = 0;
         const __transportNonce = Math.random().toString(36).slice(2);
-        const __transportCall = (type, payload) => {
+        const __transportCall = (type, payload, deviceConnect) => {
           return new Promise((resolve, reject) => {
             const requestId = pluginId + "_" + pluginGeneration + "_" + __transportNonce + "_" + (++__transportSeq);
             __transportRegister(requestId, { bridgeToken: pluginBridgeToken, resolve: resolve, reject: reject });
-            pluginHostBridge.transportRequest(pluginBridgeToken, pluginGeneration, requestId, type, payload);
+            pluginHostBridge.transportRequest(
+              pluginBridgeToken,
+              pluginGeneration,
+              requestId,
+              type,
+              payload,
+              deviceConnect && deviceConnect.registrationHandle,
+              deviceConnect && deviceConnect.invocationId
+            );
           });
         };
-        const transport = {
-          open(options) {
-            const kind = options && options.kind;
-            if (kind === "websocket" && !${manifest.permissions.contains(PluginPermissions.networkWebsocket)}) {
-              return rejectPermission("network.websocket");
-            }
-            if (kind === "tcp" && !${manifest.permissions.contains(PluginPermissions.networkTcp)}) {
-              return rejectPermission("network.tcp");
-            }
-            if (kind === "tls" && !${manifest.permissions.contains(PluginPermissions.networkTls)}) {
-              return rejectPermission("network.tls");
-            }
-            if (kind !== "websocket" && kind !== "tcp" && kind !== "tls") {
-              return Promise.reject(new Error("transport.open: unknown transport kind"));
-            }
-            return __transportCall("open", options || {});
-          },
-          onEvent(handle, callback) {
-            if (typeof callback !== "function") {
-              throw new Error("transport.onEvent: callback must be a function");
-            }
-            __transportSetListener(handle, pluginId, callback);
-            pluginHostBridge.transportRequest(
-              pluginBridgeToken, pluginGeneration, "onEvent_" + (++__transportSeq), "onEvent", { handle: handle }
-            );
-          },
-          send(handle, payload) {
-            return __transportCall("send", { handle: handle, payload: payload });
-          },
-          close(handle) {
-            return __transportCall("close", { handle: handle });
+        const __transportOpen = (options, deviceConnect) => {
+          const kind = options && options.kind;
+          if (kind === "websocket" && !${manifest.permissions.contains(PluginPermissions.networkWebsocket)}) {
+            return rejectPermission("network.websocket");
           }
+          if (kind === "tcp" && !${manifest.permissions.contains(PluginPermissions.networkTcp)}) {
+            return rejectPermission("network.tcp");
+          }
+          if (kind === "tls" && !${manifest.permissions.contains(PluginPermissions.networkTls)}) {
+            return rejectPermission("network.tls");
+          }
+          if (kind !== "websocket" && kind !== "tcp" && kind !== "tls") {
+            return Promise.reject(new Error("transport.open: unknown transport kind"));
+          }
+          return __transportCall("open", options || {}, deviceConnect);
         };
+        const __transportOnEvent = (handle, callback) => {
+          if (typeof callback !== "function") {
+            throw new Error("transport.onEvent: callback must be a function");
+          }
+          __transportSetListener(handle, pluginId, callback);
+          pluginHostBridge.transportRequest(
+            pluginBridgeToken, pluginGeneration, "onEvent_" + (++__transportSeq), "onEvent", { handle: handle }
+          );
+        };
+        const __transportSend = (handle, payload) =>
+          __transportCall("send", { handle: handle, payload: payload });
+        const __transportClose = (handle) =>
+          __transportCall("close", { handle: handle });
+        const transport = {
+          open(options) { return __transportOpen(options, null); },
+          onEvent: __transportOnEvent,
+          send: __transportSend,
+          close: __transportClose
+        };
+        const __connectTransport = (registrationHandle, invocationId) => Object.freeze({
+          open(options) {
+            return __transportOpen(options, {
+              registrationHandle: registrationHandle,
+              invocationId: invocationId
+            });
+          },
+          onEvent: __transportOnEvent,
+          send: __transportSend,
+          close: __transportClose
+        });
 
         let __deviceSeq = 0;
         const __deviceNonce = Math.random().toString(36).slice(2);
@@ -1853,7 +1873,9 @@ class PluginManager {
               pluginId: pluginId,
               generation: pluginGeneration,
               bridgeToken: pluginBridgeToken,
-              handlers: handlers
+              handlers: handlers,
+              connectTransport: (invocationId) =>
+                __connectTransport(registrationHandle, invocationId)
             });
             return __deviceCall("register", {
               registrationHandle: registrationHandle,
@@ -2050,9 +2072,6 @@ class PluginManager {
             attempt.pluginId == id && attempt.generation == retiringGeneration,
       );
       _timedOutDeviceConnects.removeWhere(
-        (key, _) => key.$1 == id && key.$2 == retiringGeneration,
-      );
-      _retiredDeviceConnectInvocations.removeWhere(
         (key, _) => key.$1 == id && key.$2 == retiringGeneration,
       );
       _removePluginBridgeToken(id);

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -46,12 +46,14 @@ class _PendingDeviceInvocation {
   _PendingDeviceInvocation({
     required this.pluginId,
     required this.generation,
+    required this.operation,
     required this.completer,
     required this.timer,
   });
 
   final String pluginId;
   final int generation;
+  final PluginDeviceOperation operation;
   final Completer<Map<String, dynamic>> completer;
   final Timer timer;
 }
@@ -105,6 +107,8 @@ class PluginManager {
   late final PluginTransportService _transportService;
   final Map<String, _PendingDeviceInvocation> _pendingDeviceInvocations = {};
   int _deviceInvocationSequence = 0;
+
+  final Set<(String, int)> _deviceDisconnectCleanup = {};
 
   De1Controller? get de1Controller => _de1controller;
   PluginManagerLifecycle get lifecycle => _lifecycle;
@@ -212,6 +216,7 @@ class PluginManager {
       _plugins.clear();
       _pluginGenerations.clear();
       _retiringPluginGenerations.clear();
+      _deviceDisconnectCleanup.clear();
       _pluginStorageOperations.clear();
       _pluginBridgeTokens.clear();
       _pluginIdsByBridgeToken.clear();
@@ -1062,16 +1067,28 @@ class PluginManager {
     final generation = msg['generation'] is num
         ? (msg['generation'] as num).toInt()
         : 0;
-    if (generation != _pluginGenerations[pluginId] ||
-        _plugins[pluginId]?.isAlive != true) {
-      return;
-    }
     final type = msg['type'];
     final payload = msg['payload'];
     if (payload is! Map) return;
     final data = Map<String, dynamic>.from(payload);
     if (type == 'invocationResult') {
+      final invocationId = data['invocationId'];
+      final pending = invocationId is String
+          ? _pendingDeviceInvocations[invocationId]
+          : null;
+      final cleanupDisconnect =
+          pending?.operation == PluginDeviceOperation.disconnect &&
+          _deviceDisconnectCleanup.contains((pluginId, generation));
+      if ((generation != _pluginGenerations[pluginId] ||
+              _plugins[pluginId]?.isAlive != true) &&
+          !cleanupDisconnect) {
+        return;
+      }
       _completeDeviceInvocation(pluginId, generation, data);
+      return;
+    }
+    if (generation != _pluginGenerations[pluginId] ||
+        _plugins[pluginId]?.isAlive != true) {
       return;
     }
     final requestId = msg['requestId'];
@@ -1188,9 +1205,15 @@ class PluginManager {
     PluginDeviceOperation operation,
     Map<String, dynamic> payload,
   ) {
-    if (_lifecycle != PluginManagerLifecycle.active ||
-        generation != _pluginGenerations[pluginId] ||
-        _plugins[pluginId]?.isAlive != true) {
+    final isCurrent =
+        _lifecycle == PluginManagerLifecycle.active &&
+        generation == _pluginGenerations[pluginId] &&
+        _plugins[pluginId]?.isAlive == true;
+    final cleanupDisconnect =
+        operation == PluginDeviceOperation.disconnect &&
+        _lifecycle == PluginManagerLifecycle.active &&
+        _deviceDisconnectCleanup.contains((pluginId, generation));
+    if (!isCurrent && !cleanupDisconnect) {
       return Future.error(
         const PluginDeviceException('Plugin generation changed'),
       );
@@ -1207,6 +1230,7 @@ class PluginManager {
     _pendingDeviceInvocations[invocationId] = _PendingDeviceInvocation(
       pluginId: pluginId,
       generation: generation,
+      operation: operation,
       completer: completer,
       timer: timer,
     );
@@ -1659,7 +1683,13 @@ class PluginManager {
                   unregister() {
                     return __deviceCall("unregister", {
                       registrationHandle: registrationHandle
-                    }).then(() => __deviceRemoveHandlers(registrationHandle));
+                    }).then(
+                      () => __deviceRemoveHandlers(registrationHandle),
+                      (error) => {
+                        __deviceRemoveHandlers(registrationHandle);
+                        throw error;
+                      }
+                    );
                   }
                 };
                 return Object.freeze(device);
@@ -1865,9 +1895,6 @@ class PluginManager {
         globalThis.__rejectDevicePendingForToken(
           ${jsonEncode(pluginBridgeToken)}, "plugin unloaded"
         );
-        globalThis.__clearDeviceHandlersForPlugin(
-          ${jsonEncode(pluginId)}
-        );
       ''');
       while (js.executePendingJob() > 0) {}
     });
@@ -1879,12 +1906,27 @@ class PluginManager {
         'Plugin unloaded',
       ),
     );
+    _deviceDisconnectCleanup.add((pluginId, retiringGeneration));
     try {
-      await deviceService.removeAllForPlugin(pluginId, retiringGeneration);
+      await deviceService.removeAllForPlugin(
+        pluginId,
+        retiringGeneration,
+        runDisconnect: _lifecycle == PluginManagerLifecycle.active,
+      );
     } catch (error, stackTrace) {
       firstError ??= error;
       firstStackTrace ??= stackTrace;
+    } finally {
+      _deviceDisconnectCleanup.remove((pluginId, retiringGeneration));
     }
+    attempt(() {
+      js.evaluate('''
+        globalThis.__clearDeviceHandlersForPlugin(
+          ${jsonEncode(pluginId)}
+        );
+      ''');
+      while (js.executePendingJob() > 0) {}
+    });
     try {
       await _transportService.closeAllForPlugin(pluginId, retiringGeneration);
     } catch (error, stackTrace) {

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -8,6 +8,7 @@ import 'package:logging/logging.dart';
 
 import 'plugin_manifest.dart';
 import 'plugin_decent_proxy_bridge.dart';
+import 'plugin_device_service.dart';
 import 'plugin_runtime.dart';
 import 'plugin_transport_service.dart';
 import 'plugin_types.dart';
@@ -39,6 +40,20 @@ class _PendingOp {
   Completer<Map<String, dynamic>>? completer;
 
   String get key => '${kind.name}:$requestId';
+}
+
+class _PendingDeviceInvocation {
+  _PendingDeviceInvocation({
+    required this.pluginId,
+    required this.generation,
+    required this.completer,
+    required this.timer,
+  });
+
+  final String pluginId;
+  final int generation;
+  final Completer<Map<String, dynamic>> completer;
+  final Timer timer;
 }
 
 class PluginHttpError implements Exception {
@@ -73,6 +88,8 @@ class PluginManager {
   final Duration pluginHttpTimeout;
   final Duration decentProxyTimeout;
   final Duration transportCloseTimeout;
+  final Duration deviceInvocationTimeout;
+  final PluginDeviceService deviceService;
 
   De1Controller? _de1controller;
   StreamSubscription<De1Interface?>? _de1Subscription;
@@ -86,6 +103,8 @@ class PluginManager {
   final Map<String, int> _retiringPluginGenerations = {};
   final Map<(String, int), Set<Future<void>>> _pluginStorageOperations = {};
   late final PluginTransportService _transportService;
+  final Map<String, _PendingDeviceInvocation> _pendingDeviceInvocations = {};
+  int _deviceInvocationSequence = 0;
 
   De1Controller? get de1Controller => _de1controller;
   PluginManagerLifecycle get lifecycle => _lifecycle;
@@ -110,7 +129,10 @@ class PluginManager {
     SocketConnector? connectSocket,
     SecureSocketConnector? connectSecureSocket,
     this.transportCloseTimeout = const Duration(seconds: 5),
-  }) : js = js ?? getJavascriptRuntime(xhr: false) {
+    this.deviceInvocationTimeout = const Duration(seconds: 10),
+    PluginDeviceService? deviceService,
+  }) : js = js ?? getJavascriptRuntime(xhr: false),
+       deviceService = deviceService ?? PluginDeviceService() {
     _decentProxyBridge = PluginDecentProxyBridge(
       decentProxyService: decentProxyService,
       log: _log,
@@ -193,6 +215,15 @@ class PluginManager {
       _pluginStorageOperations.clear();
       _pluginBridgeTokens.clear();
       _pluginIdsByBridgeToken.clear();
+      for (final pending in _pendingDeviceInvocations.values) {
+        pending.timer.cancel();
+        if (!pending.completer.isCompleted) {
+          pending.completer.completeError(
+            const PluginDeviceException('Plugin manager disposed'),
+          );
+        }
+      }
+      _pendingDeviceInvocations.clear();
       _de1Subscription = null;
       _snapshotSubscription = null;
       _de1controller = null;
@@ -638,6 +669,103 @@ class PluginManager {
           __mapClear(__transportListeners);
         });
 
+        const __devicePending = new Map();
+        const __deviceHandlers = new Map();
+        function __sendDeviceMessage(message) {
+          __nativeSendMessage("devices", __nativeJsonStringify(message));
+        }
+        __frozenTransportGlobal("__deviceRequest", function (bridgeToken, generation, requestId, type, payload) {
+          __sendDeviceMessage({
+            bridgeToken: bridgeToken,
+            generation: generation,
+            requestId: requestId,
+            type: type,
+            payload: payload
+          });
+        });
+        __frozenTransportGlobal("__deviceRegisterPending", function (requestId, entry) {
+          __mapSet(__devicePending, requestId, entry);
+        });
+        __frozenTransportGlobal("__deviceSetHandlers", function (handle, entry) {
+          __mapSet(__deviceHandlers, handle, entry);
+        });
+        __frozenTransportGlobal("__deviceRemoveHandlers", function (handle) {
+          __mapDelete(__deviceHandlers, handle);
+        });
+        __frozenTransportGlobal("__handleDeviceReply", function (msg) {
+          const pending = __mapGet(__devicePending, msg.requestId);
+          if (!pending || pending.bridgeToken !== msg.bridgeToken) return;
+          __mapDelete(__devicePending, msg.requestId);
+          if (msg.error) {
+            const error = new __NativeError(msg.error);
+            if (msg.code) error.code = msg.code;
+            pending.reject(error);
+            return;
+          }
+          pending.resolve(msg.result || {});
+        });
+        __frozenTransportGlobal("__dispatchDeviceInvocation", function (pluginId, generation, handle, invocationId, operation, payload) {
+          const entry = __mapGet(__deviceHandlers, handle);
+          if (!entry || entry.pluginId !== pluginId || entry.generation !== generation) return;
+          const handler = entry.handlers[operation];
+          if (typeof handler !== "function") {
+            __sendDeviceMessage({
+              bridgeToken: entry.bridgeToken,
+              generation: generation,
+              type: "invocationResult",
+              payload: { invocationId: invocationId, error: "Missing device " + operation + " handler" }
+            });
+            return;
+          }
+          try {
+            const promise = __nativeReflectApply(
+              __nativePromiseResolve,
+              __NativePromise,
+              [handler(payload)]
+            );
+            __nativeReflectApply(__nativePromiseThen, promise, [
+              (result) => __sendDeviceMessage({
+                bridgeToken: entry.bridgeToken,
+                generation: generation,
+                type: "invocationResult",
+                payload: { invocationId: invocationId, result: result || {} }
+              }),
+              (error) => __sendDeviceMessage({
+                bridgeToken: entry.bridgeToken,
+                generation: generation,
+                type: "invocationResult",
+                payload: { invocationId: invocationId, error: String(error) }
+              })
+            ]);
+          } catch (error) {
+            __sendDeviceMessage({
+              bridgeToken: entry.bridgeToken,
+              generation: generation,
+              type: "invocationResult",
+              payload: { invocationId: invocationId, error: String(error) }
+            });
+          }
+        });
+        __frozenTransportGlobal("__rejectDevicePendingForToken", function (bridgeToken, error) {
+          __mapForEach(__devicePending, (pending, requestId) => {
+            if (pending.bridgeToken !== bridgeToken) return;
+            __mapDelete(__devicePending, requestId);
+            pending.reject(new __NativeError(error));
+          });
+        });
+        __frozenTransportGlobal("__rejectAllDevicePending", function (error) {
+          __mapForEach(__devicePending, (pending) => pending.reject(new __NativeError(error)));
+          __mapClear(__devicePending);
+        });
+        __frozenTransportGlobal("__clearDeviceHandlersForPlugin", function (pluginId) {
+          __mapForEach(__deviceHandlers, (entry, handle) => {
+            if (entry.pluginId === pluginId) __mapDelete(__deviceHandlers, handle);
+          });
+        });
+        __frozenTransportGlobal("__clearAllDeviceHandlers", function () {
+          __mapClear(__deviceHandlers);
+        });
+
         Object.defineProperty(globalThis, "host", {
           value: __nativeFreeze({
             log(bridgeToken, generation, message) {
@@ -777,7 +905,8 @@ class PluginManager {
                 fetch: globalThis.__fetchFor,
                 timerSet: globalThis.__timerSet,
                 timerClear: globalThis.__timerClear,
-                transportRequest: globalThis.__transportRequest
+                transportRequest: globalThis.__transportRequest,
+                deviceRequest: globalThis.__deviceRequest
               }),
               writable: false,
               configurable: false,
@@ -834,6 +963,18 @@ class PluginManager {
         }
       } catch (e, st) {
         _log.warning("Invalid transport message", e, st);
+      }
+    });
+
+    js.onMessage("devices", (raw) {
+      try {
+        final msg = raw as Map<String, dynamic>;
+        final pluginId = _pluginIdForBridgeMessage(msg, 'devices');
+        if (pluginId != null) {
+          unawaited(_handleDeviceMessage(pluginId, msg));
+        }
+      } catch (e, st) {
+        _log.warning("Invalid plugin device message", e, st);
       }
     });
   }
@@ -908,6 +1049,236 @@ class PluginManager {
       await _handleTransportMessage(pluginId, msg);
     } catch (e, st) {
       _log.warning("Invalid transport message", e, st);
+    }
+  }
+
+  Future<void> _handleDeviceMessage(
+    String pluginId,
+    Map<String, dynamic> msg,
+  ) async {
+    await Future<void>.delayed(Duration.zero);
+    if (_lifecycle != PluginManagerLifecycle.active) return;
+    final bridgeToken = msg['bridgeToken'];
+    final generation = msg['generation'] is num
+        ? (msg['generation'] as num).toInt()
+        : 0;
+    if (generation != _pluginGenerations[pluginId] ||
+        _plugins[pluginId]?.isAlive != true) {
+      return;
+    }
+    final type = msg['type'];
+    final payload = msg['payload'];
+    if (payload is! Map) return;
+    final data = Map<String, dynamic>.from(payload);
+    if (type == 'invocationResult') {
+      _completeDeviceInvocation(pluginId, generation, data);
+      return;
+    }
+    final requestId = msg['requestId'];
+    if (requestId is! String) return;
+
+    try {
+      final registrationHandle = data['registrationHandle'];
+      if (registrationHandle is! String) {
+        throw const PluginDeviceException('Invalid registration handle');
+      }
+      switch (type) {
+        case 'register':
+          final definition = data['definition'];
+          if (definition is! Map) {
+            throw const PluginDeviceException(
+              'Invalid plugin device definition',
+            );
+          }
+          final typedDefinition = Map<String, dynamic>.from(definition);
+          final driverId = typedDefinition['driverId'];
+          final declared =
+              _plugins[pluginId]?.manifest.drivers.any(
+                (driver) =>
+                    driver.id == driverId &&
+                    driver.type == PluginDriverType.sensor,
+              ) ??
+              false;
+          if (!declared) {
+            throw const PluginDeviceException(
+              'Device driver is not declared by this plugin',
+            );
+          }
+          final registered = await deviceService.register(
+            pluginId: pluginId,
+            generation: generation,
+            registrationHandle: registrationHandle,
+            definition: typedDefinition,
+            invoke: (operation, parameters) => _invokeDeviceHandler(
+              pluginId,
+              generation,
+              registrationHandle,
+              operation,
+              parameters,
+            ),
+          );
+          _replyDevice(
+            requestId,
+            bridgeToken,
+            result: {'deviceId': registered.deviceId},
+          );
+        case 'publish':
+          final snapshot = data['snapshot'];
+          if (snapshot is! Map) {
+            throw const PluginDeviceException('Invalid plugin device snapshot');
+          }
+          deviceService.publish(
+            pluginId: pluginId,
+            generation: generation,
+            registrationHandle: registrationHandle,
+            snapshot: Map<String, dynamic>.from(snapshot),
+          );
+          _replyDevice(requestId, bridgeToken, result: const {});
+        case 'reportDisconnected':
+          deviceService.reportDisconnected(
+            pluginId: pluginId,
+            generation: generation,
+            registrationHandle: registrationHandle,
+          );
+          _replyDevice(requestId, bridgeToken, result: const {});
+        case 'unregister':
+          await deviceService.unregister(
+            pluginId: pluginId,
+            generation: generation,
+            registrationHandle: registrationHandle,
+          );
+          _replyDevice(requestId, bridgeToken, result: const {});
+        default:
+          throw const PluginDeviceException('Unknown plugin device operation');
+      }
+    } on PluginDeviceException catch (error) {
+      _replyDevice(
+        requestId,
+        bridgeToken,
+        error: error.message,
+        code: 'plugin_device_error',
+      );
+    } catch (error) {
+      _replyDevice(requestId, bridgeToken, error: error.toString());
+    }
+  }
+
+  void _replyDevice(
+    String requestId,
+    Object? bridgeToken, {
+    Map<String, dynamic>? result,
+    String? error,
+    String? code,
+  }) {
+    try {
+      js.evaluate(
+        'globalThis.__handleDeviceReply('
+        '${jsonEncode({'requestId': requestId, 'bridgeToken': ?bridgeToken, 'result': result, 'error': error, 'code': code})});',
+      );
+      while (js.executePendingJob() > 0) {}
+    } catch (error, stackTrace) {
+      _log.warning('Failed to deliver plugin device reply', error, stackTrace);
+    }
+  }
+
+  Future<Map<String, dynamic>> _invokeDeviceHandler(
+    String pluginId,
+    int generation,
+    String registrationHandle,
+    PluginDeviceOperation operation,
+    Map<String, dynamic> payload,
+  ) {
+    if (_lifecycle != PluginManagerLifecycle.active ||
+        generation != _pluginGenerations[pluginId] ||
+        _plugins[pluginId]?.isAlive != true) {
+      return Future.error(
+        const PluginDeviceException('Plugin generation changed'),
+      );
+    }
+    final invocationId =
+        '${pluginId}_${generation}_device_${++_deviceInvocationSequence}';
+    final completer = Completer<Map<String, dynamic>>();
+    final timer = Timer(deviceInvocationTimeout, () {
+      final pending = _pendingDeviceInvocations.remove(invocationId);
+      pending?.completer.completeError(
+        const PluginDeviceException('Plugin device invocation timed out'),
+      );
+    });
+    _pendingDeviceInvocations[invocationId] = _PendingDeviceInvocation(
+      pluginId: pluginId,
+      generation: generation,
+      completer: completer,
+      timer: timer,
+    );
+    try {
+      js.evaluate(
+        'globalThis.__dispatchDeviceInvocation('
+        '${jsonEncode(pluginId)}, $generation, '
+        '${jsonEncode(registrationHandle)}, ${jsonEncode(invocationId)}, '
+        '${jsonEncode(operation.name)}, ${jsonEncode(payload)});',
+      );
+      while (js.executePendingJob() > 0) {}
+    } catch (error) {
+      final pending = _pendingDeviceInvocations.remove(invocationId);
+      pending?.timer.cancel();
+      pending?.completer.completeError(error);
+    }
+    return completer.future;
+  }
+
+  void _completeDeviceInvocation(
+    String pluginId,
+    int generation,
+    Map<String, dynamic> payload,
+  ) {
+    final invocationId = payload['invocationId'];
+    if (invocationId is! String) return;
+    final pending = _pendingDeviceInvocations[invocationId];
+    if (pending == null ||
+        pending.pluginId != pluginId ||
+        pending.generation != generation) {
+      return;
+    }
+    _pendingDeviceInvocations.remove(invocationId);
+    pending.timer.cancel();
+    final error = payload['error'];
+    if (error != null) {
+      pending.completer.completeError(PluginDeviceException(error.toString()));
+      return;
+    }
+    final result = payload['result'];
+    if (result == null) {
+      pending.completer.complete(const {});
+    } else if (result is Map) {
+      pending.completer.complete(Map<String, dynamic>.from(result));
+    } else {
+      pending.completer.completeError(
+        const PluginDeviceException(
+          'Plugin device handler must return an object',
+        ),
+      );
+    }
+  }
+
+  void _rejectDeviceInvocations(
+    String pluginId,
+    int generation,
+    String reason,
+  ) {
+    final ids = _pendingDeviceInvocations.entries
+        .where(
+          (entry) =>
+              entry.value.pluginId == pluginId &&
+              entry.value.generation == generation,
+        )
+        .map((entry) => entry.key)
+        .toList();
+    for (final id in ids) {
+      final pending = _pendingDeviceInvocations.remove(id)!;
+      pending.timer.cancel();
+      if (!pending.completer.isCompleted) {
+        pending.completer.completeError(PluginDeviceException(reason));
+      }
     }
   }
 
@@ -1238,6 +1609,68 @@ class PluginManager {
             return __transportCall("close", { handle: handle });
           }
         };
+
+        let __deviceSeq = 0;
+        const __deviceNonce = Math.random().toString(36).slice(2);
+        const __deviceCall = (type, payload) => {
+          return new Promise((resolve, reject) => {
+            const requestId = pluginId + "_device_" + pluginGeneration + "_" + __deviceNonce + "_" + (++__deviceSeq);
+            __deviceRegisterPending(requestId, { bridgeToken: pluginBridgeToken, resolve: resolve, reject: reject });
+            pluginHostBridge.deviceRequest(pluginBridgeToken, pluginGeneration, requestId, type, payload);
+          });
+        };
+        const declaredDrivers = ${jsonEncode(manifest.drivers.map((driver) => driver.toJson()).toList())};
+        const devices = {
+          register(definition, handlers) {
+            const driver = definition && declaredDrivers.find((entry) => entry.id === definition.driverId);
+            if (!driver || driver.type !== "sensor") {
+              return Promise.reject(new Error("Device driver is not declared by this plugin"));
+            }
+            if (!handlers || typeof handlers.connect !== "function" ||
+                typeof handlers.disconnect !== "function" ||
+                typeof handlers.execute !== "function") {
+              return Promise.reject(new Error("Device handlers connect, disconnect, and execute are required"));
+            }
+            const registrationHandle = "device_" + pluginGeneration + "_" + __deviceNonce + "_" + (++__deviceSeq);
+            __deviceSetHandlers(registrationHandle, {
+              pluginId: pluginId,
+              generation: pluginGeneration,
+              bridgeToken: pluginBridgeToken,
+              handlers: handlers
+            });
+            return __deviceCall("register", {
+              registrationHandle: registrationHandle,
+              definition: definition
+            }).then(
+              (result) => {
+                const device = {
+                  deviceId: result.deviceId,
+                  publish(snapshot) {
+                    return __deviceCall("publish", {
+                      registrationHandle: registrationHandle,
+                      snapshot: snapshot
+                    });
+                  },
+                  reportDisconnected() {
+                    return __deviceCall("reportDisconnected", {
+                      registrationHandle: registrationHandle
+                    });
+                  },
+                  unregister() {
+                    return __deviceCall("unregister", {
+                      registrationHandle: registrationHandle
+                    }).then(() => __deviceRemoveHandlers(registrationHandle));
+                  }
+                };
+                return Object.freeze(device);
+              },
+              (error) => {
+                __deviceRemoveHandlers(registrationHandle);
+                throw error;
+              }
+            );
+          }
+        };
         
         // Create the host object for this plugin
         const host = {
@@ -1269,7 +1702,8 @@ class PluginManager {
               options.contentType ?? null
             );
           },
-          transport: transport
+          transport: transport,
+          devices: devices
         };
         
         // Inject and evaluate the plugin code
@@ -1428,10 +1862,29 @@ class PluginManager {
         globalThis.__clearTransportListenersForPlugin(
           ${jsonEncode(pluginId)}
         );
+        globalThis.__rejectDevicePendingForToken(
+          ${jsonEncode(pluginBridgeToken)}, "plugin unloaded"
+        );
+        globalThis.__clearDeviceHandlersForPlugin(
+          ${jsonEncode(pluginId)}
+        );
       ''');
       while (js.executePendingJob() > 0) {}
     });
     attempt(() => _cancelTimersForPlugin(pluginId, pluginBridgeToken));
+    attempt(
+      () => _rejectDeviceInvocations(
+        pluginId,
+        retiringGeneration,
+        'Plugin unloaded',
+      ),
+    );
+    try {
+      await deviceService.removeAllForPlugin(pluginId, retiringGeneration);
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
     try {
       await _transportService.closeAllForPlugin(pluginId, retiringGeneration);
     } catch (error, stackTrace) {
@@ -1634,6 +2087,8 @@ class PluginManager {
           globalThis.__reaprimePluginBridge.cancelAll("manager disposal");
           globalThis.__rejectAllTransportPending("manager disposal");
           globalThis.__clearAllTransportListeners();
+          globalThis.__rejectAllDevicePending("manager disposal");
+          globalThis.__clearAllDeviceHandlers();
         ''');
       while (js.executePendingJob() > 0) {}
     });
@@ -1647,6 +2102,12 @@ class PluginManager {
     });
     try {
       await _transportService.dispose();
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+    try {
+      await deviceService.dispose();
     } catch (error, stackTrace) {
       firstError ??= error;
       firstStackTrace ??= stackTrace;

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -1131,6 +1131,10 @@ class PluginManager {
           retired.remove(invocationId);
           if (retired.isEmpty) {
             _retiredDeviceConnectInvocations.remove((pluginId, generation));
+            await _transportService.closeRetiredConnectCandidates(
+              pluginId,
+              generation,
+            );
           }
         }
       }
@@ -1533,17 +1537,6 @@ class PluginManager {
             );
             return;
           }
-          if (!ownsDeviceConnect &&
-              _retiredDeviceConnectInvocations[(pluginId, generation)]
-                      ?.isNotEmpty ==
-                  true) {
-            _replyTransport(
-              requestId,
-              bridgeToken,
-              error: 'Plugin device connect retired',
-            );
-            return;
-          }
           final result = await _transportService.open(
             pluginId: pluginId,
             generation: generation,
@@ -1552,6 +1545,17 @@ class PluginManager {
                 ? deviceRegistrationHandle
                 : null,
             deviceInvocationId: ownsDeviceConnect ? deviceInvocationId : null,
+            retiredConnectCandidate:
+                !ownsDeviceConnect &&
+                _retiredDeviceConnectInvocations[(pluginId, generation)]
+                        ?.isNotEmpty ==
+                    true &&
+                !_pendingDeviceInvocations.values.any(
+                  (pending) =>
+                      pending.pluginId == pluginId &&
+                      pending.generation == generation &&
+                      pending.operation == PluginDeviceOperation.connect,
+                ),
           );
           if (!_isCurrentPluginMessage(pluginId, {'generation': generation})) {
             unawaited(

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -739,15 +739,23 @@ class PluginManager {
             });
             return;
           }
+          const previousDeviceConnect = __activeDeviceConnect;
+          const connectContext = operation === "connect"
+            ? { registrationHandle: handle, invocationId: invocationId }
+            : null;
           try {
-            const previousDeviceConnect = __activeDeviceConnect;
             let handlerResult;
             try {
-              __activeDeviceConnect = operation === "connect"
-                ? { registrationHandle: handle, invocationId: invocationId }
-                : null;
+              __activeDeviceConnect = connectContext;
               handlerResult = handler(payload);
-            } finally {
+            } catch (error) {
+              __activeDeviceConnect = previousDeviceConnect;
+              throw error;
+            }
+            const keepsDeviceConnectContext =
+              connectContext && handlerResult &&
+              typeof handlerResult.then === "function";
+            if (!keepsDeviceConnectContext) {
               __activeDeviceConnect = previousDeviceConnect;
             }
             const promise = __nativeReflectApply(
@@ -756,20 +764,36 @@ class PluginManager {
               [handlerResult]
             );
             __nativeReflectApply(__nativePromiseThen, promise, [
-              (result) => __sendDeviceMessage({
-                bridgeToken: entry.bridgeToken,
-                generation: generation,
-                type: "invocationResult",
-                payload: { invocationId: invocationId, result: result }
-              }),
-              (error) => __sendDeviceMessage({
-                bridgeToken: entry.bridgeToken,
-                generation: generation,
-                type: "invocationResult",
-                payload: { invocationId: invocationId, error: String(error) }
-              })
+              (result) => {
+                if (keepsDeviceConnectContext &&
+                    __activeDeviceConnect === connectContext) {
+                  __activeDeviceConnect = previousDeviceConnect;
+                }
+                __sendDeviceMessage({
+                  bridgeToken: entry.bridgeToken,
+                  generation: generation,
+                  type: "invocationResult",
+                  payload: { invocationId: invocationId, result: result }
+                });
+              },
+              (error) => {
+                if (keepsDeviceConnectContext &&
+                    __activeDeviceConnect === connectContext) {
+                  __activeDeviceConnect = previousDeviceConnect;
+                }
+                __sendDeviceMessage({
+                  bridgeToken: entry.bridgeToken,
+                  generation: generation,
+                  type: "invocationResult",
+                  payload: { invocationId: invocationId, error: String(error) }
+                });
+              }
             ]);
+            return;
           } catch (error) {
+            if (__activeDeviceConnect === connectContext) {
+              __activeDeviceConnect = previousDeviceConnect;
+            }
             __sendDeviceMessage({
               bridgeToken: entry.bridgeToken,
               generation: generation,

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -1051,7 +1051,15 @@ class PluginManager {
     Map<String, dynamic> msg,
   ) async {
     await Future<void>.delayed(Duration.zero);
-    if (_lifecycle != PluginManagerLifecycle.active) return;
+    final generation = msg['generation'];
+    final cleanupTransportClose =
+        msg['type'] == 'close' &&
+        generation is num &&
+        _isDeviceDisconnectCleanup(pluginId, generation.toInt()) &&
+        _plugins[pluginId]?.state == PluginRuntimeState.stopping;
+    if (_lifecycle != PluginManagerLifecycle.active && !cleanupTransportClose) {
+      return;
+    }
     try {
       await _handleTransportMessage(pluginId, msg);
     } catch (e, st) {
@@ -1064,7 +1072,6 @@ class PluginManager {
     Map<String, dynamic> msg,
   ) async {
     await Future<void>.delayed(Duration.zero);
-    if (_lifecycle != PluginManagerLifecycle.active) return;
     final bridgeToken = msg['bridgeToken'];
     final generation = msg['generation'] is num
         ? (msg['generation'] as num).toInt()
@@ -1073,14 +1080,18 @@ class PluginManager {
     final payload = msg['payload'];
     if (payload is! Map) return;
     final data = Map<String, dynamic>.from(payload);
+    final invocationId = data['invocationId'];
+    final pending = invocationId is String
+        ? _pendingDeviceInvocations[invocationId]
+        : null;
+    final cleanupDisconnect =
+        type == 'invocationResult' &&
+        pending?.operation == PluginDeviceOperation.disconnect &&
+        _isDeviceDisconnectCleanup(pluginId, generation);
+    if (_lifecycle != PluginManagerLifecycle.active && !cleanupDisconnect) {
+      return;
+    }
     if (type == 'invocationResult') {
-      final invocationId = data['invocationId'];
-      final pending = invocationId is String
-          ? _pendingDeviceInvocations[invocationId]
-          : null;
-      final cleanupDisconnect =
-          pending?.operation == PluginDeviceOperation.disconnect &&
-          _deviceDisconnectCleanup.contains((pluginId, generation));
       if ((generation != _pluginGenerations[pluginId] ||
               _plugins[pluginId]?.isAlive != true) &&
           !cleanupDisconnect) {
@@ -1220,8 +1231,7 @@ class PluginManager {
         _plugins[pluginId]?.isAlive == true;
     final cleanupDisconnect =
         operation == PluginDeviceOperation.disconnect &&
-        _lifecycle == PluginManagerLifecycle.active &&
-        _deviceDisconnectCleanup.contains((pluginId, generation));
+        _isDeviceDisconnectCleanup(pluginId, generation);
     if (!isCurrent && !cleanupDisconnect) {
       return Future.error(
         const PluginDeviceException('Plugin generation changed'),
@@ -1341,9 +1351,8 @@ class PluginManager {
         _plugins[pluginId]?.isAlive == true;
     final cleanupTransportClose =
         type == 'close' &&
-        _lifecycle == PluginManagerLifecycle.active &&
-        _plugins[pluginId]?.state == PluginRuntimeState.stopping &&
-        _deviceDisconnectCleanup.contains((pluginId, generation));
+        _isDeviceDisconnectCleanup(pluginId, generation) &&
+        _plugins[pluginId]?.state == PluginRuntimeState.stopping;
     if (!current && !cleanupTransportClose) {
       _replyTransport(
         requestId,
@@ -1508,6 +1517,11 @@ class PluginManager {
       _log.warning('Failed to remove transport listener', e, st);
     }
   }
+
+  bool _isDeviceDisconnectCleanup(String pluginId, int generation) =>
+      (_lifecycle == PluginManagerLifecycle.active ||
+          _lifecycle == PluginManagerLifecycle.disposing) &&
+      _deviceDisconnectCleanup.contains((pluginId, generation));
 
   int? _messageGeneration(String pluginId, Map<String, dynamic> msg) {
     final generation = msg['generation'];
@@ -1934,7 +1948,9 @@ class PluginManager {
       await deviceService.removeAllForPlugin(
         pluginId,
         retiringGeneration,
-        runDisconnect: _lifecycle == PluginManagerLifecycle.active,
+        runDisconnect:
+            _lifecycle == PluginManagerLifecycle.active ||
+            _lifecycle == PluginManagerLifecycle.disposing,
       );
     } catch (error, stackTrace) {
       firstError ??= error;

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -735,7 +735,7 @@ class PluginManager {
                 bridgeToken: entry.bridgeToken,
                 generation: generation,
                 type: "invocationResult",
-                payload: { invocationId: invocationId, result: result || {} }
+                payload: { invocationId: invocationId, result: result }
               }),
               (error) => __sendDeviceMessage({
                 bridgeToken: entry.bridgeToken,
@@ -1177,7 +1177,10 @@ class PluginManager {
             generation,
             'Plugin device unregistered',
             registrationHandle: registrationHandle,
-            excludeOperation: PluginDeviceOperation.disconnect,
+            excludeOperations: {
+              PluginDeviceOperation.connect,
+              PluginDeviceOperation.disconnect,
+            },
           );
           await deviceService.unregister(
             pluginId: pluginId,
@@ -1290,10 +1293,12 @@ class PluginManager {
       pending.completer.completeError(PluginDeviceException(error.toString()));
       return;
     }
-    final result = payload['result'];
-    if (result == null) {
+    if (pending.operation != PluginDeviceOperation.execute) {
       pending.completer.complete(const {});
-    } else if (result is Map) {
+      return;
+    }
+    final result = payload['result'];
+    if (result is Map) {
       pending.completer.complete(Map<String, dynamic>.from(result));
     } else {
       pending.completer.completeError(
@@ -1309,7 +1314,7 @@ class PluginManager {
     int generation,
     String reason, {
     String? registrationHandle,
-    PluginDeviceOperation? excludeOperation,
+    Set<PluginDeviceOperation>? excludeOperations,
   }) {
     final ids = _pendingDeviceInvocations.entries
         .where(
@@ -1318,8 +1323,8 @@ class PluginManager {
               entry.value.generation == generation &&
               (registrationHandle == null ||
                   entry.value.registrationHandle == registrationHandle) &&
-              (excludeOperation == null ||
-                  entry.value.operation != excludeOperation),
+              (excludeOperations == null ||
+                  !excludeOperations.contains(entry.value.operation)),
         )
         .map((entry) => entry.key)
         .toList();
@@ -1941,6 +1946,7 @@ class PluginManager {
         pluginId,
         retiringGeneration,
         'Plugin unloaded',
+        excludeOperations: const {PluginDeviceOperation.connect},
       ),
     );
     _deviceDisconnectCleanup.add((pluginId, retiringGeneration));

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -19,6 +19,47 @@ String pluginSettingLabel(String key, dynamic schema) {
   return trimmed.isEmpty ? key : trimmed;
 }
 
+enum PluginDriverType { sensor }
+
+List<PluginDriverDeclaration> parsePluginDrivers(dynamic json) {
+  if (json == null) return const [];
+  if (json is! List) {
+    throw const FormatException('Plugin drivers must be an array');
+  }
+  if (json.length > 8) {
+    throw const FormatException('A plugin may declare at most 8 drivers');
+  }
+  final drivers = json.map(PluginDriverDeclaration.fromJson).toList();
+  if (drivers.map((driver) => driver.id).toSet().length != drivers.length) {
+    throw const FormatException('Plugin driver ids must be unique');
+  }
+  return List.unmodifiable(drivers);
+}
+
+class PluginDriverDeclaration {
+  final String id;
+  final PluginDriverType type;
+
+  const PluginDriverDeclaration({required this.id, required this.type});
+
+  factory PluginDriverDeclaration.fromJson(dynamic json) {
+    if (json is! Map || json['id'] is! String || json['type'] is! String) {
+      throw const FormatException('Invalid plugin driver declaration');
+    }
+    final id = json['id'] as String;
+    final type = PluginDriverType.values.firstWhereOrNull(
+      (value) => value.name == json['type'],
+    );
+    if (!RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$').hasMatch(id) ||
+        type == null) {
+      throw FormatException('Invalid plugin driver declaration: $json');
+    }
+    return PluginDriverDeclaration(id: id, type: type);
+  }
+
+  Map<String, dynamic> toJson() => {'id': id, 'type': type.name};
+}
+
 class PluginManifest {
   final String id;
   final String name;
@@ -27,6 +68,7 @@ class PluginManifest {
   final String version;
   final int apiVersion;
   final Set<PluginPermissions> permissions;
+  final List<PluginDriverDeclaration> drivers;
   final Map<String, dynamic> settings;
   final PluginApi? api;
 
@@ -38,6 +80,7 @@ class PluginManifest {
     required this.version,
     required this.apiVersion,
     required this.permissions,
+    this.drivers = const [],
     required this.settings,
     required this.api,
   });
@@ -55,6 +98,7 @@ class PluginManifest {
       version: json['version'],
       apiVersion: json['apiVersion'],
       permissions: PluginPermissionsFromJson.fromJson(json['permissions']),
+      drivers: parsePluginDrivers(json['drivers']),
       settings: settings,
       api: PluginApi.fromJsonList(json['api']),
     );
@@ -69,6 +113,7 @@ class PluginManifest {
       'version': version,
       'apiVersion': apiVersion,
       'permissions': permissions.map((e) => e.wireName).toList(),
+      'drivers': drivers.map((driver) => driver.toJson()).toList(),
       'settings': settings,
       'api': api?.toJson(),
     };

--- a/lib/src/plugins/plugin_transport_service.dart
+++ b/lib/src/plugins/plugin_transport_service.dart
@@ -74,7 +74,6 @@ class PluginTransportService {
     required Map<String, dynamic> options,
     String? deviceRegistrationHandle,
     String? deviceInvocationId,
-    bool retiredConnectCandidate = false,
   }) async {
     final kind = switch (options['kind']) {
       'websocket' => PluginTransportKind.websocket,
@@ -100,7 +99,6 @@ class PluginTransportService {
       kind: kind,
       deviceRegistrationHandle: deviceRegistrationHandle,
       deviceInvocationId: deviceInvocationId,
-      retiredConnectCandidate: retiredConnectCandidate,
     );
     _records[record.handle] = record;
     try {
@@ -237,6 +235,20 @@ class PluginTransportService {
     }
   }
 
+  void finishDeviceConnect(
+    String pluginId,
+    int generation,
+    String registrationHandle,
+    String invocationId,
+  ) {
+    _retiredDeviceConnects.remove((
+      pluginId,
+      generation,
+      registrationHandle,
+      invocationId,
+    ));
+  }
+
   Future<void> closeDeviceConnect(
     String pluginId,
     int generation,
@@ -255,26 +267,6 @@ class PluginTransportService {
     for (final record in owned) {
       _records.remove(record.handle);
       if (record.terminal) continue;
-      record.terminal = true;
-      await _closeNative(record);
-    }
-  }
-
-  Future<void> closeRetiredConnectCandidates(
-    String pluginId,
-    int generation,
-  ) async {
-    final owned = _records.values
-        .where(
-          (record) =>
-              record.pluginId == pluginId &&
-              record.generation == generation &&
-              record.retiredConnectCandidate &&
-              !record.terminal,
-        )
-        .toList();
-    for (final record in owned) {
-      _records.remove(record.handle);
       record.terminal = true;
       await _closeNative(record);
     }
@@ -680,7 +672,6 @@ class _TransportRecord {
     required this.kind,
     this.deviceRegistrationHandle,
     this.deviceInvocationId,
-    this.retiredConnectCandidate = false,
   });
 
   final String handle;
@@ -689,7 +680,6 @@ class _TransportRecord {
   final PluginTransportKind kind;
   final String? deviceRegistrationHandle;
   final String? deviceInvocationId;
-  final bool retiredConnectCandidate;
 
   WebSocket? webSocket;
   Socket? socket;

--- a/lib/src/plugins/plugin_transport_service.dart
+++ b/lib/src/plugins/plugin_transport_service.dart
@@ -74,6 +74,7 @@ class PluginTransportService {
     required Map<String, dynamic> options,
     String? deviceRegistrationHandle,
     String? deviceInvocationId,
+    bool retiredConnectCandidate = false,
   }) async {
     final kind = switch (options['kind']) {
       'websocket' => PluginTransportKind.websocket,
@@ -99,6 +100,7 @@ class PluginTransportService {
       kind: kind,
       deviceRegistrationHandle: deviceRegistrationHandle,
       deviceInvocationId: deviceInvocationId,
+      retiredConnectCandidate: retiredConnectCandidate,
     );
     _records[record.handle] = record;
     try {
@@ -253,6 +255,26 @@ class PluginTransportService {
     for (final record in owned) {
       _records.remove(record.handle);
       if (record.terminal) continue;
+      record.terminal = true;
+      await _closeNative(record);
+    }
+  }
+
+  Future<void> closeRetiredConnectCandidates(
+    String pluginId,
+    int generation,
+  ) async {
+    final owned = _records.values
+        .where(
+          (record) =>
+              record.pluginId == pluginId &&
+              record.generation == generation &&
+              record.retiredConnectCandidate &&
+              !record.terminal,
+        )
+        .toList();
+    for (final record in owned) {
+      _records.remove(record.handle);
       record.terminal = true;
       await _closeNative(record);
     }
@@ -658,6 +680,7 @@ class _TransportRecord {
     required this.kind,
     this.deviceRegistrationHandle,
     this.deviceInvocationId,
+    this.retiredConnectCandidate = false,
   });
 
   final String handle;
@@ -666,6 +689,7 @@ class _TransportRecord {
   final PluginTransportKind kind;
   final String? deviceRegistrationHandle;
   final String? deviceInvocationId;
+  final bool retiredConnectCandidate;
 
   WebSocket? webSocket;
   Socket? socket;

--- a/lib/src/plugins/plugin_transport_service.dart
+++ b/lib/src/plugins/plugin_transport_service.dart
@@ -72,6 +72,8 @@ class PluginTransportService {
     required String pluginId,
     required int generation,
     required Map<String, dynamic> options,
+    String? deviceRegistrationHandle,
+    String? deviceInvocationId,
   }) async {
     final kind = switch (options['kind']) {
       'websocket' => PluginTransportKind.websocket,
@@ -79,20 +81,36 @@ class PluginTransportService {
       'tls' => PluginTransportKind.tls,
       _ => throw const PluginTransportException('Unknown transport kind'),
     };
+    if (deviceRegistrationHandle != null &&
+        deviceInvocationId != null &&
+        _retiredDeviceConnects.contains((
+          pluginId,
+          generation,
+          deviceRegistrationHandle,
+          deviceInvocationId,
+        ))) {
+      throw const PluginTransportException('Plugin device connect retired');
+    }
     _checkLiveLimit(pluginId, generation);
     final record = _TransportRecord(
       handle: _newHandle(),
       pluginId: pluginId,
       generation: generation,
       kind: kind,
+      deviceRegistrationHandle: deviceRegistrationHandle,
+      deviceInvocationId: deviceInvocationId,
     );
     _records[record.handle] = record;
     try {
-      return switch (kind) {
-        PluginTransportKind.websocket => await _openWebSocket(record, options),
-        PluginTransportKind.tcp => await _openTcp(record, options),
-        PluginTransportKind.tls => await _openTls(record, options),
+      final result = await switch (kind) {
+        PluginTransportKind.websocket => _openWebSocket(record, options),
+        PluginTransportKind.tcp => _openTcp(record, options),
+        PluginTransportKind.tls => _openTls(record, options),
       };
+      if (record.terminal) {
+        throw const PluginTransportException('Plugin device connect retired');
+      }
+      return result;
     } catch (_) {
       _records.remove(record.handle);
       rethrow;
@@ -191,6 +209,55 @@ class PluginTransportService {
     _records.remove(record.handle);
   }
 
+  void retireDeviceConnect(
+    String pluginId,
+    int generation,
+    String registrationHandle,
+    String invocationId,
+  ) {
+    final key = (pluginId, generation, registrationHandle, invocationId);
+    _retiredDeviceConnects.add(key);
+    final owned = _records.values
+        .where(
+          (record) =>
+              record.pluginId == pluginId &&
+              record.generation == generation &&
+              record.deviceRegistrationHandle == registrationHandle &&
+              record.deviceInvocationId == invocationId &&
+              !record.terminal &&
+              record.webSocket == null &&
+              record.socket == null,
+        )
+        .toList();
+    for (final record in owned) {
+      _records.remove(record.handle);
+      record.terminal = true;
+    }
+  }
+
+  Future<void> closeDeviceConnect(
+    String pluginId,
+    int generation,
+    String registrationHandle,
+    String invocationId,
+  ) async {
+    final owned = _records.values
+        .where(
+          (record) =>
+              record.pluginId == pluginId &&
+              record.generation == generation &&
+              record.deviceRegistrationHandle == registrationHandle &&
+              record.deviceInvocationId == invocationId,
+        )
+        .toList();
+    for (final record in owned) {
+      _records.remove(record.handle);
+      if (record.terminal) continue;
+      record.terminal = true;
+      await _closeNative(record);
+    }
+  }
+
   Future<void> closeAllForPlugin(String pluginId, int generation) async {
     final owned = _records.values
         .where(
@@ -213,7 +280,10 @@ class PluginTransportService {
       await _closeNative(record);
     }
     _records.clear();
+    _retiredDeviceConnects.clear();
   }
+
+  final Set<(String, int, String, String)> _retiredDeviceConnects = {};
 
   Future<TransportOpenResult> _openWebSocket(
     _TransportRecord record,
@@ -586,12 +656,16 @@ class _TransportRecord {
     required this.pluginId,
     required this.generation,
     required this.kind,
+    this.deviceRegistrationHandle,
+    this.deviceInvocationId,
   });
 
   final String handle;
   final String pluginId;
   final int generation;
   final PluginTransportKind kind;
+  final String? deviceRegistrationHandle;
+  final String? deviceInvocationId;
 
   WebSocket? webSocket;
   Socket? socket;

--- a/lib/src/services/device_factory.dart
+++ b/lib/src/services/device_factory.dart
@@ -64,6 +64,7 @@ class DeviceFactory {
       DeviceImplementation.debugPort => null,
       DeviceImplementation.sensorBasket => null,
       DeviceImplementation.bengleDebugPort => null,
+      DeviceImplementation.plugin => null,
     };
   }
 

--- a/test/plugins/plugin_device_service_test.dart
+++ b/test/plugins/plugin_device_service_test.dart
@@ -134,6 +134,69 @@ void main() {
     );
   });
 
+  test('scan keeps a disconnected plugin registration discoverable', () async {
+    final service = PluginDeviceService();
+    final deviceController = DeviceController([service]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    addTearDown(() async {
+      sensorController.dispose();
+      deviceController.dispose();
+      await service.dispose();
+    });
+
+    final operations = <PluginDeviceOperation>[];
+    final registered = await service.register(
+      pluginId: 'humidity.plugin',
+      generation: 1,
+      registrationHandle: 'registration-1',
+      definition: _definition('office'),
+      invoke: (operation, payload) async {
+        operations.add(operation);
+        return const {};
+      },
+    );
+    final sensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[registered.deviceId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.connected)
+        .first;
+
+    service.reportDisconnected(
+      pluginId: 'humidity.plugin',
+      generation: 1,
+      registrationHandle: 'registration-1',
+    );
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.disconnected)
+        .first;
+
+    final scan = await deviceController.scanForDevices();
+    expect(scan.failedServices, isEmpty);
+    expect(scan.matchedDevices.map((device) => device.deviceId), [
+      registered.deviceId,
+    ]);
+    expect(
+      deviceController.devices.map((device) => device.deviceId),
+      contains(registered.deviceId),
+    );
+    // The scan re-published the registration, so the sensor is connectable
+    // again through the existing sensor path.
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.connected)
+        .first
+        .timeout(const Duration(seconds: 2));
+    expect(
+      operations
+          .where((operation) => operation == PluginDeviceOperation.connect)
+          .length,
+      greaterThanOrEqualTo(2),
+    );
+  });
+
   test('new generation keeps identity and fences stale publications', () async {
     final service = PluginDeviceService();
     addTearDown(service.dispose);

--- a/test/plugins/plugin_device_service_test.dart
+++ b/test/plugins/plugin_device_service_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/plugins/plugin_device_service.dart';
+
+void main() {
+  test('registered plugin sensor joins inventory and publishes data', () async {
+    final service = PluginDeviceService();
+    final deviceController = DeviceController([service]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    addTearDown(() async {
+      sensorController.dispose();
+      deviceController.dispose();
+      await service.dispose();
+    });
+
+    final operations = <PluginDeviceOperation>[];
+    final registered = await service.register(
+      pluginId: 'humidity.plugin',
+      generation: 1,
+      registrationHandle: 'registration-1',
+      definition: {
+        'driverId': 'humidity',
+        'instanceId': 'office',
+        'name': 'Office humidity',
+        'vendor': 'Test',
+        'dataChannels': [
+          {'key': 'relativeHumidity', 'type': 'number', 'unit': '%RH'},
+        ],
+        'commands': [
+          {'id': 'sampleNow'},
+        ],
+      },
+      invoke: (operation, payload) async {
+        operations.add(operation);
+        return operation == PluginDeviceOperation.execute
+            ? {'relativeHumidity': 53.1}
+            : const {};
+      },
+    );
+
+    final sensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[registered.deviceId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.connected)
+        .first;
+    expect(deviceController.devices, contains(same(sensor)));
+    expect(operations, [PluginDeviceOperation.connect]);
+
+    final snapshot = sensor.data.first;
+    service.publish(
+      pluginId: 'humidity.plugin',
+      generation: 1,
+      registrationHandle: 'registration-1',
+      snapshot: const {'relativeHumidity': 52.4},
+    );
+    expect(await snapshot, {'relativeHumidity': 52.4});
+    expect(
+      () => service.publish(
+        pluginId: 'humidity.plugin',
+        generation: 1,
+        registrationHandle: 'registration-1',
+        snapshot: const {'relativeHumidity': 'humid'},
+      ),
+      throwsA(isA<PluginDeviceException>()),
+    );
+    expect(await sensor.execute('sampleNow', null), {'relativeHumidity': 53.1});
+    service.reportDisconnected(
+      pluginId: 'humidity.plugin',
+      generation: 1,
+      registrationHandle: 'registration-1',
+    );
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.disconnected)
+        .first;
+    await expectLater(
+      sensor.execute('sampleNow', null),
+      throwsA(isA<PluginDeviceException>()),
+    );
+
+    await service.unregister(
+      pluginId: 'humidity.plugin',
+      generation: 1,
+      registrationHandle: 'registration-1',
+    );
+    await sensorController.sensorRegistry
+        .where((sensors) => !sensors.containsKey(registered.deviceId))
+        .first;
+    expect(deviceController.devices, isEmpty);
+  });
+
+  test('registration validates definitions and caps devices', () async {
+    final service = PluginDeviceService();
+    addTearDown(service.dispose);
+    Future<Map<String, dynamic>> invoke(
+      PluginDeviceOperation operation,
+      Map<String, dynamic> payload,
+    ) async => const {};
+
+    await expectLater(
+      service.register(
+        pluginId: 'humidity.plugin',
+        generation: 1,
+        registrationHandle: 'invalid',
+        definition: _definition('invalid', dataChannels: const []),
+        invoke: invoke,
+      ),
+      throwsA(isA<PluginDeviceException>()),
+    );
+    for (var i = 0; i < 8; i++) {
+      await service.register(
+        pluginId: 'humidity.plugin',
+        generation: 1,
+        registrationHandle: 'registration-$i',
+        definition: _definition('room-$i'),
+        invoke: invoke,
+      );
+    }
+    await expectLater(
+      service.register(
+        pluginId: 'humidity.plugin',
+        generation: 1,
+        registrationHandle: 'registration-9',
+        definition: _definition('room-9'),
+        invoke: invoke,
+      ),
+      throwsA(isA<PluginDeviceException>()),
+    );
+  });
+
+  test('new generation keeps identity and fences stale publications', () async {
+    final service = PluginDeviceService();
+    addTearDown(service.dispose);
+    Future<Map<String, dynamic>> invoke(
+      PluginDeviceOperation operation,
+      Map<String, dynamic> payload,
+    ) async => const {};
+
+    final first = await service.register(
+      pluginId: 'humidity.plugin',
+      generation: 1,
+      registrationHandle: 'registration',
+      definition: _definition('office'),
+      invoke: invoke,
+    );
+    await service.removeAllForPlugin('humidity.plugin', 1);
+    final second = await service.register(
+      pluginId: 'humidity.plugin',
+      generation: 2,
+      registrationHandle: 'registration',
+      definition: _definition('office'),
+      invoke: invoke,
+    );
+
+    expect(second.deviceId, first.deviceId);
+    expect(
+      () => service.publish(
+        pluginId: 'humidity.plugin',
+        generation: 1,
+        registrationHandle: 'registration',
+        snapshot: const {'relativeHumidity': 52.4},
+      ),
+      throwsA(isA<PluginDeviceException>()),
+    );
+  });
+}
+
+Map<String, dynamic> _definition(
+  String instanceId, {
+  List<Map<String, dynamic>>? dataChannels,
+}) => {
+  'driverId': 'humidity',
+  'instanceId': instanceId,
+  'name': 'Humidity',
+  'vendor': 'Test',
+  'dataChannels':
+      dataChannels ??
+      [
+        {'key': 'relativeHumidity', 'type': 'number', 'unit': '%RH'},
+      ],
+};

--- a/test/plugins/plugin_device_service_test.dart
+++ b/test/plugins/plugin_device_service_test.dart
@@ -189,8 +189,6 @@ void main() {
       deviceController.devices.map((device) => device.deviceId),
       contains(registered.deviceId),
     );
-    // The scan re-published the registration, so the sensor is connectable
-    // again through the existing sensor path.
     await sensor.connectionState
         .where((state) => state == ConnectionState.connected)
         .first

--- a/test/plugins/plugin_device_service_test.dart
+++ b/test/plugins/plugin_device_service_test.dart
@@ -93,6 +93,12 @@ void main() {
         .where((sensors) => !sensors.containsKey(registered.deviceId))
         .first;
     expect(deviceController.devices, isEmpty);
+    expect(
+      operations.where(
+        (operation) => operation == PluginDeviceOperation.disconnect,
+      ),
+      hasLength(1),
+    );
   });
 
   test('registration validates definitions and caps devices', () async {

--- a/test/plugins/plugin_humidity_sensor_integration_test.dart
+++ b/test/plugins/plugin_humidity_sensor_integration_test.dart
@@ -108,8 +108,8 @@ void main() {
                   }
                 }]
               }, {
-                connect() {
-                  return host.transport.open({
+                connect(transport) {
+                  return transport.open({
                     kind: "websocket",
                     url: "ws://127.0.0.1:${humidityServer.port}/sensor"
                   }).then((opened) => {

--- a/test/plugins/plugin_humidity_sensor_integration_test.dart
+++ b/test/plugins/plugin_humidity_sensor_integration_test.dart
@@ -1,0 +1,251 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/plugins/plugin_device_service.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_plus/shelf_plus.dart';
+import 'package:web_socket_channel/io.dart';
+
+import '../helpers/mock_settings_service.dart';
+import 'plugin_test_helpers.dart';
+
+void main() {
+  test('WebSocket humidity plugin is exposed through the Sensor API', () async {
+    final humidityServer = await _startHumidityServer();
+    final deviceService = PluginDeviceService();
+    final deviceController = DeviceController([deviceService]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    final settingsController = SettingsController(MockSettingsService());
+    await settingsController.loadSettings();
+    final connectionManager = ConnectionManager(
+      deviceScanner: deviceController,
+      de1Controller: De1Controller(controller: deviceController),
+      scaleController: ScaleController(),
+      settingsController: settingsController,
+    );
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceService: deviceService,
+    );
+    final app = Router().plus;
+    SensorsHandler(controller: sensorController).addRoutes(app);
+    final devicesHandler = DevicesHandler(
+      controller: deviceController,
+      connectionManager: connectionManager,
+    );
+    devicesHandler.addRoutes(app);
+    final apiServer = await shelf_io.serve(app.call, '127.0.0.1', 0);
+    final client = HttpClient();
+    IOWebSocketChannel? snapshotChannel;
+    addTearDown(() async {
+      try {
+        await snapshotChannel?.sink.close();
+      } catch (_) {}
+      client.close(force: true);
+      await manager.dispose();
+      devicesHandler.dispose();
+      connectionManager.dispose();
+      sensorController.dispose();
+      deviceController.dispose();
+      await apiServer.close(force: true);
+      await humidityServer.close(force: true);
+    });
+
+    final registered = manager.emitStream
+        .where((event) => event['event'] == 'registered')
+        .map((event) => event['payload'] as String)
+        .first;
+    await manager.loadPlugin(
+      id: 'humidity.plugin',
+      manifest: testManifest(
+        'humidity.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        drivers: const [
+          PluginDriverDeclaration(
+            id: 'humidity',
+            type: PluginDriverType.sensor,
+          ),
+        ],
+      ),
+      settings: const {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          let device;
+          let transportHandle;
+          let pendingSample;
+          return {
+            id: "humidity.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [
+                  { key: "relativeHumidity", type: "number", unit: "%RH" }
+                ],
+                commands: [{
+                  id: "sampleNow",
+                  resultsSchema: {
+                    type: "object",
+                    properties: { relativeHumidity: { type: "number" } }
+                  }
+                }]
+              }, {
+                connect() {
+                  return host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${humidityServer.port}/sensor"
+                  }).then((opened) => {
+                    transportHandle = opened.handle;
+                    host.transport.onEvent(transportHandle, (event) => {
+                      if (event.type !== "data" || event.dataType !== "text") return;
+                      const sample = JSON.parse(event.data);
+                      device.publish({ relativeHumidity: sample.relativeHumidity });
+                      if (pendingSample) {
+                        pendingSample.resolve({ relativeHumidity: sample.relativeHumidity });
+                        pendingSample = null;
+                      }
+                    });
+                  });
+                },
+                disconnect() {
+                  return transportHandle
+                    ? host.transport.close(transportHandle)
+                    : Promise.resolve();
+                },
+                execute(command) {
+                  if (command.commandId !== "sampleNow") {
+                    return Promise.reject(new Error("unknown command"));
+                  }
+                  return new Promise((resolve, reject) => {
+                    pendingSample = { resolve: resolve, reject: reject };
+                    host.transport.send(transportHandle, {
+                      type: "text",
+                      data: JSON.stringify({ command: "sampleNow" })
+                    }).catch((error) => {
+                      pendingSample = null;
+                      reject(error);
+                    });
+                  });
+                }
+              }).then((registeredDevice) => {
+                device = registeredDevice;
+                host.emit("registered", device.deviceId);
+              });
+            }
+          };
+        }
+      ''',
+    );
+
+    final deviceId = await registered.timeout(const Duration(seconds: 2));
+    final sensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[deviceId])
+        .where((sensor) => sensor != null)
+        .first;
+    await sensor!.connectionState
+        .where((state) => state == ConnectionState.connected)
+        .first
+        .timeout(const Duration(seconds: 2));
+
+    final devicesResponse = await _get(
+      client,
+      Uri.parse('http://127.0.0.1:${apiServer.port}/api/v1/devices'),
+    );
+    expect(devicesResponse.single['id'], deviceId);
+    expect(devicesResponse.single['type'], 'sensor');
+
+    final sensorsResponse = await _get(
+      client,
+      Uri.parse('http://127.0.0.1:${apiServer.port}/api/v1/sensors'),
+    );
+    expect(sensorsResponse.single['id'], deviceId);
+    expect(sensorsResponse.single['info']['data'].single, {
+      'key': 'relativeHumidity',
+      'type': 'number',
+      'unit': '%RH',
+    });
+    expect(sensorsResponse.single['info']['commands'].single['resultsSchema'], {
+      'type': 'object',
+      'properties': {
+        'relativeHumidity': {'type': 'number'},
+      },
+    });
+
+    snapshotChannel = IOWebSocketChannel.connect(
+      Uri.parse(
+        'ws://127.0.0.1:${apiServer.port}/ws/v1/sensors/'
+        '$deviceId/snapshot',
+      ),
+    );
+    final snapshot = snapshotChannel.stream.first;
+    final commandResponse = await _post(
+      client,
+      Uri.parse(
+        'http://127.0.0.1:${apiServer.port}/api/v1/sensors/'
+        '$deviceId/execute',
+      ),
+      {'commandId': 'sampleNow', 'params': null},
+    );
+
+    expect(commandResponse, {
+      'status': 'ok',
+      'result': {'relativeHumidity': 52.4},
+    });
+    expect(jsonDecode(await snapshot as String), {'relativeHumidity': 52.4});
+  });
+}
+
+Future<HttpServer> _startHumidityServer() async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((request) async {
+    if (!WebSocketTransformer.isUpgradeRequest(request)) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+    final socket = await WebSocketTransformer.upgrade(request);
+    socket.listen((message) {
+      final command = jsonDecode(message as String) as Map<String, dynamic>;
+      if (command['command'] == 'sampleNow') {
+        socket.add(jsonEncode({'relativeHumidity': 52.4}));
+      }
+    });
+  });
+  return server;
+}
+
+Future<List<dynamic>> _get(HttpClient client, Uri uri) async {
+  final response = await (await client.getUrl(uri)).close();
+  return jsonDecode(await utf8.decoder.bind(response).join()) as List<dynamic>;
+}
+
+Future<Map<String, dynamic>> _post(
+  HttpClient client,
+  Uri uri,
+  Map<String, dynamic> body,
+) async {
+  final request = await client.postUrl(uri);
+  request.headers.contentType = ContentType.json;
+  request.write(jsonEncode(body));
+  final response = await request.close();
+  return jsonDecode(await utf8.decoder.bind(response).join())
+      as Map<String, dynamic>;
+}

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -767,7 +767,7 @@ void main() {
       ''',
     );
 
-    final ids = await registrations.timeout(const Duration(seconds: 2));
+    final ids = await registrations.timeout(const Duration(seconds: 10));
     final firstId = ids
         .firstWhere((id) => id.startsWith('First:'))
         .substring('First:'.length);
@@ -804,7 +804,7 @@ void main() {
     await Future.wait([
       firstStarted,
       secondStarted,
-    ]).timeout(const Duration(seconds: 2));
+    ]).timeout(const Duration(seconds: 10));
     final firstFailure = expectLater(
       firstCommand,
       throwsA(
@@ -822,11 +822,11 @@ void main() {
         .map((event) => event['payload'] as String)
         .first;
     manager.js.evaluate('globalThis.performFirstUnregister();');
-    expect(await unregistered.timeout(const Duration(seconds: 2)), firstId);
+    expect(await unregistered.timeout(const Duration(seconds: 10)), firstId);
     await firstFailure;
     manager.js.evaluate('globalThis.resolveFirst({});');
     manager.js.evaluate('globalThis.resolveSecond({});');
-    await secondResult.timeout(const Duration(seconds: 2));
+    await secondResult.timeout(const Duration(seconds: 10));
     await sensorController.sensorRegistry
         .where((sensors) => !sensors.containsKey(firstId))
         .first;

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -60,7 +60,9 @@ void main() {
                 commands: [{ id: "sampleNow" }, { id: "wait" }]
               }, {
                 connect() {},
-                disconnect() {},
+                disconnect() {
+                  globalThis.disconnectCalls = (globalThis.disconnectCalls || 0) + 1;
+                },
                 execute(command) {
                   if (command.commandId === "wait") return new Promise(() => {});
                   return { relativeHumidity: 53.1, commandId: command.commandId };
@@ -116,6 +118,13 @@ void main() {
       await sensorController.sensorRegistry
           .where((sensors) => !sensors.containsKey(deviceId))
           .first;
+      expect(deviceController.devices, isEmpty);
+      // Unload runs the disconnect handler exactly once even though onUnload
+      // threw, then removes the device.
+      expect(
+        manager.js.evaluate('globalThis.disconnectCalls').stringResult,
+        '1',
+      );
     },
   );
 
@@ -254,5 +263,195 @@ void main() {
         ),
       ),
     );
+  });
+
+  test(
+    'direct device.unregister calls disconnect once and removes device',
+    () async {
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      final sensorController = SensorController(controller: deviceController);
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        sensorController.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .first;
+      await manager.loadPlugin(
+        id: 'unregister.plugin',
+        manifest: testManifest(
+          'unregister.plugin',
+          permissions: const {PluginPermissions.emit},
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode: '''
+        function createPlugin(host) {
+          return {
+            id: "unregister.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {},
+                disconnect() {
+                  globalThis.disconnectCalls = (globalThis.disconnectCalls || 0) + 1;
+                },
+                execute() { return {}; }
+              }).then((device) => {
+                globalThis.testUnregisterDevice = device;
+                globalThis.performUnregister = () => device.unregister().then(() => {
+                  host.emit("unregistered", device.deviceId);
+                });
+                host.emit("registered", device.deviceId);
+              });
+            }
+          };
+        }
+      ''',
+      );
+
+      final deviceId = await registered.timeout(const Duration(seconds: 2));
+      final sensor = await sensorController.sensorRegistry
+          .map((sensors) => sensors[deviceId])
+          .where((sensor) => sensor != null)
+          .cast<Sensor>()
+          .first;
+      await sensor.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first
+          .timeout(const Duration(seconds: 2));
+
+      final unregistered = manager.emitStream
+          .where((event) => event['event'] == 'unregistered')
+          .map((event) => event['payload'] as String)
+          .first;
+      manager.js.evaluate('globalThis.performUnregister();');
+      expect(await unregistered.timeout(const Duration(seconds: 2)), deviceId);
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectCalls || 0)')
+            .stringResult,
+        '1',
+      );
+      await sensorController.sensorRegistry
+          .where((sensors) => !sensors.containsKey(deviceId))
+          .first;
+      expect(deviceController.devices, isEmpty);
+    },
+  );
+
+  test('unregister removes the device even when disconnect fails', () async {
+    final deviceService = PluginDeviceService();
+    final deviceController = DeviceController([deviceService]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceService: deviceService,
+    );
+    addTearDown(() async {
+      await manager.dispose();
+      sensorController.dispose();
+      deviceController.dispose();
+    });
+
+    final registered = manager.emitStream
+        .where((event) => event['event'] == 'registered')
+        .map((event) => event['payload'] as String)
+        .first;
+    await manager.loadPlugin(
+      id: 'unregister-failure.plugin',
+      manifest: testManifest(
+        'unregister-failure.plugin',
+        permissions: const {PluginPermissions.emit},
+        drivers: const [
+          PluginDriverDeclaration(
+            id: 'humidity',
+            type: PluginDriverType.sensor,
+          ),
+        ],
+      ),
+      settings: const {},
+      jsCode: '''
+        function createPlugin(host) {
+          return {
+            id: "unregister-failure.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {},
+                disconnect() {
+                  globalThis.disconnectCalls = (globalThis.disconnectCalls || 0) + 1;
+                  throw new Error("transport busy");
+                },
+                execute() { return {}; }
+              }).then((device) => {
+                globalThis.performFailingUnregister = () => device.unregister().then(
+                  () => host.emit("unregistered", "unexpected success"),
+                  (error) => host.emit("unregistered-failed", String(error))
+                );
+                host.emit("registered", device.deviceId);
+              });
+            }
+          };
+        }
+      ''',
+    );
+
+    final deviceId = await registered.timeout(const Duration(seconds: 2));
+    final sensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[deviceId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.connected)
+        .first
+        .timeout(const Duration(seconds: 2));
+
+    final failure = manager.emitStream
+        .where((event) => event['event'] == 'unregistered-failed')
+        .map((event) => event['payload'] as String)
+        .first;
+    manager.js.evaluate('globalThis.performFailingUnregister();');
+    expect(
+      await failure.timeout(const Duration(seconds: 2)),
+      contains('transport busy'),
+    );
+    expect(
+      manager.js
+          .evaluate('String(globalThis.disconnectCalls || 0)')
+          .stringResult,
+      '1',
+    );
+    // The disconnect failure does not leave a half-registered device behind.
+    await sensorController.sensorRegistry
+        .where((sensors) => !sensors.containsKey(deviceId))
+        .first;
+    expect(deviceController.devices, isEmpty);
   });
 }

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -59,7 +59,11 @@ void main() {
                 dataChannels: [
                   { key: "relativeHumidity", type: "number", unit: "%RH" }
                 ],
-                commands: [{ id: "sampleNow" }, { id: "wait" }]
+                commands: [
+                  { id: "sampleNow" },
+                  { id: "wait" },
+                  { id: "badResult" }
+                ]
               }, {
                 connect() {},
                 disconnect() {
@@ -67,6 +71,7 @@ void main() {
                 },
                 execute(command) {
                   if (command.commandId === "wait") return new Promise(() => {});
+                  if (command.commandId === "badResult") return false;
                   return { relativeHumidity: 53.1, commandId: command.commandId };
                 }
               }).then((device) => {
@@ -97,6 +102,16 @@ void main() {
         'relativeHumidity': 53.1,
         'commandId': 'sampleNow',
       });
+      await expectLater(
+        sensor.execute('badResult', null),
+        throwsA(
+          isA<PluginDeviceException>().having(
+            (error) => error.message,
+            'message',
+            contains('must return an object'),
+          ),
+        ),
+      );
       final snapshot = sensor.data.first;
       manager.js.evaluate(
         'globalThis.testHumidityDevice.publish({ relativeHumidity: 52.4 });',
@@ -689,6 +704,265 @@ void main() {
           .where((sensors) => !sensors.containsKey(deviceId))
           .first;
       expect(deviceController.devices, isEmpty);
+    },
+  );
+
+  test('device disconnect cleanup runs again after reconnect', () async {
+    final server = await _startWsServer((ws) {
+      ws.listen((data) {});
+    });
+    final deviceService = PluginDeviceService();
+    final deviceController = DeviceController([deviceService]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceService: deviceService,
+    );
+    addTearDown(() async {
+      await manager.dispose();
+      sensorController.dispose();
+      deviceController.dispose();
+    });
+
+    final registered = manager.emitStream
+        .where((event) => event['event'] == 'registered')
+        .map((event) => event['payload'] as String)
+        .first;
+    await manager.loadPlugin(
+      id: 'reconnect-cleanup.plugin',
+      manifest: testManifest(
+        'reconnect-cleanup.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        drivers: const [
+          PluginDriverDeclaration(
+            id: 'humidity',
+            type: PluginDriverType.sensor,
+          ),
+        ],
+      ),
+      settings: const {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          let transportHandle;
+          return {
+            id: "reconnect-cleanup.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {
+                  return host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${server.port}/x"
+                  }).then((opened) => {
+                    transportHandle = opened.handle;
+                    globalThis.connectCalls =
+                      (globalThis.connectCalls || 0) + 1;
+                    return {};
+                  });
+                },
+                disconnect() {
+                  const handle = transportHandle;
+                  transportHandle = null;
+                  return host.transport.close(handle).then(() => {
+                    globalThis.disconnectCalls =
+                      (globalThis.disconnectCalls || 0) + 1;
+                    return {};
+                  });
+                },
+                execute() { return {}; }
+              }).then((device) => host.emit("registered", device.deviceId));
+            }
+          };
+        }
+      ''',
+    );
+
+    final deviceId = await registered.timeout(const Duration(seconds: 2));
+    final sensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[deviceId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.connected)
+        .first
+        .timeout(const Duration(seconds: 2));
+    expect(manager.liveTransportCount, 1);
+
+    final firstDisconnect = sensor.disconnect();
+    final repeatedDisconnect = sensor.disconnect();
+    expect(identical(firstDisconnect, repeatedDisconnect), isTrue);
+    await firstDisconnect;
+    expect(manager.liveTransportCount, 0);
+    expect(
+      manager.js
+          .evaluate('String(globalThis.disconnectCalls || 0)')
+          .stringResult,
+      '1',
+    );
+
+    await sensor.onConnect();
+    expect(manager.liveTransportCount, 1);
+    expect(
+      manager.js.evaluate('String(globalThis.connectCalls || 0)').stringResult,
+      '2',
+    );
+
+    await sensor.disconnect();
+    expect(manager.liveTransportCount, 0);
+    expect(
+      manager.js
+          .evaluate('String(globalThis.disconnectCalls || 0)')
+          .stringResult,
+      '2',
+    );
+  });
+
+  test(
+    'direct unregister waits for an in-flight connect before cleanup',
+    () async {
+      final server = await _startWsServer((ws) {
+        ws.listen((data) {});
+      });
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      final sensorController = SensorController(controller: deviceController);
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        sensorController.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .first;
+      await manager.loadPlugin(
+        id: 'delayed-connect.plugin',
+        manifest: testManifest(
+          'delayed-connect.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          let transportHandle;
+          return {
+            id: "delayed-connect.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {
+                  globalThis.connectStarted = true;
+                  return new Promise((resolve) => {
+                    globalThis.continueConnect = () => {
+                      host.transport.open({
+                        kind: "websocket",
+                        url: "ws://127.0.0.1:${server.port}/x"
+                      }).then((opened) => {
+                        transportHandle = opened.handle;
+                        globalThis.connectCompleted =
+                          (globalThis.connectCompleted || 0) + 1;
+                        resolve({});
+                      });
+                    };
+                  });
+                },
+                disconnect() {
+                  const handle = transportHandle;
+                  transportHandle = null;
+                  globalThis.disconnectCalls =
+                    (globalThis.disconnectCalls || 0) + 1;
+                  return handle
+                    ? host.transport.close(handle)
+                    : Promise.resolve();
+                },
+                execute() { return {}; }
+              }).then((device) => {
+                globalThis.delayedDevice = device;
+                globalThis.performUnregister = () =>
+                  device.unregister().then(() => {
+                    host.emit("unregistered", device.deviceId);
+                  });
+                host.emit("registered", device.deviceId);
+              });
+            }
+          };
+        }
+      ''',
+      );
+
+      final deviceId = await registered.timeout(const Duration(seconds: 2));
+      final sensor = await sensorController.sensorRegistry
+          .map((sensors) => sensors[deviceId])
+          .where((sensor) => sensor != null)
+          .cast<Sensor>()
+          .first;
+      await sensor.connectionState
+          .where((state) => state == ConnectionState.connecting)
+          .first
+          .timeout(const Duration(seconds: 2));
+      final states = <ConnectionState>[];
+      final stateSubscription = sensor.connectionState.listen(states.add);
+      addTearDown(stateSubscription.cancel);
+
+      final unregistered = manager.emitStream
+          .where((event) => event['event'] == 'unregistered')
+          .map((event) => event['payload'] as String)
+          .first;
+      manager.js.evaluate('globalThis.performUnregister();');
+      manager.js.evaluate('globalThis.continueConnect();');
+      while (manager.js.executePendingJob() > 0) {}
+
+      expect(await unregistered.timeout(const Duration(seconds: 10)), deviceId);
+      expect(manager.liveTransportCount, 0);
+      expect(
+        manager.js
+            .evaluate('String(globalThis.connectCompleted || 0)')
+            .stringResult,
+        '1',
+      );
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectCalls || 0)')
+            .stringResult,
+        '1',
+      );
+      await sensorController.sensorRegistry
+          .where((sensors) => !sensors.containsKey(deviceId))
+          .first;
+      expect(deviceController.devices, isEmpty);
+      expect(states, isNot(contains(ConnectionState.connected)));
     },
   );
 

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -320,6 +320,7 @@ void main() {
                 execute() { return {}; }
               }).then((device) => {
                 globalThis.testUnregisterDevice = device;
+                globalThis.performReportDisconnected = () => device.reportDisconnected();
                 globalThis.performUnregister = () => device.unregister().then(() => {
                   host.emit("unregistered", device.deviceId);
                 });
@@ -341,6 +342,11 @@ void main() {
           .where((state) => state == ConnectionState.connected)
           .first
           .timeout(const Duration(seconds: 2));
+      final disconnected = sensor.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .first;
+      manager.js.evaluate('globalThis.performReportDisconnected();');
+      await disconnected.timeout(const Duration(seconds: 2));
 
       final unregistered = manager.emitStream
           .where((event) => event['event'] == 'unregistered')
@@ -565,6 +571,269 @@ void main() {
       expect(deviceController.devices, isEmpty);
     },
   );
+
+  test(
+    'direct unregister after reportDisconnected closes device transport',
+    () async {
+      final server = await _startWsServer((ws) {
+        ws.listen((data) {});
+      });
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      final sensorController = SensorController(controller: deviceController);
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        sensorController.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .first;
+      await manager.loadPlugin(
+        id: 'direct-cleanup-transport.plugin',
+        manifest: testManifest(
+          'direct-cleanup-transport.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          return {
+            id: "direct-cleanup-transport.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {
+                  return host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${server.port}/x"
+                  }).then((opened) => {
+                    globalThis.directCleanupHandle = opened.handle;
+                  });
+                },
+                disconnect() {
+                  return host.transport.close(globalThis.directCleanupHandle)
+                    .then(() => {
+                      globalThis.directDisconnectClosed =
+                        (globalThis.directDisconnectClosed || 0) + 1;
+                    });
+                },
+                execute() { return {}; }
+              }).then((device) => {
+                globalThis.directCleanupDevice = device;
+                globalThis.performDirectUnregister = () =>
+                  device.unregister().then(() => {
+                    host.emit("unregistered", device.deviceId);
+                  });
+                host.emit("registered", device.deviceId);
+              });
+            }
+          };
+        }
+      ''',
+      );
+
+      final deviceId = await registered.timeout(const Duration(seconds: 2));
+      final sensor = await sensorController.sensorRegistry
+          .map((sensors) => sensors[deviceId])
+          .where((sensor) => sensor != null)
+          .cast<Sensor>()
+          .first;
+      await sensor.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first
+          .timeout(const Duration(seconds: 2));
+      expect(manager.liveTransportCount, 1);
+
+      final disconnected = sensor.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .first;
+      manager.js.evaluate(
+        'globalThis.directCleanupDevice.reportDisconnected();',
+      );
+      await disconnected.timeout(const Duration(seconds: 2));
+
+      final unregistered = manager.emitStream
+          .where((event) => event['event'] == 'unregistered')
+          .map((event) => event['payload'] as String)
+          .first;
+      manager.js.evaluate('globalThis.performDirectUnregister();');
+      expect(await unregistered.timeout(const Duration(seconds: 2)), deviceId);
+      expect(manager.liveTransportCount, 0);
+      expect(
+        manager.js
+            .evaluate('String(globalThis.directDisconnectClosed || 0)')
+            .stringResult,
+        '1',
+      );
+      await sensorController.sensorRegistry
+          .where((sensors) => !sensors.containsKey(deviceId))
+          .first;
+      expect(deviceController.devices, isEmpty);
+    },
+  );
+
+  test('unregister rejects only pending invocations for its device', () async {
+    final deviceService = PluginDeviceService();
+    final deviceController = DeviceController([deviceService]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceService: deviceService,
+    );
+    addTearDown(() async {
+      await manager.dispose();
+      sensorController.dispose();
+      deviceController.dispose();
+    });
+
+    final registrations = manager.emitStream
+        .where((event) => event['event'] == 'registered')
+        .map((event) => event['payload'] as String)
+        .take(2)
+        .toList();
+    await manager.loadPlugin(
+      id: 'pending-device.plugin',
+      manifest: testManifest(
+        'pending-device.plugin',
+        permissions: const {PluginPermissions.emit},
+        drivers: const [
+          PluginDriverDeclaration(
+            id: 'humidity',
+            type: PluginDriverType.sensor,
+          ),
+        ],
+      ),
+      settings: const {},
+      jsCode: '''
+        function createPlugin(host) {
+          function register(instanceId, key) {
+            return host.devices.register({
+              driverId: "humidity",
+              instanceId: instanceId,
+              name: instanceId,
+              vendor: "Test",
+              dataChannels: [{ key: "relativeHumidity", type: "number" }],
+              commands: [{ id: "wait" }]
+            }, {
+              connect() {},
+              disconnect() { return {}; },
+              execute() {
+                return new Promise((resolve) => {
+                  globalThis["resolve" + key] = resolve;
+                  host.emit(key + "-started", null);
+                });
+              }
+            }).then((device) => {
+              globalThis[key + "Device"] = device;
+              host.emit("registered", key + ":" + device.deviceId);
+            });
+          }
+          return {
+            id: "pending-device.plugin",
+            onLoad() {
+              globalThis.performFirstUnregister = () =>
+                globalThis.FirstDevice.unregister().then(() => {
+                  host.emit("unregistered", globalThis.FirstDevice.deviceId);
+                });
+              register("one", "First");
+              register("two", "Second");
+            }
+          };
+        }
+      ''',
+    );
+
+    final ids = await registrations.timeout(const Duration(seconds: 2));
+    final firstId = ids
+        .firstWhere((id) => id.startsWith('First:'))
+        .substring('First:'.length);
+    final secondId = ids
+        .firstWhere((id) => id.startsWith('Second:'))
+        .substring('Second:'.length);
+    final firstSensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[firstId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    final secondSensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[secondId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    await Future.wait([
+      firstSensor.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first,
+      secondSensor.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first,
+    ]);
+
+    final firstStarted = manager.emitStream
+        .where((event) => event['event'] == 'First-started')
+        .first;
+    final secondStarted = manager.emitStream
+        .where((event) => event['event'] == 'Second-started')
+        .first;
+    final firstCommand = firstSensor.execute('wait', null);
+    final secondCommand = secondSensor.execute('wait', null);
+    await Future.wait([
+      firstStarted,
+      secondStarted,
+    ]).timeout(const Duration(seconds: 2));
+    final firstFailure = expectLater(
+      firstCommand,
+      throwsA(
+        isA<PluginDeviceException>().having(
+          (error) => error.message,
+          'message',
+          'Plugin device unregistered',
+        ),
+      ),
+    );
+    final secondResult = expectLater(secondCommand, completion(isEmpty));
+
+    final unregistered = manager.emitStream
+        .where((event) => event['event'] == 'unregistered')
+        .map((event) => event['payload'] as String)
+        .first;
+    manager.js.evaluate('globalThis.performFirstUnregister();');
+    expect(await unregistered.timeout(const Duration(seconds: 2)), firstId);
+    await firstFailure;
+    manager.js.evaluate('globalThis.resolveFirst({});');
+    manager.js.evaluate('globalThis.resolveSecond({});');
+    await secondResult.timeout(const Duration(seconds: 2));
+    await sensorController.sensorRegistry
+        .where((sensors) => !sensors.containsKey(firstId))
+        .first;
+    expect(deviceController.devices.map((device) => device.deviceId), [
+      secondId,
+    ]);
+  });
 }
 
 Future<HttpServer> _startWsServer(void Function(WebSocket ws) handler) async {

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/plugins/plugin_device_service.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+
+import 'plugin_test_helpers.dart';
+
+void main() {
+  test(
+    'declared plugin sensor connects, publishes, and executes commands',
+    () async {
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      final sensorController = SensorController(controller: deviceController);
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        sensorController.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .first;
+      await manager.loadPlugin(
+        id: 'humidity.plugin',
+        manifest: testManifest(
+          'humidity.plugin',
+          permissions: const {PluginPermissions.emit},
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode: '''
+        function createPlugin(host) {
+          return {
+            id: "humidity.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [
+                  { key: "relativeHumidity", type: "number", unit: "%RH" }
+                ],
+                commands: [{ id: "sampleNow" }, { id: "wait" }]
+              }, {
+                connect() {},
+                disconnect() {},
+                execute(command) {
+                  if (command.commandId === "wait") return new Promise(() => {});
+                  return { relativeHumidity: 53.1, commandId: command.commandId };
+                }
+              }).then((device) => {
+                globalThis.testHumidityDevice = device;
+                host.emit("registered", device.deviceId);
+              });
+            },
+            onUnload() {
+              throw new Error("unload failed");
+            }
+          };
+        }
+      ''',
+      );
+
+      final deviceId = await registered.timeout(const Duration(seconds: 2));
+      expect(deviceId, 'plugin:humidity.plugin:humidity:office');
+      final sensor = await sensorController.sensorRegistry
+          .map((sensors) => sensors[deviceId])
+          .where((sensor) => sensor != null)
+          .cast<Sensor>()
+          .first;
+      await sensor.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first;
+
+      expect(await sensor.execute('sampleNow', null), {
+        'relativeHumidity': 53.1,
+        'commandId': 'sampleNow',
+      });
+      final snapshot = sensor.data.first;
+      manager.js.evaluate(
+        'globalThis.testHumidityDevice.publish({ relativeHumidity: 52.4 });',
+      );
+      expect(await snapshot.timeout(const Duration(seconds: 2)), {
+        'relativeHumidity': 52.4,
+      });
+
+      final pendingCommand = expectLater(
+        sensor.execute('wait', null),
+        throwsA(
+          isA<PluginDeviceException>().having(
+            (error) => error.message,
+            'message',
+            contains('unloaded'),
+          ),
+        ),
+      );
+      await manager.unloadPlugin('humidity.plugin');
+      await pendingCommand;
+      await sensorController.sensorRegistry
+          .where((sensors) => !sensors.containsKey(deviceId))
+          .first;
+    },
+  );
+
+  test('undeclared driver registration is rejected', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    final error = manager.emitStream
+        .where((event) => event['event'] == 'result')
+        .map((event) => event['payload'] as String)
+        .first;
+
+    await manager.loadPlugin(
+      id: 'undeclared.plugin',
+      manifest: testManifest(
+        'undeclared.plugin',
+        permissions: const {PluginPermissions.emit},
+      ),
+      settings: const {},
+      jsCode: '''
+        function createPlugin(host) {
+          return {
+            id: "undeclared.plugin",
+            onLoad() {
+              __deviceSetHandlers("direct_registration", {
+                pluginId: "undeclared.plugin",
+                generation: pluginGeneration,
+                bridgeToken: pluginBridgeToken,
+                handlers: { connect() {}, disconnect() {}, execute() {} }
+              });
+              __deviceRegisterPending("direct_request", {
+                bridgeToken: pluginBridgeToken,
+                resolve: () => host.emit("result", "unexpected"),
+                reject: (error) => host.emit("result", error.message)
+              });
+              pluginHostBridge.deviceRequest(
+                pluginBridgeToken,
+                pluginGeneration,
+                "direct_request",
+                "register",
+                {
+                  registrationHandle: "direct_registration",
+                  definition: {
+                    driverId: "humidity",
+                    instanceId: "office",
+                    name: "Office humidity",
+                    vendor: "Test",
+                    dataChannels: [{ key: "relativeHumidity", type: "number" }]
+                  }
+                }
+              );
+            }
+          };
+        }
+      ''',
+    );
+
+    expect(
+      await error.timeout(const Duration(seconds: 2)),
+      contains('not declared'),
+    );
+    expect(await manager.deviceService.devices.first, isEmpty);
+  });
+
+  test('device command times out', () async {
+    final deviceService = PluginDeviceService();
+    final deviceController = DeviceController([deviceService]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceService: deviceService,
+      deviceInvocationTimeout: const Duration(milliseconds: 20),
+    );
+    addTearDown(() async {
+      await manager.dispose();
+      sensorController.dispose();
+      deviceController.dispose();
+    });
+
+    final registered = manager.emitStream
+        .where((event) => event['event'] == 'registered')
+        .map((event) => event['payload'] as String)
+        .first;
+    await manager.loadPlugin(
+      id: 'timeout.plugin',
+      manifest: testManifest(
+        'timeout.plugin',
+        permissions: const {PluginPermissions.emit},
+        drivers: const [
+          PluginDriverDeclaration(
+            id: 'humidity',
+            type: PluginDriverType.sensor,
+          ),
+        ],
+      ),
+      settings: const {},
+      jsCode: '''
+        function createPlugin(host) {
+          return {
+            id: "timeout.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }],
+                commands: [{ id: "sampleNow" }]
+              }, {
+                connect() {},
+                disconnect() {},
+                execute() { return new Promise(() => {}); }
+              }).then((device) => host.emit("registered", device.deviceId));
+            }
+          };
+        }
+      ''',
+    );
+    final deviceId = await registered.timeout(const Duration(seconds: 2));
+    final sensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[deviceId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.connected)
+        .first;
+
+    await expectLater(
+      sensor.execute('sampleNow', null),
+      throwsA(
+        isA<PluginDeviceException>().having(
+          (error) => error.message,
+          'message',
+          contains('timed out'),
+        ),
+      ),
+    );
+  });
+}

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -706,6 +707,304 @@ void main() {
       expect(deviceController.devices, isEmpty);
     },
   );
+
+  test(
+    'unload settles a retiring connect invocation before its timeout',
+    () async {
+      final server = await _startWsServer((ws) {
+        ws.listen((data) {});
+      });
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      final sensorController = SensorController(controller: deviceController);
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+        deviceInvocationTimeout: const Duration(seconds: 20),
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        sensorController.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .first;
+      await manager.loadPlugin(
+        id: 'unload-delayed-connect.plugin',
+        manifest: testManifest(
+          'unload-delayed-connect.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          let transportHandle;
+          return {
+            id: "unload-delayed-connect.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {
+                  globalThis.connectStarted = true;
+                  return new Promise((resolve, reject) => {
+                    globalThis.releaseConnect = () => {
+                      host.transport.open({
+                        kind: "websocket",
+                        url: "ws://127.0.0.1:${server.port}/x"
+                      }).then((opened) => {
+                        transportHandle = opened.handle;
+                        globalThis.openAllowed = true;
+                        resolve({});
+                      }, (error) => {
+                        globalThis.openRejected = true;
+                        reject(error);
+                      });
+                    };
+                  });
+                },
+                disconnect() {
+                  const handle = transportHandle;
+                  transportHandle = null;
+                  globalThis.disconnectCalls =
+                    (globalThis.disconnectCalls || 0) + 1;
+                  return handle
+                    ? host.transport.close(handle)
+                    : Promise.resolve();
+                },
+                execute() { return {}; }
+              }).then((device) => host.emit("registered", device.deviceId));
+            },
+            onUnload() {
+              globalThis.unloadStarted = true;
+            }
+          };
+        }
+      ''',
+      );
+
+      final deviceId = await registered.timeout(const Duration(seconds: 2));
+      final sensor = await sensorController.sensorRegistry
+          .map((sensors) => sensors[deviceId])
+          .where((sensor) => sensor != null)
+          .cast<Sensor>()
+          .first;
+      await sensor.connectionState
+          .where((state) => state == ConnectionState.connecting)
+          .first
+          .timeout(const Duration(seconds: 2));
+
+      final unloading = manager.unloadPlugin('unload-delayed-connect.plugin');
+      var unloadStarted = false;
+      for (
+        var i = 0;
+        i < 100 && manager.lifecycle == PluginManagerLifecycle.active;
+        i++
+      ) {
+        final result = manager.js.evaluate(
+          'String(globalThis.unloadStarted || false)',
+        );
+        if (!result.isError && result.stringResult == 'true') {
+          unloadStarted = true;
+          break;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(unloadStarted, isTrue);
+
+      manager.js.evaluate('globalThis.releaseConnect();');
+      while (manager.js.executePendingJob() > 0) {}
+      await expectLater(
+        unloading.timeout(const Duration(seconds: 2)),
+        completes,
+      );
+      expect(
+        manager.js
+            .evaluate('String(globalThis.openRejected || false)')
+            .stringResult,
+        'true',
+      );
+      expect(
+        manager.js
+            .evaluate('String(globalThis.openAllowed || false)')
+            .stringResult,
+        'false',
+      );
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectCalls || 0)')
+            .stringResult,
+        '1',
+      );
+      expect(manager.liveTransportCount, 0);
+      await sensorController.sensorRegistry
+          .where((sensors) => !sensors.containsKey(deviceId))
+          .first;
+      expect(deviceController.devices, isEmpty);
+    },
+  );
+
+  test('direct unregister retires a timed-out connect transport', () async {
+    final server = await _startWsServer((ws) {
+      ws.listen((data) {});
+    });
+    final nativeOpen = Completer<WebSocket>();
+    final connectorStarted = Completer<void>();
+    final deviceService = PluginDeviceService();
+    final deviceController = DeviceController([deviceService]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceService: deviceService,
+      deviceInvocationTimeout: const Duration(milliseconds: 30),
+      connectWebSocket: (url, {protocols}) {
+        if (!connectorStarted.isCompleted) connectorStarted.complete();
+        return nativeOpen.future;
+      },
+    );
+    addTearDown(() async {
+      await manager.dispose();
+      sensorController.dispose();
+      deviceController.dispose();
+    });
+
+    final registered = manager.emitStream
+        .where((event) => event['event'] == 'registered')
+        .map((event) => event['payload'] as String)
+        .first;
+    await manager.loadPlugin(
+      id: 'timeout-connect.plugin',
+      manifest: testManifest(
+        'timeout-connect.plugin',
+        permissions: const {
+          PluginPermissions.emit,
+          PluginPermissions.networkWebsocket,
+        },
+        drivers: const [
+          PluginDriverDeclaration(
+            id: 'humidity',
+            type: PluginDriverType.sensor,
+          ),
+        ],
+      ),
+      settings: const {},
+      jsCode:
+          '''
+        function createPlugin(host) {
+          let transportHandle;
+          return {
+            id: "timeout-connect.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {
+                  return host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${server.port}/x"
+                  }).then((opened) => {
+                    transportHandle = opened.handle;
+                    globalThis.connectCompleted = true;
+                    return {};
+                  }, (error) => {
+                    globalThis.connectRejected = true;
+                    throw error;
+                  });
+                },
+                disconnect() {
+                  const handle = transportHandle;
+                  transportHandle = null;
+                  globalThis.disconnectCalls =
+                    (globalThis.disconnectCalls || 0) + 1;
+                  return handle
+                    ? host.transport.close(handle)
+                    : Promise.resolve();
+                },
+                execute() { return {}; }
+              }).then((device) => {
+                globalThis.timeoutDevice = device;
+                globalThis.performUnregister = () =>
+                  device.unregister().then(() => {
+                    host.emit("unregistered", device.deviceId);
+                  });
+                host.emit("registered", device.deviceId);
+              });
+            }
+          };
+        }
+      ''',
+    );
+
+    final deviceId = await registered.timeout(const Duration(seconds: 2));
+    final sensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[deviceId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.connecting)
+        .first
+        .timeout(const Duration(seconds: 2));
+    await connectorStarted.future.timeout(const Duration(seconds: 2));
+    final states = <ConnectionState>[];
+    final stateSubscription = sensor.connectionState.listen(states.add);
+    addTearDown(stateSubscription.cancel);
+
+    final unregistered = manager.emitStream
+        .where((event) => event['event'] == 'unregistered')
+        .map((event) => event['payload'] as String)
+        .first;
+    manager.js.evaluate('globalThis.performUnregister();');
+    expect(await unregistered.timeout(const Duration(seconds: 2)), deviceId);
+    expect(manager.liveTransportCount, 0);
+    expect(
+      manager.js
+          .evaluate('String(globalThis.disconnectCalls || 0)')
+          .stringResult,
+      '1',
+    );
+    await sensorController.sensorRegistry
+        .where((sensors) => !sensors.containsKey(deviceId))
+        .first;
+    expect(deviceController.devices, isEmpty);
+    expect(states, isNot(contains(ConnectionState.connected)));
+
+    final socket = await WebSocket.connect('ws://127.0.0.1:${server.port}/x');
+    nativeOpen.complete(socket);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    while (manager.js.executePendingJob() > 0) {}
+    expect(manager.liveTransportCount, 0);
+    expect(
+      manager.js
+          .evaluate('String(globalThis.connectRejected || false)')
+          .stringResult,
+      'true',
+    );
+    expect(states, isNot(contains(ConnectionState.connected)));
+  });
 
   test('device disconnect cleanup runs again after reconnect', () async {
     final server = await _startWsServer((ws) {

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -529,8 +529,8 @@ void main() {
                 vendor: "Test",
                 dataChannels: [{ key: "relativeHumidity", type: "number" }]
               }, {
-                connect() {
-                  return host.transport.open({
+                connect(transport) {
+                  return transport.open({
                     kind: "websocket",
                     url: "ws://127.0.0.1:${server.port}/x"
                   }).then((opened) => {
@@ -638,8 +638,8 @@ void main() {
                 vendor: "Test",
                 dataChannels: [{ key: "relativeHumidity", type: "number" }]
               }, {
-                connect() {
-                  return host.transport.open({
+                connect(transport) {
+                  return transport.open({
                     kind: "websocket",
                     url: "ws://127.0.0.1:${server.port}/x"
                   }).then((opened) => {
@@ -763,11 +763,11 @@ void main() {
                 vendor: "Test",
                 dataChannels: [{ key: "relativeHumidity", type: "number" }]
               }, {
-                connect() {
+                connect(transport) {
                   globalThis.connectStarted = true;
                   return new Promise((resolve, reject) => {
                     globalThis.releaseConnect = () => {
-                      host.transport.open({
+                      transport.open({
                         kind: "websocket",
                         url: "ws://127.0.0.1:${server.port}/x"
                       }).then((opened) => {
@@ -921,8 +921,8 @@ void main() {
                 vendor: "Test",
                 dataChannels: [{ key: "relativeHumidity", type: "number" }]
               }, {
-                connect() {
-                  return host.transport.open({
+                connect(transport) {
+                  return transport.open({
                     kind: "websocket",
                     url: "ws://127.0.0.1:${server.port}/x"
                   }).then((opened) => {
@@ -1059,12 +1059,12 @@ void main() {
                 vendor: "Test",
                 dataChannels: [{ key: "relativeHumidity", type: "number" }]
               }, {
-                async connect() {
+                async connect(transport) {
                   await new Promise((resolve) => {
                     globalThis.releaseAsyncConnect = resolve;
                   });
                   try {
-                    const opened = await host.transport.open({
+                    const opened = await transport.open({
                       kind: "websocket",
                       url: "ws://127.0.0.1:${server.port}/x"
                     });
@@ -1136,18 +1136,18 @@ void main() {
       );
 
       manager.js.evaluate('globalThis.releaseAsyncConnect();');
-      var connectCompleted = false;
-      for (var i = 0; i < 100 && !connectCompleted; i++) {
+      var connectRejected = false;
+      for (var i = 0; i < 100 && !connectRejected; i++) {
         while (manager.js.executePendingJob() > 0) {}
         final result = manager.js.evaluate(
-          'String(globalThis.connectCompleted || false)',
+          'String(globalThis.connectRejected || false)',
         );
-        connectCompleted = !result.isError && result.stringResult == 'true';
-        if (!connectCompleted) {
+        connectRejected = !result.isError && result.stringResult == 'true';
+        if (!connectRejected) {
           await Future<void>.delayed(const Duration(milliseconds: 10));
         }
       }
-      expect(connectCompleted, isTrue);
+      expect(connectRejected, isTrue);
       for (var i = 0; i < 100 && manager.liveTransportCount != 0; i++) {
         while (manager.js.executePendingJob() > 0) {}
         await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -1164,7 +1164,7 @@ void main() {
   );
 
   test(
-    'retiring one async connect does not claim another device transport',
+    'retired A cannot open a transport while B remains pending and B connects',
     () async {
       final server = await _startWsServer((ws) {
         ws.listen((data) {});
@@ -1209,12 +1209,12 @@ void main() {
           function makeHandlers(instanceKey) {
             let transportHandle;
             return {
-              async connect() {
+              async connect(transport) {
                 await new Promise((resolve) => {
                   globalThis.connectGates[instanceKey] = resolve;
                 });
                 try {
-                  const opened = await host.transport.open({
+                  const opened = await transport.open({
                     kind: "websocket",
                     url: "ws://127.0.0.1:${server.port}/x"
                   });
@@ -1265,16 +1265,6 @@ void main() {
                       devices[key === "office" ? 0 : 1].deviceId
                     );
                   });
-                globalThis.performExtraOpen = () =>
-                  host.transport.open({
-                    kind: "websocket",
-                    url: "ws://127.0.0.1:${server.port}/x"
-                  }).then((opened) => {
-                    globalThis.extraHandle = opened.handle;
-                    globalThis.extraOpened = true;
-                  });
-                globalThis.performExtraClose = () =>
-                  host.transport.close(globalThis.extraHandle);
                 host.emit("registered", devices[0].deviceId);
                 host.emit("registered", devices[1].deviceId);
               });
@@ -1304,22 +1294,10 @@ void main() {
       final labStatesSubscription = lab.connectionState.listen(labStates.add);
       addTearDown(labStatesSubscription.cancel);
       unawaited(office.onConnect().catchError((_) {}));
-      unawaited(lab.onConnect().catchError((_) {}));
       await office.connectionState
           .where((state) => state == ConnectionState.connecting)
           .first
           .timeout(const Duration(seconds: 2));
-      await lab.connectionState
-          .where((state) => state == ConnectionState.connecting)
-          .first
-          .timeout(const Duration(seconds: 2));
-      manager.js.evaluate('globalThis.connectGates.lab();');
-      while (manager.js.executePendingJob() > 0) {}
-      await lab.connectionState
-          .where((state) => state == ConnectionState.connected)
-          .first
-          .timeout(const Duration(seconds: 2));
-      expect(manager.liveTransportCount, 1);
       await office.connectionState
           .where((state) => state == ConnectionState.disconnected)
           .first
@@ -1335,7 +1313,7 @@ void main() {
           .first;
       manager.js.evaluate('globalThis.performUnregister("office");');
       expect(await unregistered.timeout(const Duration(seconds: 2)), officeId);
-      expect(manager.liveTransportCount, 1);
+      expect(manager.liveTransportCount, 0);
       expect(
         manager.js
             .evaluate('String(globalThis.disconnectCounts.office || 0)')
@@ -1348,28 +1326,29 @@ void main() {
                 devices.length == 1 && devices.single.deviceId == labId,
           )
           .first;
-      expect(labStates, contains(ConnectionState.connected));
+      expect(labStates, isNot(contains(ConnectionState.connected)));
 
+      unawaited(lab.onConnect().catchError((_) {}));
+      await lab.connectionState
+          .where((state) => state == ConnectionState.connecting)
+          .first
+          .timeout(const Duration(seconds: 2));
       manager.js.evaluate('globalThis.connectGates.office();');
       while (manager.js.executePendingJob() > 0) {}
-      var officeOpened = false;
-      for (var i = 0; i < 100 && !officeOpened; i++) {
+      var officeRejected = false;
+      for (var i = 0; i < 100 && !officeRejected; i++) {
         while (manager.js.executePendingJob() > 0) {}
         final result = manager.js.evaluate(
           'String(globalThis.connectOutcomes.office || "")',
         );
-        officeOpened = !result.isError && result.stringResult == 'opened';
-        if (!officeOpened) {
+        officeRejected = !result.isError && result.stringResult == 'rejected';
+        if (!officeRejected) {
           await Future<void>.delayed(const Duration(milliseconds: 10));
         }
       }
-      expect(officeOpened, isTrue);
-      for (var i = 0; i < 100 && manager.liveTransportCount != 1; i++) {
-        while (manager.js.executePendingJob() > 0) {}
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      }
-      expect(manager.liveTransportCount, 1);
-      expect(labStates, contains(ConnectionState.connected));
+      expect(officeRejected, isTrue);
+      expect(manager.liveTransportCount, 0);
+      expect(labStates, isNot(contains(ConnectionState.connected)));
       expect(
         manager.js
             .evaluate('String(globalThis.disconnectCounts.office || 0)')
@@ -1378,35 +1357,26 @@ void main() {
       );
       expect(officeStates, isNot(contains(ConnectionState.connected)));
 
-      manager.js.evaluate('globalThis.performExtraOpen();');
-      var extraOpened = false;
-      for (var i = 0; i < 100 && !extraOpened; i++) {
-        while (manager.js.executePendingJob() > 0) {}
-        final result = manager.js.evaluate(
-          'String(globalThis.extraOpened || false)',
-        );
-        extraOpened = !result.isError && result.stringResult == 'true';
-        if (!extraOpened) {
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-        }
-      }
-      expect(extraOpened, isTrue);
-      expect(manager.liveTransportCount, 2);
-      manager.js.evaluate('globalThis.performExtraClose();');
-      for (var i = 0; i < 100 && manager.liveTransportCount != 1; i++) {
-        while (manager.js.executePendingJob() > 0) {}
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      }
+      manager.js.evaluate('globalThis.connectGates.lab();');
+      while (manager.js.executePendingJob() > 0) {}
+      await lab.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first
+          .timeout(const Duration(seconds: 2));
       expect(manager.liveTransportCount, 1);
       expect(labStates, contains(ConnectionState.connected));
     },
   );
 
   test(
-    'unrelated opens and a later device connect survive a retired connect',
+    'persistent unrelated plugin transport stays usable after retired A settles',
     () async {
       final server = await _startWsServer((ws) {
-        ws.listen((data) {});
+        ws.listen((data) {
+          try {
+            ws.add(data);
+          } catch (_) {}
+        });
       });
       final deviceService = PluginDeviceService();
       final deviceController = DeviceController([deviceService]);
@@ -1448,12 +1418,12 @@ void main() {
           function makeHandlers(instanceKey) {
             let transportHandle;
             return {
-              async connect() {
+              async connect(transport) {
                 await new Promise((resolve) => {
                   globalThis.connectGates[instanceKey] = resolve;
                 });
                 try {
-                  const opened = await host.transport.open({
+                  const opened = await transport.open({
                     kind: "websocket",
                     url: "ws://127.0.0.1:${server.port}/x"
                   });
@@ -1507,7 +1477,17 @@ void main() {
                     url: "ws://127.0.0.1:${server.port}/x"
                   }).then((opened) => {
                     globalThis.unrelatedHandle = opened.handle;
+                    host.transport.onEvent(opened.handle, (event) => {
+                      if (event.type === "data" && event.data === "still-live") {
+                        host.emit("unrelated-roundtrip", event.data);
+                      }
+                    });
                     globalThis.unrelatedOpened = true;
+                  });
+                globalThis.performUnrelatedRoundTrip = () =>
+                  host.transport.send(globalThis.unrelatedHandle, {
+                    type: "text",
+                    data: "still-live"
                   });
                 globalThis.performUnrelatedClose = () =>
                   host.transport.close(globalThis.unrelatedHandle);
@@ -1580,46 +1560,22 @@ void main() {
       }
       expect(unrelatedOpened, isTrue);
       expect(manager.liveTransportCount, 1);
-      manager.js.evaluate('globalThis.performUnrelatedClose();');
-      for (var i = 0; i < 100 && manager.liveTransportCount != 0; i++) {
-        while (manager.js.executePendingJob() > 0) {}
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      }
-      expect(manager.liveTransportCount, 0);
-
-      unawaited(lab.onConnect().catchError((_) {}));
-      await lab.connectionState
-          .where((state) => state == ConnectionState.connecting)
-          .first
-          .timeout(const Duration(seconds: 2));
-      manager.js.evaluate('globalThis.connectGates.lab();');
-      while (manager.js.executePendingJob() > 0) {}
-      await lab.connectionState
-          .where((state) => state == ConnectionState.connected)
-          .first
-          .timeout(const Duration(seconds: 2));
-      expect(manager.liveTransportCount, 1);
 
       manager.js.evaluate('globalThis.connectGates.office();');
       while (manager.js.executePendingJob() > 0) {}
-      var officeOpened = false;
-      for (var i = 0; i < 100 && !officeOpened; i++) {
+      var officeRejected = false;
+      for (var i = 0; i < 100 && !officeRejected; i++) {
         while (manager.js.executePendingJob() > 0) {}
         final result = manager.js.evaluate(
           'String(globalThis.connectOutcomes.office || "")',
         );
-        officeOpened = !result.isError && result.stringResult == 'opened';
-        if (!officeOpened) {
+        officeRejected = !result.isError && result.stringResult == 'rejected';
+        if (!officeRejected) {
           await Future<void>.delayed(const Duration(milliseconds: 10));
         }
       }
-      expect(officeOpened, isTrue);
-      for (var i = 0; i < 100 && manager.liveTransportCount != 1; i++) {
-        while (manager.js.executePendingJob() > 0) {}
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      }
+      expect(officeRejected, isTrue);
       expect(manager.liveTransportCount, 1);
-      expect(labStates, contains(ConnectionState.connected));
       expect(officeStates, isNot(contains(ConnectionState.connected)));
       expect(
         manager.js
@@ -1627,6 +1583,21 @@ void main() {
             .stringResult,
         '1',
       );
+
+      final roundTrip = manager.emitStream
+          .where((event) => event['event'] == 'unrelated-roundtrip')
+          .map((event) => event['payload'] as String)
+          .first;
+      manager.js.evaluate('globalThis.performUnrelatedRoundTrip();');
+      expect(await roundTrip.timeout(const Duration(seconds: 2)), 'still-live');
+      expect(manager.liveTransportCount, 1);
+
+      manager.js.evaluate('globalThis.performUnrelatedClose();');
+      for (var i = 0; i < 100 && manager.liveTransportCount != 0; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(manager.liveTransportCount, 0);
     },
   );
 
@@ -1682,8 +1653,8 @@ void main() {
                 vendor: "Test",
                 dataChannels: [{ key: "relativeHumidity", type: "number" }]
               }, {
-                connect() {
-                  return host.transport.open({
+                connect(transport) {
+                  return transport.open({
                     kind: "websocket",
                     url: "ws://127.0.0.1:${server.port}/x"
                   }).then((opened) => {
@@ -1805,11 +1776,11 @@ void main() {
                 vendor: "Test",
                 dataChannels: [{ key: "relativeHumidity", type: "number" }]
               }, {
-                connect() {
+                connect(transport) {
                   globalThis.connectStarted = true;
                   return new Promise((resolve) => {
                     globalThis.continueConnect = () => {
-                      host.transport.open({
+                      transport.open({
                         kind: "websocket",
                         url: "ws://127.0.0.1:${server.port}/x"
                       }).then((opened) => {

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -121,8 +121,6 @@ void main() {
           .where((sensors) => !sensors.containsKey(deviceId))
           .first;
       expect(deviceController.devices, isEmpty);
-      // Unload runs the disconnect handler exactly once even though onUnload
-      // threw, then removes the device.
       expect(
         manager.js.evaluate('globalThis.disconnectCalls').stringResult,
         '1',
@@ -456,7 +454,6 @@ void main() {
           .stringResult,
       '1',
     );
-    // The disconnect failure does not leave a half-registered device behind.
     await sensorController.sensorRegistry
         .where((sensors) => !sensors.containsKey(deviceId))
         .first;
@@ -694,6 +691,121 @@ void main() {
       expect(deviceController.devices, isEmpty);
     },
   );
+
+  test('dispose runs plugin device disconnect cleanup', () async {
+    final deviceService = PluginDeviceService();
+    final deviceController = DeviceController([deviceService]);
+    await deviceController.initialize();
+    final sensorController = SensorController(controller: deviceController);
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceService: deviceService,
+    );
+    addTearDown(() async {
+      await manager.dispose();
+      sensorController.dispose();
+      deviceController.dispose();
+    });
+
+    final registered = manager.emitStream
+        .where((event) => event['event'] == 'registered')
+        .map((event) => event['payload'] as String)
+        .first;
+    await manager.loadPlugin(
+      id: 'dispose-device.plugin',
+      manifest: testManifest(
+        'dispose-device.plugin',
+        permissions: const {PluginPermissions.emit},
+        drivers: const [
+          PluginDriverDeclaration(
+            id: 'humidity',
+            type: PluginDriverType.sensor,
+          ),
+        ],
+      ),
+      settings: const {},
+      jsCode: '''
+        function createPlugin(host) {
+          return {
+            id: "dispose-device.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {},
+                disconnect() {
+                  globalThis.disposeDisconnectCalls =
+                    (globalThis.disposeDisconnectCalls || 0) + 1;
+                  return new Promise((resolve) => {
+                    globalThis.resolveDisposeDisconnect = () => {
+                      globalThis.disposeDisconnectCompleted =
+                        (globalThis.disposeDisconnectCompleted || 0) + 1;
+                      resolve();
+                    };
+                  });
+                },
+                execute() { return {}; }
+              }).then((device) => host.emit("registered", device.deviceId));
+            }
+          };
+        }
+      ''',
+    );
+
+    final deviceId = await registered.timeout(const Duration(seconds: 2));
+    final sensor = await sensorController.sensorRegistry
+        .map((sensors) => sensors[deviceId])
+        .where((sensor) => sensor != null)
+        .cast<Sensor>()
+        .first;
+    await sensor.connectionState
+        .where((state) => state == ConnectionState.connected)
+        .first
+        .timeout(const Duration(seconds: 2));
+
+    final disposal = manager.dispose();
+    var disconnectStarted = false;
+    for (
+      var i = 0;
+      i < 1000 && manager.lifecycle == PluginManagerLifecycle.disposing;
+      i++
+    ) {
+      final calls = manager.js.evaluate(
+        'String(globalThis.disposeDisconnectCalls || 0)',
+      );
+      if (!calls.isError && calls.stringResult == '1') {
+        disconnectStarted = true;
+        break;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    expect(disconnectStarted, isTrue);
+    expect(
+      manager.js
+          .evaluate('String(globalThis.disposeDisconnectCalls || 0)')
+          .stringResult,
+      '1',
+    );
+
+    manager.js.evaluate('globalThis.resolveDisposeDisconnect();');
+    while (manager.js.executePendingJob() > 0) {}
+    expect(
+      manager.js
+          .evaluate('String(globalThis.disposeDisconnectCompleted || 0)')
+          .stringResult,
+      '1',
+    );
+    await expectLater(disposal, completes);
+    expect(manager.lifecycle, PluginManagerLifecycle.disposed);
+    await sensorController.sensorRegistry
+        .where((sensors) => !sensors.containsKey(deviceId))
+        .first;
+    expect(deviceController.devices, isEmpty);
+  });
 
   test('unregister rejects only pending invocations for its device', () async {
     final deviceService = PluginDeviceService();

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -1180,7 +1180,7 @@ void main() {
       final manager = PluginManager(
         kvStore: FakeKeyValueStoreService(),
         deviceService: deviceService,
-        deviceInvocationTimeout: const Duration(milliseconds: 60),
+        deviceInvocationTimeout: const Duration(milliseconds: 500),
       );
       addTearDown(() async {
         await manager.dispose();
@@ -1318,8 +1318,8 @@ void main() {
           .where((state) => state == ConnectionState.connecting)
           .first
           .timeout(const Duration(seconds: 2));
-
       manager.js.evaluate('globalThis.connectGates.lab();');
+      while (manager.js.executePendingJob() > 0) {}
       await lab.connectionState
           .where((state) => state == ConnectionState.connected)
           .first
@@ -1356,6 +1356,7 @@ void main() {
       expect(labStates, contains(ConnectionState.connected));
 
       manager.js.evaluate('globalThis.connectGates.office();');
+      while (manager.js.executePendingJob() > 0) {}
       var officeRejected = false;
       for (var i = 0; i < 100 && !officeRejected; i++) {
         while (manager.js.executePendingJob() > 0) {}

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -1007,21 +1007,18 @@ void main() {
   });
 
   test(
-    'async connect cannot open a transport after direct unregister',
+    'stale async connect transport is retired once the attempt settles',
     () async {
-      final nativeOpen = Completer<WebSocket>();
+      final server = await _startWsServer((ws) {
+        ws.listen((data) {});
+      });
       final deviceService = PluginDeviceService();
       final deviceController = DeviceController([deviceService]);
       await deviceController.initialize();
-      var connectorCalls = 0;
       final manager = PluginManager(
         kvStore: FakeKeyValueStoreService(),
         deviceService: deviceService,
         deviceInvocationTimeout: const Duration(milliseconds: 30),
-        connectWebSocket: (url, {protocols}) {
-          connectorCalls++;
-          return nativeOpen.future;
-        },
       );
       addTearDown(() async {
         await manager.dispose();
@@ -1048,7 +1045,8 @@ void main() {
           ],
         ),
         settings: const {},
-        jsCode: '''
+        jsCode:
+            '''
         function createPlugin(host) {
           let transportHandle;
           return {
@@ -1068,7 +1066,7 @@ void main() {
                   try {
                     const opened = await host.transport.open({
                       kind: "websocket",
-                      url: "ws://127.0.0.1:1/x"
+                      url: "ws://127.0.0.1:${server.port}/x"
                     });
                     transportHandle = opened.handle;
                     globalThis.connectCompleted = true;
@@ -1128,7 +1126,6 @@ void main() {
       manager.js.evaluate('globalThis.performAsyncUnregister();');
       expect(await unregistered.timeout(const Duration(seconds: 2)), deviceId);
       expect(manager.liveTransportCount, 0);
-      expect(connectorCalls, 0);
       await deviceService.devices.where((devices) => devices.isEmpty).first;
       expect(deviceController.devices, isEmpty);
       expect(
@@ -1139,24 +1136,22 @@ void main() {
       );
 
       manager.js.evaluate('globalThis.releaseAsyncConnect();');
-      var connectRejected = false;
-      for (var i = 0; i < 100 && !connectRejected; i++) {
+      var connectCompleted = false;
+      for (var i = 0; i < 100 && !connectCompleted; i++) {
         while (manager.js.executePendingJob() > 0) {}
         final result = manager.js.evaluate(
-          'String(globalThis.connectRejected || false)',
+          'String(globalThis.connectCompleted || false)',
         );
-        connectRejected = !result.isError && result.stringResult == 'true';
-        if (!connectRejected) {
+        connectCompleted = !result.isError && result.stringResult == 'true';
+        if (!connectCompleted) {
           await Future<void>.delayed(const Duration(milliseconds: 10));
         }
       }
-      expect(connectRejected, isTrue);
-      expect(
-        manager.js
-            .evaluate('String(globalThis.connectCompleted || false)')
-            .stringResult,
-        'false',
-      );
+      expect(connectCompleted, isTrue);
+      for (var i = 0; i < 100 && manager.liveTransportCount != 0; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
       expect(manager.liveTransportCount, 0);
       expect(states, isNot(contains(ConnectionState.connected)));
       expect(
@@ -1357,18 +1352,22 @@ void main() {
 
       manager.js.evaluate('globalThis.connectGates.office();');
       while (manager.js.executePendingJob() > 0) {}
-      var officeRejected = false;
-      for (var i = 0; i < 100 && !officeRejected; i++) {
+      var officeOpened = false;
+      for (var i = 0; i < 100 && !officeOpened; i++) {
         while (manager.js.executePendingJob() > 0) {}
         final result = manager.js.evaluate(
           'String(globalThis.connectOutcomes.office || "")',
         );
-        officeRejected = !result.isError && result.stringResult == 'rejected';
-        if (!officeRejected) {
+        officeOpened = !result.isError && result.stringResult == 'opened';
+        if (!officeOpened) {
           await Future<void>.delayed(const Duration(milliseconds: 10));
         }
       }
-      expect(officeRejected, isTrue);
+      expect(officeOpened, isTrue);
+      for (var i = 0; i < 100 && manager.liveTransportCount != 1; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
       expect(manager.liveTransportCount, 1);
       expect(labStates, contains(ConnectionState.connected));
       expect(
@@ -1400,6 +1399,234 @@ void main() {
       }
       expect(manager.liveTransportCount, 1);
       expect(labStates, contains(ConnectionState.connected));
+    },
+  );
+
+  test(
+    'unrelated opens and a later device connect survive a retired connect',
+    () async {
+      final server = await _startWsServer((ws) {
+        ws.listen((data) {});
+      });
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+        deviceInvocationTimeout: const Duration(milliseconds: 500),
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .take(2)
+          .toList();
+      await manager.loadPlugin(
+        id: 'retired-window.plugin',
+        manifest: testManifest(
+          'retired-window.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          function makeHandlers(instanceKey) {
+            let transportHandle;
+            return {
+              async connect() {
+                await new Promise((resolve) => {
+                  globalThis.connectGates[instanceKey] = resolve;
+                });
+                try {
+                  const opened = await host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${server.port}/x"
+                  });
+                  transportHandle = opened.handle;
+                  globalThis.connectOutcomes[instanceKey] = "opened";
+                  return {};
+                } catch (error) {
+                  globalThis.connectOutcomes[instanceKey] = "rejected";
+                  throw error;
+                }
+              },
+              disconnect() {
+                const handle = transportHandle;
+                transportHandle = null;
+                globalThis.disconnectCounts[instanceKey] =
+                  (globalThis.disconnectCounts[instanceKey] || 0) + 1;
+                return handle
+                  ? host.transport.close(handle)
+                  : Promise.resolve();
+              },
+              execute() { return {}; }
+            };
+          }
+          return {
+            id: "retired-window.plugin",
+            onLoad() {
+              globalThis.connectGates = {};
+              globalThis.connectOutcomes = {};
+              globalThis.disconnectCounts = {};
+              const define = (instanceId) => ({
+                driverId: "humidity",
+                instanceId: instanceId,
+                name: "Humidity " + instanceId,
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              });
+              Promise.all([
+                host.devices.register(
+                  define("office"),
+                  makeHandlers("office")
+                ),
+                host.devices.register(define("lab"), makeHandlers("lab"))
+              ]).then((devices) => {
+                globalThis.performUnregisterOffice = () =>
+                  devices[0].unregister().then(() => {
+                    host.emit("unregistered", devices[0].deviceId);
+                  });
+                globalThis.performUnrelatedOpen = () =>
+                  host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${server.port}/x"
+                  }).then((opened) => {
+                    globalThis.unrelatedHandle = opened.handle;
+                    globalThis.unrelatedOpened = true;
+                  });
+                globalThis.performUnrelatedClose = () =>
+                  host.transport.close(globalThis.unrelatedHandle);
+                host.emit("registered", devices[0].deviceId);
+                host.emit("registered", devices[1].deviceId);
+              });
+            }
+          };
+        }
+      ''',
+      );
+
+      final ids = await registered.timeout(const Duration(seconds: 2));
+      final officeId = ids.firstWhere((id) => id.endsWith(':office'));
+      final labId = ids.firstWhere((id) => id.endsWith(':lab'));
+      final sensors = await deviceService.devices
+          .where((devices) => devices.length == 2)
+          .first;
+      final office =
+          sensors.singleWhere((device) => device.deviceId == officeId)
+              as Sensor;
+      final lab =
+          sensors.singleWhere((device) => device.deviceId == labId) as Sensor;
+      final officeStates = <ConnectionState>[];
+      final officeStatesSubscription = office.connectionState.listen(
+        officeStates.add,
+      );
+      addTearDown(officeStatesSubscription.cancel);
+      final labStates = <ConnectionState>[];
+      final labStatesSubscription = lab.connectionState.listen(labStates.add);
+      addTearDown(labStatesSubscription.cancel);
+      unawaited(office.onConnect().catchError((_) {}));
+      await office.connectionState
+          .where((state) => state == ConnectionState.connecting)
+          .first
+          .timeout(const Duration(seconds: 2));
+      await office.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .first
+          .timeout(const Duration(seconds: 2));
+
+      final unregistered = manager.emitStream
+          .where(
+            (event) =>
+                event['event'] == 'unregistered' &&
+                event['payload'] == officeId,
+          )
+          .map((event) => event['payload'] as String)
+          .first;
+      manager.js.evaluate('globalThis.performUnregisterOffice();');
+      expect(await unregistered.timeout(const Duration(seconds: 2)), officeId);
+      await deviceService.devices
+          .where(
+            (devices) =>
+                devices.length == 1 && devices.single.deviceId == labId,
+          )
+          .first;
+
+      manager.js.evaluate('globalThis.performUnrelatedOpen();');
+      var unrelatedOpened = false;
+      for (var i = 0; i < 100 && !unrelatedOpened; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        final result = manager.js.evaluate(
+          'String(globalThis.unrelatedOpened || false)',
+        );
+        unrelatedOpened = !result.isError && result.stringResult == 'true';
+        if (!unrelatedOpened) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      }
+      expect(unrelatedOpened, isTrue);
+      expect(manager.liveTransportCount, 1);
+      manager.js.evaluate('globalThis.performUnrelatedClose();');
+      for (var i = 0; i < 100 && manager.liveTransportCount != 0; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(manager.liveTransportCount, 0);
+
+      unawaited(lab.onConnect().catchError((_) {}));
+      await lab.connectionState
+          .where((state) => state == ConnectionState.connecting)
+          .first
+          .timeout(const Duration(seconds: 2));
+      manager.js.evaluate('globalThis.connectGates.lab();');
+      while (manager.js.executePendingJob() > 0) {}
+      await lab.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first
+          .timeout(const Duration(seconds: 2));
+      expect(manager.liveTransportCount, 1);
+
+      manager.js.evaluate('globalThis.connectGates.office();');
+      while (manager.js.executePendingJob() > 0) {}
+      var officeOpened = false;
+      for (var i = 0; i < 100 && !officeOpened; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        final result = manager.js.evaluate(
+          'String(globalThis.connectOutcomes.office || "")',
+        );
+        officeOpened = !result.isError && result.stringResult == 'opened';
+        if (!officeOpened) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      }
+      expect(officeOpened, isTrue);
+      for (var i = 0; i < 100 && manager.liveTransportCount != 1; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(manager.liveTransportCount, 1);
+      expect(labStates, contains(ConnectionState.connected));
+      expect(officeStates, isNot(contains(ConnectionState.connected)));
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectCounts.office || 0)')
+            .stringResult,
+        '1',
+      );
     },
   );
 

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -1006,6 +1006,156 @@ void main() {
     expect(states, isNot(contains(ConnectionState.connected)));
   });
 
+  test(
+    'async connect cannot open a transport after direct unregister',
+    () async {
+      final nativeOpen = Completer<WebSocket>();
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      var connectorCalls = 0;
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+        deviceInvocationTimeout: const Duration(milliseconds: 30),
+        connectWebSocket: (url, {protocols}) {
+          connectorCalls++;
+          return nativeOpen.future;
+        },
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .first;
+      await manager.loadPlugin(
+        id: 'async-timeout-connect.plugin',
+        manifest: testManifest(
+          'async-timeout-connect.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode: '''
+        function createPlugin(host) {
+          let transportHandle;
+          return {
+            id: "async-timeout-connect.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                async connect() {
+                  await new Promise((resolve) => {
+                    globalThis.releaseAsyncConnect = resolve;
+                  });
+                  try {
+                    const opened = await host.transport.open({
+                      kind: "websocket",
+                      url: "ws://127.0.0.1:1/x"
+                    });
+                    transportHandle = opened.handle;
+                    globalThis.connectCompleted = true;
+                    return {};
+                  } catch (error) {
+                    globalThis.connectRejected = true;
+                    throw error;
+                  }
+                },
+                disconnect() {
+                  const handle = transportHandle;
+                  transportHandle = null;
+                  globalThis.disconnectCalls =
+                    (globalThis.disconnectCalls || 0) + 1;
+                  return handle
+                    ? host.transport.close(handle)
+                    : Promise.resolve();
+                },
+                execute() { return {}; }
+              }).then((device) => {
+                globalThis.performAsyncUnregister = () =>
+                  device.unregister().then(() => {
+                    host.emit("unregistered", device.deviceId);
+                  });
+                host.emit("registered", device.deviceId);
+              });
+            }
+          };
+        }
+      ''',
+      );
+
+      final deviceId = await registered.timeout(const Duration(seconds: 2));
+      final devices = await deviceService.devices
+          .where(
+            (devices) => devices.any((device) => device.deviceId == deviceId),
+          )
+          .first;
+      final sensor = devices.single as Sensor;
+      unawaited(sensor.onConnect().catchError((_) {}));
+      await sensor.connectionState
+          .where((state) => state == ConnectionState.connecting)
+          .first
+          .timeout(const Duration(seconds: 2));
+      await sensor.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .first
+          .timeout(const Duration(seconds: 2));
+
+      final states = <ConnectionState>[];
+      final stateSubscription = sensor.connectionState.listen(states.add);
+      addTearDown(stateSubscription.cancel);
+      final unregistered = manager.emitStream
+          .where((event) => event['event'] == 'unregistered')
+          .map((event) => event['payload'] as String)
+          .first;
+      manager.js.evaluate('globalThis.performAsyncUnregister();');
+      expect(await unregistered.timeout(const Duration(seconds: 2)), deviceId);
+      expect(manager.liveTransportCount, 0);
+      expect(connectorCalls, 0);
+      await deviceService.devices.where((devices) => devices.isEmpty).first;
+      expect(deviceController.devices, isEmpty);
+
+      manager.js.evaluate('globalThis.releaseAsyncConnect();');
+      var connectRejected = false;
+      for (var i = 0; i < 100 && !connectRejected; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        final result = manager.js.evaluate(
+          'String(globalThis.connectRejected || false)',
+        );
+        connectRejected = !result.isError && result.stringResult == 'true';
+        if (!connectRejected) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      }
+      expect(connectRejected, isTrue);
+      expect(
+        manager.js
+            .evaluate('String(globalThis.connectCompleted || false)')
+            .stringResult,
+        'false',
+      );
+      expect(manager.liveTransportCount, 0);
+      expect(states, isNot(contains(ConnectionState.connected)));
+    },
+  );
+
   test('device disconnect cleanup runs again after reconnect', () async {
     final server = await _startWsServer((ws) {
       ws.listen((data) {});

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -822,10 +822,12 @@ void main() {
         .map((event) => event['payload'] as String)
         .first;
     manager.js.evaluate('globalThis.performFirstUnregister();');
+    while (manager.js.executePendingJob() > 0) {}
     expect(await unregistered.timeout(const Duration(seconds: 10)), firstId);
     await firstFailure;
     manager.js.evaluate('globalThis.resolveFirst({});');
     manager.js.evaluate('globalThis.resolveSecond({});');
+    while (manager.js.executePendingJob() > 0) {}
     await secondResult.timeout(const Duration(seconds: 10));
     await sensorController.sensorRegistry
         .where((sensors) => !sensors.containsKey(firstId))

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/device_controller.dart';
 import 'package:reaprime/src/controllers/sensor_controller.dart';
@@ -454,4 +456,130 @@ void main() {
         .first;
     expect(deviceController.devices, isEmpty);
   });
+
+  test(
+    'unload lets a device disconnect handler close its own transport',
+    () async {
+      final server = await _startWsServer((ws) {
+        ws.listen((data) {});
+      });
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      final sensorController = SensorController(controller: deviceController);
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        sensorController.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .first;
+      await manager.loadPlugin(
+        id: 'cleanup-transport.plugin',
+        manifest: testManifest(
+          'cleanup-transport.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          return {
+            id: "cleanup-transport.plugin",
+            onLoad() {
+              host.devices.register({
+                driverId: "humidity",
+                instanceId: "office",
+                name: "Office humidity",
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              }, {
+                connect() {
+                  return host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${server.port}/x"
+                  }).then((opened) => {
+                    globalThis.cleanupTransportHandle = opened.handle;
+                    return {};
+                  });
+                },
+                disconnect() {
+                  return host.transport.close(globalThis.cleanupTransportHandle)
+                    .then(() => {
+                      globalThis.disconnectClosed =
+                        (globalThis.disconnectClosed || 0) + 1;
+                      return {};
+                    });
+                },
+                execute() { return {}; }
+              }).then((device) => {
+                globalThis.cleanupDevice = device;
+                host.emit("registered", device.deviceId);
+              });
+            }
+          };
+        }
+      ''',
+      );
+
+      final deviceId = await registered.timeout(const Duration(seconds: 2));
+      final sensor = await sensorController.sensorRegistry
+          .map((sensors) => sensors[deviceId])
+          .where((sensor) => sensor != null)
+          .cast<Sensor>()
+          .first;
+      await sensor.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first
+          .timeout(const Duration(seconds: 2));
+      expect(manager.liveTransportCount, 1);
+
+      await manager.unloadPlugin('cleanup-transport.plugin');
+
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectClosed || 0)')
+            .stringResult,
+        '1',
+      );
+      expect(manager.liveTransportCount, 0);
+      await sensorController.sensorRegistry
+          .where((sensors) => !sensors.containsKey(deviceId))
+          .first;
+      expect(deviceController.devices, isEmpty);
+    },
+  );
+}
+
+Future<HttpServer> _startWsServer(void Function(WebSocket ws) handler) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((req) async {
+    try {
+      if (WebSocketTransformer.isUpgradeRequest(req)) {
+        final ws = await WebSocketTransformer.upgrade(req);
+        handler(ws);
+      } else {
+        req.response.statusCode = 404;
+        await req.response.close();
+      }
+    } catch (_) {}
+  });
+  addTearDown(() => server.close(force: true));
+  return server;
 }

--- a/test/plugins/plugin_manager_devices_test.dart
+++ b/test/plugins/plugin_manager_devices_test.dart
@@ -1131,6 +1131,12 @@ void main() {
       expect(connectorCalls, 0);
       await deviceService.devices.where((devices) => devices.isEmpty).first;
       expect(deviceController.devices, isEmpty);
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectCalls || 0)')
+            .stringResult,
+        '1',
+      );
 
       manager.js.evaluate('globalThis.releaseAsyncConnect();');
       var connectRejected = false;
@@ -1153,6 +1159,246 @@ void main() {
       );
       expect(manager.liveTransportCount, 0);
       expect(states, isNot(contains(ConnectionState.connected)));
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectCalls || 0)')
+            .stringResult,
+        '1',
+      );
+    },
+  );
+
+  test(
+    'retiring one async connect does not claim another device transport',
+    () async {
+      final server = await _startWsServer((ws) {
+        ws.listen((data) {});
+      });
+      final deviceService = PluginDeviceService();
+      final deviceController = DeviceController([deviceService]);
+      await deviceController.initialize();
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceService: deviceService,
+        deviceInvocationTimeout: const Duration(milliseconds: 60),
+      );
+      addTearDown(() async {
+        await manager.dispose();
+        deviceController.dispose();
+      });
+
+      final registered = manager.emitStream
+          .where((event) => event['event'] == 'registered')
+          .map((event) => event['payload'] as String)
+          .take(2)
+          .toList();
+      await manager.loadPlugin(
+        id: 'overlap-connect.plugin',
+        manifest: testManifest(
+          'overlap-connect.plugin',
+          permissions: const {
+            PluginPermissions.emit,
+            PluginPermissions.networkWebsocket,
+          },
+          drivers: const [
+            PluginDriverDeclaration(
+              id: 'humidity',
+              type: PluginDriverType.sensor,
+            ),
+          ],
+        ),
+        settings: const {},
+        jsCode:
+            '''
+        function createPlugin(host) {
+          function makeHandlers(instanceKey) {
+            let transportHandle;
+            return {
+              async connect() {
+                await new Promise((resolve) => {
+                  globalThis.connectGates[instanceKey] = resolve;
+                });
+                try {
+                  const opened = await host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${server.port}/x"
+                  });
+                  transportHandle = opened.handle;
+                  globalThis.connectOutcomes[instanceKey] = "opened";
+                  return {};
+                } catch (error) {
+                  globalThis.connectOutcomes[instanceKey] = "rejected";
+                  throw error;
+                }
+              },
+              disconnect() {
+                const handle = transportHandle;
+                transportHandle = null;
+                globalThis.disconnectCounts[instanceKey] =
+                  (globalThis.disconnectCounts[instanceKey] || 0) + 1;
+                return handle
+                  ? host.transport.close(handle)
+                  : Promise.resolve();
+              },
+              execute() { return {}; }
+            };
+          }
+          return {
+            id: "overlap-connect.plugin",
+            onLoad() {
+              globalThis.connectGates = {};
+              globalThis.connectOutcomes = {};
+              globalThis.disconnectCounts = {};
+              const define = (instanceId) => ({
+                driverId: "humidity",
+                instanceId: instanceId,
+                name: "Humidity " + instanceId,
+                vendor: "Test",
+                dataChannels: [{ key: "relativeHumidity", type: "number" }]
+              });
+              Promise.all([
+                host.devices.register(
+                  define("office"),
+                  makeHandlers("office")
+                ),
+                host.devices.register(define("lab"), makeHandlers("lab"))
+              ]).then((devices) => {
+                globalThis.performUnregister = (key) =>
+                  devices[key === "office" ? 0 : 1].unregister().then(() => {
+                    host.emit(
+                      "unregistered",
+                      devices[key === "office" ? 0 : 1].deviceId
+                    );
+                  });
+                globalThis.performExtraOpen = () =>
+                  host.transport.open({
+                    kind: "websocket",
+                    url: "ws://127.0.0.1:${server.port}/x"
+                  }).then((opened) => {
+                    globalThis.extraHandle = opened.handle;
+                    globalThis.extraOpened = true;
+                  });
+                globalThis.performExtraClose = () =>
+                  host.transport.close(globalThis.extraHandle);
+                host.emit("registered", devices[0].deviceId);
+                host.emit("registered", devices[1].deviceId);
+              });
+            }
+          };
+        }
+      ''',
+      );
+
+      final ids = await registered.timeout(const Duration(seconds: 2));
+      final officeId = ids.firstWhere((id) => id.endsWith(':office'));
+      final labId = ids.firstWhere((id) => id.endsWith(':lab'));
+      final sensors = await deviceService.devices
+          .where((devices) => devices.length == 2)
+          .first;
+      final office =
+          sensors.singleWhere((device) => device.deviceId == officeId)
+              as Sensor;
+      final lab =
+          sensors.singleWhere((device) => device.deviceId == labId) as Sensor;
+      final officeStates = <ConnectionState>[];
+      final officeStatesSubscription = office.connectionState.listen(
+        officeStates.add,
+      );
+      addTearDown(officeStatesSubscription.cancel);
+      final labStates = <ConnectionState>[];
+      final labStatesSubscription = lab.connectionState.listen(labStates.add);
+      addTearDown(labStatesSubscription.cancel);
+      unawaited(office.onConnect().catchError((_) {}));
+      unawaited(lab.onConnect().catchError((_) {}));
+      await office.connectionState
+          .where((state) => state == ConnectionState.connecting)
+          .first
+          .timeout(const Duration(seconds: 2));
+      await lab.connectionState
+          .where((state) => state == ConnectionState.connecting)
+          .first
+          .timeout(const Duration(seconds: 2));
+
+      manager.js.evaluate('globalThis.connectGates.lab();');
+      await lab.connectionState
+          .where((state) => state == ConnectionState.connected)
+          .first
+          .timeout(const Duration(seconds: 2));
+      expect(manager.liveTransportCount, 1);
+      await office.connectionState
+          .where((state) => state == ConnectionState.disconnected)
+          .first
+          .timeout(const Duration(seconds: 2));
+
+      final unregistered = manager.emitStream
+          .where(
+            (event) =>
+                event['event'] == 'unregistered' &&
+                event['payload'] == officeId,
+          )
+          .map((event) => event['payload'] as String)
+          .first;
+      manager.js.evaluate('globalThis.performUnregister("office");');
+      expect(await unregistered.timeout(const Duration(seconds: 2)), officeId);
+      expect(manager.liveTransportCount, 1);
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectCounts.office || 0)')
+            .stringResult,
+        '1',
+      );
+      await deviceService.devices
+          .where(
+            (devices) =>
+                devices.length == 1 && devices.single.deviceId == labId,
+          )
+          .first;
+      expect(labStates, contains(ConnectionState.connected));
+
+      manager.js.evaluate('globalThis.connectGates.office();');
+      var officeRejected = false;
+      for (var i = 0; i < 100 && !officeRejected; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        final result = manager.js.evaluate(
+          'String(globalThis.connectOutcomes.office || "")',
+        );
+        officeRejected = !result.isError && result.stringResult == 'rejected';
+        if (!officeRejected) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      }
+      expect(officeRejected, isTrue);
+      expect(manager.liveTransportCount, 1);
+      expect(labStates, contains(ConnectionState.connected));
+      expect(
+        manager.js
+            .evaluate('String(globalThis.disconnectCounts.office || 0)')
+            .stringResult,
+        '1',
+      );
+      expect(officeStates, isNot(contains(ConnectionState.connected)));
+
+      manager.js.evaluate('globalThis.performExtraOpen();');
+      var extraOpened = false;
+      for (var i = 0; i < 100 && !extraOpened; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        final result = manager.js.evaluate(
+          'String(globalThis.extraOpened || false)',
+        );
+        extraOpened = !result.isError && result.stringResult == 'true';
+        if (!extraOpened) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      }
+      expect(extraOpened, isTrue);
+      expect(manager.liveTransportCount, 2);
+      manager.js.evaluate('globalThis.performExtraClose();');
+      for (var i = 0; i < 100 && manager.liveTransportCount != 1; i++) {
+        while (manager.js.executePendingJob() > 0) {}
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(manager.liveTransportCount, 1);
+      expect(labStates, contains(ConnectionState.connected));
     },
   );
 

--- a/test/plugins/plugin_manifest_permissions_test.dart
+++ b/test/plugins/plugin_manifest_permissions_test.dart
@@ -2,6 +2,66 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 
 void main() {
+  test('parses sensor driver contributions separately from permissions', () {
+    final manifest = PluginManifest.fromJson(<String, dynamic>{
+      'id': 'test.plugin',
+      'name': 'Test Plugin',
+      'author': 'Test',
+      'description': 'Test',
+      'version': '1.0.0',
+      'apiVersion': 1,
+      'permissions': ['network.websocket'],
+      'drivers': [
+        {'id': 'humidity', 'type': 'sensor'},
+      ],
+      'settings': <String, dynamic>{},
+      'api': <dynamic>[],
+    });
+
+    expect(manifest.drivers.single.id, 'humidity');
+    expect(manifest.drivers.single.type, PluginDriverType.sensor);
+    expect(manifest.toJson()['drivers'], [
+      {'id': 'humidity', 'type': 'sensor'},
+    ]);
+    expect(manifest.permissions, {PluginPermissions.networkWebsocket});
+  });
+
+  test('rejects invalid or duplicate driver contributions', () {
+    Map<String, dynamic> manifestWith(dynamic drivers) => <String, dynamic>{
+      'id': 'test.plugin',
+      'name': 'Test Plugin',
+      'author': 'Test',
+      'description': 'Test',
+      'version': '1.0.0',
+      'apiVersion': 1,
+      'permissions': <String>[],
+      'drivers': drivers,
+      'settings': <String, dynamic>{},
+      'api': <dynamic>[],
+    };
+
+    for (final drivers in [
+      'sensor',
+      [
+        {'id': '../humidity', 'type': 'sensor'},
+      ],
+      [
+        {'id': 'humidity', 'type': 'grinder'},
+      ],
+      [
+        {'id': 'humidity', 'type': 'sensor'},
+        {'id': 'humidity', 'type': 'sensor'},
+      ],
+      List.generate(9, (index) => {'id': 'driver-$index', 'type': 'sensor'}),
+    ]) {
+      expect(
+        () => PluginManifest.fromJson(manifestWith(drivers)),
+        throwsFormatException,
+        reason: '$drivers',
+      );
+    }
+  });
+
   test('parses manifest permission wire values', () {
     final manifest = PluginManifest.fromJson(<String, dynamic>{
       'id': 'test.plugin',

--- a/test/plugins/plugin_test_helpers.dart
+++ b/test/plugins/plugin_test_helpers.dart
@@ -54,6 +54,7 @@ PluginManifest testManifest(
     PluginPermissions.emit,
     PluginPermissions.pluginStorage,
   },
+  List<PluginDriverDeclaration> drivers = const [],
   PluginApi? api,
 }) {
   return PluginManifest(
@@ -64,6 +65,7 @@ PluginManifest testManifest(
     version: '1.0.0',
     apiVersion: 1,
     permissions: permissions,
+    drivers: drivers,
     settings: {},
     api: api ?? PluginApi(endpoints: []),
   );


### PR DESCRIPTION
## Summary

What changed, and why?

- Add manifest-declared `sensor` drivers and a generation-owned `host.devices` registration bridge.
- Feed plugin-backed sensors through `DeviceController` and `SensorController` so the existing device, sensor REST, and sensor WebSocket APIs expose them without new routes.
- Prove the boundary with a fake localhost WebSocket humidity sensor, including `sampleNow`, lifecycle cleanup, stale-generation fencing, validation, timeouts, and resource limits.

## Linked Issue

N/A — implements the first sensor-registration slice of [Discussion #749: Generic device drivers through the JavaScript extension system](https://github.com/decentespresso/decaid/discussions/749).

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `dart format lib test`
- `flutter analyze` — no issues
- `flutter test` — 3867 passed, 1 skipped
- `./scripts/fetch_dye2_plugin.sh`
- Parsed `assets/api/rest_v1.yml` with Ruby YAML
- Fake localhost WebSocket integration covers `/api/v1/devices`, `/api/v1/sensors`, `/api/v1/sensors/:id/execute`, and `/ws/v1/sensors/:id/snapshot`

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Plugin manifests may now declare `drivers`; the only supported type is `sensor`.
- Plugins gain `host.devices.register()`, publication, disconnect reporting, and unregister operations. Driver declarations remain separate from transport permissions.
- Existing plugins remain compatible; no persistence migration or new REST/WebSocket route is introduced.
- Updated the REST schema and plugin, API, and device-management documentation.
- Grinder, BLE driver access, remembered plugin devices, probing, and generic device UI remain out of scope.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
