### PR TITLE
docs: refresh Decent app agent skill

### DIFF
--- a/.agents/skills/decent-app/SKILL.md
+++ b/.agents/skills/decent-app/SKILL.md
@@ -11,7 +11,7 @@ This is an Agent Skills-compatible bundle. Codex discovers repository skills und
 
 ## Routing
 
-Read only the file relevant to the current task.
+Read only the routing target(s) needed for the current task. Do not preload unrelated references or scenarios.
 
 | Task | File |
 |---|---|

--- a/.agents/skills/decent-app/SKILL.md
+++ b/.agents/skills/decent-app/SKILL.md
@@ -5,7 +5,7 @@ description: Drive or verify a running Decent app via sb-dev, REST, WebSockets, 
 
 # Decent app runtime
 
-Use this skill to drive a running Decent Flutter app from the shell. Simulate mode is the default; `--real` uses BLE or USB hardware, with `--adb-forward` when the app runs on Android.
+Use this skill to drive a running Decent Flutter app from the shell. Simulate mode is the default; `--real` stops injecting `--dart-define=simulate=1` so BLE or USB hardware can be used, with `--adb-forward` when the app runs on Android. Persisted simulated-device settings still apply.
 
 This is an Agent Skills-compatible bundle. Codex discovers repository skills under `.agents/skills`; other clients may use different discovery locations. Claude Code uses the forwarder under `.claude/skills/decent-app/`.
 
@@ -53,8 +53,9 @@ scripts/sb-dev.sh start \
   --adb-forward \
   --connect-machine DE1 \
   --preferred-machine-id D9:11:0B:E6:9F:86
+curl -sf http://localhost:8080/api/v1/settings | jq -e '.simulatedDevices == []'
 curl -sf http://localhost:8080/api/v1/devices | jq .
 scripts/sb-dev.sh stop
 ```
 
-`--connect-machine` matches the scan result by name or ID. In real mode, use `--preferred-machine-id` when the saved preference must target a BLE MAC or UUID.
+Before a hardware smoke test, verify that `GET /api/v1/settings` reports an empty `simulatedDevices` list. See `lifecycle.md` for the preflight and cleanup commands. `--connect-machine` matches the scan result by name or ID. In real mode, use `--preferred-machine-id` when the saved preference must target a BLE MAC or UUID.

--- a/.agents/skills/decent-app/SKILL.md
+++ b/.agents/skills/decent-app/SKILL.md
@@ -1,79 +1,42 @@
 ---
 name: decent-app
-description: Use when touching the Decent Flutter app, its REST/WebSocket API, profiles, shots, simulated devices, or real BLE/USB hardware via an Android tablet or desktop, or whenever exercising a code change against a running Decent instance. Covers the sb-dev dev loop and shell-based verification.
+description: Drive or verify a running Decent app via sb-dev, REST, WebSockets, simulated devices, or real hardware. Use for API/WebSocket changes, runtime/device flows, smoke tests, and end-to-end regression scenarios; not for pure Dart changes that do not require a running app.
 ---
 
-# Decent — agent skill
+# Decent app runtime
 
-This skill covers driving a running Decent Flutter app from the shell — simulate mode by default, real hardware via `--real` (+ `--adb-forward` for Android). It exposes REST via `curl`, WebSocket via `websocat`, and lifecycle (start, stop, reload, logs) via `scripts/sb-dev.sh`. Written for any agent that can read markdown and execute shell commands — Claude Code, Cursor, Codex, Windsurf, humans — and deliberately avoids agent-specific mechanisms like MCP tools or slash commands.
+Use this skill to drive a running Decent Flutter app from the shell. Simulate mode is the default; `--real` uses BLE or USB hardware, with `--adb-forward` when the app runs on Android.
 
-The skill lives under `.agents/skills/decent-app/` following the [agentskills.io](https://agentskills.io) cross-client convention. Any compliant client will auto-discover it. Claude Code also loads it via a forwarder at `.claude/skills/decent-app/SKILL.md`.
+This is an Agent Skills-compatible bundle. Codex discovers repository skills under `.agents/skills`; other clients may use different discovery locations. Claude Code uses the forwarder under `.claude/skills/decent-app/`.
 
 ## Routing
 
+Read only the file relevant to the current task.
+
 | Task | File |
 |---|---|
-| Start/stop/reload the app | `lifecycle.md` |
-| Call REST endpoints, add endpoints | `rest.md` |
-| Read/write WebSocket streams | `websocket.md` |
-| Work with MockDe1 / MockScale | `simulated-devices.md` |
-| Smoke-test a code change | `verification.md` |
-| End-to-end regression recipes | `scenarios/` (index below) |
+| Start, stop, or reload the app | `lifecycle.md` |
+| Call or add REST endpoints | `rest.md` |
+| Read or write WebSocket streams | `websocket.md` |
+| Work with simulated devices | `simulated-devices.md` |
+| Smoke-test a change | `verification.md` |
+| Diagnose local build problems | `troubleshooting.md` |
+| Run an end-to-end regression | `scenarios/README.md` |
 
-All files above are siblings of this `SKILL.md` under `.agents/skills/decent-app/`. Relative paths in the sub-files resolve against that directory.
-
-### Scenario index
-
-Pick the scenario that matches the task, run it verbatim, and finish before calling related work done. Each file lists preconditions, a `curl` / `websocat` sequence, expected output hints, and postconditions.
-
-| Scenario | File |
-|---|---|
-| BLE error surfacing (adapterOff, scaleConnectFailed, sticky errors) | `scenarios/ble-error-surfacing.md` |
-| Device scan + connection policy | `scenarios/device-scan-connection-policy.md` |
-| Onboarding connection phases (MockDe1 + MockScale auto-connect) | `scenarios/onboarding-connection-phases.md` |
-| Preferred-device fast-path round-trip | `scenarios/onboarding-preferred-device.md` |
-| Build-info endpoint | `scenarios/build-info.md` |
-| Firmware endpoints | `scenarios/firmware.md` |
-| ETag / If-None-Match on list endpoints | `scenarios/etag-conditional-gets.md` |
-| Discover / restore default profiles | `scenarios/profiles-defaults.md` |
-| Hot-water stop-at-weight | `scenarios/hot-water-stop-at-weight.md` |
-| Shot-state WebSocket + persisted stop reason | `scenarios/shot-state-ws.md` |
-| Display brightness 0-100 + low-battery toggle | `scenarios/display-brightness.md` |
-| Debug scale control (simulate) | `scenarios/debug-scale-control.md` |
-| Bengle LED strip v2 | `scenarios/bengle-led-strip.md` |
-| Bengle integrated scale end-to-end | `scenarios/bengle-integrated-scale.md` |
-| Bengle cup-warmer + preheat + capability discovery | `scenarios/bengle-cup-warmer.md` |
-| Bengle scale calibration | `scenarios/bengle-scale-calibration.md` |
-| Bengle firmware wake-schedule sync | `scenarios/bengle-wake-schedule.md` |
-| Account-proxy CORS pinned to skin origin | `scenarios/account-proxy-cors.md` |
-| Account-proxy write forwarding + write-scope gate | `scenarios/account-proxy-write.md` |
-| Account-proxy native consent gate | `scenarios/account-proxy-consent.md` |
-| Plugin Decent-account proxy bridge (host.decentProxy) | `scenarios/plugin-decent-proxy.md` |
-| API pressure hardening | `scenarios/api-pressure-hardening.md` |
+All paths are relative to `.agents/skills/decent-app/`.
 
 ## Authoritative sources
 
-**Always read the spec before making API calls.** Never guess paths or shapes — the specs are the ground truth and stay in sync with the code.
+Read the relevant source before acting. Do not guess paths, payloads, or current defaults.
 
-- `assets/api/rest_v1.yml` — OpenAPI 3.0 spec. Canonical REST endpoint reference.
-- `assets/api/websocket_v1.yml` — AsyncAPI 3.0 spec. Canonical WebSocket channels and message shapes.
-- `scripts/sb-dev.sh` — lifecycle helper. The entry point for driving a running dev instance.
-- `CLAUDE.md` and `AGENTS.md` at the repo root — project-wide conventions, architecture, and workflow rules.
-
-## Prerequisites
-
-Hard dependencies on `PATH`:
-
-- `bash`
-- `curl`
-- `jq`
-- `websocat` (or `wscat` fallback — see `websocket.md`)
-- `flutter`
-- `mkfifo` (POSIX — macOS and Linux only; Windows contributors run `flutter run` directly, see `lifecycle.md`)
+- `assets/api/rest_v1.yml`: REST endpoints and payloads.
+- `assets/api/websocket_v1.yml`: WebSocket channels and messages.
+- `scripts/sb-dev.sh`: lifecycle flags and defaults.
+- Root `AGENTS.md`: project workflow and completion requirements.
 
 ## Quick start
 
-Simulate mode (default — no hardware needed):
+Simulated machine:
 
 ```bash
 scripts/sb-dev.sh start --connect-machine MockDe1
