### PR TITLE
fix(serial): deduplicate Android devices by ID

### DIFF
--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -893,6 +893,10 @@ attach recovery"). Explicit native, REST, and WebSocket scans call
 `connectingMachine` is published before the attempt, then phase falls
 through to `scanning` (existing scan path).
 
+Android serial discovery replaces a registry entry when quick-connect detects
+a new device instance with the same `deviceId`, so REST and WebSocket inventory
+never retain the disconnected instance beside its connected replacement.
+
 ### Initial App Startup
 
 ```

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -262,7 +262,7 @@ class SerialServiceAndroid
         deviceName: machine.name,
       );
     }
-    _devices.add(machine);
+    _addDevices([machine]);
     _recordPhysicalOwnership(machine.deviceId, device);
     machine.connectionState.listen((state) {
       if (state == ConnectionState.disconnected) {
@@ -340,7 +340,7 @@ class SerialServiceAndroid
       try {
         await device.onConnect().timeout(const Duration(seconds: 10));
         final connected = device;
-        _devices.add(connected);
+        _addDevices([connected]);
         _recordPhysicalOwnership(connected.deviceId, d);
         connected.connectionState.listen((state) {
           if (state == ConnectionState.disconnected) {
@@ -393,6 +393,13 @@ class SerialServiceAndroid
     final physicalId = physical.deviceId;
     if (physicalId != null) {
       _logicalToPhysicalDeviceId[logicalDeviceId] = physicalId;
+    }
+  }
+
+  void _addDevices(Iterable<Device> devices) {
+    for (final device in devices) {
+      _devices.removeWhere((known) => known.deviceId == device.deviceId);
+      _devices.add(device);
     }
   }
 
@@ -509,7 +516,7 @@ class SerialServiceAndroid
         return found;
       }),
     );
-    _devices.addAll(results.expand((e) => e));
+    _addDevices(results.expand((e) => e));
     _machineSubject.add(_devices);
   }
 

--- a/lib/src/services/serial/serial_service_android.dart
+++ b/lib/src/services/serial/serial_service_android.dart
@@ -266,7 +266,7 @@ class SerialServiceAndroid
     _recordPhysicalOwnership(machine.deviceId, device);
     machine.connectionState.listen((state) {
       if (state == ConnectionState.disconnected) {
-        _devices.remove(machine);
+        if (!_devices.remove(machine)) return;
         _machineSubject.add(_devices);
         _logicalToPhysicalDeviceId.remove(machine.deviceId);
         final t = _transportForDeviceId.remove(machine.deviceId);
@@ -344,7 +344,7 @@ class SerialServiceAndroid
         _recordPhysicalOwnership(connected.deviceId, d);
         connected.connectionState.listen((state) {
           if (state == ConnectionState.disconnected) {
-            _devices.remove(connected);
+            if (!_devices.remove(connected)) return;
             _machineSubject.add(_devices);
             _logicalToPhysicalDeviceId.remove(connected.deviceId);
             final t = _transportForDeviceId.remove(connected.deviceId);

--- a/test/services/serial/usb_attach_probe_test.dart
+++ b/test/services/serial/usb_attach_probe_test.dart
@@ -360,6 +360,38 @@ void main() {
     expect(liveDevices, [same(reconnected)]);
   });
 
+  test('stale disconnect preserves replacement ownership', () async {
+    final stale = _FakeMachine();
+    final reconnected = _FakeMachine();
+    var detections = 0;
+    listed = [_device()];
+    detection = (_) async => detections++ == 0 ? stale : reconnected;
+    service = build();
+    const remembered = RememberedDevice(
+      id: 'usb-2e8a-a-8549628789ABCDEF',
+      name: 'DE1',
+      type: DeviceType.machine,
+      implementation: DeviceImplementation.unifiedDe1,
+      transportType: TransportType.serial,
+    );
+
+    await service.tryQuickConnect(remembered);
+    await service.tryQuickConnect(remembered);
+    stale.setConnectionState(ConnectionState.disconnected);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(await service.devices.first, [same(reconnected)]);
+
+    await service.handleUsbEvent(
+      UsbEvent()
+        ..event = UsbEvent.ACTION_USB_DETACHED
+        ..device = _device(),
+    );
+
+    expect(reconnected.disconnectCalls, 1);
+    expect(await service.devices.first, isEmpty);
+  });
+
   for (final order in ['de1-first', 'keyboard-first']) {
     test('generic startup hint with multiple devices ($order) still finds '
         'the supported machine', () async {

--- a/test/services/serial/usb_attach_probe_test.dart
+++ b/test/services/serial/usb_attach_probe_test.dart
@@ -6,9 +6,11 @@ import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/device_attach_notifier.dart';
 import 'package:reaprime/src/models/device/device_implementation.dart';
 import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/usb_attach_probe.dart';
 import 'package:reaprime/src/services/serial/serial_service_android.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
 import 'package:rxdart/subjects.dart';
 
 // ignore: depend_on_referenced_packages
@@ -74,6 +76,8 @@ class _FakeMachine implements De1Interface {
   Future<void> disconnect() async {
     disconnectCalls++;
   }
+
+  void setConnectionState(ConnectionState state) => _connectionState.add(state);
 
   @override
   Future<void> dispose() async {}
@@ -326,6 +330,34 @@ void main() {
 
     expect(result, isA<AttachProbeUnsupported>());
     expect(await service.devices.first, isEmpty);
+  });
+
+  test('quick-connect replaces a stale same-ID API entry', () async {
+    final stale = _FakeMachine();
+    final reconnected = _FakeMachine();
+    var detections = 0;
+    listed = [_device()];
+    detection = (_) async => detections++ == 0 ? stale : reconnected;
+    service = build();
+
+    await service.scanForDevices();
+    stale.setConnectionState(ConnectionState.disconnected);
+
+    final result = await service.tryQuickConnect(
+      const RememberedDevice(
+        id: 'usb-2e8a-a-8549628789ABCDEF',
+        name: 'DE1',
+        type: DeviceType.machine,
+        implementation: DeviceImplementation.unifiedDe1,
+        transportType: TransportType.serial,
+      ),
+    );
+    final liveDevices = await service.devices.first;
+    final apiDevices = await buildAvailabilityDeviceList(liveDevices, const []);
+
+    expect(result, same(reconnected));
+    expect(apiDevices, [containsPair('state', 'connected')]);
+    expect(liveDevices, [same(reconnected)]);
   });
 
   for (final order in ['de1-first', 'keyboard-first']) {


### PR DESCRIPTION
## Summary

- Replace same-ID Android serial devices at the shared registry insertion point so quick-connect cannot retain a stale duplicate.
- Prevent superseded devices from clearing the replacement's physical ownership and transport when their stale disconnect listeners fire.
- Cover scan-to-quick-connect API inventory and stale-listener detach regressions, and document the registry invariant.

## Linked Issue

Fixes #767

## Verification

- `dart format lib/src/services/serial/serial_service_android.dart test/services/serial/usb_attach_probe_test.dart`
- `flutter test --no-pub test/services/serial/usb_attach_probe_test.dart test/unit/services/availability_device_list_test.dart test/devices_handler_test.dart` (59 passed)
- `flutter analyze --no-pub` (no issues)
- `flutter test --no-pub` (3,865 passed, 1 skipped)
- I could not run the Android hardware API smoke: `adb devices -l` returned no connected devices. Earlier Windows desktop and emulator attempts also hit host toolchain and Gradle loopback errors.

## Impact

- Android REST and WebSocket device inventory no longer exposes stale and connected serial instances with the same `deviceId`.
- A superseded instance can no longer clear the active replacement's detach ownership or transport.
- No API schema, migration, compatibility, or security impact.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
