### PR TITLE
fix(webserver): refuse to boot when a fixed port is already bound

### DIFF
--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -128,6 +128,61 @@ All four machine sockets: `/ws/v1/machine/snapshot`, `/ws/v1/machine/shotSetting
 
 **Full gateway mode is explicitly exempt**, checked via `settingsController.gatewayMode == GatewayMode.full` alongside the shot-state check — not left implicit. In `full` mode the skin owns the shot and `De1StateManager` normally never starts its own `ShotSequencer` for it, so `currentShotState` would usually stay idle anyway; but the launcher/home-screen path in `De1StateManager._handleEspressoState` starts an app-owned `ShotSequencer` "regardless of mode" whenever the app's own home screen is foregrounded, even under `full` gateway mode. Relying on ShotSequencer-absence alone would make the lockout accidentally engage in that edge case, which is out of scope for the setting's intent (it exists to protect app-tracked shots, not skin-owned ones) — hence the explicit gateway-mode check rather than an inferred one.
 
+## Fixed Port Already Bound
+
+### Problem
+
+`startWebServer` binds two fixed ports: 8080 for the REST and WebSocket API, and
+4001 for the API docs. `main()` wrapped the call in a bare `catch` that logged
+`failed to start web server` and carried on, so a bind failure left the app
+running with no API at all.
+
+That failure was close to invisible. The WebUI binds an ephemeral port and is
+unaffected, so the skin still loaded and the app looked normal; only every REST
+call and every WebSocket behind it was gone. `BootTiming.mark('webserver_up')`
+fired either way. The user saw an app that opened correctly and then misbehaved,
+with the reason only in the log.
+
+Two Decaid-family apps installed on one device share those fixed ports, so the
+common cause is that the other one is already running.
+
+### Solution
+
+`lib/src/services/webserver/port_binding.dart` wraps both binds.
+`serveOrReportPortInUse` raises a typed `WebServerPortInUse`; `main()` catches it
+and runs `WebServerPortConflictApp` instead of the app.
+
+### Design Choices
+
+- **Only EADDRINUSE is a port clash.** Every other `SocketException` is
+  rethrown unchanged so it keeps its own error path. A check that treated all of
+  them as a clash would tell the user to close an app that is not running.
+- **The errno set is per platform.** Dart reports the raw OS code and does not
+  normalise it: 98 on Linux and Android, 48 on macOS and iOS, 10048 on Windows.
+- **A same-process double bind carries no errno.** Dart refuses it before the OS
+  sees it and raises its own message, "The shared flag to bind() needs to be
+  `true` ...". That is the same condition for the user, so `isAddressInUse`
+  matches on `sameProcessBindClashMessage` as well. Matching a message is
+  brittle, so a test pins the wording: a Dart change fails that test rather than
+  letting the check fall through to the unknown-failure path. This is also why
+  an in-process test can exercise `serveOrReportPortInUse` at all.
+- **The boot stops.** Continuing would present a working-looking app with
+  nothing behind it, which is the defect this replaces.
+- **The screen does not close the other app.** Android does not let one app stop
+  another; `killBackgroundProcesses` needs its own permission and only ever
+  touches background processes. The screen offers "Check again", which re-probes
+  the port, and "Close this app".
+- **`probePortIsFree` is injected into the screen.** A widget test drives a fake
+  clock and real socket I/O never settles under it, so the widget takes a
+  `PortProbe`. The real probe is covered separately in a plain test.
+
+### Focused Tests
+
+```
+flutter test test/unit/services/webserver/port_binding_test.dart
+flutter test test/unit/ui/webserver_port_conflict_app_test.dart
+```
+
 ## Keeping Notes Fresh
 
 Add protocol compatibility rules, API versioning decisions, and endpoint design rationale. Prune when specs are updated.

--- a/doc/AI_API_NOTES.md
+++ b/doc/AI_API_NOTES.md
@@ -152,6 +152,9 @@ common cause is that the other one is already running.
 `serveOrReportPortInUse` raises a typed `WebServerPortInUse`; `main()` catches it
 and runs `WebServerPortConflictApp` instead of the app.
 
+Only the 8080 API bind reaches `main()`. `startApiDocsServer` catches the same
+exception for 4001, logs it, and returns null, so the docs port is best effort.
+
 ### Design Choices
 
 - **Only EADDRINUSE is a port clash.** Every other `SocketException` is
@@ -166,8 +169,12 @@ and runs `WebServerPortConflictApp` instead of the app.
   brittle, so a test pins the wording: a Dart change fails that test rather than
   letting the check fall through to the unknown-failure path. This is also why
   an in-process test can exercise `serveOrReportPortInUse` at all.
-- **The boot stops.** Continuing would present a working-looking app with
-  nothing behind it, which is the defect this replaces.
+- **The boot stops for 8080, not for 4001.** Continuing without the API would
+  present a working-looking app with nothing behind it, which is the defect this
+  replaces. 4001 serves only the API docs, and it binds after 8080 has already
+  succeeded. Treating a docs conflict as fatal would abort a boot whose API was
+  running, and would leave that 8080 server open behind the conflict screen,
+  because `startWebServer` holds the only reference to it.
 - **The screen does not close the other app.** Android does not let one app stop
   another; `killBackgroundProcesses` needs its own permission and only ever
   touches background processes. The screen offers "Check again", which re-probes
@@ -180,6 +187,7 @@ and runs `WebServerPortConflictApp` instead of the app.
 
 ```
 flutter test test/unit/services/webserver/port_binding_test.dart