@@ -81,18 +44,17 @@ curl -sf http://localhost:8080/api/v1/devices | jq .
 scripts/sb-dev.sh stop
 ```
 
-Real hardware on an Android tablet (adb serial from `flutter devices`):
+Real BLE machine on an Android tablet:
 
 ```bash
 scripts/sb-dev.sh start \
-  --platform 8734SCCFAC00000747 --real --adb-forward \
-  --connect-machine DE1
+  --platform 8734SCCFAC00000747 \
+  --real \
+  --adb-forward \
+  --connect-machine DE1 \
+  --preferred-machine-id D9:11:0B:E6:9F:86
 curl -sf http://localhost:8080/api/v1/devices | jq .
 scripts/sb-dev.sh stop
 ```
 
-From here, pick the file in the routing table that matches your task.
-
-## Rule of thumb
-
-If you're about to guess an endpoint path, payload shape, or WebSocket channel — stop and read the relevant spec first. If you're about to run `flutter run` by hand, use `scripts/sb-dev.sh start` instead.
+`--connect-machine` matches the scan result by name or ID. In real mode, use `--preferred-machine-id` when the saved preference must target a BLE MAC or UUID.

--- a/.agents/skills/decent-app/lifecycle.md
+++ b/.agents/skills/decent-app/lifecycle.md
@@ -1,6 +1,6 @@
 # sb-dev lifecycle
 
-`scripts/sb-dev.sh` drives `flutter run` on macOS and Linux. It starts in simulate mode unless `--real` is passed, waits for the REST server, owns the Flutter process, and supports reload, restart, logs, and shutdown. Windows users should run `flutter run` directly and use the other skill files normally.
+`scripts/sb-dev.sh` drives `flutter run` on macOS and Linux. It injects `--dart-define=simulate=1` by default; `--real` omits that define. The script waits for the REST server, owns the Flutter process, and supports reload, restart, logs, and shutdown. Windows users should run `flutter run` directly and use the other skill files normally.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ Run commands from the repository root as `scripts/sb-dev.sh <command>`.
 | `--connect-scale <name|id>` | In simulate mode, set `preferredScaleId`. |
 | `--preferred-machine-id <id>` | Explicitly set `preferredMachineId`; use a BLE MAC or UUID in real mode. |
 | `--preferred-scale-id <id>` | Explicitly set `preferredScaleId`. |
-| `--real` | Disable simulated-device registration. |
+| `--real` | Do not inject `--dart-define=simulate=1`; persisted simulated-device settings still apply. |
 | `--adb-forward` | Forward the REST port to an Android device until `stop`. |
 | `--dart-define <key=value>` | Pass an additional Dart define; repeat as needed. |
 
@@ -40,6 +40,24 @@ scripts/sb-dev.sh start \
   --adb-forward \
   --connect-machine DE1 \
   --preferred-machine-id D9:11:0B:E6:9F:86
+```
+
+`--real` does not clear simulations enabled in Settings. After settings load, the app combines dart-define devices with the persisted `simulatedDevices` selection. Before a hardware smoke test, verify that the persisted selection is empty:
+
+```bash
+curl -sf http://localhost:8080/api/v1/settings \
+  | jq -e '.simulatedDevices == []'
+```
+
+If the check fails, clear the selection and restart with the saved `--real` flags before testing hardware:
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/settings \
+  -H 'content-type: application/json' \
+  -d '{"simulatedDevices":[]}'
+scripts/sb-dev.sh restart
+curl -sf http://localhost:8080/api/v1/settings \
+  | jq -e '.simulatedDevices == []'
 ```
 
 ### Status and logs

--- a/.agents/skills/decent-app/lifecycle.md
+++ b/.agents/skills/decent-app/lifecycle.md
@@ -1,158 +1,99 @@
 # sb-dev lifecycle
 
-`scripts/sb-dev.sh` is a POSIX Bash helper that drives `flutter run` for development work. By default it injects `--dart-define=simulate=1` for MockDe1/MockScale; `--real` opts out to exercise real BLE or USB devices. It owns the flutter child process, exposes hot reload / hot restart / cold restart, and tails the combined log — replacing the old MCP lifecycle tools (`app_start`, `app_stop`, etc). It targets macOS and Linux contributors. Windows users should run `flutter run` directly (add `--dart-define=simulate=1` for simulate mode) and skip this file.
+`scripts/sb-dev.sh` drives `flutter run` on macOS and Linux. It starts in simulate mode unless `--real` is passed, waits for the REST server, owns the Flutter process, and supports reload, restart, logs, and shutdown. Windows users should run `flutter run` directly and use the other skill files normally.
 
 ## Prerequisites
 
-Hard dependencies on `PATH`:
-
-- `bash`
-- `curl`
-- `jq` — sb-dev errors out at startup if missing
-- `mkfifo` (part of coreutils)
-- `flutter`
+The script requires `bash`, `curl`, `jq`, `mkfifo`, and `flutter` on `PATH`.
 
 ## Commands
 
-All commands are run from the repo root as `scripts/sb-dev.sh <cmd>`.
+Run commands from the repository root as `scripts/sb-dev.sh <command>`.
 
-### `start`
+### Start
 
-Spawns `flutter run` via `./flutter_with_commit.sh run`, waits up to 120s for `GET /api/v1/devices` to respond, then (if `--connect-machine` was passed) scans and waits up to 30s for the named device to report `connected`. `--dart-define=simulate=1` is injected by default — add `--real` for real hardware.
+`start` launches the app and waits up to 120 seconds for `GET /api/v1/devices`. When `--connect-machine` is present, it also scans and waits up to 30 seconds for a matching name or device ID to report `connected`.
 
-Flags:
-
-- `--platform <id>` — forwarded as `-d <id>` to flutter (`macos`, `linux`, `chrome`, or an Android adb serial like `8734SCCFAC00000747`).
-- `--connect-machine <name|id>` — sets `--dart-define=preferredMachineId=<value>` and triggers a post-boot scan loop. Simulate: `MockDe1`. Real BLE: the advertised name (`DE1`) or the MAC (`D9:11:0B:E6:9F:86`) — the scan loop matches either.
-- `--connect-scale <name|id>` — same semantics for the scale. Simulate example: `MockScale` — that's the scale's `deviceId`; its display `name` in `/api/v1/devices` is `"Mock Scale"` (with a space).
-- `--real` — skip injecting `--dart-define=simulate=1`. Mock device registration is compiled out, so only real transports (BLE, USB serial, HDS) will discover devices.
-- `--adb-forward` — before spawning flutter, run `adb forward tcp:$PORT tcp:$PORT` so the readiness check and all `curl` calls against `localhost:$PORT` reach the REST server on an Android device. Removed on `stop`.
-- `--dart-define key=val` — repeatable passthrough for extra defines.
+| Flag | Purpose |
+|---|---|
+| `--platform <id>` | Pass `-d <id>` to Flutter. |
+| `--connect-machine <name|id>` | Match a machine in the post-boot scan loop. In simulate mode, also set `preferredMachineId`. |
+| `--connect-scale <name|id>` | In simulate mode, set `preferredScaleId`. |
+| `--preferred-machine-id <id>` | Explicitly set `preferredMachineId`; use a BLE MAC or UUID in real mode. |
+| `--preferred-scale-id <id>` | Explicitly set `preferredScaleId`. |
+| `--real` | Disable simulated-device registration. |
+| `--adb-forward` | Forward the REST port to an Android device until `stop`. |
+| `--dart-define <key=value>` | Pass an additional Dart define; repeat as needed. |
 
 ```bash
