### PR TITLE
fix(webui): give each skin a stable origin, so its browser storage survives

### DIFF
--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -64,6 +64,29 @@ backgrounded. After ten minutes in the background, it unloads the page and
 reloads the selected skin when the app returns. Skin state that must survive
 this reload should be persisted through the Decaid API or browser storage.
 
+### Skin Origins and Browser Storage
+
+Each installed skin is served from its own **stable origin** — a port derived
+from the skin's identity and remembered across restarts. Browser storage is
+keyed by origin, so `localStorage`, `sessionStorage` and IndexedDB written by a
+skin are still there the next time the app starts.
+
+Ports are assigned from 24800 upward. 3000, 4001 and 8080 are reserved, so a
+skin never lands on the entry point, the local listener or the REST API.
+`localhost:3000` remains the entry point and redirects to the skin's own
+origin.
+
+**The fallback, and what it costs.** If a skin's assigned port cannot be bound
+— another process holds it — Decaid retries briefly, then falls back to a
+**temporary origin** for that run. The skin loads and works normally, but
+because the origin differs, **browser storage written under the stable origin
+is not visible**, and anything written during that run is not visible after it.
+Nothing is deleted; it is simply keyed to a different origin.
+
+A skin that must not lose state across such a run should persist it through the
+Decaid API rather than browser storage. The KV endpoints are unaffected by
+origin, because that data lives in the app.
+
 ### Offline Operation
 
 Decaid serves installed skins from `localhost`, so Wi-Fi and internet access

--- a/doc/Skins.md
+++ b/doc/Skins.md
@@ -67,9 +67,13 @@ this reload should be persisted through the Decaid API or browser storage.
 ### Skin Origins and Browser Storage
 
 Each installed skin is served from its own **stable origin** — a port derived
-from the skin's identity and remembered across restarts. Browser storage is
-keyed by origin, so `localStorage`, `sessionStorage` and IndexedDB written by a
-skin are still there the next time the app starts.
+from the skin's identity and remembered across restarts. Persistent browser
+storage is keyed by origin, so `localStorage` and IndexedDB written by a skin
+are still there the next time the app starts.
+
+`sessionStorage` is not covered by that guarantee. It is scoped to a page
+session, so it is cleared when the page is unloaded — including the background
+unload described above — and it never survives an app restart.
 
 Ports are assigned from 24800 upward. 3000, 4001 and 8080 are reserved, so a
 skin never lands on the entry point, the local listener or the REST API.
@@ -79,9 +83,9 @@ origin.
 **The fallback, and what it costs.** If a skin's assigned port cannot be bound
 — another process holds it — Decaid retries briefly, then falls back to a
 **temporary origin** for that run. The skin loads and works normally, but
-because the origin differs, **browser storage written under the stable origin
-is not visible**, and anything written during that run is not visible after it.
-Nothing is deleted; it is simply keyed to a different origin.
+because the origin differs, **persistent browser storage written under the
+stable origin is not visible**, and anything written during that run is not
+visible after it. Nothing is deleted; it is simply keyed to a different origin.
 
 A skin that must not lose state across such a run should persist it through the
 Decaid API rather than browser storage. The KV endpoints are unaffected by

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:ui' show AppExitResponse, AppExitType;
 
@@ -175,6 +176,37 @@ ActiveSkinConsent? _activeSkinConsent(String path, WebUIStorage storage) {
     id: skin?.id,
     name: skin?.name ?? 'Custom skin',
     path: value,
+  );
+}
+
+const skinPortAssignmentsPreferenceKey = 'webUISkinPorts';
+
+Map<String, int> decodeSkinPortAssignments(String? raw) {
+  if (raw == null || raw.isEmpty) return {};
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) return {};
+    return {
+      for (final entry in decoded.entries)
+        if (entry.key is String && entry.value is int)
+          entry.key as String: entry.value as int,
+    };
+  } catch (_) {
+    return {};
+  }
+}
+
+Future<Map<String, int>> loadPersistedSkinPortAssignments() async {
+  final raw = await SharedPreferencesAsync().getString(
+    skinPortAssignmentsPreferenceKey,
+  );
+  return decodeSkinPortAssignments(raw);
+}
+
+Future<void> persistSkinPortAssignments(Map<String, int> assignments) async {
+  await SharedPreferencesAsync().setString(
+    skinPortAssignmentsPreferenceKey,
+    jsonEncode(assignments),
   );
 }
 