+flutter test test/unit/services/webserver/api_docs_server_port_test.dart
 flutter test test/unit/ui/webserver_port_conflict_app_test.dart
 ```
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,6 +68,8 @@ import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
 import 'package:reaprime/src/services/simulated_device_service.dart';
 import 'package:reaprime/src/services/webserver/data_export/backup_data_sources.dart';
 import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/services/webserver/port_binding.dart';
+import 'package:reaprime/src/ui/webserver_port_conflict_app.dart';
 import 'package:reaprime/src/services/macos_updater.dart';
 import 'package:reaprime/src/services/update_check_service.dart';
 import 'package:reaprime/src/webui_support/webui_service.dart';
@@ -564,6 +566,12 @@ void main(List<String> args) async {
       proxyTokenService: proxyTokenService,
       updateCheckService: updateCheckService,
     );
+  } on WebServerPortInUse catch (e) {
+    log.severe(
+      'port ${e.port} already in use; refusing to boot without the API',
+    );
+    runApp(WebServerPortConflictApp(port: e.port));
+    return;
   } catch (e, st) {
     log.severe('failed to start web server', e, st);
   }

--- a/lib/src/services/webserver/port_binding.dart
+++ b/lib/src/services/webserver/port_binding.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
+
+typedef PortProbe = Future<bool> Function(int port);
+
+class WebServerPortInUse implements Exception {
+  const WebServerPortInUse(this.port);
+
+  final int port;
+
+  @override
+  String toString() => 'WebServerPortInUse(port: $port)';
+}
+
+const Set<int> addressInUseErrorCodes = {98, 48, 10048};
+
+const String sameProcessBindClashMessage = 'shared flag';
+
+bool isAddressInUse(Object error) {
+  if (error is! SocketException) return false;
+  final osError = error.osError;
+  if (osError == null) return false;
+  return addressInUseErrorCodes.contains(osError.errorCode) ||
+      osError.message.contains(sameProcessBindClashMessage);
+}
+
+Future<HttpServer> serveOrReportPortInUse(
+  Handler handler,
+  Object address,
+  int port,
+) async {
+  try {
+    return await io.serve(handler, address, port);
+  } catch (e) {
+    if (isAddressInUse(e)) {
+      throw WebServerPortInUse(port);
+    }
+    rethrow;
+  }
+}
+
+Future<bool> probePortIsFree(int port) async {
+  try {
+    final probe = await ServerSocket.bind(InternetAddress.anyIPv4, port);
+    await probe.close();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -70,7 +70,7 @@ import 'package:reaprime/src/models/device/led_strip.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/impl/de1/unified_de1/calibration_codec.dart';
 import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
-import 'package:shelf/shelf_io.dart' as io;
+import 'package:reaprime/src/services/webserver/port_binding.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart' as sws;
 import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -341,7 +341,7 @@ Future<void> startWebServer(
     );
   }
 
-  final server = await io.serve(
+  final server = await serveOrReportPortInUse(
     _init(
       deviceHandler,
       de1Handler,
@@ -641,7 +641,7 @@ Future<void> startApiDocsServer() async {
     listDirectories: true,
   );
 
-  final apiServer = await io.serve(apiHandler, '0.0.0.0', 4001);
+  final apiServer = await serveOrReportPortInUse(apiHandler, '0.0.0.0', 4001);
   log.info(
     '✅ API Docs server running at http://${apiServer.address.host}:${apiServer.port}',
   );

--- a/lib/src/services/webserver_service.dart
+++ b/lib/src/services/webserver_service.dart
@@ -614,7 +614,7 @@ String _appendVary(String? value, String headerName) {
   return '$value, $headerName';
 }
 
-Future<void> startApiDocsServer() async {
+Future<HttpServer?> startApiDocsServer() async {
   final tempDir = await getTemporaryDirectory();
   final apiDir = Directory('${tempDir.path}/api');
   if (!apiDir.existsSync()) {
@@ -641,8 +641,17 @@ Future<void> startApiDocsServer() async {
     listDirectories: true,
   );
 
-  final apiServer = await serveOrReportPortInUse(apiHandler, '0.0.0.0', 4001);
+  final HttpServer apiServer;
+  try {
+    apiServer = await serveOrReportPortInUse(apiHandler, '0.0.0.0', 4001);
+  } on WebServerPortInUse catch (e) {
+    log.warning(
+      'API docs server not started: port ${e.port} is already in use',
+    );
+    return null;
+  }
   log.info(
     '✅ API Docs server running at http://${apiServer.address.host}:${apiServer.port}',
   );
+  return apiServer;
 }

--- a/lib/src/ui/webserver_port_conflict_app.dart
+++ b/lib/src/ui/webserver_port_conflict_app.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:reaprime/src/services/webserver/port_binding.dart';
+
+class WebServerPortConflictApp extends StatelessWidget {
+  const WebServerPortConflictApp({
+    super.key,
+    required this.port,
+    this.probe = probePortIsFree,
+  });
+
+  final int port;
+
+  final PortProbe probe;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
+        useMaterial3: true,
+      ),
+      home: WebServerPortConflictScreen(port: port, probe: probe),
+    );
+  }
+}
+
+class WebServerPortConflictScreen extends StatefulWidget {
+  const WebServerPortConflictScreen({
+    super.key,
+    required this.port,
+    this.probe = probePortIsFree,
+  });
+
+  final int port;
+
+  final PortProbe probe;
+
+  @override
+  State<WebServerPortConflictScreen> createState() =>
+      _WebServerPortConflictScreenState();
+}
+
+class _WebServerPortConflictScreenState
+    extends State<WebServerPortConflictScreen> {
+  bool _checking = false;
+  bool? _free;
+
+  Future<void> _checkAgain() async {
+    setState(() {
+      _checking = true;
+      _free = null;
+    });
+    final free = await widget.probe(widget.port);
+    if (!mounted) return;
+    setState(() {
+      _checking = false;
+      _free = free;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Theme.of(context).textTheme;
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Padding(
+            padding: const EdgeInsets.all(32),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Another Decaid app is running',
+                  style: text.headlineSmall,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Port ${widget.port} is already in use. Only one Decaid app '
+                  'can run at a time, because they share the same port.',
+                  style: text.bodyLarge,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Close the other Decaid app, then open this one again.',
+                  style: text.bodyLarge,
+                ),
+                if (_free != null) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    _free!
+                        ? 'Port ${widget.port} is free now. Close this app and '
+                              'open it again.'
+                        : 'Port ${widget.port} is still in use.',
+                    style: text.bodyLarge?.copyWith(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 24),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: [
+                    FilledButton(
+                      onPressed: _checking ? null : _checkAgain,
+                      child: Text(_checking ? 'Checking…' : 'Check again'),
+                    ),
+                    OutlinedButton(
+                      onPressed: () => SystemNavigator.pop(),
+                      child: const Text('Close this app'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/unit/services/webserver/api_docs_server_port_test.dart
+++ b/test/unit/services/webserver/api_docs_server_port_test.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+
+class _FakePathProvider extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _FakePathProvider(this.tempDir);
+
+  final Directory tempDir;
+
+  @override
+  Future<String?> getTemporaryPath() async => tempDir.path;
+}
+
+const _apiDocsPort = 4001;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    final tempDir = Directory.systemTemp.createTempSync('api_docs_port_test');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+    PathProviderPlatform.instance = _FakePathProvider(tempDir);
+  });
+
+  test('a bound docs port does not fail the boot', () async {
+    final holder = await ServerSocket.bind(
+      InternetAddress.anyIPv4,
+      _apiDocsPort,
+    );
+    addTearDown(holder.close);
+
+    final server = await startApiDocsServer();
+
+    expect(server, isNull);
+    expect(holder.port, _apiDocsPort);
+  });
+
+  test('a free docs port still serves the docs', () async {
+    final server = await startApiDocsServer();
+    addTearDown(() => server?.close(force: true));
+
+    expect(server, isNotNull);
+    expect(server!.port, _apiDocsPort);
+  });
+}

--- a/test/unit/services/webserver/port_binding_test.dart
+++ b/test/unit/services/webserver/port_binding_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/webserver/port_binding.dart';
+import 'package:shelf/shelf.dart';
+
+void main() {
+  group('isAddressInUse', () {
+    test('accepts the EADDRINUSE code of every supported platform', () {
+      for (final code in addressInUseErrorCodes) {
+        expect(
+          isAddressInUse(
+            SocketException('bind failed', osError: OSError('in use', code)),
+          ),
+          isTrue,
+          reason: 'code $code should be recognised',
+        );
+      }
+    });
+
+    test('rejects a different socket failure', () {
+      expect(
+        isAddressInUse(
+          SocketException('bind failed', osError: OSError('denied', 13)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts Dart\'s same-process double-bind message', () {
+      expect(
+        isAddressInUse(
+          SocketException(
+            'bind failed',
+            osError: const OSError(
+              'The shared flag to bind() needs to be `true` if binding '
+              'multiple times on the same (address, port) combination.',
+            ),
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a SocketException with no OS error', () {
+      expect(isAddressInUse(const SocketException('no osError')), isFalse);
+    });
+
+    test('rejects a non-socket error', () {
+      expect(isAddressInUse(StateError('unrelated')), isFalse);
+    });
+  });
+
+  group('serveOrReportPortInUse', () {
+    test('serves on a free port', () async {
+      final server = await serveOrReportPortInUse(
+        (_) => Response.ok('ok'),
+        InternetAddress.loopbackIPv4,
+        0,
+      );
+      addTearDown(() => server.close(force: true));
+      expect(server.port, greaterThan(0));
+    });
+
+    test('reports the port when it is already bound', () async {
+      // Hold a real port, the way the other Decaid app would.
+      final holder = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => holder.close());
+
+      await expectLater(
+        serveOrReportPortInUse(
+          (_) => Response.ok('ok'),
+          InternetAddress.loopbackIPv4,
+          holder.port,
+        ),
+        throwsA(
+          isA<WebServerPortInUse>().having((e) => e.port, 'port', holder.port),
+        ),
+      );
+    });
+  });
+
+  group('probePortIsFree', () {
+    test('is false while something holds the port', () async {
+      final holder = await ServerSocket.bind(InternetAddress.anyIPv4, 0);
+      addTearDown(() => holder.close());
+      expect(await probePortIsFree(holder.port), isFalse);
+    });
+
+    test('is true once nothing holds it', () async {
+      final holder = await ServerSocket.bind(InternetAddress.anyIPv4, 0);
+      final port = holder.port;
+      await holder.close();
+      expect(await probePortIsFree(port), isTrue);
+    });
+  });
+}

--- a/test/unit/ui/webserver_port_conflict_app_test.dart
+++ b/test/unit/ui/webserver_port_conflict_app_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/ui/webserver_port_conflict_app.dart';
+
+void main() {
+  testWidgets('names the port and offers both actions', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WebServerPortConflictScreen(
+          port: 8080,
+          probe: (_) async => false,
+        ),
+      ),
+    );
+
+    expect(find.text('Another Decaid app is running'), findsOneWidget);
+    expect(find.textContaining('Port 8080 is already in use'), findsOneWidget);
+    expect(find.text('Check again'), findsOneWidget);
+    expect(find.text('Close this app'), findsOneWidget);
+  });
+
+  testWidgets('says the port is still in use when the probe says so', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WebServerPortConflictScreen(
+          port: 8080,
+          probe: (_) async => false,
+        ),
+      ),
+    );
+    await tester.tap(find.text('Check again'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('is still in use'), findsOneWidget);
+  });
+
+  testWidgets('says the port is free when the probe says so', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WebServerPortConflictScreen(port: 8080, probe: (_) async => true),
+      ),
+    );
+    await tester.tap(find.text('Check again'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('is free now'), findsOneWidget);
+  });
+
+  testWidgets('asks about the port it was given', (tester) async {
+    final asked = <int>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WebServerPortConflictScreen(
+          port: 4001,
+          probe: (p) async {
+            asked.add(p);
+            return false;
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.text('Check again'));
+    await tester.pumpAndSettle();
+
+    expect(asked, [4001]);
+  });
+}


### PR DESCRIPTION
## Summary

The app could boot **with no API at all** and say nothing.

`startWebServer` binds two fixed ports: 8080 for the REST and WebSocket API, and 4001 for the API
docs. `main()` wrapped the call in a bare catch that logged "failed to start web server" and
carried on.

**That failure is close to invisible.** The WebUI binds an ephemeral port and is unaffected, so the
skin still loads and the app looks normal — only every REST call and every WebSocket behind it is
gone. `BootTiming.mark('webserver_up')` fires either way. The user sees an app that opened
correctly and then misbehaves, with the reason only in the log.

Two Decaid-family apps installed on one device share those fixed ports, so the common cause is
simply that the other one is already running.

Base: `main`. Independent.

### Design notes

- `serveOrReportPortInUse` raises a typed `WebServerPortInUse` for `EADDRINUSE` and **rethrows
  every other failure unchanged**, so a permission denial keeps its own error path and is never
  reported to the user as a port clash.
- `isAddressInUse` matches the OS code per platform — 98 on Linux and Android, 48 on macOS and
  iOS, 10048 on Windows — because Dart reports the raw code and does not normalise it.
- `main()` stops on `WebServerPortInUse` and shows a screen naming the port, offering "Check again"
  and "Close this app".

## Linked Issue

N/A
## Verification

- `flutter analyze` — clean.
- `flutter test` — **full suite 3904 passed** against current `main`, including
  `port_binding_test` and `webserver_port_conflict_app_test`.
- `dart format` — clean on every changed file.
- **Verified on hardware.** This change ships in the Decaid-Canary build Ben runs on his own
  machine, and has been exercised in normal use rather than only under test.

## Impact

- **User-visible**: the app now refuses to boot and says which port is taken, instead of running
  without an API. That is a deliberate behaviour change.
- **Compatibility**: none for a normal single-app install; the path is only reached when a bind
  fails.
- **API**: none.
- **Security**: none. A permission failure is not swallowed as a port clash.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
