### PR TITLE
feat(plugins): expose workflow updates

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -7123,7 +7123,7 @@ components:
           type: array
           items:
             type: string
-            enum: [log, api, emit, pluginStorage, events.machine, events.shots, proxy.decent_api, proxy.decent_api.write, network.websocket, network.tcp, network.tls]
+            enum: [log, api, emit, pluginStorage, events.machine, events.shots, events.workflow, proxy.decent_api, proxy.decent_api.write, network.websocket, network.tcp, network.tls]
         drivers:
           type: array
           maxItems: 8

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -78,6 +78,7 @@ A Decaid plugin consists of two required files:
   - `pluginStorage`: Call `host.storage`
   - `events.machine`: Receive `stateUpdate`
   - `events.shots`: Receive `shotStored` and `shotUpdated`
+  - `events.workflow`: Receive `workflowUpdated`
   - `proxy.decent_api`: Send read requests through `host.decentProxy`
   - `proxy.decent_api.write`: Send allowlisted write requests through `host.decentProxy`
   - `network.websocket`: Open outbound WebSocket connections (`ws://` and `wss://`) through `host.transport`
@@ -191,7 +192,7 @@ The returned object has `{ status, headers, body }`. Consent denial or non-decis
 Plugins receive events in the `onEvent` method:
 
 Machine broadcasts require `events.machine`. Shot lifecycle broadcasts require
-`events.shots`.
+`events.shots`. Workflow broadcasts require `events.workflow`.
 
 - **`stateUpdate`**: Machine state changes (temperature, pressure, flow, etc.)
 
@@ -204,6 +205,20 @@ Machine broadcasts require `events.machine`. Shot lifecycle broadcasts require
       pressure: 9.2,
       flow: 2.1,
       // ... other machine metrics
+    }
+  }
+  ```
+
+- **`workflowUpdated`**: Signals that workflow state changed without exposing
+  the workflow itself. A permitted plugin receives one current-revision snapshot
+  after each successful load or reload, followed by events only for new
+  revisions. `revision` is a JavaScript Number.
+
+  ```javascript
+  {
+    name: "workflowUpdated",
+    payload: {
+      revision: 42
     }
   }
   ```

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -209,16 +209,27 @@ Machine broadcasts require `events.machine`. Shot lifecycle broadcasts require
   }
   ```
 
-- **`workflowUpdated`**: Signals that workflow state changed without exposing
-  the workflow itself. A permitted plugin receives one current-revision snapshot
-  after each successful load or reload, followed by events only for new
-  revisions. `revision` is a JavaScript Number.
+- **`workflowUpdated`**: Contains exactly the current workflow serialization
+  returned by `WorkflowController.currentWorkflow.toJson()`. A permitted plugin
+  receives the current workflow when a controller is attached or replaced and
+  after each successful load or reload. Later events are delivered when the
+  workflow revision changes.
 
   ```javascript
   {
     name: "workflowUpdated",
     payload: {
-      revision: 42
+      id: "workflow-id",
+      name: "Espresso",
+      description: "",
+      profile: { /* profile fields */ },
+      context: {
+        targetDoseWeight: 18.0,
+        targetYield: 36.0
+      },
+      steamSettings: { /* steam fields */ },
+      hotWaterData: { /* hot-water fields */ },
+      rinseData: { /* rinse fields */ }
     }
   }
   ```

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -509,6 +509,7 @@ void main(List<String> args) async {
     deviceService: pluginDeviceService,
   );
   await pluginService.pluginManager.attachDe1Controller(de1Controller);
+  pluginService.pluginManager.attachWorkflowController(workflowController);
   persistenceController.onShotStored = (shotId) =>
       pluginService.pluginManager.broadcastEvent('shotStored', {'id': shotId});
 

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -14,6 +14,7 @@ import 'plugin_transport_service.dart';
 import 'plugin_types.dart';
 import '../services/storage/kv_store_service.dart';
 import '../controllers/de1_controller.dart';
+import '../controllers/workflow_controller.dart';
 import '../models/device/de1_interface.dart';
 import '../models/device/machine.dart';
 import '../services/account/decent_proxy_service.dart';