@@ -413,7 +445,10 @@ void main(List<String> args) async {
     scaleController: scaleController,
     settingsController: settingsController,
   );
-  final WebUIService webUIService = WebUIService();
+  final WebUIService webUIService = WebUIService(
+    loadSkinPortAssignments: loadPersistedSkinPortAssignments,
+    saveSkinPortAssignments: persistSkinPortAssignments,
+  );
   final WebUIStorage webUIStorage = WebUIStorage(settingsController);
 
   DecentAccountService? decentAccountService;

--- a/lib/src/webui_support/webui_service.dart
+++ b/lib/src/webui_support/webui_service.dart
@@ -115,10 +115,12 @@ Future<List<String>> _listDeviceAddresses() async {
 class WebUIService {
   final _log = Logger("WebUIService");
   final Future<List<String>> Function() _listLocalAddresses;
+  final Future<Map<String, int>> Function()? _loadSkinPortAssignments;
+  final Future<void> Function(Map<String, int>)? _saveSkinPortAssignments;
   final Duration _wifiIpResolutionTimeout;
   HttpServer? _server;
   HttpServer? _entryServer;
-  final Set<int> _usedPorts = {};
+  Map<String, int>? _skinPortAssignments;
   int port = 3000;
   String _path = "";
   String? _localIP;
@@ -133,13 +135,28 @@ class WebUIService {
   @visibleForTesting
   static Duration hostResolutionTtl = const Duration(seconds: 30);
 
+  @visibleForTesting
+  static int skinPortRangeStart = 24800;
+
+  @visibleForTesting
+  static int skinPortRangeSize = 4096;
+
+  static const Set<int> _reservedSkinPorts = {3000, 4001, 8080};
+  static const int _skinPortBindAttempts = 3;
+  static const int _temporarySkinPortAttempts = 8;
+  static const Duration _skinPortBindRetryDelay = Duration(milliseconds: 150);
+
   static const int _resolvedHostLimit = 128;
   final Map<String, _ResolvedHost> _resolvedHosts = {};
 
   WebUIService({
     Future<List<String>> Function()? listLocalAddresses,
+    Future<Map<String, int>> Function()? loadSkinPortAssignments,
+    Future<void> Function(Map<String, int>)? saveSkinPortAssignments,
     Duration wifiIpResolutionTimeout = const Duration(seconds: 2),
   }) : _listLocalAddresses = listLocalAddresses ?? _listDeviceAddresses,
+       _loadSkinPortAssignments = loadSkinPortAssignments,
+       _saveSkinPortAssignments = saveSkinPortAssignments,
        _wifiIpResolutionTimeout = wifiIpResolutionTimeout;
 
   Future<String> _resolveLocalIP() async {
@@ -157,6 +174,7 @@ class WebUIService {
   String? skinProxyToken;
   String? Function(String path)? skinProxyTokenProvider;
   void Function()? skinProxyTokenRevoker;
+  String? Function(String path)? skinIdentityProvider;
 
   Future<bool> _isDeviceAddress(String host) async {
     if (host == 'localhost' || host == '127.0.0.1' || host == '::1') {
@@ -316,7 +334,9 @@ class WebUIService {
 
     try {
       if (tokenProvider != null) skinProxyToken = tokenProvider(path);
-      _server = await _serveFresh(handler);
+      final identityProvider = skinIdentityProvider;
+      final identity = identityProvider == null ? path : identityProvider(path);
+      _server = await _serveStable(handler, identity);
       this.port = _server!.port;
       await _serveEntryPoint(port);
       _log.fine("serving $path");
@@ -337,11 +357,140 @@ class WebUIService {
     skinProxyToken = null;
   }
 
-  Future<HttpServer> _serveFresh(Handler handler) async {
-    while (true) {
-      final server = await shelf_io.serve(handler, '0.0.0.0', 0);
-      if (_usedPorts.add(server.port)) return server;
+  int _fnv1a(String value) {
+    var hash = 0x811c9dc5;
+    for (final byte in utf8.encode(value)) {
+      hash = (hash ^ byte) & 0xFFFFFFFF;
+      hash = (hash * 0x01000193) & 0xFFFFFFFF;
+    }
+    return hash;
+  }
+
+  Future<Map<String, int>> _loadedSkinPortAssignments() async {
+    final cached = _skinPortAssignments;
+    if (cached != null) return cached;
+    final loader = _loadSkinPortAssignments;
+    var loaded = <String, int>{};
+    if (loader != null) {
+      try {
+        loaded = _validSkinPortAssignments(await loader());
+      } catch (e) {
+        _log.warning('Failed to load skin port assignments', e);
+      }
+    }
+    _skinPortAssignments = loaded;
+    return loaded;
+  }
+
+  Map<String, int> _validSkinPortAssignments(Map<String, int> stored) {
+    final valueCounts = <int, int>{};
+    for (final port in stored.values) {
+      valueCounts[port] = (valueCounts[port] ?? 0) + 1;
+    }
+    final rangeEnd = skinPortRangeStart + skinPortRangeSize;
+    final valid = <String, int>{};
+    for (final entry in stored.entries) {
+      final port = entry.value;
+      if (port < skinPortRangeStart ||
+          port >= rangeEnd ||
+          _reservedSkinPorts.contains(port) ||
+          valueCounts[port] != 1) {
+        _log.warning(
+          'Dropping stored skin port $port for ${entry.key}: '
+          'outside the skin port range or not unique',
+        );
+        continue;
+      }
+      valid[entry.key] = port;
+    }
+    return valid;
+  }
+
+  Future<HttpServer?> _bindSkinPort(Handler handler, int port) async {
+    try {
+      return await shelf_io.serve(handler, '0.0.0.0', port);
+    } on SocketException catch (e) {
+      _log.fine('Skin port $port unavailable: $e');
+      return null;
+    }
+  }
+
+  Future<HttpServer?> _bindAssignedSkinPort(Handler handler, int port) async {
+    for (var attempt = 0; attempt < _skinPortBindAttempts; attempt++) {
+      final server = await _bindSkinPort(handler, port);
+      if (server != null) return server;
+      if (attempt < _skinPortBindAttempts - 1) {
+        await Future<void>.delayed(_skinPortBindRetryDelay);
+      }
+    }
+    return null;
+  }
+
+  Future<HttpServer> _serveStable(Handler handler, String? identity) async {
+    final assignments = await _loadedSkinPortAssignments();
+    if (identity == null) {
+      _log.warning('Skin has no identity; serving on a temporary port');
+      return _serveTemporarySkinPort(handler, assignments);
+    }
+    final assigned = assignments[identity];
+    if (assigned != null) {
+      final server = await _bindAssignedSkinPort(handler, assigned);
+      if (server != null) return server;
+      _log.severe(
+        'Skin port $assigned for $identity is in use; '
+        'serving this session on a temporary port',
+      );
+      return _serveTemporarySkinPort(handler, assignments);
+    }
+
+    final taken = assignments.values.toSet();
+    final seed = _fnv1a(identity) % skinPortRangeSize;
+    for (var offset = 0; offset < skinPortRangeSize; offset++) {
+      final candidate =
+          skinPortRangeStart + (seed + offset) % skinPortRangeSize;
+      if (taken.contains(candidate) || _reservedSkinPorts.contains(candidate)) {
+        continue;
+      }
+      final server = await _bindSkinPort(handler, candidate);
+      if (server == null) continue;
+      assignments[identity] = candidate;
+      await _persistSkinPortAssignments(assignments);
+      return server;
+    }
+
+    _log.severe('No free skin port for $identity; serving on a temporary port');
+    return _serveTemporarySkinPort(handler, assignments);
+  }
+
+  Future<HttpServer> _serveTemporarySkinPort(
+    Handler handler,
+    Map<String, int> assignments,
+  ) async {
+    final avoid = {...assignments.values, ..._reservedSkinPorts};
+    var server = await shelf_io.serve(handler, '0.0.0.0', 0);
+    for (
+      var attempt = 1;
+      attempt < _temporarySkinPortAttempts && avoid.contains(server.port);
+      attempt++
+    ) {
       await server.close(force: true);
+      server = await shelf_io.serve(handler, '0.0.0.0', 0);
+    }
+    if (avoid.contains(server.port)) {
+      _log.severe(
+        'Temporary skin port ${server.port} collides with an assigned port',
+      );
+    }
+    return server;
+  }
+
+  Future<void> _persistSkinPortAssignments(Map<String, int> assignments) async {
+    final saver = _saveSkinPortAssignments;
+    if (saver == null) return;
+    try {
+      await saver(Map<String, int>.from(assignments));
+    } catch (e) {
+      _log.warning('Failed to persist skin port assignments', e);
     }
   }
 

--- a/test/skin_port_assignments_test.dart
+++ b/test/skin_port_assignments_test.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/main.dart' as app;
+
+void main() {
+  test('decodes a stored assignment map', () {
+    final raw = jsonEncode({'skin:decal': 25123, 'skin:path:abc': 24801});
+
+    expect(app.decodeSkinPortAssignments(raw), {
+      'skin:decal': 25123,
+      'skin:path:abc': 24801,
+    });
+  });
+
+  test('returns an empty map for null or empty storage', () {
+    expect(app.decodeSkinPortAssignments(null), isEmpty);
+    expect(app.decodeSkinPortAssignments(''), isEmpty);
+  });
+
+  test('returns an empty map for garbage JSON', () {
+    expect(app.decodeSkinPortAssignments('{not json'), isEmpty);
+    expect(app.decodeSkinPortAssignments('\u0000\u0001'), isEmpty);
+  });
+
+  test('returns an empty map for JSON that is not a map', () {
+    expect(app.decodeSkinPortAssignments('[25123]'), isEmpty);
+    expect(app.decodeSkinPortAssignments('"skin:decal"'), isEmpty);
+  });
+
+  test('drops entries whose value is not an integer', () {
+    final raw = jsonEncode({
+      'skin:decal': 25123,
+      'skin:bad': 'high',
+      'skin:worse': 25123.5,
+      'skin:null': null,
+    });
+
+    expect(app.decodeSkinPortAssignments(raw), {'skin:decal': 25123});
+  });
+}

--- a/test/webui_support/webui_stable_origin_test.dart
+++ b/test/webui_support/webui_stable_origin_test.dart
@@ -1,0 +1,279 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_info_plus/network_info_plus.dart';
+import 'package:reaprime/src/webui_support/webui_service.dart';
+
+void main() {
+  const entryPort = 3011;
+  const testRangeStart = 26700;
+  const testRangeSize = 32;
+
+  late Directory skinA;
+  late Directory skinB;
+  final services = <WebUIService>[];
+
+  Future<Directory> createSkin(String prefix, String body) async {
+    final dir = await Directory.systemTemp.createTemp(prefix);
+    await File(
+      '${dir.path}/index.html',
+    ).writeAsString('<html><body>$body</body></html>');
+    return dir;
+  }
+
+  WebUIService createService({
+    Future<Map<String, int>> Function()? load,
+    Future<void> Function(Map<String, int>)? save,
+  }) {
+    final service = WebUIService(
+      listLocalAddresses: () async => const <String>[],
+      loadSkinPortAssignments: load,
+      saveSkinPortAssignments: save,
+    );
+    services.add(service);
+    return service;
+  }
+
+  Future<String> fetchBody(int port) async {
+    final client = HttpClient();
+    addTearDown(client.close);
+    final request = await client.getUrl(Uri.parse('http://localhost:$port/'));
+    final response = await request.close();
+    return response.transform(utf8.decoder).join();
+  }
+
+  setUp(() async {
+    WebUIService.resolveWifiIP = () async => 'localhost';
+    WebUIService.skinPortRangeStart = testRangeStart;
+    WebUIService.skinPortRangeSize = testRangeSize;
+    skinA = await createSkin('webui_stable_a', 'skin-a');
+    skinB = await createSkin('webui_stable_b', 'skin-b');
+  });
+
+  tearDown(() async {
+    for (final service in services) {
+      await service.stopServing();
+    }
+    services.clear();
+    for (final dir in [skinA, skinB]) {
+      if (dir.existsSync()) await dir.delete(recursive: true);
+    }
+    WebUIService.resolveWifiIP = NetworkInfo().getWifiIP;
+    WebUIService.skinPortRangeStart = 24800;
+    WebUIService.skinPortRangeSize = 4096;
+  });
+
+  test('serves a skin on the same origin across restarts', () async {
+    var saved = <String, int>{};
+    final service = createService(
+      load: () async => saved,
+      save: (assignments) async => saved = assignments,
+    );
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+    final assignedPort = service.port;
+
+    expect(assignedPort, greaterThanOrEqualTo(testRangeStart));
+    expect(assignedPort, lessThan(testRangeStart + testRangeSize));
+    expect(saved, {skinA.path: assignedPort});
+
+    await service.stopServing();
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(service.port, assignedPort);
+
+    await service.stopServing();
+
+    var relaunchSaves = 0;
+    final relaunched = createService(
+      load: () async => Map<String, int>.from(saved),
+      save: (_) async => relaunchSaves++,
+    );
+    await relaunched.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(relaunched.port, assignedPort);
+    expect(relaunchSaves, 0);
+    expect(await fetchBody(relaunched.port), contains('skin-a'));
+  });
+
+  test('gives a different skin a different origin', () async {
+    final service = createService();
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+    final portA = service.port;
+    await service.serveFolderAtPath(skinB.path, port: entryPort);
+    final portB = service.port;
+
+    expect(portB, isNot(portA));
+    expect(await fetchBody(portB), contains('skin-b'));
+
+    final client = HttpClient();
+    addTearDown(client.close);
+    await expectLater(
+      client.getUrl(Uri.parse('http://localhost:$portA/')),
+      throwsA(isA<SocketException>()),
+    );
+
+    final entryRequest = await client.getUrl(
+      Uri.parse('http://localhost:$entryPort/'),
+    );
+    entryRequest.followRedirects = false;
+    final entryResponse = await entryRequest.close();
+    await entryResponse.drain<void>();
+
+    expect(entryResponse.statusCode, HttpStatus.temporaryRedirect);
+    expect(
+      entryResponse.headers.value(HttpHeaders.locationHeader),
+      'http://localhost:$portB/',
+    );
+    expect(
+      entryResponse.headers.value(HttpHeaders.cacheControlHeader),
+      'no-store',
+    );
+  });
+
+  test('keeps one origin for one identity served from two paths', () async {
+    final service = createService();
+    service.skinIdentityProvider = (_) => 'skin:reinstalled';
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+    final portA = service.port;
+    await service.serveFolderAtPath(skinB.path, port: entryPort);
+
+    expect(service.port, portA);
+    expect(await fetchBody(service.port), contains('skin-b'));
+  });
+
+  test('never adopts a port already assigned to another skin', () async {
+    final first = createService();
+    await first.serveFolderAtPath(skinA.path, port: entryPort);
+    final seededPort = first.port;
+    await first.stopServing();
+
+    var saved = <String, int>{};
+    final service = createService(
+      load: () async => {'skin:other': seededPort},
+      save: (assignments) async => saved = assignments,
+    );
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(service.port, isNot(seededPort));
+    expect(saved['skin:other'], seededPort);
+    expect(saved[skinA.path], service.port);
+  });
+
+  test('falls back to an ephemeral port when its own port is taken', () async {
+    var saved = <String, int>{};
+    var saves = 0;
+    final service = createService(
+      load: () async => Map<String, int>.from(saved),
+      save: (assignments) async {
+        saved = assignments;
+        saves++;
+      },
+    );
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+    final assignedPort = service.port;
+    await service.stopServing();
+
+    final squatter = await ServerSocket.bind('0.0.0.0', assignedPort);
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(service.port, isNot(assignedPort));
+    expect(saved, {skinA.path: assignedPort});
+    expect(saves, 1);
+    expect(await fetchBody(service.port), contains('skin-a'));
+
+    await service.stopServing();
+    await squatter.close();
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(service.port, assignedPort);
+    expect(saves, 1);
+  });
+
+  test('serves and reassigns when the loader throws', () async {
+    var saved = <String, int>{};
+    final service = createService(
+      load: () async => throw const FormatException('corrupt prefs'),
+      save: (assignments) async => saved = assignments,
+    );
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(service.port, greaterThanOrEqualTo(testRangeStart));
+    expect(service.port, lessThan(testRangeStart + testRangeSize));
+    expect(saved, {skinA.path: service.port});
+    expect(await fetchBody(service.port), contains('skin-a'));
+  });
+
+  test('never adopts a stored port outside the skin range', () async {
+    var saved = <String, int>{};
+    final service = createService(
+      load: () async => {skinA.path: 8080, 'skin:other': 65000},
+      save: (assignments) async => saved = assignments,
+    );
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(service.port, greaterThanOrEqualTo(testRangeStart));
+    expect(service.port, lessThan(testRangeStart + testRangeSize));
+    expect(saved, {skinA.path: service.port});
+  });
+
+  test('drops stored assignments that share one port', () async {
+    final duplicatedPort = testRangeStart + 5;
+    var saved = <String, int>{};
+    final service = createService(
+      load: () async => {'skin:x': duplicatedPort, 'skin:y': duplicatedPort},
+      save: (assignments) async => saved = assignments,
+    );
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(saved.keys, [skinA.path]);
+  });
+
+  test('serves a skin without an identity on a temporary port', () async {
+    var saves = 0;
+    final service = createService(
+      load: () async => {},
+      save: (_) async {
+        saves++;
+      },
+    );
+    service.skinIdentityProvider = (_) => null;
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(
+      service.port,
+      isNot(inInclusiveRange(testRangeStart, testRangeStart + testRangeSize)),
+    );
+    expect(saves, 0);
+    expect(await fetchBody(service.port), contains('skin-a'));
+  });
+
+  test('saves an assignment once, not on every serve', () async {
+    var saves = 0;
+    var saved = <String, int>{};
+    final service = createService(
+      load: () async => Map<String, int>.from(saved),
+      save: (assignments) async {
+        saved = assignments;
+        saves++;
+      },
+    );
+
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+    await service.stopServing();
+    await service.serveFolderAtPath(skinA.path, port: entryPort);
+
+    expect(saves, 1);
+  });
+}


### PR DESCRIPTION
## Summary

A skin's browser storage was wiped at every app start, because its **origin changed every time**.

`_serveFresh` bound the skin server on port 0 and refused to reuse a port. Browser storage is
keyed by origin, so every setting a skin had written was gone after a restart. `:3000` is only an
entry point that 307-redirects to whichever ephemeral port was chosen that run.

Measured on the tablet, 28 Aug 2026: the same skin was served at 41825, then 39055, then 45939
across three restarts, and both keys written before a restart were absent after it. **Every skin is
affected, not one.**

Base: `main`. Independent.

### Design notes

A skin now gets a **stable port derived from its identity** by FNV-1a, persisted in
`shared_preferences` under `webUISkinPorts`.

- Range 24800 + 4096, with 3000, 4001 and 8080 reserved, so a skin can never land on the entry
  point, the `:644` listener or the API.
- Three bind attempts with a 150 ms retry, then eight temporary-port attempts as a fallback. **A
  taken port degrades to today's behaviour rather than failing the boot.**
- `loadSkinPortAssignments` / `saveSkinPortAssignments` are injected, so `WebUIService` keeps no
  ambient dependency and the tests drive it directly.

The KV layer was never affected — `store/<skin>/*` lives in the app, not the browser — which is
why this looked like a skin bug for so long.

## Linked Issue

N/A
## Verification

- `flutter analyze` — clean.
- `flutter test` — **full suite 3906 passed / 1 skipped**, run against current `main` on
  5 Sep 2026.
- `flutter test` — `test/webui_support` 41 passed, including the new
  `webui_stable_origin_test.dart` and `skin_port_assignments_test.dart`.
- `dart format` — clean on every changed file.
- **Verified on hardware.** Measured on the tablet before the fix: the same skin served at 41825,
  then 39055, then 45939 across three restarts, with its stored keys gone each time. The fix ships
  in the Decaid-Canary build Ben runs, and skin settings now survive a restart.

## Impact

- **User-visible**: skin settings stop disappearing on restart. This is the fix for the screensaver
  bug, and it applies to every skin.
- **Compatibility**: additive. A skin with no stored assignment gets one on first serve.
- **Migration**: none. Settings lost before this change are already gone; nothing is recoverable.
- **Security**: none. The port is derived from the skin's own identity, not from user input.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