-# Simulate (default)
-scripts/sb-dev.sh start --connect-machine MockDe1 --connect-scale MockScale
+scripts/sb-dev.sh start \
+  --connect-machine MockDe1 \
+  --connect-scale MockScale
+```
 
-# Real hardware on an Android tablet (adb serial from `flutter devices`)
+For real hardware, `--connect-machine DE1` can match the advertised name during scanning but does not set a saved preference. Supply the actual BLE device ID separately when needed:
+
+```bash
 scripts/sb-dev.sh start \
   --platform 8734SCCFAC00000747 \
   --real \
   --adb-forward \
-  --connect-machine DE1
+  --connect-machine DE1 \
+  --preferred-machine-id D9:11:0B:E6:9F:86
 ```
 
-### `stop`
+### Status and logs
 
-Writes `q` to the stdin fifo (the key `flutter run` honours for a graceful quit), waits up to 5s, then falls back to `SIGKILL`. Cleans up the fifo and pid files.
+```bash
+scripts/sb-dev.sh status
+scripts/sb-dev.sh logs -n 200
+scripts/sb-dev.sh logs --filter scale
+```
+
+`status` reports the process, REST reachability, and current device list. `logs` reads `$SB_RUNTIME_DIR/flutter.log`; `-n` defaults to 50 lines.
+
+### Reload and restart
+
+```bash
+scripts/sb-dev.sh reload
+scripts/sb-dev.sh hot-restart
+scripts/sb-dev.sh restart
+```
+
+- `reload` preserves widget and app state.
+- `hot-restart` rebuilds from `main()` while keeping the Flutter process.
+- `restart` stops and starts the app with the last saved flags. Use it for native code, plugin registration, initialization, or suspect process state.
+
+### Stop
 
 ```bash
 scripts/sb-dev.sh stop
 ```
 
-### `status`
-
-Reports running pid, whether `http://localhost:8080/api/v1/devices` is reachable, and the current device list from that endpoint.
-
-```bash
-scripts/sb-dev.sh status
-```
-
-### `logs`
-
-Tails `$SB_RUNTIME_DIR/flutter.log`. `-n` / `--count` controls how many lines (default 50). `--filter <text>` does a case-insensitive grep first.
-
-```bash
-scripts/sb-dev.sh logs -n 200
-scripts/sb-dev.sh logs --filter 'scale'
-```
-
-### `reload`
-
-Sends `r` to flutter's stdin and waits up to 30s for a `Reloaded N libraries` line in the log. Preserves app state.
-
-```bash
-scripts/sb-dev.sh reload
-```
-
-### `hot-restart`
-
-Sends `R` and waits up to 60s for `Restarted application in Nms`. Resets the widget tree but keeps the flutter process and VM running.
-
-```bash
-scripts/sb-dev.sh hot-restart
-```
-
-### `restart`
-
-Cold restart: `stop` followed by `start`, replaying the flags persisted in `$SB_RUNTIME_DIR/last-flags`. Use when neither hot reload nor hot restart is enough.
-
-```bash
-scripts/sb-dev.sh restart
-```
-
-## Reload vs hot-restart vs cold restart
-
-- **`reload`** preserves app state (widget tree, ephemeral variables, current route). Use for most Dart source edits. Typical completion: under 5s.
-- **`hot-restart`** resets the widget tree and rebuilds from `main()` but keeps the process running. Use when stale state confuses the UI, or when you edit code that only runs during widget-tree construction. Typical: 10–30s.
-- **`restart`** is `stop && start` with the last flags. Use for native-side changes (Android / iOS / desktop shell), plugin registration changes, async init path changes, or when you suspect a corrupted on-disk DB or runtime dir.
+`stop` asks Flutter to quit, waits five seconds, then terminates it and removes runtime files and any adb forward.
 
 ## Runtime state
 
