### PR TITLE
chore(deps): pin flutter_js 0.8.6

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -619,11 +619,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ce2edeb
-      resolved-ref: ce2edeb2f3ab705c4d6c94a42b1af663750ea9b8
+      ref: d6e8849
+      resolved-ref: d6e8849210c0081d19c78be97628947e6e2976e2
       url: "https://github.com/tadelv/dart_js"
     source: git
-    version: "0.8.5"
+    version: "0.8.6"
   flutter_launcher_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,7 +85,7 @@ dependencies:
     # path: ../dart_js
     git:
       url: https://github.com/tadelv/dart_js
-      ref: ce2edeb
+      ref: d6e8849
   firebase_core: ^4.3.0
   firebase_crashlytics: ^5.0.6
   firebase_performance: ^0.11.1+3


### PR DESCRIPTION
## Summary

What changed, and why?

- Pin `flutter_js` to the audited 0.8.6 release from https://github.com/tadelv/dart_js/pull/24.
- Refresh the lockfile entry to the matching full commit and package version.

## Linked Issue

N/A

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `flutter analyze --no-pub`
- `flutter test --no-pub` (3,852 passed before the only local failure: OpenSSL was not on `PATH` for the TLS fixture)
- `flutter test --no-pub test/plugins/plugin_manager_transport_tls_test.dart` with Git for Windows OpenSSL on `PATH` (4 passed)

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Pulls in audited QuickJS ownership, async callback lifetime, promise settlement, XHR, and invalid JSON handling fixes. No Decaid API or migration changes.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->