### PR TITLE
fix: suppress Bengle internal scale disconnect error

### DIFF
--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -759,6 +759,11 @@ class ConnectionManager {
 
   void markExpectingDisconnect(String deviceId) {
     _disconnectExpectations.mark(deviceId);
+    final scaleId = scaleController.lastConnectedDeviceId;
+    if (_disconnectSupervisor.isScaleConnected &&
+        scaleId == 'bengle-internal-$deviceId') {
+      _disconnectExpectations.mark(scaleId!);
+    }
   }
 
   @visibleForTesting

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -2089,6 +2089,27 @@ void main() {
         expect(connectionManager.currentStatus.error, isNull);
       });
 
+      test(
+        'machine expectation also suppresses its connected Bengle scale',
+        () async {
+          mockScaleController.debugSetLastConnectedId(
+            'bengle-internal-machine-1',
+          );
+          mockScaleController.mockEmitConnectionState(
+            ConnectionState.connected,
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          connectionManager.markExpectingDisconnect('machine-1');
+          connectionManager.debugNotifyMachineDisconnected('machine-1');
+          connectionManager.debugNotifyScaleDisconnected(
+            'bengle-internal-machine-1',
+          );
+
+          expect(connectionManager.currentStatus.error, isNull);
+        },
+      );
+
       test('unexpected disconnect emits scaleDisconnected', () {
         connectionManager.debugNotifyScaleDisconnected('50:78:7D:1F:AE:E1');
         expect(

--- a/test/devices_handler_test.dart
+++ b/test/devices_handler_test.dart
@@ -348,6 +348,26 @@ void main() {
         );
         expect(response.statusCode, 404);
       });
+
+      test(
+        'deliberate Bengle disconnect suppresses its internal-scale error',
+        () async {
+          final bengle = MockBengle();
+          mockDiscovery.addDevice(bengle);
+          await de1Controller.connectToDe1(bengle);
+          await scaleController.connectToScale(BengleVirtualScale(bengle));
+          await Future<void>.delayed(Duration.zero);
+
+          final response = await sendPut(
+            '/api/v1/devices/disconnect',
+            body: jsonEncode({'deviceId': bengle.deviceId}),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(response.statusCode, 200);
+          expect(connectionManager.currentStatus.error, isNull);
+        },
+      );
     });
 
     group('scan endpoint', () {


### PR DESCRIPTION
## Summary

- Mark a connected Bengle internal scale as expecting disconnect when its machine is deliberately disconnected.
- Cover the shared supervisor path and REST disconnect flow with regressions.

## Linked Issue

Fixes #766

## Verification

- `dart format --output=none --set-exit-if-changed lib/src/controllers/connection_manager.dart test/controllers/connection_manager_test.dart test/devices_handler_test.dart`
- `flutter analyze --no-pub`
- `flutter test --no-pub test/controllers/connection_manager_test.dart test/devices_handler_test.dart`
- `flutter test --no-pub` (3,865 passed, 1 skipped)
- Windows `MockBengle` smoke: `PUT /api/v1/devices/disconnect` returned 200; the device WebSocket reported the machine and internal scale disconnected with `connectionStatus.error` null.

## Impact

- Deliberate Bengle machine disconnects no longer surface a false `scaleDisconnected` error for the internal scale. No API shape, compatibility, migration, documentation, or security impact.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