-Everything sb-dev owns lives under `$SB_RUNTIME_DIR` (default `/tmp/decent-app-$USER/`):
+Runtime files live under `$SB_RUNTIME_DIR` (default `/tmp/decent-$USER/`):
 
-- `flutter.pid` — flutter process id
-- `holder.pid` — a `tail -f /dev/null` writer that keeps the stdin fifo open so flutter never sees EOF
-- `stdin` — named pipe; flutter's stdin reads from it (`r`, `R`, `q` are written here)
-- `flutter.log` — combined stdout + stderr
-- `last-flags` — the flags from the most recent `start`, used by `restart`
-- `adb-forwarded` — touched when `start --adb-forward` installed a forward; `stop` removes the forward iff this marker is present
+- `flutter.pid`
+- `holder.pid`
+- `stdin`
+- `flutter.log`
+- `last-flags`
+- `adb-forwarded`
 
-`SB_HOST` and `SB_PORT` override the host/port used for `curl` checks (default `localhost:8080`).
+`SB_HOST` and `SB_PORT` override the REST health-check address, which defaults to `localhost:8080`.
 
-## If things get wedged
-
-Escape hatch when state on disk disagrees with what is actually running:
+## Recovery
 
 ```bash
 scripts/sb-dev.sh stop || true
-rm -rf /tmp/decent-app-$USER/
-pgrep -af flutter_tools.snapshot   # should be empty
+rm -rf "${SB_RUNTIME_DIR:-/tmp/decent-$USER}"
 ```
 
-Then `sb-dev start` cleanly.
-
-## Build environment gotchas
-
-### macOS/iOS: stale SPM clone breaks firebase resolution (Flutter ≥ 3.44)
-
-**Symptom:** `flutter run`/`build macos`/`build ios` fails during "Adding Swift Package Manager integration…" with:
-
-```
-xcodebuild: error: Could not resolve package dependencies:
-  Failed to resolve dependencies Dependencies could not be resolved because no
-  versions of 'firebase-ios-sdk' match the requirement 12.13.0..<13.0.0 and
-  'firebase_analytics-…' depends on 'firebase-ios-sdk' 12.13.0..<13.0.0.
-```
-
-**Cause — the error is misleading.** The pin is fine: firebase-ios-sdk 12.13.0/12.14.0 exist upstream and the requirement is satisfiable. The real problem is a **stale project-local SPM clone**. Flutter ≥ 3.44 enables Swift Package Manager by default and points xcodebuild at a per-project clone cache via `-clonedSourcePackagesDirPath build/<platform>/SourcePackages`. If `build/macos/SourcePackages/repositories/firebase-ios-sdk-*` is an old clone (e.g. last fetched months ago, max tag 12.3.0), it never refetched the newer tag and resolution fails. Do **not** disable SPM — keep riding the migration.
-
-**Confirm in 30s** — if the max tag is below the required version, it's a stale clone:
-
-```bash
-git --git-dir=build/macos/SourcePackages/repositories/firebase-ios-sdk-* tag | grep '^12\.' | tail
-```
-
-**Fix (keeps SPM on):**
-
-```bash
-rm -rf build/macos/SourcePackages build/ios/SourcePackages
-flutter build macos --debug    # or flutter run — xcodebuild re-clones with current tags
-```
-
-The global SPM cache (`~/Library/Caches/org.swift.swiftpm/repositories/firebase-ios-sdk-*`) can also go stale, but the per-project clone under `build/` is what the probe actually reads — clear that one. `build/` is gitignored, so this is a local-dev cleanup, nothing to commit.
-
-**CI:** `.github/workflows/develop-builds.yml` pins `build-macos`/`build-ios` to a specific `flutter-version` (currently `3.41.8`), predating the SPM default. `pr-checks.yml` floats `channel: stable` but `runs-on: ubuntu-latest` (no Apple build). A fresh CI runner clones fresh, so the stale-clone trap is essentially local-only. Android builds are never affected (SPM is Apple-only).
+See `troubleshooting.md` for platform-specific build failures.
 
 ## Windows
 
