### PR TITLE
bundle Decal, the open-source ReaPrime skin

### DIFF
--- a/skin_sources.json
+++ b/skin_sources.json
@@ -26,5 +26,9 @@
   {
     "type": "github_release",
     "repo": "decentespresso/insight-js"
+  },
+  {
+    "type": "github_release",
+    "repo": "ChampionDesigns/decal"
   }
 ]


### PR DESCRIPTION
## Summary

Lists Decal in `skin_sources.json`, so Decaid bundles it the way it already bundles six other
third-party skins.

Base: `main`. Independent. **Four lines.**

```json
{
  "type": "github_release",
  "repo": "ChampionDesigns/decal"
}
```

### What this is and is not

`assets/bundled_skins/` is gitignored — Decaid does not commit skins. It reads this manifest and
fetches each repo's latest release. So this PR adds no skin code, only a source to fetch from,
exactly as `allofmeng/streamline_project`, `tadelv/passione`, `rotium/OverDose`,
`giladger/Beanie`, `NilsBruch/NSX` and `Sabotage1/WorkFlow-Skin` already are.

**Whether Decaid should ship Decal is a product decision, not a technical one.** The change itself
is trivial; the question is whether you want it in the box.

## Linked Issue

N/A
## Verification

- `flutter analyze` — clean.
- `flutter test` — **full suite 3891 passed / 1 skipped**, run against current `main` on
  5 Sep 2026.
- `flutter test` — `test/webui_support` 26 passed.
- `skin_sources.json` parses; 8 entries, Decal among them.
- **`ChampionDesigns/decal` is public** and has release `v0.1.0` with `decal-0.1.0.zip`, matching
  the single-zip asset shape the fetcher already consumes from `passione-v0.9.5.zip`.
- **Verified on hardware.** Decal is bundled in the Decaid-Canary build Ben runs, fetched from the
  same public release this entry points at.

## Impact

- **User-visible**: Decal appears in the bundled skin list on a fresh install.
- **Download size**: one more skin fetched at first run — `decal-0.1.0.zip` is about 1.0 MB.
- **Compatibility**: additive. Existing installs are unaffected until they refresh their skin list.
- **Security**: the skin is fetched from a public GitHub release, the same trust path as the other
  six.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
