### PR TITLE
fix(shots): read back shots imported from de1app

### DIFF
--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -81,6 +81,31 @@ Content-based hash IDs for deduplication. `ProfileController` manages the profil
 - `ProfileStorageService` interface with `DriftProfileStorageService` implementation.
 - ID-changing updates use `ProfileStorageService.replace`, which inserts the replacement and deletes the original in one Drift transaction. Target-ID collisions throw `ArgumentError` and leave both records unchanged.
 
+### Recorded Shot Profiles Are Not Executable Profiles
+
+A shot's stored `workflowJson.profile` is a historical record, not something the
+app brews from, so `ShotMapper.fromRow` reads it with
+`Workflow.fromRecordedJson`, which parses the profile via
+`Profile.fromRecordedJson` and allows an empty `steps` array and a missing
+title. `Workflow.fromJson` and `Profile.fromJson` stay strict and back the
+profile library, the profile and workflow REST handlers, the stored current
+workflow, and DE1 upload; a step-less profile must never enter the brewable
+library, and `PUT /api/v1/workflow` must keep returning 400 for one (issue
+#338).
+
+de1app `.shot` files carry the shot, not the profile that produced it, so
+`TclShotParser` and the no-profile branch of `ShotV2JsonParser` store a
+placeholder profile with `steps: []`. Before the lenient read path existed, the
+strict parser refused to read those rows back, and because
+`DriftStorageService.getShotsPaginated` mapped rows with a bare `rows.map(...)`,
+a single de1app import made `GET /api/v1/shots` return 500 and hid the entire
+history rather than one shot (issue #784).
+
+`ShotMapper.fromRows` now skips and logs a row it cannot map, so any future
+corruption costs its own shot instead of the whole list. Single-shot reads
+(`getShot`, `getLatestShot`) still surface the error, because there the failing
+row is the answer.
+
 ### Legacy Profile Corpus Ingestion
 
 `tools/ingest_profiles.py` rejects de1app TCL profiles whose type is `settings_2a`

--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -101,6 +101,14 @@ strict parser refused to read those rows back, and because
 a single de1app import made `GET /api/v1/shots` return 500 and hid the entire
 history rather than one shot (issue #784).
 
+The same leniency has to hold for every path that re-reads a stored shot as
+JSON, not just the row mapper. `PUT /api/v1/shots/<id>` merges the patch into
+`existingShot.toJson()` and reparses the result, and `ShotImporter` reads back
+shots from a backup export, so both use `ShotRecord.fromRecordedJson`. With the
+strict parser there, an imported step-less shot read back fine but could not be
+annotated or re-imported. `ShotRecord.fromJson` stays strict for everything
+else.
+
 `ShotMapper.fromRows` now skips and logs a row it cannot map, so any future
 corruption costs its own shot instead of the whole list. Single-shot reads
 (`getShot`, `getLatestShot`) still surface the error, because there the failing

--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -103,16 +103,28 @@ history rather than one shot (issue #784).
 
 The same leniency has to hold for every path that re-reads a stored shot as
 JSON, not just the row mapper. `PUT /api/v1/shots/<id>` merges the patch into
-`existingShot.toJson()` and reparses the result, and `ShotImporter` reads back
-shots from a backup export, so both use `ShotRecord.fromRecordedJson`. With the
-strict parser there, an imported step-less shot read back fine but could not be
-annotated or re-imported. `ShotRecord.fromJson` stays strict for everything
-else.
+`existingShot.toJson()` and reparses the result; `ShotImporter`
+(`lib/src/util/shot_importer.dart`) reads shots from a standalone backup file;
+and `ShotExportSection.importJson` (`lib/src/services/webserver/data_export/shot_export_section.dart`)
+is the restore side of the app's own `/backup` archive endpoint. All three use
+`ShotRecord.fromRecordedJson`. With the strict parser there, an imported
+step-less shot read back fine but could not be annotated, re-imported, or
+restored from a `/backup` archive. `ShotRecord.fromJson` stays strict for
+everything else.
 
 `ShotMapper.fromRows` now skips and logs a row it cannot map, so any future
 corruption costs its own shot instead of the whole list. Single-shot reads
 (`getShot`, `getLatestShot`) still surface the error, because there the failing
 row is the answer.
+
+`ShotExportSection.exportJson` (wired from `pageShotsForExport` in
+`lib/main.dart`) pages through `ShotDao.getShotsForExport` and treats a page
+shorter than the requested page size as end-of-stream. Because
+`ShotMapper.fromRows` drops unmappable rows, a raw page that happened to
+contain one would come back short even with more rows waiting, truncating the
+backup. `pageShotsForExport` re-queries past a dropped row, using the raw
+row's cursor (not the last successfully mapped shot's) to advance, until it
+either fills the requested page or the table is genuinely exhausted.
 
 ### Legacy Profile Corpus Ingestion
 

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -109,6 +109,21 @@ REA uses **content-based hashing** for profile identification instead of random 
 - **Conflict-free merging**: No manual conflict resolution needed
 - **Provable identity**: ID proves the profile content hasn't changed
 
+#### Parsing Strictness
+
+`Profile.fromJson` requires a non-empty `title`, a non-empty `steps` array,
+`tank_temperature`, and `target_volume_count_start`. It backs the profile
+library, `POST`/`PUT /api/v1/profiles`, and DE1 profile upload, so a profile that
+cannot be brewed is rejected at the boundary.
+
+`Profile.fromRecordedJson` relaxes those requirements and is reached only
+through `Workflow.fromRecordedJson`, which `ShotMapper.fromRow` uses to read the
+profile embedded in a stored shot's workflow. A shot's profile is a
+record of what happened, and shots imported from de1app `.shot` files carry no
+profile steps at all. Missing or empty titles read back as `Unknown profile`;
+missing numeric fields read back as `0`. Never use it to load a profile the user
+can brew from.
+
 #### Hash Types
 
 Profiles use three SHA-256 hashes:

--- a/doc/Profiles.md
+++ b/doc/Profiles.md
@@ -117,8 +117,9 @@ library, `POST`/`PUT /api/v1/profiles`, and DE1 profile upload, so a profile tha
 cannot be brewed is rejected at the boundary.
 
 `Profile.fromRecordedJson` relaxes those requirements and is reached only
-through `Workflow.fromRecordedJson`, which `ShotMapper.fromRow` uses to read the
-profile embedded in a stored shot's workflow. A shot's profile is a
+through `Workflow.fromRecordedJson`, which `ShotMapper.fromRow` and
+`ShotRecord.fromRecordedJson` use to read the profile embedded in a stored
+shot's workflow. A shot's profile is a
 record of what happened, and shots imported from de1app `.shot` files carry no
 profile steps at all. Missing or empty titles read back as `Unknown profile`;
 missing numeric fields read back as `0`. Never use it to load a profile the user

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -560,7 +560,7 @@ void main(List<String> args) async {
             cursorTimestamp: afterTimestamp,
             cursorId: afterId,
           );
-          return rows.map(ShotMapper.fromRow).toList();
+          return ShotMapper.fromRows(rows);
         },
         pageSteams: (limit, {afterTimestamp, afterCreatedAt, afterId}) async {
           final rows = await appDatabase.steamDao.getSteamsForExport(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:reaprime/src/plugins/plugin_source_service.dart';
 import 'package:reaprime/src/services/android_updater.dart';
 import 'package:reaprime/src/services/wifi/wifi_scale_discovery_service.dart';
 import 'package:reaprime/src/services/database/database.dart' hide Workflow;
+import 'package:reaprime/src/models/data/shot_record.dart' as domain;
 import 'package:reaprime/src/services/database/mappers/shot_mapper.dart';
 import 'package:reaprime/src/services/database/mappers/steam_mapper.dart';
 import 'package:reaprime/src/services/database/mappers/bean_mapper.dart';
@@ -149,6 +150,34 @@ Set<SimulatedDevicesTypes> _parseSimulateFlag(String value) {
       .map((e) => SimulatedDevicesTypesFromString.fromString(e))
       .whereType<SimulatedDevicesTypes>()
       .toSet();
+}
+
+/// Pages shots for backup export, skipping unreadable rows without letting
+/// them shrink the page below [limit] while more rows remain -- otherwise the
+/// exporter's `page.length < pageSize` end-of-stream check would truncate a
+/// backup at the first unreadable row (gh#784).
+Future<List<domain.ShotRecord>> pageShotsForExport(
+  AppDatabase appDatabase,
+  int limit, {
+  DateTime? afterTimestamp,
+  DateTime? afterCreatedAt,
+  String? afterId,
+}) async {
+  final result = <domain.ShotRecord>[];
+  DateTime? cursorTimestamp = afterTimestamp;
+  String? cursorId = afterId;
+  while (result.length < limit) {
+    final rows = await appDatabase.shotDao.getShotsForExport(
+      limit: limit - result.length,
+      cursorTimestamp: cursorTimestamp,
+      cursorId: cursorId,
+    );
+    if (rows.isEmpty) break;
+    cursorTimestamp = rows.last.timestamp;
+    cursorId = rows.last.id;
+    result.addAll(ShotMapper.fromRows(rows));
+  }
+  return result;
 }
 
 Future<void> _printStoragePaths() async {
@@ -554,14 +583,14 @@ void main(List<String> args) async {
       grinderStorage: grinderStorage,
       connectionManager: connectionManager,
       backupSources: BackupDataSources(
-        pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) async {
-          final rows = await appDatabase.shotDao.getShotsForExport(
-            limit: limit,
-            cursorTimestamp: afterTimestamp,
-            cursorId: afterId,
-          );
-          return ShotMapper.fromRows(rows);
-        },
+        pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) =>
+            pageShotsForExport(
+              appDatabase,
+              limit,
+              afterTimestamp: afterTimestamp,
+              afterCreatedAt: afterCreatedAt,
+              afterId: afterId,
+            ),
         pageSteams: (limit, {afterTimestamp, afterCreatedAt, afterId}) async {
           final rows = await appDatabase.steamDao.getSteamsForExport(
             limit: limit,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -152,10 +152,6 @@ Set<SimulatedDevicesTypes> _parseSimulateFlag(String value) {
       .toSet();
 }
 
-/// Pages shots for backup export, skipping unreadable rows without letting
-/// them shrink the page below [limit] while more rows remain -- otherwise the
-/// exporter's `page.length < pageSize` end-of-stream check would truncate a
-/// backup at the first unreadable row (gh#784).
 Future<List<domain.ShotRecord>> pageShotsForExport(
   AppDatabase appDatabase,
   int limit, {

--- a/lib/src/models/data/profile.dart
+++ b/lib/src/models/data/profile.dart
@@ -42,34 +42,51 @@ class Profile extends Equatable {
     tankTemperature,
   ];
 
-  factory Profile.fromJson(Map<String, dynamic> json) {
+  static const unknownTitle = 'Unknown profile';
+
+  factory Profile.fromJson(Map<String, dynamic> json) =>
+      Profile._parse(json, requireExecutable: true);
+
+  factory Profile.fromRecordedJson(Map<String, dynamic> json) =>
+      Profile._parse(json, requireExecutable: false);
+
+  static Profile _parse(
+    Map<String, dynamic> json, {
+    required bool requireExecutable,
+  }) {
     final title = parseOptionalString(json['title']);
-    if (title == null || title.isEmpty) {
-      throw ArgumentError('Profile must have a non-empty "title"');
-    }
     final rawSteps = json['steps'];
-    if (rawSteps is! List || rawSteps.isEmpty) {
-      throw ArgumentError('Profile must have a non-empty "steps" array');
-    }
-    if (json['tank_temperature'] == null) {
-      throw ArgumentError('Profile must have "tank_temperature"');
-    }
-    if (json['target_volume_count_start'] == null) {
-      throw ArgumentError('Profile must have "target_volume_count_start"');
+    if (requireExecutable) {
+      if (title == null || title.isEmpty) {
+        throw ArgumentError('Profile must have a non-empty "title"');
+      }
+      if (rawSteps is! List || rawSteps.isEmpty) {
+        throw ArgumentError('Profile must have a non-empty "steps" array');
+      }
+      if (json['tank_temperature'] == null) {
+        throw ArgumentError('Profile must have "tank_temperature"');
+      }
+      if (json['target_volume_count_start'] == null) {
+        throw ArgumentError('Profile must have "target_volume_count_start"');
+      }
     }
     return Profile(
       version: parseOptionalString(json['version']),
-      title: title,
+      title: title == null || title.isEmpty ? unknownTitle : title,
       notes: parseOptionalString(json['notes']) ?? '',
       author: parseOptionalString(json['author']) ?? '',
       beverageType: _parseBeverageType(json['beverage_type']),
-      steps: rawSteps
-          .map((step) => ProfileStep.fromJson(step as Map<String, dynamic>))
-          .toList(),
+      steps: rawSteps is List
+          ? rawSteps
+                .map(
+                  (step) => ProfileStep.fromJson(step as Map<String, dynamic>),
+                )
+                .toList()
+          : const [],
       targetVolume: parseOptionalDouble(json['target_volume']),
       targetWeight: parseOptionalDouble(json['target_weight']),
-      targetVolumeCountStart: parseInt(json['target_volume_count_start']),
-      tankTemperature: parseDouble(json['tank_temperature']),
+      targetVolumeCountStart: parseInt(json['target_volume_count_start'] ?? 0),
+      tankTemperature: parseDouble(json['tank_temperature'] ?? 0),
     );
   }
 

--- a/lib/src/models/data/shot_record.dart
+++ b/lib/src/models/data/shot_record.dart
@@ -76,7 +76,16 @@ class ShotRecord {
     };
   }
 
-  factory ShotRecord.fromJson(Map<String, dynamic> json) {
+  factory ShotRecord.fromJson(Map<String, dynamic> json) =>
+      ShotRecord._parse(json, recorded: false);
+
+  factory ShotRecord.fromRecordedJson(Map<String, dynamic> json) =>
+      ShotRecord._parse(json, recorded: true);
+
+  static ShotRecord _parse(
+    Map<String, dynamic> json, {
+    required bool recorded,
+  }) {
     ShotAnnotations? ann;
     if (json.containsKey('annotations')) {
       final annotations = json['annotations'];
@@ -103,7 +112,9 @@ class ShotRecord {
       measurements: (json["measurements"] as List)
           .map((e) => ShotSnapshot.fromJson(e))
           .toList(),
-      workflow: Workflow.fromJson(json["workflow"]),
+      workflow: recorded
+          ? Workflow.fromRecordedJson(json["workflow"])
+          : Workflow.fromJson(json["workflow"]),
       annotations: ann,
       stopReason: json["stopReason"] as String?,
       shotNotes: json.containsKey('annotations')

--- a/lib/src/models/data/workflow.dart
+++ b/lib/src/models/data/workflow.dart
@@ -27,7 +27,13 @@ class Workflow {
     this.machine,
   });
 
-  factory Workflow.fromJson(Map<String, dynamic> json) {
+  factory Workflow.fromJson(Map<String, dynamic> json) =>
+      Workflow._parse(json, recorded: false);
+
+  factory Workflow.fromRecordedJson(Map<String, dynamic> json) =>
+      Workflow._parse(json, recorded: true);
+
+  static Workflow _parse(Map<String, dynamic> json, {required bool recorded}) {
     WorkflowContext? ctx;
     if (json['context'] != null) {
       ctx = WorkflowContext.fromJson(json['context'] as Map<String, dynamic>);
@@ -65,7 +71,9 @@ class Workflow {
       id: json['id'],
       name: json['name'],
       description: json['description'],
-      profile: Profile.fromJson(json['profile']),
+      profile: recorded
+          ? Profile.fromRecordedJson(json['profile'])
+          : Profile.fromJson(json['profile']),
       context: ctx,
       steamSettings: json['steamSettings'] != null
           ? SteamSettings.fromJson(json['steamSettings'])

--- a/lib/src/services/database/mappers/shot_mapper.dart
+++ b/lib/src/services/database/mappers/shot_mapper.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:drift/drift.dart';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/models/data/shot_annotations.dart';
 import 'package:reaprime/src/models/data/shot_record.dart' as domain;
 import 'package:reaprime/src/models/data/shot_snapshot.dart';
@@ -8,8 +9,24 @@ import 'package:reaprime/src/models/data/workflow.dart' as domain_workflow;
 import 'package:reaprime/src/services/database/database.dart' as db;
 
 class ShotMapper {
+  static final Logger _log = Logger('ShotMapper');
+
+  static List<domain.ShotRecord> fromRows(Iterable<db.ShotRecord> rows) {
+    final records = <domain.ShotRecord>[];
+    for (final row in rows) {
+      try {
+        records.add(fromRow(row));
+      } catch (e) {
+        _log.warning('Skipping unreadable shot ${row.id}', e);
+      }
+    }
+    return records;
+  }
+
   static domain.ShotRecord fromRow(db.ShotRecord row) {
-    final workflow = domain_workflow.Workflow.fromJson(row.workflowJson);
+    final workflow = domain_workflow.Workflow.fromRecordedJson(
+      row.workflowJson,
+    );
 
     ShotAnnotations? annotations;
     if (row.annotationsJson != null) {

--- a/lib/src/services/storage/drift_storage_service.dart
+++ b/lib/src/services/storage/drift_storage_service.dart
@@ -43,7 +43,7 @@ class DriftStorageService implements StorageService {
   @override
   Future<List<domain.ShotRecord>> getAllShots() async {
     final rows = await _db.shotDao.getAllShots();
-    return rows.map(ShotMapper.fromRow).toList();
+    return ShotMapper.fromRows(rows);
   }
 
   @override
@@ -92,7 +92,7 @@ class DriftStorageService implements StorageService {
       search: search,
       ascending: ascending,
     );
-    return rows.map(ShotMapper.fromRow).toList();
+    return ShotMapper.fromRows(rows);
   }
 
   @override

--- a/lib/src/services/webserver/data_export/shot_export_section.dart
+++ b/lib/src/services/webserver/data_export/shot_export_section.dart
@@ -59,7 +59,9 @@ class ShotExportSection implements DataExportSection {
 
     await for (final event in input.valuesAtDepth(1)) {
       try {
-        final record = ShotRecord.fromJson(event.value as Map<String, dynamic>);
+        final record = ShotRecord.fromRecordedJson(
+          event.value as Map<String, dynamic>,
+        );
         final existing = await _controller.storageService.getShot(record.id);
 
         if (existing != null) {

--- a/lib/src/services/webserver/shots_handler.dart
+++ b/lib/src/services/webserver/shots_handler.dart
@@ -230,7 +230,7 @@ class ShotsHandler {
       _synchronizeLegacyAnnotationAliases(merged);
       merged['id'] = id;
 
-      final contentChanged = !ShotRecord.fromJson(
+      final contentChanged = !ShotRecord.fromRecordedJson(
         merged,
       ).sameContent(existingShot);
       merged['updatedAt'] =
@@ -241,7 +241,7 @@ class ShotsHandler {
                         existingShot.timestamp)
               .toIso8601String();
 
-      final updatedShot = ShotRecord.fromJson(merged);
+      final updatedShot = ShotRecord.fromRecordedJson(merged);
       await _controller.updateShot(updatedShot);
       _log.info("Broadcasting shotUpdated for ${updatedShot.id}");
       _pluginManager?.broadcastEvent('shotUpdated', {

--- a/lib/src/util/shot_importer.dart
+++ b/lib/src/util/shot_importer.dart
@@ -22,7 +22,7 @@ class ShotImporter {
           'Expected JSON object in array, got ${item.runtimeType}',
         );
       }
-      final shot = ShotRecord.fromJson(item);
+      final shot = ShotRecord.fromRecordedJson(item);
       await storage.storeShot(shot);
       count++;
     }
@@ -37,7 +37,7 @@ class ShotImporter {
       throw FormatException('Expected JSON object, got ${json.runtimeType}');
     }
 
-    final shot = ShotRecord.fromJson(json);
+    final shot = ShotRecord.fromRecordedJson(json);
     await storage.storeShot(shot);
   }
 }

--- a/test/data_export/shot_export_section_test.dart
+++ b/test/data_export/shot_export_section_test.dart
@@ -497,6 +497,54 @@ void main() {
       expect(storage.shots, isEmpty);
     });
 
+    test(
+      'imports a recorded shot with a step-less imported profile (gh#784)',
+      () async {
+        final storage = _TestShotStorage();
+        final section = ShotExportSection(
+          controller: PersistenceController(storageService: storage.service),
+          pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) async =>
+              [],
+        );
+
+        final stepLessWorkflow = Workflow(
+          id: 'workflow-1',
+          name: 'Test Workflow',
+          description: '',
+          profile: Profile(
+            version: '2',
+            title: 'de1app profile',
+            author: '',
+            notes: '',
+            beverageType: BeverageType.espresso,
+            steps: const [],
+            tankTemperature: 0,
+            targetVolumeCountStart: 0,
+          ),
+          steamSettings: SteamSettings.defaults(),
+          hotWaterData: HotWaterData.defaults(),
+          rinseData: RinseData.defaults(),
+        ).toJson();
+
+        final result = await importSectionJson(
+          section,
+          jsonEncode([
+            {
+              'id': 'de1app-1626149813',
+              'timestamp': '2021-07-13T00:00:00Z',
+              'measurements': <Object?>[],
+              'workflow': stepLessWorkflow,
+            },
+          ]),
+          ConflictStrategy.skip,
+        );
+
+        expect(result.errors, isEmpty);
+        expect(result.imported, 1);
+        expect(storage.shots['de1app-1626149813'], isNotNull);
+      },
+    );
+
     test('rejects a non-array payload without importing', () async {
       final storage = _TestShotStorage();
       final section = ShotExportSection(

--- a/test/database/shot_history_imported_profile_test.dart
+++ b/test/database/shot_history_imported_profile_test.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/data/shot_record.dart' as domain;
+import 'package:reaprime/src/models/data/workflow.dart' as domain_workflow;
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:reaprime/src/services/database/mappers/shot_mapper.dart';
+import 'package:reaprime/src/services/storage/drift_storage_service.dart';
+
+void main() {
+  late AppDatabase db;
+  late DriftStorageService storage;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    storage = DriftStorageService(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  domain_workflow.Workflow importedWorkflow({
+    String title = 'de1app profile',
+    List<ProfileStep> steps = const [],
+  }) {
+    final base = WorkflowController().currentWorkflow;
+    return base.copyWith(
+      profile: Profile(
+        version: '2',
+        title: title,
+        notes: '',
+        author: '',
+        beverageType: BeverageType.espresso,
+        steps: steps,
+        targetVolumeCountStart: 0,
+        tankTemperature: 0,
+      ),
+    );
+  }
+
+  Future<void> insertShot(
+    String id,
+    domain_workflow.Workflow workflow, {
+    required DateTime timestamp,
+  }) async {
+    await db.shotDao.insertShot(
+      ShotMapper.toCompanion(
+        domain.ShotRecord(
+          id: id,
+          timestamp: timestamp,
+          measurements: const [],
+          workflow: workflow,
+        ),
+      ),
+    );
+  }
+
+  group('de1app imported shots (gh#784)', () {
+    test('a stored profile with no steps reads back', () async {
+      await insertShot(
+        'de1app-1626149813',
+        importedWorkflow(),
+        timestamp: DateTime.utc(2021, 7, 13),
+      );
+
+      final restored = await storage.getShot('de1app-1626149813');
+
+      expect(restored, isNotNull);
+      expect(restored!.workflow.profile.steps, isEmpty);
+      expect(restored.workflow.profile.title, 'de1app profile');
+    });
+
+    test('a stored profile with no title reads back', () async {
+      await insertShot(
+        'de1app-1626149814',
+        importedWorkflow(title: ''),
+        timestamp: DateTime.utc(2021, 7, 13),
+      );
+
+      final restored = await storage.getShot('de1app-1626149814');
+
+      expect(restored, isNotNull);
+      expect(restored!.workflow.profile.title, isNotEmpty);
+    });
+
+    test('one step-less shot does not hide the rest of the history', () async {
+      await insertShot(
+        'shot-good-1',
+        WorkflowController().currentWorkflow,
+        timestamp: DateTime.utc(2026, 9, 1),
+      );
+      await insertShot(
+        'de1app-1626149813',
+        importedWorkflow(),
+        timestamp: DateTime.utc(2021, 7, 13),
+      );
+      await insertShot(
+        'shot-good-2',
+        WorkflowController().currentWorkflow,
+        timestamp: DateTime.utc(2026, 9, 2),
+      );
+
+      final page = await storage.getShotsPaginated(limit: 20);
+
+      expect(page.map((s) => s.id), [
+        'shot-good-2',
+        'shot-good-1',
+        'de1app-1626149813',
+      ]);
+    });
+  });
+
+  group('unreadable rows', () {
+    test('a row that cannot be mapped is skipped, not fatal', () async {
+      await insertShot(
+        'shot-good-1',
+        WorkflowController().currentWorkflow,
+        timestamp: DateTime.utc(2026, 9, 1),
+      );
+      await db
+          .into(db.shotRecords)
+          .insert(
+            ShotRecordsCompanion.insert(
+              id: 'shot-corrupt',
+              timestamp: DateTime.utc(2026, 9, 2),
+              workflowJson: const <String, dynamic>{
+                'name': 'no profile at all',
+              },
+              measurementsJson: jsonEncode(const []),
+            ),
+          );
+
+      final page = await storage.getShotsPaginated(limit: 20);
+
+      expect(page.map((s) => s.id), ['shot-good-1']);
+    });
+
+    test('getShot surfaces the failure for a single unreadable id', () async {
+      await db
+          .into(db.shotRecords)
+          .insert(
+            ShotRecordsCompanion.insert(
+              id: 'shot-corrupt',
+              timestamp: DateTime.utc(2026, 9, 2),
+              workflowJson: const <String, dynamic>{
+                'name': 'no profile at all',
+              },
+              measurementsJson: jsonEncode(const []),
+            ),
+          );
+
+      await expectLater(
+        storage.getShot('shot-corrupt'),
+        throwsA(isA<Object>()),
+      );
+    });
+  });
+
+  group('the profile library stays strict', () {
+    test('Workflow.fromJson still rejects a step-less profile (gh#338)', () {
+      final recorded = importedWorkflow().toJson();
+
+      expect(
+        () => domain_workflow.Workflow.fromJson(recorded),
+        throwsArgumentError,
+      );
+      expect(
+        domain_workflow.Workflow.fromRecordedJson(recorded).profile.steps,
+        isEmpty,
+      );
+    });
+
+    test('Profile.fromJson still rejects an empty steps array', () {
+      expect(
+        () => Profile.fromJson(const {
+          'title': 'no steps',
+          'steps': <dynamic>[],
+          'tank_temperature': 0,
+          'target_volume_count_start': 0,
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('Profile.fromJson still rejects an empty title', () {
+      expect(
+        () => Profile.fromJson(const {
+          'title': '',
+          'steps': [
+            {'name': 'preinfusion'},
+          ],
+          'tank_temperature': 0,
+          'target_volume_count_start': 0,
+        }),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/database/shot_history_imported_profile_test.dart
+++ b/test/database/shot_history_imported_profile_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/main.dart' as app;
 import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/profile.dart';
@@ -11,8 +12,11 @@ import 'package:reaprime/src/services/database/database.dart';
 import 'package:reaprime/src/services/database/mappers/shot_mapper.dart';
 import 'package:reaprime/src/services/storage/drift_bean_storage.dart';
 import 'package:reaprime/src/services/storage/drift_storage_service.dart';
+import 'package:reaprime/src/services/webserver/data_export/shot_export_section.dart';
 import 'package:reaprime/src/services/webserver/shots_handler.dart';
 import 'package:shelf_plus/shelf_plus.dart';
+
+import '../data_export/streaming_test_helpers.dart';
 
 void main() {
   late AppDatabase db;
@@ -218,6 +222,63 @@ void main() {
         throwsA(isA<Object>()),
       );
     });
+  });
+
+  group('backup export (gh#784)', () {
+    test(
+      'an unreadable row does not truncate the rest of a paged backup',
+      () async {
+        await insertShot(
+          'shot-good-1',
+          WorkflowController().currentWorkflow,
+          timestamp: DateTime.utc(2026, 9, 1),
+        );
+        await insertShot(
+          'shot-good-2',
+          WorkflowController().currentWorkflow,
+          timestamp: DateTime.utc(2026, 9, 2),
+        );
+        await db
+            .into(db.shotRecords)
+            .insert(
+              ShotRecordsCompanion.insert(
+                id: 'shot-corrupt',
+                timestamp: DateTime.utc(2026, 9, 3),
+                workflowJson: const <String, dynamic>{
+                  'name': 'no profile at all',
+                },
+                measurementsJson: jsonEncode(const []),
+              ),
+            );
+        await insertShot(
+          'shot-good-3',
+          WorkflowController().currentWorkflow,
+          timestamp: DateTime.utc(2026, 9, 4),
+        );
+
+        final section = ShotExportSection(
+          controller: persistence,
+          pageShots: (limit, {afterTimestamp, afterCreatedAt, afterId}) =>
+              app.pageShotsForExport(
+                db,
+                limit,
+                afterTimestamp: afterTimestamp,
+                afterCreatedAt: afterCreatedAt,
+                afterId: afterId,
+              ),
+          pageSize: 2,
+        );
+        final sink = CapturingJsonSink();
+        await section.exportJson(sink);
+
+        final decoded = jsonDecode(sink.json) as List;
+        expect(decoded.map((s) => s['id']), [
+          'shot-good-3',
+          'shot-good-2',
+          'shot-good-1',
+        ]);
+      },
+    );
   });
 
   group('the profile library stays strict', () {

--- a/test/database/shot_history_imported_profile_test.dart
+++ b/test/database/shot_history_imported_profile_test.dart
@@ -2,24 +2,38 @@ import 'dart:convert';
 
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
 import 'package:reaprime/src/models/data/profile.dart';
 import 'package:reaprime/src/models/data/shot_record.dart' as domain;
 import 'package:reaprime/src/models/data/workflow.dart' as domain_workflow;
 import 'package:reaprime/src/services/database/database.dart';
 import 'package:reaprime/src/services/database/mappers/shot_mapper.dart';
+import 'package:reaprime/src/services/storage/drift_bean_storage.dart';
 import 'package:reaprime/src/services/storage/drift_storage_service.dart';
+import 'package:reaprime/src/services/webserver/shots_handler.dart';
+import 'package:shelf_plus/shelf_plus.dart';
 
 void main() {
   late AppDatabase db;
   late DriftStorageService storage;
+  late PersistenceController persistence;
+  late Handler handler;
 
   setUp(() {
     db = AppDatabase(NativeDatabase.memory());
     storage = DriftStorageService(db);
+    persistence = PersistenceController(storageService: storage);
+    final app = Router().plus;
+    ShotsHandler(
+      controller: persistence,
+      beanStorage: DriftBeanStorageService(db),
+    ).addRoutes(app);
+    handler = app.call;
   });
 
   tearDown(() async {
+    persistence.dispose();
     await db.close();
   });
 
@@ -111,6 +125,52 @@ void main() {
         'shot-good-1',
         'de1app-1626149813',
       ]);
+    });
+  });
+
+  group('updating de1app imported shots (gh#784)', () {
+    Future<Response> sendPut(String id, Map<String, dynamic> patch) async =>
+        handler(
+          Request(
+            'PUT',
+            Uri.parse('http://localhost/api/v1/shots/$id'),
+            headers: {'content-type': 'application/json'},
+            body: jsonEncode(patch),
+          ),
+        );
+
+    test('a step-less imported shot accepts an annotation patch', () async {
+      await insertShot(
+        'de1app-1626149813',
+        importedWorkflow(),
+        timestamp: DateTime.utc(2021, 7, 13),
+      );
+
+      final response = await sendPut('de1app-1626149813', {
+        'annotations': {'espressoNotes': 'imported, still editable'},
+      });
+
+      expect(response.statusCode, 200);
+      final restored = await storage.getShot('de1app-1626149813');
+      expect(restored!.annotations?.espressoNotes, 'imported, still editable');
+      expect(restored.workflow.profile.steps, isEmpty);
+    });
+
+    test('a title-less imported shot accepts an annotation patch', () async {
+      await insertShot(
+        'de1app-1626149814',
+        importedWorkflow(title: ''),
+        timestamp: DateTime.utc(2021, 7, 13),
+      );
+
+      final response = await sendPut('de1app-1626149814', {
+        'annotations': {'espressoNotes': 'no title, still editable'},
+      });
+
+      expect(response.statusCode, 200);
+      final restored = await storage.getShot('de1app-1626149814');
+      expect(restored!.annotations?.espressoNotes, 'no title, still editable');
+      expect(restored.workflow.profile.title, Profile.unknownTitle);
     });
   });
 


### PR DESCRIPTION
## Summary

What changed, and why?

- de1app `.shot` files record the shot, not the profile that produced it, so `TclShotParser` (`tcl_shot_parser.dart:48`) and the no-profile branch of `ShotV2JsonParser` (`shot_v2_json_parser.dart:80`) store a placeholder profile with an empty `steps` array. `Profile.fromJson` (`profile.dart:52`) refuses to read that back, so importing a de1app folder made every later `GET /api/v1/shots` throw `ArgumentError` and return 500, and streamline.js rendered no history at all.
- `DriftStorageService` mapped rows with a bare `rows.map(ShotMapper.fromRow)`, so the single unreadable row aborted the whole page — one 2021 import hid a history of otherwise fine shots.
- `ShotMapper.fromRow` now reads the stored workflow with `Workflow.fromRecordedJson`, which parses its profile with `Profile.fromRecordedJson`. A recorded profile is history, not something to brew from.
- `Workflow.fromJson` and `Profile.fromJson` stay strict, backing the profile library, the profile and workflow REST handlers, the stored current workflow, and DE1 upload.
- Reading was only half of it (review feedback). `PUT /api/v1/shots/<id>` merges the patch into `existingShot.toJson()` and reparses the result, and `ShotImporter` reads back shots from a backup export; both used the strict `ShotRecord.fromJson`, so a recovered de1app shot read back fine but threw again on any annotation edit or re-import. `ShotRecord.fromRecordedJson` mirrors the same split and is used on those two stored-shot paths; `ShotRecord.fromJson` is unchanged and stays strict everywhere else.
- `ShotMapper.fromRows` skips and logs a row it cannot map, so future corruption costs its own shot instead of the entire list. Single-shot reads (`getShot`, `getLatestShot`) still surface the error, because there the failing row is the answer.
- Two more strict paths, found by review (b7fd4718). `ShotExportSection.importJson` — the restore side of the app's own `/backup` archive endpoint, distinct from `ShotImporter` — still used strict `ShotRecord.fromJson`, so a recovered de1app shot could be exported but rejected on restore; switched to `fromRecordedJson`. Separately, `ShotExportSection.exportJson` treats a page shorter than `pageSize` as end-of-stream, but `ShotMapper.fromRows` silently drops unmappable rows, so a raw page containing one unreadable row came back short even with more rows waiting, truncating the backup. The `pageShots` wiring is now a standalone `pageShotsForExport` (`lib/main.dart`) that re-queries past a dropped row — advancing the cursor from the raw row, not the last successfully mapped shot — until it either fills the requested page or the table is genuinely exhausted.

The evidence, from the logs attached to the issue. `webview_console.log`:

```
[streamline.js] [WARN] Could not load shot history source: Error: HTTP error! status: 500
```

`nohisotry_log.txt`, 132 identical failures:

```
19:53:27 SEVERE ShotsHandler - Error getting paginated shots
### ArgumentError: Invalid argument(s): Profile must have a non-empty "steps" array
#0  new Profile.fromJson (profile.dart:52)
#1  new Workflow.fromJson (workflow.dart:68)
#2  ShotMapper.fromRow (shot_mapper.dart:12)
#9  DriftStorageService.getShotsPaginated (drift_storage_service.dart:95)
#10 ShotsHandler._getShots (shots_handler.dart:107)
```

The timeline pins the trigger to a de1app import:

```
19:38-19:52  GET /api/v1/shots  -> 200   (repeatedly, history works)
19:53:16     SafFolderCopier - Picked directory: de1plus ... Copied 6 files
19:53:27     GET /api/v1/shots  -> 500   (and every call after)
```

The poison row is named by the one single-shot failure: `GET /api/v1/shots/de1app-1626149813` -> 500, while `de1app-1785894912`, `-1785895243` and `-1785895651` still return 200. Unix `1626149813` is July 2021, an old TCL-format `.shot` file; the 2026 ones came through the v2 JSON parser's real-profile branch.

## Linked Issue

Fixes #784

<!--
External contributions must reference an open issue accepted with the
`ready-for-agent` or `ready-for-human` label. Maintainer and automated
repository-maintenance PRs may write N/A.
-->

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `flutter analyze` — `No issues found!`
- `flutter test` — 3868 passed, 8 failed, out of 3877 (the new suite added 2 tests). The 8 are `test/webui_support/webui_token_injection_test.dart` failing with `SocketException: Failed to create server socket (OS Error: Address already in use, errno = 48), address = 0.0.0.0, port = 3000`, caused by a Decaid instance running on the dev machine holding port 3000. They fail identically on clean `origin/main` with none of this branch's changes, and are unrelated to shots.
- Regression suite `test/database/shot_history_imported_profile_test.dart` (11 tests), against an in-memory Drift database (the update tests drive the real `ShotsHandler`):
  - a stored profile with no steps reads back (reproduces `de1app-1626149813`);
  - a stored profile with no title reads back;
  - one step-less shot does not hide the rest of the history (the actual issue: the page returns all three shots instead of throwing);
  - `PUT /api/v1/shots/de1app-1626149813` with an annotation patch on a step-less shot returns 200, persists the note, and leaves the profile step-less (both update tests return 500 on the previous commit);
  - the same for a title-less imported shot, which reads back as `Unknown profile`;
  - a row that cannot be mapped at all is skipped, not fatal;
  - `getShot` still surfaces the failure for a single unreadable id;
  - an unreadable row does not truncate the rest of a paged backup — drives the real `pageShotsForExport` (via `import 'package:reaprime/main.dart' as app;`) against a real Drift DB with `pageSize: 2`, an unmappable row placed inside what would otherwise be the first page, and asserts all three good shots are exported. Confirmed this fails (truncates to one shot) against the pre-fix callback;
  - `Workflow.fromJson` still rejects a step-less profile while `Workflow.fromRecordedJson` accepts it;
  - `Profile.fromJson` still rejects an empty steps array and an empty title.
- `test/data_export/shot_export_section_test.dart` gained "imports a recorded shot with a step-less imported profile (gh#784)", driving `ShotExportSection.importJson` directly with a de1app-style step-less-profile record — exercises the `/backup` restore endpoint specifically, since `ShotImporter` is a separate code path.
- `test/webserver/workflow_handler_test.dart` caught a first attempt that made `Workflow.fromJson` lenient everywhere: `PUT /api/v1/workflow` with an empty profile title returned 200 instead of 400, breaking issue #338. Leniency is now reached only through `Workflow.fromRecordedJson`, that suite is green (47 tests), and the new suite pins the boundary.
- No hardware testing; this is a storage read path exercised entirely by the Drift tests.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Users who imported a de1app folder get their shot history back. `GET /api/v1/shots` returns 200 instead of 500, and streamline.js renders the list again. This recovers existing databases with no migration — the offending rows become readable rather than needing repair or deletion.
- A recorded profile with no title reads back as `Unknown profile`, and missing `tank_temperature` / `target_volume_count_start` read back as `0`. These only apply to profiles embedded in stored shots.
- No behavior change for the profile library or any write boundary: with `requireExecutable: true` every guard still fires before the new fallbacks, so `Profile.fromJson` is byte-for-byte the parser it was. `PUT /api/v1/workflow` still returns 400 for a step-less profile (issue #338), verified by the existing suite.
- The app's `/backup` archive round-trips a recovered de1app shot: export via `ShotExportSection.exportJson` no longer truncates around an unreadable row, and `ShotExportSection.importJson` can restore a step-less-profile shot from that archive. `ShotImporter` (a separate, non-`/backup` code path) already handled this from the prior commit.
- Recovered de1app shots are editable: annotations, notes and metadata can be written through `PUT /api/v1/shots/<id>` instead of returning 500.
- No API, spec, schema, or migration changes. No REST or WebSocket surface was touched, so `assets/api/rest_v1.yml` and `assets/api/websocket_v1.yml` are unchanged.
- `doc/Profiles.md` documents the strict/lenient split and when each parser applies. `doc/AI_STORAGE_NOTES.md` records why de1app imports carry a step-less profile, why one bad row used to hide the whole history, the single-shot-read exception, why every stored-shot JSON read path (row mapper, shot update, backup import/export) has to be lenient together, and why `pageShotsForExport` re-queries past a dropped row instead of trusting the mapped page length.
- The importers still store `steps: []`. That is the honest representation of a `.shot` file, and it now round-trips.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYQbrfYh9W4xTy2tsEya3m