-`sb-dev.sh` is POSIX-only — it relies on `mkfifo`, named pipes, and process substitution. Windows contributors should run `flutter run --dart-define=simulate=1` in a regular terminal and use the other skill files (`rest.md`, `websocket.md`, `simulated-devices.md`) as normal.
+`sb-dev.sh` depends on POSIX named pipes. On Windows, run `flutter run --dart-define=simulate=1` in a terminal instead.

--- a/.agents/skills/decent-app/scenarios/README.md
+++ b/.agents/skills/decent-app/scenarios/README.md
@@ -1,0 +1,28 @@
+# Regression scenarios
+
+Pick the scenario that matches the task and run it before calling related work done. Each file lists its preconditions, commands, expected output, and postconditions.
+
+| Scenario | File |
+|---|---|
+| Account proxy native consent gate | `scenarios/account-proxy-consent.md` |
+| Account proxy CORS pinned to skin origin | `scenarios/account-proxy-cors.md` |
+| Account proxy write forwarding and scope gate | `scenarios/account-proxy-write.md` |
+| API pressure hardening | `scenarios/api-pressure-hardening.md` |
+| Bengle cup warmer, preheat, and capability discovery | `scenarios/bengle-cup-warmer.md` |
+| Bengle integrated scale | `scenarios/bengle-integrated-scale.md` |
+| Bengle LED strip v2 | `scenarios/bengle-led-strip.md` |
+| Bengle scale calibration | `scenarios/bengle-scale-calibration.md` |
+| Bengle firmware wake-schedule sync | `scenarios/bengle-wake-schedule.md` |
+| BLE error surfacing | `scenarios/ble-error-surfacing.md` |
+| Build-info endpoint | `scenarios/build-info.md` |
+| Debug scale control | `scenarios/debug-scale-control.md` |
+| Device scan and connection policy | `scenarios/device-scan-connection-policy.md` |
+| Display brightness and low-battery toggle | `scenarios/display-brightness.md` |
+| ETag conditional GETs | `scenarios/etag-conditional-gets.md` |
+| Firmware endpoints | `scenarios/firmware.md` |
+| Hot-water stop at weight | `scenarios/hot-water-stop-at-weight.md` |
+| Onboarding connection phases | `scenarios/onboarding-connection-phases.md` |
+| Preferred-device fast path | `scenarios/onboarding-preferred-device.md` |
+| Plugin Decent account proxy bridge | `scenarios/plugin-decent-proxy.md` |
+| Discover and restore default profiles | `scenarios/profiles-defaults.md` |
+| Shot-state WebSocket and persisted stop reason | `scenarios/shot-state-ws.md` |

--- a/.agents/skills/decent-app/scenarios/plugin-decent-proxy.md
+++ b/.agents/skills/decent-app/scenarios/plugin-decent-proxy.md
@@ -17,12 +17,15 @@ linked, so a *granted* plugin reaches the service and gets
 
 ## Preconditions
 
-Fixture plugins live in the app documents `plugins/` dir, which is scanned at boot.
-On sandboxed macOS that is:
+Fixture plugins live under `AppDirectories.plugins`, which is scanned at boot.
+Resolve the current path from the app instead of assuming an OS-specific location:
 
 ```bash
-PLUGINS_DIR="$HOME/Library/Containers/net.tadel.reaprime/Data/Documents/plugins"
-# Linux (non-sandboxed): $HOME/.local/share/net.tadel.reaprime/plugins  (verify per build)
+PLUGINS_DIR="$(
+  flutter run -d macos --dart-entrypoint-args=--print-storage-paths \
+    | sed -n 's/^plugins: //p'
+)"
+[[ -n "$PLUGINS_DIR" ]] || { echo "Could not resolve plugins path" >&2; exit 1; }
 mkdir -p "$PLUGINS_DIR/proxy-smoke-granted" "$PLUGINS_DIR/proxy-smoke-denied"
 ```
 

--- a/.agents/skills/decent-app/simulated-devices.md
+++ b/.agents/skills/decent-app/simulated-devices.md
@@ -1,6 +1,6 @@
 # Simulated devices
 
-Decent ships with in-process mock implementations of its supported devices so you can develop and run tests without a real DE1 or scale on hand. Simulate mode is deterministic, CI-friendly, and enabled via `--dart-define=simulate=1` (all mocks), a comma-delimited subset like `--dart-define=simulate=machine,scale`, or the in-app Settings UI toggle (`SimulatedDevicesTypes` — machine, scale, sensor). `sb-dev start` injects `--dart-define=simulate=1` by default; pass `--real` to opt out and run against real hardware (see `lifecycle.md`).
+Decent ships with in-process device implementations for development without hardware. Simulate mode is enabled with `--dart-define=simulate=1`, a comma-delimited subset such as `--dart-define=simulate=machine,scale`, or the Settings UI. The current `SimulatedDevicesTypes` values are `machine, scale, sensor, bengle, replay`. `sb-dev start` enables the default set from `lib/main.dart`; pass `--real` to disable simulated devices.
 
 ## Available mocks
 
@@ -9,6 +9,8 @@ Registered in `lib/src/services/simulated_device_service.dart`:
 | Type    | Internal id         | REST `name` field | Source |
 |---------|---------------------|-------------------|--------|
 | Machine | `MockDe1`           | `MockDe1`         | `lib/src/models/device/impl/mock_de1/mock_de1.dart` |
