### PR TITLE
fix(updates): respect externally managed app builds

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -535,7 +535,9 @@ void main(List<String> args) async {
     pluginSourceService: PluginSourceService(pluginService),
   );
 
-  final macosUpdater = Platform.isMacOS ? MacOSUpdater() : null;
+  final macosUpdater = Platform.isMacOS && !BuildInfo.appStore
+      ? MacOSUpdater()
+      : null;
 
   try {
     await startWebServer(

--- a/lib/src/services/update_check_service.dart
+++ b/lib/src/services/update_check_service.dart
@@ -18,6 +18,7 @@ class UpdateCheckService {
   final PluginSourceService? _pluginSourceService;
 
   final bool _isAndroid;
+  final bool externallyManaged;
 
   final bool _isMacOS;
 
@@ -38,6 +39,7 @@ class UpdateCheckService {
     PluginSourceService? pluginSourceService,
     bool? platformIsAndroid,
     bool? platformIsMacOS,
+    this.externallyManaged = BuildInfo.appStore,
   }) : _settingsService = settingsService,
        _updater = updater ?? AndroidUpdater(owner: 'tadelv', repo: 'reaprime'),
        _webUIStorage = webUIStorage,
@@ -47,9 +49,10 @@ class UpdateCheckService {
     _state = BehaviorSubject.seeded(_snapshot(AppUpdatePhase.idle));
   }
 
-  UpdateInfo? get availableUpdate => _availableUpdate;
+  UpdateInfo? get availableUpdate =>
+      externallyManaged ? null : _availableUpdate;
 
-  bool get hasAvailableUpdate => _availableUpdate != null;
+  bool get hasAvailableUpdate => availableUpdate != null;
 
   Stream<AppUpdateState> get updateState => _state.stream;
 
@@ -62,7 +65,7 @@ class UpdateCheckService {
     double? progress,
     String? error,
   }) {
-    final update = _availableUpdate;
+    final update = availableUpdate;
     final hasUpdate = update != null;
     return AppUpdateState(
       phase: phase,
@@ -143,7 +146,7 @@ class UpdateCheckService {
       '${_isMacOS ? ' [skins only — Sparkle owns macOS app updates]' : ''}',
     );
 
-    if (_isMacOS) {
+    if (_isMacOS || externallyManaged) {
       await _updateManagedContent();
     } else {
       final lastCheck = await _settingsService.lastUpdateCheckTime();
@@ -190,6 +193,11 @@ class UpdateCheckService {
   }
 
   Future<UpdateInfo?> checkForUpdate() async {
+    if (externallyManaged) {
+      _availableUpdate = null;
+      _emit(AppUpdatePhase.idle);
+      return null;
+    }
     if (_isMacOS) {
       _log.info('macOS app updates are owned by Sparkle; skipping APK check');
       return null;
@@ -259,6 +267,11 @@ class UpdateCheckService {
   }
 
   void debugForceUpdate({String version = '99.0.0', String? downloadUrl}) {
+    if (externallyManaged) {
+      _availableUpdate = null;
+      _emit(AppUpdatePhase.idle);
+      return;
+    }
     _log.info('DEBUG: forcing fake update notification ($version)');
     _availableUpdate = UpdateInfo(
       version: version,

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -44,6 +44,9 @@ class SettingsView extends StatelessWidget {
         listenable: controller,
         builder: (context, _) {
           final isMobile = Platform.isAndroid || Platform.isIOS;
+          final managedContentOnly =
+              (updateCheckService?.externallyManaged ?? BuildInfo.appStore) &&
+              macosUpdater?.isSupported != true;
           return ListView(
             children: [
               const SettingsSectionHeader('General'),
@@ -72,7 +75,7 @@ class SettingsView extends StatelessWidget {
               ),
 
               const SettingsSectionHeader('Updates'),
-              if (!Platform.isIOS) ...[
+              if (!Platform.isIOS && !managedContentOnly) ...[
                 SettingsTile(
                   icon: Icons.science_outlined,
                   label: 'Update channel',
@@ -107,25 +110,37 @@ class SettingsView extends StatelessWidget {
                       }
                     }
                   },
-                  label: const Text('Automatic update checks'),
-                  sublabel: const Text('Check for updates every 12 hours'),
+                  label: Text(
+                    managedContentOnly
+                        ? 'Automatic skin and plugin updates'
+                        : 'Automatic update checks',
+                  ),
+                  sublabel: Text(
+                    managedContentOnly
+                        ? 'Check for skin and plugin updates every 12 hours'
+                        : 'Check for updates every 12 hours',
+                  ),
                 ),
               ),
-              const SettingsDivider(),
-              ListTile(
-                leading: const Icon(LucideIcons.refreshCcwDot),
-                title: const Text('Check for updates'),
-                trailing: updateCheckService?.hasAvailableUpdate == true
-                    ? Chip(
-                        label: Text(
-                          updateCheckService?.availableUpdate?.version ?? '',
-                          style: const TextStyle(fontSize: 12),
-                        ),
-                        backgroundColor: Theme.of(context).colorScheme.primary,
-                      )
-                    : null,
-                onTap: () => _checkForUpdates(context),
-              ),
+              if (!managedContentOnly) ...[
+                const SettingsDivider(),
+                ListTile(
+                  leading: const Icon(LucideIcons.refreshCcwDot),
+                  title: const Text('Check for updates'),
+                  trailing: updateCheckService?.hasAvailableUpdate == true
+                      ? Chip(
+                          label: Text(
+                            updateCheckService?.availableUpdate?.version ?? '',
+                            style: const TextStyle(fontSize: 12),
+                          ),
+                          backgroundColor: Theme.of(
+                            context,
+                          ).colorScheme.primary,
+                        )
+                      : null,
+                  onTap: () => _checkForUpdates(context),
+                ),
+              ],
 
               const SettingsSectionHeader('Power'),
               if (isMobile) ...[

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -45,8 +45,7 @@ class SettingsView extends StatelessWidget {
         builder: (context, _) {
           final isMobile = Platform.isAndroid || Platform.isIOS;
           final managedContentOnly =
-              (updateCheckService?.externallyManaged ?? BuildInfo.appStore) &&
-              macosUpdater?.isSupported != true;
+              updateCheckService?.externallyManaged ?? BuildInfo.appStore;
           return ListView(
             children: [
               const SettingsSectionHeader('General'),
@@ -98,7 +97,8 @@ class SettingsView extends StatelessWidget {
                     } else {
                       await updateCheckService?.disableAutomaticChecks();
                     }
-                    if (macosUpdater?.isAvailable == true) {
+                    if (!managedContentOnly &&
+                        macosUpdater?.isAvailable == true) {
                       try {
                         await macosUpdater?.setAutomaticChecks(v);
                       } catch (e, st) {

--- a/test/settings/settings_view_updates_test.dart
+++ b/test/settings/settings_view_updates_test.dart
@@ -41,6 +41,7 @@ Future<(UpdateCheckService, _RecordingUpdater)> _pumpSettingsView(
   bool sparkleConfigureFails = false,
   bool sparkleCheckThrows = false,
   bool serviceIsMacOS = false,
+  bool externallyManaged = false,
 }) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -70,6 +71,7 @@ Future<(UpdateCheckService, _RecordingUpdater)> _pumpSettingsView(
     updater: updater,
     platformIsAndroid: false,
     platformIsMacOS: serviceIsMacOS,
+    externallyManaged: externallyManaged,
   );
   if (initializeService) {
     await updateCheckService.initialize();
@@ -284,6 +286,26 @@ void main() {
       await tester.pump();
 
       expect(calls.where((c) => c.method == 'setAutomaticChecks'), isEmpty);
+    });
+
+    testWidgets('externally managed builds hide application update controls', (
+      tester,
+    ) async {
+      final calls = <MethodCall>[];
+      await _pumpSettingsView(
+        tester,
+        calls,
+        macos: false,
+        externallyManaged: true,
+      );
+
+      expect(find.text('Update channel'), findsNothing);
+      expect(find.text('Check for updates'), findsNothing);
+      expect(find.text('Automatic skin and plugin updates'), findsOneWidget);
+      expect(
+        find.text('Check for skin and plugin updates every 12 hours'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('non-macOS manual check keeps the existing Snackbar flow', (

--- a/test/settings/settings_view_updates_test.dart
+++ b/test/settings/settings_view_updates_test.dart
@@ -308,6 +308,45 @@ void main() {
       );
     });
 
+    testWidgets('externally managed macOS hides application update controls '
+        'even when Sparkle is available', (tester) async {
+      final calls = <MethodCall>[];
+      await _pumpSettingsView(
+        tester,
+        calls,
+        macos: true,
+        externallyManaged: true,
+      );
+
+      expect(find.text('Update channel'), findsNothing);
+      expect(find.text('Check for updates'), findsNothing);
+      expect(find.text('Automatic skin and plugin updates'), findsOneWidget);
+      expect(
+        find.text('Check for skin and plugin updates every 12 hours'),
+        findsOneWidget,
+      );
+      expect(calls.where((c) => c.method == 'checkForUpdates'), isEmpty);
+    });
+
+    testWidgets('externally managed macOS content toggle does not drive '
+        'Sparkle even when Sparkle is available', (tester) async {
+      final calls = <MethodCall>[];
+      await _pumpSettingsView(
+        tester,
+        calls,
+        macos: true,
+        externallyManaged: true,
+      );
+
+      await tester.tap(
+        find.widgetWithText(ShadSwitch, 'Automatic skin and plugin updates'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(calls.where((c) => c.method == 'setAutomaticChecks'), isEmpty);
+      expect(calls.where((c) => c.method == 'setChannel'), isEmpty);
+    });
+
     testWidgets('non-macOS manual check keeps the existing Snackbar flow', (
       tester,
     ) async {

--- a/test/update_check_service_test.dart
+++ b/test/update_check_service_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/build_info.dart';
 import 'package:reaprime/src/plugins/plugin_loader_service.dart';
 import 'package:reaprime/src/plugins/plugin_source_service.dart';
 import 'package:reaprime/src/services/android_updater.dart';
@@ -21,6 +23,17 @@ class _RecordingPluginSourceService extends PluginSourceService {
 
   @override
   Future<void> updateAllPlugins() async {
+    updateCalls++;
+  }
+}
+
+class _RecordingWebUIStorage extends WebUIStorage {
+  _RecordingWebUIStorage(super.settingsController);
+
+  int updateCalls = 0;
+
+  @override
+  Future<void> updateAllSkins() async {
     updateCalls++;
   }
 }
@@ -88,14 +101,18 @@ UpdateInfo _update({String version = '9.9.9'}) => UpdateInfo(
 void main() {
   late _FakeUpdater updater;
   late MockSettingsService settingsService;
-  late WebUIStorage webUIStorage;
+  late _RecordingWebUIStorage webUIStorage;
   late _RecordingPluginSourceService pluginSourceService;
 
-  UpdateCheckService build({bool isAndroid = true, bool isMacOS = false}) {
+  UpdateCheckService build({
+    bool isAndroid = true,
+    bool isMacOS = false,
+    bool externallyManaged = false,
+  }) {
     updater = _FakeUpdater();
     settingsService = MockSettingsService();
     final settingsController = SettingsController(settingsService);
-    webUIStorage = WebUIStorage(settingsController);
+    webUIStorage = _RecordingWebUIStorage(settingsController);
     pluginSourceService = _RecordingPluginSourceService();
     return UpdateCheckService(
       settingsService: settingsService,
@@ -104,6 +121,7 @@ void main() {
       updater: updater,
       platformIsAndroid: isAndroid,
       platformIsMacOS: isMacOS,
+      externallyManaged: externallyManaged,
     );
   }
 
@@ -125,6 +143,9 @@ void main() {
       await svc.checkForUpdate();
 
       final s = svc.currentState;
+      expect(updater.checkCalls, 1);
+      expect(svc.availableUpdate?.version, '9.9.9');
+      expect(svc.hasAvailableUpdate, isTrue);
       expect(s.phase, AppUpdatePhase.available);
       expect(s.latestVersion, '9.9.9');
       expect(s.releaseNotes, 'shiny');
@@ -292,6 +313,90 @@ void main() {
     });
   });
 
+  group('externally managed builds', () {
+    test('constructor defaults ownership to the build setting', () {
+      final settings = MockSettingsService();
+      final svc = UpdateCheckService(
+        settingsService: settings,
+        webUIStorage: WebUIStorage(SettingsController(settings)),
+        updater: _FakeUpdater(),
+        platformIsAndroid: true,
+        platformIsMacOS: false,
+      );
+
+      expect(svc.externallyManaged, BuildInfo.appStore);
+      svc.dispose();
+    });
+
+    test(
+      'direct and debug checks cannot populate application update state',
+      () async {
+        final svc = build(externallyManaged: true);
+        updater.nextCheck = _update();
+
+        svc.debugForceUpdate();
+        expect(svc.availableUpdate, isNull);
+        expect(svc.hasAvailableUpdate, isFalse);
+        expect(svc.currentState.phase, AppUpdatePhase.idle);
+
+        final result = await svc.checkForUpdate();
+
+        expect(result, isNull);
+        expect(updater.checkCalls, 0);
+        expect(await settingsService.lastUpdateCheckTime(), isNull);
+        expect(svc.availableUpdate, isNull);
+        expect(svc.hasAvailableUpdate, isFalse);
+        expect(svc.currentState.phase, AppUpdatePhase.idle);
+        svc.dispose();
+      },
+    );
+
+    test(
+      'automatic startup and periodic checks update skins and plugins only',
+      () {
+        fakeAsync((async) {
+          final svc = build(externallyManaged: true);
+          updater.nextCheck = _update();
+          unawaited(settingsService.setLastUpdateCheckTime(DateTime.now()));
+
+          unawaited(svc.initialize());
+          async.flushMicrotasks();
+
+          expect(updater.checkCalls, 0);
+          expect(webUIStorage.updateCalls, 1);
+          expect(pluginSourceService.updateCalls, 1);
+          expect(svc.availableUpdate, isNull);
+          expect(svc.hasAvailableUpdate, isFalse);
+          expect(svc.currentState.phase, AppUpdatePhase.idle);
+
+          async.elapse(const Duration(hours: 12));
+          async.flushMicrotasks();
+
+          expect(updater.checkCalls, 0);
+          expect(webUIStorage.updateCalls, 2);
+          expect(pluginSourceService.updateCalls, 2);
+          expect(svc.availableUpdate, isNull);
+          expect(svc.hasAvailableUpdate, isFalse);
+          expect(svc.currentState.phase, AppUpdatePhase.idle);
+          svc.dispose();
+        });
+      },
+    );
+
+    test('requestCheck cannot create an application update', () async {
+      final svc = build(externallyManaged: true);
+      updater.nextCheck = _update();
+
+      await svc.requestCheck();
+
+      expect(updater.checkCalls, 0);
+      expect(svc.availableUpdate, isNull);
+      expect(svc.hasAvailableUpdate, isFalse);
+      expect(svc.currentState.phase, AppUpdatePhase.idle);
+      svc.dispose();
+    });
+  });
+
   group('requestCheck', () {
     test('coalesces while a check is in flight', () async {
       final svc = build();
@@ -345,6 +450,25 @@ void main() {
   });
 
   group('managed content', () {
+    test(
+      'a recent app check skips startup application and content updates',
+      () async {
+        final svc = build();
+        updater.nextCheck = _update();
+        await settingsService.setLastUpdateCheckTime(DateTime.now());
+
+        await svc.initialize();
+
+        expect(updater.checkCalls, 0);
+        expect(webUIStorage.updateCalls, 0);
+        expect(pluginSourceService.updateCalls, 0);
+        expect(svc.availableUpdate, isNull);
+        expect(svc.hasAvailableUpdate, isFalse);
+        expect(svc.currentState.phase, AppUpdatePhase.idle);
+        svc.dispose();
+      },
+    );
+
     test('enabling automatic checks also updates managed plugins', () async {
       final svc = build();
 
@@ -360,6 +484,7 @@ void main() {
       await svc.enableAutomaticChecks();
 
       expect(pluginSourceService.updateCalls, 1);
+      expect(webUIStorage.updateCalls, 1);
       svc.dispose();
     });
   });


### PR DESCRIPTION
## Summary

- Treat `BuildInfo.appStore` builds as externally managed in `UpdateCheckService`.
- Keep skin and plugin updates running while suppressing GitHub application checks.
- Preserve existing recent-check throttling for ordinary builds.
- Hide non-Sparkle application update controls in Settings and clarify managed-content wording.

## Linked Issue

Fixes #725

## Verification

- Regression tests added in `test/update_check_service_test.dart` and `test/settings/settings_view_updates_test.dart`.
- Focused update/settings/handler/updater tests: 57 passed.
- `flutter test --dart-define=APP_STORE=true test/update_check_service_test.dart`: 25 passed.
- Full `flutter test`: 3904 passed, 1 skipped.
- `flutter analyze`: clean.
- `dart format lib test`: clean.

## Impact

- App Store/external builds no longer query GitHub for application updates or expose misleading application-update controls.
- Skin/plugin automatic updates remain enabled and continue on startup and timer intervals for externally managed builds, while ordinary recent-check throttling is unchanged.
- Android/GitHub updater behavior and macOS Sparkle behavior remain unchanged.
- No API, protocol, domain, migration, release workflow, or documentation contract changes.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->

