### PR TITLE
feat(api): derived hydraulic channels on MachineSnapshot

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -5825,6 +5825,25 @@ components:
           type: integer
         steamTemperature:
           type: number
+        puckResistance:
+          type: number
+          description: >
+            Puck hydraulic resistance R = P / F² in bar·s²/mL², derived
+            from pressure and flow. Only computed when flow >= 0.3 mL/s and
+            pressure >= 0.3 bar; when gated the key is omitted entirely
+            (never null).
+        loadImpedance:
+          type: number
+          description: >
+            Hydraulic load impedance Z = P / F in bar·s/mL, derived from
+            pressure and flow. Same >= 0.3 gating as puckResistance; key
+            omitted when gated.
+        hydraulicPower:
+          type: number
+          description: >
+            Hydraulic power delivered to the puck, W = 0.1 · P · F in watts
+            (1 bar × 1 mL/s = 0.1 W; espresso is roughly 0.5–4 W). Same >= 0.3
+            gating as puckResistance; key omitted when gated.
     MachineState:
       type: string
       enum:

--- a/assets/api/websocket_v1.yml
+++ b/assets/api/websocket_v1.yml
@@ -639,6 +639,25 @@ components:
           type: integer
         steamTemperature:
           type: number
+        puckResistance:
+          type: number
+          description: >
+            Puck hydraulic resistance R = P / F² in bar·s²/mL², derived
+            from pressure and flow. Only computed when flow >= 0.3 mL/s and
+            pressure >= 0.3 bar; when gated the key is omitted entirely
+            (never null).
+        loadImpedance:
+          type: number
+          description: >
+            Hydraulic load impedance Z = P / F in bar·s/mL, derived from
+            pressure and flow. Same >= 0.3 gating as puckResistance; key
+            omitted when gated.
+        hydraulicPower:
+          type: number
+          description: >
+            Hydraulic power delivered to the puck, W = 0.1 · P · F in watts
+            (1 bar × 1 mL/s = 0.1 W; espresso is roughly 0.5–4 W). Same >= 0.3
+            gating as puckResistance; key omitted when gated.
     MachineState:
       type: string
       enum:

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -70,6 +70,18 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | GET | `/api/v1/machine/scaleCalibration` | Read decoded scale-calibration state (step, cell, sub-state, seconds remaining, status) — Bengle only, 404 elsewhere | |
 | PUT | `/api/v1/machine/scaleCalibration` | Start `zero`/`latch`/`abort` calibration step (`weightGrams` 1–10000 required for `latch`); 202 accepted / 409 rejected (busy or shot in progress) — Bengle only | |
 
+#### Derived hydraulic channels
+
+`MachineSnapshot` carries three channels the app computes from pressure and group flow rather than
+reads from the machine: `puckResistance` (R = P / F², bar·s²/mL²), `loadImpedance` (Z = P / F,
+bar·s/mL) and `hydraulicPower` (W = 0.1 · P · F, watts — 1 bar × 1 mL/s = 0.1 W, and espresso sits
+at roughly 0.5–4 W).
+
+All three are gated on flow ≥ 0.3 mL/s **and** pressure ≥ 0.3 bar. Below either threshold the key is
+omitted from the payload entirely rather than sent as `null`. A client must read an absent key as
+"not computable right now", never as zero. The channels appear wherever a `MachineSnapshot` does,
+`/ws/v1/machine/snapshot` included.
+
 #### Firmware updates
 
 The catalog endpoint is available offline and without a connected machine. It returns bundled artifact metadata, compatibility and version eligibility, the recommended artifact, tri-state `updateAvailable`, and the shared machine operation state. The bundled Phase 1 artifact is official DE1 firmware build 1352 for `DE1Pro`, `DE1XL`, `DE1XXL`, and `DE1XXXL`.

--- a/lib/src/models/device/machine.dart
+++ b/lib/src/models/device/machine.dart
@@ -63,6 +63,41 @@ class MachineSnapshot {
     required this.steamTemperature,
   });
 