+| Bengle  | `MockBengle`        | `MockBengle`      | `lib/src/models/device/impl/bengle/mock_bengle.dart` |
+| Replay  | `MockReplayDe1`     | `Replay DE1`      | `lib/src/models/device/impl/replay/mock_replay_de1.dart` |
 | Scale   | `MockScale`         | `Mock Scale`      | `lib/src/models/device/impl/mock_scale/mock_scale.dart` (id is `MockScale`; `name` carries the space) |
 | Sensor  | `MockSensorBasket`  | `SensorBasket`    | `lib/src/models/device/impl/sensor/mock/mock_sensor_basket.dart` |
 | Sensor  | `MockDebugPort`     | `DebugPort`       | `lib/src/models/device/impl/sensor/mock/mock_debug_port.dart` |
@@ -66,7 +68,7 @@ See `websocket.md` for why all four of `--no-async-stdio -n -U -t` are needed.
 
 ```bash
 scripts/sb-dev.sh stop
-rm -rf "${SB_RUNTIME_DIR:-/tmp/decent-app-$USER}"
+rm -rf "${SB_RUNTIME_DIR:-/tmp/decent-$USER}"
 rm -rf "$HOME/Library/Containers/net.tadel.reaprime/Data/Documents"  # macOS
 ```
 

--- a/.agents/skills/decent-app/simulated-devices.md
+++ b/.agents/skills/decent-app/simulated-devices.md
@@ -1,6 +1,6 @@
 # Simulated devices
 
-Decent ships with in-process device implementations for development without hardware. Simulate mode is enabled with `--dart-define=simulate=1`, a comma-delimited subset such as `--dart-define=simulate=machine,scale`, or the Settings UI. The current `SimulatedDevicesTypes` values are `machine, scale, sensor, bengle, replay`. `sb-dev start` enables the default set from `lib/main.dart`; pass `--real` to disable simulated devices.
+Decent ships with in-process device implementations for development without hardware. Simulate mode is enabled with `--dart-define=simulate=1`, a comma-delimited subset such as `--dart-define=simulate=machine,scale`, or the Settings UI. The current `SimulatedDevicesTypes` values are `machine, scale, sensor, bengle, replay`. `sb-dev start` enables the default set from `lib/main.dart`; `--real` omits `--dart-define=simulate=1` but does not clear devices enabled in Settings. Before testing hardware, use the verification and cleanup steps in `lifecycle.md`.
 
 ## Available mocks
 

--- a/.agents/skills/decent-app/simulated-devices.md
+++ b/.agents/skills/decent-app/simulated-devices.md
@@ -64,15 +64,14 @@ See `websocket.md` for why all four of `--no-async-stdio -n -U -t` are needed.
 
 - **Hot restart** (`sb-dev hot-restart`) rebuilds the widget tree from `main()` but keeps the process and every on-disk file intact.
 - **Cold restart** (`sb-dev stop && sb-dev start`) gives a fresh flutter process, but the Drift SQLite DB and `shared_preferences` survive.
-- **Fresh slate** — stop, wipe the runtime dir, and wipe the app's documents dir:
+- **Fresh slate** - stop the app, remove the runtime directory, then remove persistent state from the resolved support directory:
 
 ```bash
 scripts/sb-dev.sh stop
 rm -rf "${SB_RUNTIME_DIR:-/tmp/decent-$USER}"
-rm -rf "$HOME/Library/Containers/net.tadel.reaprime/Data/Documents"  # macOS
 ```
 
-On Linux the app documents dir is under `$HOME/.local/share/reaprime/` (or `$XDG_DATA_HOME`); see `getApplicationDocumentsDirectory()` in `lib/main.dart`.
+Persistent desktop state lives under `AppDirectories.support`, which uses `getApplicationSupportDirectory()`. Run the desktop executable with `--print-storage-paths` and remove only the reported `support:` path after backing up anything needed. Do not assume the Documents directory; see `doc/AI_STORAGE_NOTES.md`.
 
 ## Known weirdness
 

--- a/.agents/skills/decent-app/troubleshooting.md
+++ b/.agents/skills/decent-app/troubleshooting.md
@@ -6,7 +6,7 @@ Flutter's Apple build can report that no `firebase-ios-sdk` version satisfies a 
 
 ```bash
 git --git-dir=build/macos/SourcePackages/repositories/firebase-ios-sdk-* \
-  tag | grep '^12\.' | tail
+  tag --sort=-version:refname | head
 ```
 
 If it is stale, remove only the generated project-local package clones and rebuild:

--- a/.agents/skills/decent-app/troubleshooting.md
+++ b/.agents/skills/decent-app/troubleshooting.md
@@ -1,0 +1,19 @@
+# Runtime troubleshooting
+
+## macOS and iOS Swift Package Manager clones
+
+Flutter's Apple build can report that no `firebase-ios-sdk` version satisfies a valid constraint when a project-local Swift Package Manager clone is stale. Confirm whether the cached repository is missing the required tag:
+
+```bash
+git --git-dir=build/macos/SourcePackages/repositories/firebase-ios-sdk-* \
+  tag | grep '^12\.' | tail
+```
+
+If it is stale, remove only the generated project-local package clones and rebuild:
+
+```bash
+rm -rf build/macos/SourcePackages build/ios/SourcePackages
+flutter build macos --debug
+```
+
+Do not disable Swift Package Manager. The current Flutter pin is authoritative in `.github/workflows/develop-builds.yml`; do not copy its exact version into this skill.

--- a/.agents/skills/decent-app/verification.md
+++ b/.agents/skills/decent-app/verification.md
@@ -25,7 +25,7 @@ Boot the app with a mock machine connected, confirm REST is reachable and a DE1 
 
 ## Added a new REST endpoint
 
-1. Implement the handler under `lib/src/services/webserver/` and register its route — see `CLAUDE.md` → "Adding a New API Endpoint".
+1. Implement the handler under `lib/src/services/webserver/` and register its route; see `doc/AI_API_NOTES.md` -> "Adding An Endpoint (Checklist)".
 2. `scripts/sb-dev.sh reload` to pick up the change.
 3. `curl -sf` the new endpoint and confirm the response shape.
 4. **Update `assets/api/rest_v1.yml` in the same commit as the handler change.** Stale spec = stale agent knowledge — future `rest.md` users read the spec, not your handler.