@@ -102,6 +103,10 @@ class PluginManager {
   Future<void> _snapshotQueue = Future.value();
   int _attachmentGeneration = 0;
   int _snapshotGeneration = 0;
+  WorkflowController? _workflowController;
+  void Function()? _workflowListener;
+  int? _lastWorkflowRevision;
+  int _workflowAttachmentGeneration = 0;
   PluginManagerLifecycle _lifecycle = PluginManagerLifecycle.active;
   Future<void>? _disposeFuture;
   final Map<String, int> _retiringPluginGenerations = {};
@@ -195,6 +200,10 @@ class PluginManager {
     }
 
     try {
+      await runStage(
+        'workflow controller detachment',
+        _detachWorkflowController,
+      );
       await runStage('attachment queue', () => _attachmentQueue);
       await runStage('snapshot queue', () => _snapshotQueue);
       await runStage('controller detachment', _cancelControllerSubscriptions);
@@ -242,6 +251,9 @@ class PluginManager {
       _de1Subscription = null;
       _snapshotSubscription = null;
       _de1controller = null;
+      _workflowController = null;
+      _workflowListener = null;
+      _lastWorkflowRevision = null;
       _lifecycle = PluginManagerLifecycle.disposed;
     }
 
@@ -1999,6 +2011,15 @@ class PluginManager {
       while (js.executePendingJob() > 0) {}
 
       runtime.markRunning();
+      if (identical(_plugins[id], runtime) &&
+          generation == _pluginGenerations[id]) {
+        final workflowController = _workflowController;
+        if (workflowController != null) {
+          dispatchEvent(id, 'workflowUpdated', {
+            'revision': workflowController.revision,
+          });
+        }
+      }
       _log.info("loaded: $id");
     } catch (e, st) {
       try {
@@ -2181,6 +2202,7 @@ class PluginManager {
     final permission = switch (name) {
       'stateUpdate' => PluginPermissions.eventsMachine,
       'shotStored' || 'shotUpdated' => PluginPermissions.eventsShots,
+      'workflowUpdated' => PluginPermissions.eventsWorkflow,
       _ => null,
     };
     if (permission != null && !_hasPermission(pluginId, permission)) return;
@@ -2667,6 +2689,43 @@ class PluginManager {
   }
 
   List<PluginRuntime> get loadedPlugins => _plugins.values.toList();
+
+  void attachWorkflowController(WorkflowController controller) {
+    _ensureActive();
+    if (identical(controller, _workflowController)) return;
+
+    _detachWorkflowController();
+    final generation = _workflowAttachmentGeneration;
+    _workflowController = controller;
+    _lastWorkflowRevision = controller.revision;
+
+    void listener() {
+      if (_lifecycle != PluginManagerLifecycle.active ||
+          !identical(controller, _workflowController) ||
+          generation != _workflowAttachmentGeneration) {
+        return;
+      }
+      final revision = controller.revision;
+      if (revision == _lastWorkflowRevision) return;
+      _lastWorkflowRevision = revision;
+      broadcastEvent('workflowUpdated', {'revision': revision});
+    }
+
+    _workflowListener = listener;
+    controller.addListener(listener);
+  }
+
+  void _detachWorkflowController() {
+    _workflowAttachmentGeneration += 1;
+    final controller = _workflowController;
+    final listener = _workflowListener;
+    _workflowController = null;
+    _workflowListener = null;
+    _lastWorkflowRevision = null;
+    if (controller != null && listener != null) {
+      controller.removeListener(listener);
+    }
+  }
 
   Future<void> attachDe1Controller(De1Controller? controller) {
     _ensureActive();

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -2015,9 +2015,11 @@ class PluginManager {
           generation == _pluginGenerations[id]) {
         final workflowController = _workflowController;
         if (workflowController != null) {
-          dispatchEvent(id, 'workflowUpdated', {
-            'revision': workflowController.revision,
-          });
+          dispatchEvent(
+            id,
+            'workflowUpdated',
+            workflowController.currentWorkflow.toJson(),
+          );
         }
       }
       _log.info("loaded: $id");
@@ -2690,11 +2692,12 @@ class PluginManager {
 
   List<PluginRuntime> get loadedPlugins => _plugins.values.toList();
 
-  void attachWorkflowController(WorkflowController controller) {
+  void attachWorkflowController(WorkflowController? controller) {
     _ensureActive();
     if (identical(controller, _workflowController)) return;
 
     _detachWorkflowController();
+    if (controller == null) return;
     final generation = _workflowAttachmentGeneration;
     _workflowController = controller;
     _lastWorkflowRevision = controller.revision;
@@ -2708,11 +2711,12 @@ class PluginManager {
       final revision = controller.revision;
       if (revision == _lastWorkflowRevision) return;
       _lastWorkflowRevision = revision;
-      broadcastEvent('workflowUpdated', {'revision': revision});
+      broadcastEvent('workflowUpdated', controller.currentWorkflow.toJson());
     }
 
     _workflowListener = listener;
     controller.addListener(listener);
+    broadcastEvent('workflowUpdated', controller.currentWorkflow.toJson());
   }
 
   void _detachWorkflowController() {

--- a/lib/src/plugins/plugin_manifest.dart
+++ b/lib/src/plugins/plugin_manifest.dart
@@ -127,6 +127,7 @@ enum PluginPermissions {
   pluginStorage('pluginStorage'),
   eventsMachine('events.machine'),
   eventsShots('events.shots'),
+  eventsWorkflow('events.workflow'),
   proxyDecentApi('proxy.decent_api'),
   proxyDecentApiWrite('proxy.decent_api.write'),
   networkWebsocket('network.websocket'),

--- a/test/plugins/plugin_manager_workflow_events_test.dart
+++ b/test/plugins/plugin_manager_workflow_events_test.dart
@@ -1,0 +1,196 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+
+import 'plugin_test_helpers.dart';
+
+class _CountingWorkflowController extends WorkflowController {
+  int addListenerCalls = 0;
+  int removeListenerCalls = 0;
+
+  @override
+  void addListener(VoidCallback listener) {
+    addListenerCalls += 1;
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    removeListenerCalls += 1;
+    super.removeListener(listener);
+  }
+}
+
+Future<void> _loadPlugin(
+  PluginManager manager,
+  String id, {
+  bool permitted = true,
+  String onLoad = '',
+}) {
+  return manager.loadPlugin(
+    id: id,
+    manifest: testManifest(
+      id,
+      permissions: {if (permitted) PluginPermissions.eventsWorkflow},
+    ),
+    settings: const {},
+    jsCode:
+        '''
+      function createPlugin(host) {
+        return {
+          id: "$id",
+          onLoad() { $onLoad },
+          onEvent(event) {
+            if (event.name !== "workflowUpdated") return;
+            globalThis.__workflowEvents ??= {};
+            globalThis.__workflowEvents["$id"] ??= [];
+            globalThis.__workflowEvents["$id"].push({
+              revision: event.payload.revision,
+              revisionType: typeof event.payload.revision,
+              keys: Object.keys(event.payload).sort()
+            });
+          }
+        };
+      }
+    ''',
+  );
+}
+
+List<Map<String, dynamic>> _events(PluginManager manager, String id) {
+  final result = manager.js.evaluate(
+    'JSON.stringify(globalThis.__workflowEvents?.["$id"] ?? [])',
+  );
+  return (jsonDecode(result.stringResult) as List<dynamic>)
+      .cast<Map<String, dynamic>>();
+}
+
+void _advance(WorkflowController controller) {
+  controller.setWorkflow(controller.currentWorkflow.copyWith());
+}
+
+void main() {
+  test('permission gates snapshots and live revision events', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    final controller = WorkflowController();
+    addTearDown(manager.dispose);
+    addTearDown(controller.dispose);
+
+    manager.attachWorkflowController(controller);
+    await _loadPlugin(manager, 'permitted.plugin');
+    await _loadPlugin(manager, 'denied.plugin', permitted: false);
+    controller.notifyListeners();
+    _advance(controller);
+    _advance(controller);
+
+    expect(_events(manager, 'permitted.plugin'), [
+      {
+        'revision': 0,
+        'revisionType': 'number',
+        'keys': ['revision'],
+      },
+      {
+        'revision': 1,
+        'revisionType': 'number',
+        'keys': ['revision'],
+      },
+      {
+        'revision': 2,
+        'revisionType': 'number',
+        'keys': ['revision'],
+      },
+    ]);
+    expect(_events(manager, 'denied.plugin'), isEmpty);
+  });
+
+  test('late load and reload each receive one current snapshot', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    final controller = WorkflowController();
+    addTearDown(manager.dispose);
+    addTearDown(controller.dispose);
+
+    manager.attachWorkflowController(controller);
+    _advance(controller);
+    _advance(controller);
+    await _loadPlugin(manager, 'reloaded.plugin');
+    await _loadPlugin(manager, 'reloaded.plugin');
+
+    expect(
+      _events(manager, 'reloaded.plugin').map((event) => event['revision']),
+      [2, 2],
+    );
+  });
+
+  test('loading another plugin does not repeat existing snapshots', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    final controller = WorkflowController();
+    addTearDown(manager.dispose);
+    addTearDown(controller.dispose);
+
+    manager.attachWorkflowController(controller);
+    await _loadPlugin(manager, 'first.plugin');
+    await _loadPlugin(manager, 'second.plugin');
+
+    expect(_events(manager, 'first.plugin'), hasLength(1));
+    expect(_events(manager, 'second.plugin'), hasLength(1));
+  });
+
+  test(
+    'same attachment is ignored and replacement invalidates the old one',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      final first = _CountingWorkflowController();
+      final second = _CountingWorkflowController();
+      addTearDown(manager.dispose);
+      addTearDown(first.dispose);
+      addTearDown(second.dispose);
+
+      manager.attachWorkflowController(first);
+      manager.attachWorkflowController(first);
+      await _loadPlugin(manager, 'events.plugin');
+      manager.attachWorkflowController(second);
+      _advance(first);
+      _advance(second);
+
+      expect(first.addListenerCalls, 1);
+      expect(first.removeListenerCalls, 1);
+      expect(second.addListenerCalls, 1);
+      expect(
+        _events(manager, 'events.plugin').map((event) => event['revision']),
+        [0, 1],
+      );
+    },
+  );
+
+  test('dispose removes the listener and blocks later events', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    final controller = _CountingWorkflowController();
+    addTearDown(controller.dispose);
+
+    manager.attachWorkflowController(controller);
+    await _loadPlugin(manager, 'events.plugin');
+    await manager.dispose();
+    _advance(controller);
+
+    expect(controller.addListenerCalls, 1);
+    expect(controller.removeListenerCalls, 1);
+  });
+
+  test('failed loads do not receive snapshots', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    final controller = WorkflowController();
+    addTearDown(manager.dispose);
+    addTearDown(controller.dispose);
+
+    manager.attachWorkflowController(controller);
+    await expectLater(
+      _loadPlugin(manager, 'failed.plugin', onLoad: 'throw new Error("boom");'),
+      throwsException,
+    );
+
+    expect(_events(manager, 'failed.plugin'), isEmpty);
+  });
+}

--- a/test/plugins/plugin_manager_workflow_events_test.dart
+++ b/test/plugins/plugin_manager_workflow_events_test.dart
@@ -48,11 +48,7 @@ Future<void> _loadPlugin(
             if (event.name !== "workflowUpdated") return;
             globalThis.__workflowEvents ??= {};
             globalThis.__workflowEvents["$id"] ??= [];
-            globalThis.__workflowEvents["$id"].push({
-              revision: event.payload.revision,
-              revisionType: typeof event.payload.revision,
-              keys: Object.keys(event.payload).sort()
-            });
+            globalThis.__workflowEvents["$id"].push(event.payload);
           }
         };
       }
@@ -73,7 +69,7 @@ void _advance(WorkflowController controller) {
 }
 
 void main() {
-  test('permission gates snapshots and live revision events', () async {
+  test('permission gates snapshots and workflow change events', () async {
     final manager = PluginManager(kvStore: FakeKeyValueStoreService());
     final controller = WorkflowController();
     addTearDown(manager.dispose);
@@ -82,26 +78,21 @@ void main() {
     manager.attachWorkflowController(controller);
     await _loadPlugin(manager, 'permitted.plugin');
     await _loadPlugin(manager, 'denied.plugin', permitted: false);
+    final initialWorkflow = controller.currentWorkflow.toJson();
     controller.notifyListeners();
-    _advance(controller);
-    _advance(controller);
+    controller.setWorkflow(
+      controller.currentWorkflow.copyWith(name: 'Selected workflow'),
+    );
+    final selectedWorkflow = controller.currentWorkflow.toJson();
+    controller.updateWorkflow(
+      context: controller.currentWorkflow.context!.copyWith(targetYield: 42),
+    );
+    final updatedWorkflow = controller.currentWorkflow.toJson();
 
     expect(_events(manager, 'permitted.plugin'), [
-      {
-        'revision': 0,
-        'revisionType': 'number',
-        'keys': ['revision'],
-      },
-      {
-        'revision': 1,
-        'revisionType': 'number',
-        'keys': ['revision'],
-      },
-      {
-        'revision': 2,
-        'revisionType': 'number',
-        'keys': ['revision'],
-      },
+      initialWorkflow,
+      selectedWorkflow,
+      updatedWorkflow,
     ]);
     expect(_events(manager, 'denied.plugin'), isEmpty);
   });
@@ -115,13 +106,14 @@ void main() {
     manager.attachWorkflowController(controller);
     _advance(controller);
     _advance(controller);
+    final currentWorkflow = controller.currentWorkflow.toJson();
     await _loadPlugin(manager, 'reloaded.plugin');
     await _loadPlugin(manager, 'reloaded.plugin');
 
-    expect(
-      _events(manager, 'reloaded.plugin').map((event) => event['revision']),
-      [2, 2],
-    );
+    expect(_events(manager, 'reloaded.plugin'), [
+      currentWorkflow,
+      currentWorkflow,
+    ]);
   });
 
   test('loading another plugin does not repeat existing snapshots', () async {
@@ -139,7 +131,7 @@ void main() {
   });
 
   test(
-    'same attachment is ignored and replacement invalidates the old one',
+    'attachment snapshots once and replacement or detach removes listeners',
     () async {
       final manager = PluginManager(kvStore: FakeKeyValueStoreService());
       final first = _CountingWorkflowController();
@@ -148,20 +140,29 @@ void main() {
       addTearDown(first.dispose);
       addTearDown(second.dispose);
 
-      manager.attachWorkflowController(first);
-      manager.attachWorkflowController(first);
       await _loadPlugin(manager, 'events.plugin');
+      expect(_events(manager, 'events.plugin'), isEmpty);
+
+      manager.attachWorkflowController(first);
+      final firstWorkflow = first.currentWorkflow.toJson();
+      manager.attachWorkflowController(first);
       manager.attachWorkflowController(second);
+      final secondWorkflow = second.currentWorkflow.toJson();
       _advance(first);
+      _advance(second);
+      final updatedSecondWorkflow = second.currentWorkflow.toJson();
+      manager.attachWorkflowController(null);
       _advance(second);
 
       expect(first.addListenerCalls, 1);
       expect(first.removeListenerCalls, 1);
       expect(second.addListenerCalls, 1);
-      expect(
-        _events(manager, 'events.plugin').map((event) => event['revision']),
-        [0, 1],
-      );
+      expect(second.removeListenerCalls, 1);
+      expect(_events(manager, 'events.plugin'), [
+        firstWorkflow,
+        secondWorkflow,
+        updatedSecondWorkflow,
+      ]);
     },
   );
 

--- a/test/plugins/plugin_manifest_permissions_test.dart
+++ b/test/plugins/plugin_manifest_permissions_test.dart
@@ -75,6 +75,7 @@ void main() {
         'api',
         'events.machine',
         'events.shots',
+        'events.workflow',
         'proxy.decent_api',
         'proxy.decent_api.write',
         'network.websocket',
@@ -89,6 +90,7 @@ void main() {
     expect(manifest.permissions, contains(PluginPermissions.api));
     expect(manifest.permissions, contains(PluginPermissions.eventsMachine));
     expect(manifest.permissions, contains(PluginPermissions.eventsShots));
+    expect(manifest.permissions, contains(PluginPermissions.eventsWorkflow));
     expect(manifest.permissions, contains(PluginPermissions.proxyDecentApi));
     expect(
       manifest.permissions,
@@ -128,6 +130,7 @@ void main() {
 
   test('rejects Dart enum names as manifest permission aliases', () {
     expect(PluginPermissions.fromString('eventsShots'), isNull);
+    expect(PluginPermissions.fromString('eventsWorkflow'), isNull);
   });
 
   test('serializes permissions using manifest wire values', () {
@@ -141,6 +144,7 @@ void main() {
       permissions: {
         PluginPermissions.api,
         PluginPermissions.pluginStorage,
+        PluginPermissions.eventsWorkflow,
         PluginPermissions.proxyDecentApi,
       },
       settings: {},
@@ -149,7 +153,12 @@ void main() {
 
     expect(
       manifest.toJson()['permissions'],
-      containsAll(['api', 'pluginStorage', 'proxy.decent_api']),
+      containsAll([
+        'api',
+        'pluginStorage',
+        'events.workflow',
+        'proxy.decent_api',
+      ]),
     );
   });
 }

--- a/test/plugins/plugin_settings_schema_spec_test.dart
+++ b/test/plugins/plugin_settings_schema_spec_test.dart
@@ -83,6 +83,18 @@ void main() {
     },
   );
 
+  test('PluginManifest permissions match runtime wire values', () {
+    final properties = _pluginManifestSchema()['properties'] as YamlMap;
+    final permissions = properties['permissions'] as YamlMap;
+    final items = permissions['items'] as YamlMap;
+    final documented = (items['enum'] as YamlList).cast<String>().toSet();
+    final runtime = PluginPermissions.values
+        .map((value) => value.wireName)
+        .toSet();
+
+    expect(documented, runtime);
+  });
+
   test('every field bundled plugins use is documented', () {
     final documented = (_pluginSettingSchema()['properties'] as YamlMap).keys
         .cast<String>()


### PR DESCRIPTION
## Summary

What changed, and why?

- Add the opt-in `events.workflow` plugin permission and route `workflowUpdated` through the existing permission boundary.
- Deliver the exact `WorkflowController.currentWorkflow.toJson()` payload for live changes, controller attachment or replacement, and successful plugin load or reload.
- Guard controller replacement, explicit detachment, manager disposal, and plugin generations so stale listeners or loads cannot dispatch events.
- Keep the REST `PluginManifest.permissions` schema synchronized with all runtime permission wire values, including the `network.*` values also added by #775.
- Document the event contract and lifecycle behavior.

## Linked Issue

Fixes #756

<!--
External contributions must reference an open issue accepted with the
`ready-for-agent` or `ready-for-human` label. Maintainer and automated
repository-maintenance PRs may write N/A.
-->

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `dart format --output=none --set-exit-if-changed lib/src/plugins/plugin_manager.dart test/plugins/plugin_manager_workflow_events_test.dart test/plugins/plugin_settings_schema_spec_test.dart` (passed; no changes)
- `flutter test --reporter expanded test/plugins/plugin_settings_schema_spec_test.dart test/plugins/plugin_manifest_permissions_test.dart test/plugins/plugin_manager_workflow_events_test.dart` (18 passed)
- `flutter analyze --no-pub` (no issues)
- `flutter test --exclude-tags golden --reporter expanded test/plugins` (224 passed)
- `flutter test --exclude-tags golden --reporter compact` (3,874 passed, 1 skipped)
- `git diff --check` (passed)
- `flutter run -d windows --dart-define=simulate=1` could not start because the installed CMake is 3.20 and the Windows Firebase build requires 3.22 or newer. No running-app smoke was possible on this host.

## Impact

Note any user-visible behavior, compatibility, migration, API/spec, documentation, or security impact. Write `None` if there is none.

- Plugins may opt in to current workflow data with `events.workflow`. Existing plugins are unaffected. No migration, dependency, generated-file, or plugin API version changes.
- The REST OpenAPI schema now lists every permission accepted and serialized by `PluginManifest`, including `events.workflow` and the existing `network.websocket`, `network.tcp`, and `network.tls` permissions.
- `doc/Plugins.md` documents the new permission and event.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->