+  // Derived hydraulic channels R / Z / W, computed on read from the raw
+  // [pressure] and [flow] fields — never stored — so already-recorded history
+  // shots gain these channels with zero migration ([fromJson] does not read
+  // them; [toJson] recomputes them).
+
+  /// Shared gate for the derived channels: returns [value] only when
+  /// `flow >= 0.3 mL/s && pressure >= 0.3 bar` (below that the ratios are
+  /// numerically meaningless noise) and inputs and result are finite. The
+  /// finite guard is mandatory: `jsonEncode` throws on NaN/Infinity and
+  /// [toJson] is streamed on the live `/ws/v1/machine/snapshot` websocket.
+  double? _derivedOrNull(double value) {
+    if (flow < 0.3 || pressure < 0.3) return null;
+    if (!flow.isFinite || !pressure.isFinite || !value.isFinite) return null;
+    return value;
+  }
+
+  /// Puck hydraulic resistance **R = P / F²** in bar·s²/mL².
+  ///
+  /// How strongly the puck resists water flow; rises as the puck compacts
+  /// or clogs, drops on channeling/erosion. `null` (and omitted from
+  /// [toJson]) unless flow ≥ 0.3 mL/s and pressure ≥ 0.3 bar.
+  double? get puckResistance => _derivedOrNull(pressure / (flow * flow));
+
+  /// Hydraulic load impedance **Z = P / F** in bar·s/mL.
+  ///
+  /// Pressure-to-flow ratio at the current operating point (the "AC"
+  /// analogue of [puckResistance]). Same ≥ 0.3 gating as [puckResistance].
+  double? get loadImpedance => _derivedOrNull(pressure / flow);
+
+  /// Hydraulic power delivered to the puck **W = 0.1 · P · F** in watts
+  /// (1 bar × 1 mL/s = 0.1 W; espresso is roughly 0.5–4 W).
+  ///
+  /// Same ≥ 0.3 gating as [puckResistance].
+  double? get hydraulicPower => _derivedOrNull(0.1 * pressure * flow);
+
   MachineSnapshot copyWith({
     DateTime? timestamp,
     MachineStateSnapshot? state,
@@ -108,6 +143,12 @@ class MachineSnapshot {
       'targetGroupTemperature': targetGroupTemperature,
       'profileFrame': profileFrame,
       'steamTemperature': steamTemperature,
+      // Derived channels. Keys are OMITTED (not null) when gated — old skins
+      // never see them, and consumers can rely on key presence as the
+      // validity signal.
+      if (puckResistance != null) 'puckResistance': puckResistance,
+      if (loadImpedance != null) 'loadImpedance': loadImpedance,
+      if (hydraulicPower != null) 'hydraulicPower': hydraulicPower,
     };
   }
 

--- a/test/models/machine_snapshot_derived_test.dart
+++ b/test/models/machine_snapshot_derived_test.dart
@@ -1,0 +1,106 @@
+// Tests for the derived hydraulic channels R (puckResistance),
+// Z (loadImpedance) and W (hydraulicPower) on MachineSnapshot.
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+
+MachineSnapshot _snapshot({required double flow, required double pressure}) =>
+    MachineSnapshot(
+      timestamp: DateTime.utc(2026, 7, 17, 12, 0, 0),
+      state: const MachineStateSnapshot(
+        state: MachineState.espresso,
+        substate: MachineSubstate.pouring,
+      ),
+      flow: flow,
+      pressure: pressure,
+      targetFlow: 2.0,
+      targetPressure: 9.0,
+      mixTemperature: 92.0,
+      groupTemperature: 93.0,
+      targetMixTemperature: 93.0,
+      targetGroupTemperature: 93.0,
+      profileFrame: 1,
+      steamTemperature: 140,
+    );
+
+void main() {
+  group('MachineSnapshot derived channels', () {
+    test('computes R, Z and W from pressure and flow', () {
+      final snapshot = _snapshot(pressure: 9.0, flow: 2.0);
+      expect(snapshot.puckResistance, closeTo(2.25, 1e-9));
+      expect(snapshot.loadImpedance, closeTo(4.5, 1e-9));
+      expect(snapshot.hydraulicPower, closeTo(1.8, 1e-9));
+
+      final json = snapshot.toJson();
+      expect(json['puckResistance'], closeTo(2.25, 1e-9));
+      expect(json['loadImpedance'], closeTo(4.5, 1e-9));
+      expect(json['hydraulicPower'], closeTo(1.8, 1e-9));
+    });
+
+    test('gates on low flow: getters null, keys absent from toJson', () {
+      final snapshot = _snapshot(pressure: 9.0, flow: 0.2);
+      expect(snapshot.puckResistance, isNull);
+      expect(snapshot.loadImpedance, isNull);
+      expect(snapshot.hydraulicPower, isNull);
+
+      final json = snapshot.toJson();
+      expect(json.containsKey('puckResistance'), isFalse);
+      expect(json.containsKey('loadImpedance'), isFalse);
+      expect(json.containsKey('hydraulicPower'), isFalse);
+    });
+
+    test('gates on low pressure: getters null, keys absent from toJson', () {
+      final snapshot = _snapshot(pressure: 0.2, flow: 2.0);
+      expect(snapshot.puckResistance, isNull);
+      expect(snapshot.loadImpedance, isNull);
+      expect(snapshot.hydraulicPower, isNull);
+
+      final json = snapshot.toJson();
+      expect(json.containsKey('puckResistance'), isFalse);
+      expect(json.containsKey('loadImpedance'), isFalse);
+      expect(json.containsKey('hydraulicPower'), isFalse);
+    });
+
+    test('zero flow: keys absent and jsonEncode does not throw', () {
+      final snapshot = _snapshot(pressure: 9.0, flow: 0.0);
+      final json = snapshot.toJson();
+      expect(json.containsKey('puckResistance'), isFalse);
+      expect(json.containsKey('loadImpedance'), isFalse);
+      expect(json.containsKey('hydraulicPower'), isFalse);
+      // jsonEncode throws on NaN/Infinity — the gate must keep the
+      // division-by-zero results out of the websocket payload entirely.
+      expect(() => jsonEncode(snapshot.toJson()), returnsNormally);
+    });
+
+    test('round-trip recomputes derived keys from raw fields', () {
+      final original = _snapshot(pressure: 9.0, flow: 2.0);
+      // Encode/decode simulates a shot stored to history and read back.
+      final stored =
+          jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>;
+      final restored = MachineSnapshot.fromJson(stored);
+      // fromJson never reads the derived keys; toJson recomputes them from
+      // the raw pressure/flow fields, so stored history gains the channels
+      // on read with zero migration.
+      final json = restored.toJson();
+      expect(json['puckResistance'], closeTo(2.25, 1e-9));
+      expect(json['loadImpedance'], closeTo(4.5, 1e-9));
+      expect(json['hydraulicPower'], closeTo(1.8, 1e-9));
+    });
+
+    test(
+      'boundary: flow and pressure exactly 0.3 are emitted (gate is >=)',
+      () {
+        final snapshot = _snapshot(pressure: 0.3, flow: 0.3);
+        expect(snapshot.puckResistance, isNotNull);
+        expect(snapshot.loadImpedance, isNotNull);
+        expect(snapshot.hydraulicPower, isNotNull);
+
+        final json = snapshot.toJson();
+        expect(json['puckResistance'], closeTo(0.3 / (0.3 * 0.3), 1e-9));
+        expect(json['loadImpedance'], closeTo(1.0, 1e-9));
+        expect(json['hydraulicPower'], closeTo(0.009, 1e-12));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds three compute-on-read channels to `MachineSnapshot`, derived from the pressure and flow fields
that already exist.

Base: `main`. Independent, and prerequisite for the puck-estimator PR.

```
puckResistance   R = P / F²    bar·s²/mL²
loadImpedance    Z = P / F     bar·s/mL
hydraulicPower   W = 0.1·P·F   W
```

They are pure functions of pressure and flow, so **any DE1-class machine gets them** with no extra
hardware, no firmware change, and no new characteristic. They also apply retroactively to historical
shots, since the inputs were always recorded.

### Design notes

Computed on read rather than stored, so there is no migration and no risk of a persisted value
drifting from the pressure/flow it was derived from.

Division guards are explicit. Each channel is gated on flow >= 0.3 mL/s and pressure >= 0.3 bar, and
below either threshold the key is **omitted** rather than emitted as `null`, infinity or NaN. Near-zero
flow is the normal state during preinfusion, so this path is hit on every shot.

### Note on naming

The follow-up puck-estimator PR renames these to make the derived/measured distinction explicit. On a
Bengle the firmware reports its own measured equivalents from the flow actually passing through the
puck, and the two must not be confused. That rename is in the estimator PR because it necessarily
touches both sides.

## Linked Issue

N/A
## Verification

- `flutter analyze` — clean.
- `flutter test` — **full suite 3897 passed / 1 skipped**, run against current `main` on 5 Sep 2026.
- `dart format` — clean on every changed file.
- `test/models/machine_snapshot_derived_test.dart` covers gating, omission and JSON round-trip.
- No hardware run is required. The channels are pure functions of two existing fields.

- **Verified on hardware.** This change ships in the Decaid-Canary build Ben runs on his own
  machine, and has been exercised in normal use rather than only under test.

## Impact

- **API**: `assets/api/rest_v1.yml` and `assets/api/websocket_v1.yml` gain the three fields on
  `MachineSnapshot`. `doc/Api.md` documents them and states the omit-when-gated rule.
- **Compatibility**: additive and optional. A client that ignores the keys is unaffected.
- **User-visible**: none on its own. It gives skins three new channels to plot.
- **Client note**: an absent key means "not computable right now", not zero. A client that reads it as
  zero plots a false trace during preinfusion.
- **Security**: none.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