--- a/.agents/skills/decent-app/verification.md
+++ b/.agents/skills/decent-app/verification.md
@@ -1,6 +1,6 @@
 # Verification
 
-Deciding how to smoke-test a change to Decent, and the concrete recipes for each workflow. For the broader test-tier decision process (unit / integration / MCP) see `.claude/skills/tdd-workflow/SKILL.md` — this file is specifically about end-to-end verification against a running Decent instance driven by `scripts/sb-dev.sh`.
+Use this file for end-to-end verification against a running Decent instance. For unit, integration, and end-to-end test policy, follow the root `AGENTS.md` and `doc/AI_TESTING_NOTES.md`.
 
 ## When to verify via a running app
 
@@ -48,19 +48,13 @@ Boot the app with a mock machine connected, confirm REST is reachable and a DE1 
 
 Shortest loop: reload, re-hit the endpoint, diff the response against the spec. If the shape changed, update `assets/api/rest_v1.yml` or `assets/api/websocket_v1.yml` in the same commit, and update `doc/Api.md` / `doc/Plugins.md` if user-facing.
 
-## Pre-PR checklist
+## Completion requirements
 
-Before opening a PR, merging locally, or calling work done:
-
-- Plans moved from `doc/plans/` to `doc/plans/archive/<meaningful-subfolder>/`.
-- Docs updated for any behavior change that touches them: `doc/Api.md`, `doc/Skins.md`, `doc/Plugins.md`, `doc/Profiles.md`, `doc/DeviceManagement.md`.
-- `flutter analyze` clean.
-- `flutter test` green.
-- Full sb-dev smoke completed: `start` → `status` → exercise feature → `reload` → re-exercise → `stop`.
+Follow the root `AGENTS.md` for formatting, tests, plan archival or deletion, documentation, and PR requirements. In addition, runtime-facing changes need the relevant `sb-dev` smoke or regression scenario.
 
 ## Regression scenarios
 
-Concrete end-to-end recipes that used to live as MCP yaml fixtures now live as markdown under `scenarios/`. The full index is in `SKILL.md` - pick the scenario that matches your task there. Run it before calling related work done. Each file lists preconditions, a sequence of `curl` / `websocat` commands, expected output hints, and postconditions - paste them verbatim.
+The scenario index is in `scenarios/README.md`. Pick the matching recipe and run it before calling related work done.
 
 ## Stale spec, stale skill
 

--- a/.agents/skills/decent-app/websocket.md
+++ b/.agents/skills/decent-app/websocket.md
@@ -16,7 +16,7 @@ Fallback if websocat isn't available: `npm install -g wscat`. All examples below
 
 ## One-shot snapshot — the default
 
-Each `Bash` tool call is a fresh shell, so bounded reads (no background state) are the safe default. Always bound by message count (`--max-messages-rev N`) — websocat exits cleanly as soon as it has received N messages from the WebSocket.
+Each shell call may be independent, so bounded reads are the safe default. Bound by message count (`--max-messages-rev N`) so websocat exits after receiving N messages.
 
 ```bash
 websocat --no-async-stdio -n -U -t --max-messages-rev 5 \
@@ -55,7 +55,7 @@ Same flags as the one-shot form but without `--max-messages-rev` so the subscrip
 
 ## Bidirectional channels
 
-`ws/v1/devices` and `ws/v1/display` accept commands as well as emit state. Payload shape lives in the spec (`DevicesCommand`, `DisplayCommand`) — check before sending. Drop `-U` (we need stdin→ws now) and bound by `--max-messages-rev` so the shell returns after reading the ack. Example: kick off a scan on the devices channel.
+Several channels are bidirectional. Consult `assets/api/websocket_v1.yml` for the current channel and payload inventory. Drop `-U` when sending and bound by `--max-messages-rev` so the shell returns after the acknowledgement. This representative example starts a device scan:
 
 ```bash
 echo '{"command": "scan", "connect": false, "quick": true}' \

--- a/.claude/skills/decent-app/SKILL.md
+++ b/.claude/skills/decent-app/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: decent-app
-description: Use when touching the Flutter app, its REST/WebSocket API, profiles, shots, or simulated devices, or whenever exercising a code change against a running Decent instance. Covers the dev loop (sb-dev start/reload/stop), REST calls via curl, WebSocket streams via websocat, and smoke-test verification.
+description: Drive or verify a running Decent app via sb-dev, REST, WebSockets, simulated devices, or real hardware. Use for API/WebSocket changes, runtime/device flows, smoke tests, and end-to-end regression scenarios; not for pure Dart changes that do not require a running app.
 ---
 
 # Decent
 
-This is a Claude Code forwarder. The canonical skill lives under the cross-client [agentskills.io](https://agentskills.io) path:
+This is a Claude Code forwarder. The canonical skill is `.agents/skills/decent-app/SKILL.md`.
 
-**`.agents/skills/decent-app/SKILL.md`**
-
-Read that file and the sibling routing targets (`lifecycle.md`, `rest.md`, `websocket.md`, `simulated-devices.md`, `verification.md`, `scenarios/`) for everything the skill covers. Relative paths in those files resolve against `.agents/skills/decent-app/`.
+Read the canonical skill, then only the routing target relevant to the current task. Do not load all references or scenarios.

--- a/.claude/skills/decent-app/SKILL.md
+++ b/.claude/skills/decent-app/SKILL.md
@@ -7,4 +7,4 @@ description: Drive or verify a running Decent app via sb-dev, REST, WebSockets, 
 
 This is a Claude Code forwarder. The canonical skill is `.agents/skills/decent-app/SKILL.md`.
 
-Read the canonical skill, then only the routing target relevant to the current task. Do not load all references or scenarios.
+Read the canonical skill, then only the routing target(s) needed for the current task. Do not preload unrelated references or scenarios.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -182,6 +182,9 @@ jobs:
       - name: Test release aliases
         run: scripts/test_release_aliases.sh
 
+      - name: Test Decent app skill docs
+        run: scripts/test_decent_app_skill.sh
+
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/scripts/test_decent_app_skill.sh
+++ b/scripts/test_decent_app_skill.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL_DIR="$REPO_ROOT/.agents/skills/decent-app"
+SKILL_FILE="$SKILL_DIR/SKILL.md"
+SCENARIO_INDEX="$SKILL_DIR/scenarios/README.md"
+
+[[ "$(head -n 1 "$SKILL_FILE")" == "---" ]]
+grep -qx 'name: decent-app' "$SKILL_FILE"
+grep -q '^description: .\+$' "$SKILL_FILE"
+
+if grep -RFn '/tmp/decent-app-' "$SKILL_DIR"; then
+  echo "Stale sb-dev runtime directory found" >&2
+  exit 1
+fi
+
+runtime_default="$(
+  sed -n 's/^RUNTIME_DIR="${SB_RUNTIME_DIR:-\(.*\)}"/\1/p' \
+    "$REPO_ROOT/scripts/sb-dev.sh" |
+    sed 's/${USER:-default}/$USER/'
+)"
+grep -Fq "default \`$runtime_default/\`" "$SKILL_DIR/lifecycle.md"
+
+simulated_types="$(
+  sed -n 's/^enum SimulatedDevicesTypes { \(.*\) }$/\1/p' \
+    "$REPO_ROOT/lib/src/settings/settings_service.dart"
+)"
+grep -Fq "\`$simulated_types\`" "$SKILL_DIR/simulated-devices.md"
+
+mapfile -t indexed_scenarios < <(
+  sed -n 's/.*`scenarios\/\([^`]*\.md\)`.*/\1/p' "$SCENARIO_INDEX" |
+    sort
+)
+mapfile -t actual_scenarios < <(
+  find "$SKILL_DIR/scenarios" -maxdepth 1 -type f -name '*.md' \
+    ! -name README.md -printf '%f\n' |
+    sort
+)
+
+diff \
+  <(printf '%s\n' "${indexed_scenarios[@]}") \
+  <(printf '%s\n' "${actual_scenarios[@]}")

--- a/scripts/test_decent_app_skill.sh
+++ b/scripts/test_decent_app_skill.sh
@@ -9,7 +9,7 @@ SCENARIO_INDEX="$SKILL_DIR/scenarios/README.md"
 
 [[ "$(head -n 1 "$SKILL_FILE")" == "---" ]]
 grep -qx 'name: decent-app' "$SKILL_FILE"
-grep -q '^description: .\+$' "$SKILL_FILE"
+grep -Eq '^description: .+$' "$SKILL_FILE"
 
 if grep -RFn '/tmp/decent-app-' "$SKILL_DIR"; then
   echo "Stale sb-dev runtime directory found" >&2
@@ -24,21 +24,50 @@ runtime_default="$(
 grep -Fq "default \`$runtime_default/\`" "$SKILL_DIR/lifecycle.md"
 
 simulated_types="$(
-  sed -n 's/^enum SimulatedDevicesTypes { \(.*\) }$/\1/p' \
+  awk '
+    /enum SimulatedDevicesTypes[[:space:]]*\{/ {
+      collecting = 1
+      sub(/^.*enum SimulatedDevicesTypes[[:space:]]*\{[[:space:]]*/, "")
+    }
+    collecting {
+      if ($0 ~ /}/) {
+        sub(/[[:space:]]*}.*/, "")
+        values = values " " $0
+        exit
+      }
+      values = values " " $0
+    }
+    END {
+      gsub(/[[:space:]]+/, " ", values)
+      sub(/^ /, "", values)
+      sub(/ $/, "", values)
+      gsub(/,[[:space:]]*/, ", ", values)
+      sub(/,[[:space:]]*$/, "", values)
+      print values
+    }
+  ' \
     "$REPO_ROOT/lib/src/settings/settings_service.dart"
 )"
+[[ -n "$simulated_types" ]] || {
+  echo "Could not parse SimulatedDevicesTypes" >&2
+  exit 1
+}
 grep -Fq "\`$simulated_types\`" "$SKILL_DIR/simulated-devices.md"
 
-mapfile -t indexed_scenarios < <(
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+indexed_scenarios="$TEMP_DIR/indexed-scenarios"
+actual_scenarios="$TEMP_DIR/actual-scenarios"
+
+{
   sed -n 's/.*`scenarios\/\([^`]*\.md\)`.*/\1/p' "$SCENARIO_INDEX" |
     sort
-)
-mapfile -t actual_scenarios < <(
-  find "$SKILL_DIR/scenarios" -maxdepth 1 -type f -name '*.md' \
-    ! -name README.md -printf '%f\n' |
+} > "$indexed_scenarios"
+{
+  find "$SKILL_DIR/scenarios" -type f -name '*.md' ! -name README.md \
+    -exec basename {} \; |
     sort
-)
+} > "$actual_scenarios"
 
-diff \
-  <(printf '%s\n' "${indexed_scenarios[@]}") \
-  <(printf '%s\n' "${actual_scenarios[@]}")
+diff "$indexed_scenarios" "$actual_scenarios"


### PR DESCRIPTION
## Summary

What changed, and why?

- Narrow the Decent app skill trigger and preserve progressive disclosure.
- Correct sb-dev runtime paths, real-device preference flags, simulated device coverage, WebSocket guidance, and verification terminology.
- Move the scenario index and volatile Apple build troubleshooting out of the always-loaded skill instructions.
- Add a dependency-free CI check for skill metadata, runtime defaults, simulator types, and scenario index drift.

## Linked Issue

N/A - repository documentation maintenance.

## Verification

How did you verify the change? Include relevant tests and any manual or hardware testing.

- `scripts/test_decent_app_skill.sh`
- `bash -n scripts/test_decent_app_skill.sh`
- `git diff --cached --check`
- `flutter analyze --no-pub`

## Impact

Documentation and CI only. No runtime, API, compatibility, migration, or security behavior changes.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->