### PR TITLE
Plugin BLE binding and Sensor discovery checkpoint

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -443,6 +443,34 @@ stalled write resume later and overwrite a newer one. Bound the actual
 unbounded read instead; a real anti-wedge mechanism needs explicit
 cancellation or fencing.
 
+## Plugin BLE Binding (#809 Checkpoint)
+
+`PluginBleBinding` reserves the physical ID before transport creation and owns a
+fresh `PluginBleSession` per connect. Factory metadata has no mutable publication
+target: all publication and GATT closures capture a session capability. Do not
+move those closures onto a persistent factory object when adding Scale protocols.
+
+Retirement and native teardown are different boundaries. The session fences normal
+operations immediately, permits only bounded cleanup reads/writes, then awaits
+`disconnectConfirmed`. If confirmation times out, retain the physical claim. A
+caller-facing timeout must never imply that the native link has closed.
+`BleAdmissionTransport` applies the same physical exclusion to native candidates;
+discarding a candidate which never reserved ownership must not disconnect another
+owner's link.
+
+Discovery records whole observations before its native empty-name gate. System
+metadata is incomplete; it cannot erase complete advertisements. Observations
+arriving during async candidate creation are replayed and admission rechecks the
+current registry/evidence. Watch filter changes use the existing scan owner rather
+than a second scanner. Initial loader settlement gates native fallback.
+
+Real-JS integration fixtures are in `test/plugins/plugin_manager_ble_test.dart`,
+`plugin_ble_native_bridge_test.dart`, and `plugin_ble_sensor_api_test.dart`. The
+last drives actual HTTP/WebSocket clients through DeviceController, SensorController,
+the JS bridge, and a fake GATT edge. Native bridge coverage uses
+UniversalBleTransport to prove CCCD reset and write-property error behavior.
+These checks do not replace hardware or Scale timing acceptance.
+
 ## Keeping Notes Fresh
 
 Add lessons that would have saved debugging time: new footguns, thread-safety constraints, connection-lifecycle changes, non-obvious symptoms, and cross-transport dependencies. Prune stale claims. Prefer fewer, sharper notes over long background.

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -469,6 +469,11 @@ arriving during async candidate creation are replayed and admission rechecks the
 current registry/evidence. Watch filter changes use the existing scan owner rather
 than a second scanner. Initial loader settlement gates native fallback.
 
+Every scan-generation advance also resets evidence, observations, ownership
+decisions, and queued observation work. Watch stop and adapter recovery are
+generation boundaries too; otherwise fresh Apple quick-connect system evidence
+is rejected by the previous cache generation.
+
 Real-JS integration fixtures are in `test/plugins/plugin_manager_ble_test.dart`,
 `plugin_ble_native_bridge_test.dart`, and `plugin_ble_sensor_api_test.dart`. The
 last drives actual HTTP/WebSocket clients through DeviceController, SensorController,

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -458,6 +458,11 @@ caller-facing timeout must never imply that the native link has closed.
 discarding a candidate which never reserved ownership must not disconnect another
 owner's link.
 
+Plugin arbitration uses the native cache's identity-fenced eviction and adoption
+helpers. Cache eviction never disconnects a native candidate. Plugin candidate
+retirement rechecks binding occupancy and physical claims after asynchronous
+listener cancellation; active or unconfirmed-teardown bindings remain owned.
+
 Discovery records whole observations before its native empty-name gate. System
 metadata is incomplete; it cannot erase complete advertisements. Observations
 arriving during async candidate creation are replayed and admission rechecks the

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -1653,6 +1653,10 @@ and remembered native quick-connect. Initial scanning waits for plugin loading
 to settle, including failed or disabled plugins. Factories do not perform
 hardware initialization during registration.
 
+On Apple platforms, remembered quick-connect records fresh system-device names
+and services before arbitration, with service evidence still incomplete. Persisted
+remembered names are not fresh ownership evidence on any platform.
+
 One definite plugin match wins only when no other matcher is unresolved. Multiple
 definite matches conflict; missing or incomplete required evidence stays pending.
 A complete observation proving a required field absent is a definite non-match.

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -1645,6 +1645,33 @@ sequence as normal connection. It receives the same generation and
 device protections — a stale init from an adopted machine is rejected
 identically.
 
+## Plugin BLE Ownership
+
+The existing BLE discovery service arbitrates plugin ownership before native
+matching, including nameless advertisements, system results, background watch,
+and remembered native quick-connect. Initial scanning waits for plugin loading
+to settle, including failed or disabled plugins. Factories do not perform
+hardware initialization during registration.
+
+One definite plugin match wins only when no other matcher is unresolved. Multiple
+definite matches conflict; missing or incomplete required evidence stays pending.
+A complete observation proving a required field absent is a definite non-match.
+Pending and conflict exclude native fallback and remain visible in BLE diagnostics
+through the normal scan deadline. Evidence is generation-scoped and replaced as
+whole observations, never merged across packets.
+
+Loading or unloading a driver re-evaluates unconnected candidates. Occupied links
+keep their ownership until teardown; native admission and plugin admission both
+reserve the normalized physical ID before connecting. A failed plugin handshake
+does not trigger native fallback in the same attempt. A timed-out teardown retains
+the claim until native disconnection is confirmed. Adapter loss revokes sessions
+without attempting protocol cleanup over a lost link.
+
+Plugin Sensors join the existing SensorController and REST/WebSocket APIs. Their
+public IDs include plugin, driver, and physical identity. Remembered plugin IDs
+are not reconstructed through native quick-connect: fresh discovery must establish
+current ownership. See `doc/Plugins.md` for the session-bound GATT contract.
+
 ## Glossary
 
 - **BLE:** Bluetooth Low Energy, wireless protocol for IoT devices

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -712,8 +712,71 @@ is not remembered across app restarts. On plugin unload, Decaid runs each
 device's `disconnect()` handler, removes every device, and rejects in-flight
 commands owned by the retiring generation, even if `onUnload()` fails. Late
 publications and command results from older generations
-are ignored. BLE-backed drivers, discovery, probing and grinder registration are
-not supported by this first sensor registration contract.
+are ignored. BLE-backed drivers use the separate binding contract below;
+probing and grinder registration are not supported.
+
+### BLE Driver Binding (`host.devices.bindDriver`)
+
+Declare a BLE matcher and `transport.ble` permission, then bind its factory from
+`onLoad()`. Binding does not open a connection or register a synthetic device.
+The existing scanner selects physical candidates before invoking the factory.
+
+```json
+{
+  "permissions": ["transport.ble"],
+  "drivers": [{
+    "id": "humidity",
+    "type": "sensor",
+    "ble": {"match": {"serviceUuids": ["180f"]}}
+  }]
+}
+```
+
+`await host.devices.bindDriver('humidity', {create(device) { ... }})` binds one
+factory per plugin generation. `create` must synchronously return `connect`,
+`disconnect`, and `execute` handlers plus Sensor `vendor`, `dataChannels`, and
+`commands` metadata using the schema above. Async factories are rejected: all
+hardware initialization belongs in `connect(context)`. The frozen factory input
+contains `id`, `name`, and `advertisement` (`name`, `nameComplete`, `serviceUuids`,
+`servicesComplete`). It has no publication or GATT authority.
+
+The public ID is `plugin:<pluginId>:<driverId>:<normalizedPhysicalId>`, stable
+across reloads and reconnects. Sensor inventory, commands, and snapshots use the
+existing REST/WebSocket paths. Each connection receives a fresh context:
+
+- `context.publish(snapshot)` and `context.reportDisconnected()` belong only to
+  that connection. Retaining a context cannot authorize a replacement session.
+- `context.gatt.discoverServices()` returns normalized 128-bit service UUIDs.
+- `read(service, characteristic)` returns base64 bytes.
+- `writeWithResponse(service, characteristic, base64)` and
+  `writeWithoutResponse(service, characteristic, base64)` select acknowledgement
+  explicitly. Unsupported acknowledged writes are not silently downgraded.
+- `subscribe(service, characteristic, callback)` returns an object with an async
+  `unsubscribe()`. The callback receives base64 bytes and may run before subscribe
+  resolves. Replacing the same tuple resets native notifications; the old logical
+  unsubscribe cannot remove the replacement.
+- `onDisconnect(callback)` installs one terminal listener for the session.
+
+These GATT methods are on `context.gatt`. UUID input accepts Bluetooth aliases
+but native calls always use 128-bit UUIDs. Resolving `connect` declares protocol
+readiness. `disconnect({gatt})` receives separate, bounded cleanup authority for
+discover/read/write only. Link loss or adapter revocation skips protocol cleanup.
+After retirement, normal GATT calls and publications fail even if a JavaScript
+Promise never settles. Physical ownership remains reserved until native teardown
+is confirmed; a cleanup deadline alone cannot authorize another connection.
+
+Limits per session are 16 pending GATT operations, 8 subscriptions, 256 queued
+notification events / 64 KiB, and 16 KiB per read or write. Notification overflow
+retires the session rather than dropping protocol data silently. Production permits
+one active physical binding per plugin generation. Definitions and Sensor payloads
+retain the 64 KiB JSON limit. Bridge failures carry `code`, including
+`stale_session`, `permission_denied`, `resource_limit`, `attribute_unavailable`,
+`link_lost`, and `timeout`; other native BLE codes are preserved.
+
+BLE Scale bindings reuse the Scale adapter and declared capability checks. The
+current checkpoint proves the Sensor path with a fake BLE edge; Bookoo hardware,
+Scale timing acceptance, automatic optional Scale operations, and sleep policy
+remain #809 follow-up work.
 
 ## Plugin Lifecycle
 

--- a/doc/plans/archive/issue-809-ble-sensor/binding-and-discovery.md
+++ b/doc/plans/archive/issue-809-ble-sensor/binding-and-discovery.md
@@ -1,0 +1,55 @@
+# BLE binding and Sensor checkpoint
+
+Status: draft checkpoint. Follows merged PR #813; does not complete #809.
+Baseline: 4939dbb799c60ddf47a7db0a0388859201af572e (origin/main).
+Branch: odev/issue-809-ble-sensor-checkpoint.
+Contract: #809 and the assignment amendments A-D, reviewed 2026-09-08.
+The user authorized a new checkpoint and a draft PR instead of the assignment's
+original single-PR delivery. Existing unrelated work remains untouched.
+
+## Design
+
+Reuse PluginBleRegistry, PluginBleSession, PluginDeviceService and the existing
+manager invocation bridge. One host-owned binding holds immutable physical and
+driver identity; each connection creates a new GATT session. Sensor and Scale
+adapters compose the binding rather than placing protocol logic in discovery.
+
+The factory runs once per candidate binding and returns handlers plus Sensor
+metadata (vendor, dataChannels, commands). It receives frozen identity and
+advertisement metadata, not GATT authority. Publication and failure methods are
+provided only on the connection context, as required by amendment C; persistent
+factory metadata cannot redirect an old callback into a replacement session.
+Cleanup receives a distinct GATT context with invocation-scoped authority.
+
+Discovery retains its scanner and scan ownership. Whole observations enter the
+generation-owned evidence cache before the native empty-name gate. All paths,
+including system results, background scans and remembered native connections,
+arbitrate against the same registry. Registry changes reconcile unconnected
+candidates; occupied connections remain stable. Connection admission rechecks
+current ownership, and physical exclusion survives unconfirmed native teardown.
+
+Startup waits for initial loader settlement, including failed/disabled plugins.
+Factory registration cannot wait on hardware. Unload and shutdown retire sessions
+before clearing callbacks; forced process death has no Dart cleanup guarantee.
+
+## Verification
+
+The real-JS tests cover advertisement -> existing selection -> factory/connect ->
+fake GATT -> Sensor inventory, commands, and WebSocket snapshots. Discovery tests
+cover both evidence orders, conflicts/pending deadline, startup settlement after
+load failure, driver load/unload, native admission fencing, and failed-handshake
+exclusion. Lifecycle tests cover permanently suspended initialization, throwing
+and hanging cleanup, unconfirmed teardown, stale authority, production capacity,
+injected two-device isolation, and link-loss/revocation terminal delivery.
+
+UniversalBleTransport integration proves native CCCD reset, logical subscription
+replacement, missing-attribute errors, cancellation, and no acknowledged-write
+downgrade. Existing Scale and non-BLE Sensor tests remain part of the full suite.
+
+Broad timing/interleaving fuzzing, exhaustive reload-during-selection coverage,
+and physical BLE acceptance remain merge-readiness work. The PR records the final
+format, analysis, full-test, native-build, and runtime-smoke evidence.
+
+Bookoo protocol/hardware, Scale measurement timing acceptance, optional automatic
+Scale operations and sleep policy remain subsequent #809 checkpoints, not claims
+of this draft. Existing Scale and non-BLE Sensor compatibility must remain green.

--- a/doc/plans/archive/issue-809-ble-sensor/binding-and-discovery.md
+++ b/doc/plans/archive/issue-809-ble-sensor/binding-and-discovery.md
@@ -1,6 +1,7 @@
 # BLE binding and Sensor checkpoint
 
-Status: draft checkpoint. Follows merged PR #813; does not complete #809.
+Status: review-ready BLE binding and Sensor checkpoint (#820). Follows merged
+PR #813; does not complete #809.
 Baseline: 4939dbb799c60ddf47a7db0a0388859201af572e (origin/main).
 Branch: odev/issue-809-ble-sensor-checkpoint.
 Contract: #809 and the assignment amendments A-D, reviewed 2026-09-08.
@@ -47,9 +48,14 @@ replacement, missing-attribute errors, cancellation, and no acknowledged-write
 downgrade. Existing Scale and non-BLE Sensor tests remain part of the full suite.
 
 Broad timing/interleaving fuzzing, exhaustive reload-during-selection coverage,
-and physical BLE acceptance remain merge-readiness work. The PR records the final
+and physical BLE acceptance remain broader #809 acceptance work, not claims of
+this checkpoint. The PR records the final
 format, analysis, full-test, native-build, and runtime-smoke evidence.
 
 Bookoo protocol/hardware, Scale measurement timing acceptance, optional automatic
 Scale operations and sleep policy remain subsequent #809 checkpoints, not claims
-of this draft. Existing Scale and non-BLE Sensor compatibility must remain green.
+of #820. Its merge boundary is host-owned BLE arbitration/lifecycle and Sensor
+integration through existing controllers and APIs, verified with a fake BLE edge.
+Contract tests preserve an occupied native owner until normal teardown and keep
+loaded declarations without runtime bindings native-eligible.
+Existing Scale and non-BLE Sensor compatibility must remain green.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -280,9 +280,12 @@ void main(List<String> args) async {
 
   final List<DeviceDiscoveryService> services = [];
   final pluginDeviceService = PluginDeviceService();
+  late final PluginLoaderService pluginService;
   services.add(pluginDeviceService);
 
-  final bleDiscoveryService = UniversalBleDiscoveryService();
+  final bleDiscoveryService = UniversalBleDiscoveryService(
+    pluginBleService: () => pluginService.pluginManager.bleService,
+  );
   if (!cliArgs.serial) {
     services.add(bleDiscoveryService);
   } else {
@@ -502,7 +505,7 @@ void main(List<String> args) async {
   };
   webUIService.skinProxyTokenRevoker = proxyTokenService.revokeSkinToken;
 
-  final PluginLoaderService pluginService = PluginLoaderService(
+  pluginService = PluginLoaderService(
     kvStore: HiveStoreService(defaultNamespace: "plugins")..initialize(),
     decentProxyService: decentProxyService,
     credentialStore: credentialStore,

--- a/lib/src/controllers/sensor_controller.dart
+++ b/lib/src/controllers/sensor_controller.dart
@@ -32,7 +32,19 @@ class SensorController {
       ..clear()
       ..addEntries(sensors.map((s) => MapEntry(s.deviceId, s)));
     _publishSensors();
-    await Future.wait(sensors.map((s) => s.onConnect()));
+    await Future.wait(
+      sensors.map((sensor) async {
+        try {
+          await sensor.onConnect();
+        } catch (error, stackTrace) {
+          _log.warning(
+            'Sensor connect failed: ${sensor.deviceId}',
+            error,
+            stackTrace,
+          );
+        }
+      }),
+    );
   }
 
   Future<void> register(Sensor sensor) async {

--- a/lib/src/plugins/plugin_ble_binding.dart
+++ b/lib/src/plugins/plugin_ble_binding.dart
@@ -1,0 +1,200 @@
+import 'dart:async';
+
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+
+import 'plugin_ble_registry.dart';
+import 'plugin_ble_session.dart';
+import 'plugin_bound_sensor.dart';
+import 'plugin_device_contract.dart';
+import 'plugin_manifest.dart';
+import 'plugin_scale.dart';
+
+class PluginBleBinding {
+  final PluginBleRegistry registry;
+  final PluginBleDriver driver;
+  final String physicalId;
+  final String handle;
+  final BLETransport Function() createTransport;
+  final bool Function() admit;
+  final bool Function() runtimeAlive;
+  final PluginDeviceInvoker invokeHandler;
+  final Future<void> Function(Map<String, dynamic>) eventSink;
+  final Duration invocationTimeout;
+  late final PluginDeviceAdapter device;
+  PluginBleSession? _session;
+  String? _domainSession;
+  bool _disposed = false;
+  Future<void>? _disposal;
+
+  PluginBleBinding({
+    required this.registry,
+    required this.driver,
+    required this.physicalId,
+    required this.handle,
+    required this.createTransport,
+    required this.admit,
+    required this.runtimeAlive,
+    required this.invokeHandler,
+    required this.eventSink,
+    required this.invocationTimeout,
+    required String name,
+    required Map<String, dynamic> definition,
+  }) {
+    final publicId =
+        'plugin:${driver.pluginId}:${driver.declaration.id}:$physicalId';
+    device = driver.declaration.type == PluginDriverType.sensor
+        ? PluginBoundSensor(
+            deviceId: publicId,
+            name: name,
+            invoke: invoke,
+            transportType: TransportType.ble,
+            onReady: () => _session!.markReady(),
+            invocationTimeout: invocationTimeout,
+            definition: definition,
+          )
+        : PluginScale(
+            deviceId: publicId,
+            name: name,
+            invoke: invoke,
+            transportType: TransportType.ble,
+            onReady: () => _session!.markReady(),
+            invocationTimeout: invocationTimeout,
+            capabilities: driver.declaration.capabilities,
+          );
+  }
+
+  bool get occupied =>
+      _session != null && _session!.state != PluginBleSessionState.closed;
+
+  void revoke() => _session?.revoke();
+
+  Future<Map<String, dynamic>> invoke(
+    PluginDeviceOperation operation,
+    Map<String, dynamic> payload,
+  ) async {
+    if (operation == PluginDeviceOperation.disconnect) {
+      final session = _session;
+      _domainSession = null;
+      if (session != null) {
+        await session.retire(
+          cleanup: (authority) async {
+            await invokeHandler(operation, {'gattSession': authority});
+          },
+        );
+        await session.closed.timeout(invocationTimeout);
+      }
+      return const {};
+    }
+    if (_disposed || !registry.isCurrent(driver) || !runtimeAlive()) {
+      throw const PluginBleException('stale_session', 'BLE binding retired');
+    }
+    if (operation != PluginDeviceOperation.connect) {
+      final session = _session;
+      if (session == null || session.state != PluginBleSessionState.ready) {
+        throw const PluginBleException(
+          'stale_session',
+          'BLE device is not ready',
+        );
+      }
+      final result = await invokeHandler(operation, payload);
+      if (!identical(_session, session) || !session.acceptsPublications) {
+        throw const PluginBleException('stale_session', 'BLE command retired');
+      }
+      return result;
+    }
+    if (occupied) {
+      throw const PluginBleException(
+        'resource_limit',
+        'BLE teardown is pending',
+      );
+    }
+    if (!admit()) {
+      throw const PluginBleException('stale_session', 'BLE ownership changed');
+    }
+    final PluginBleClaim claim;
+    try {
+      claim = registry.reserve(driver, physicalId);
+    } on StateError catch (error) {
+      throw PluginBleException('resource_limit', error.message);
+    }
+    final PluginBleSession session;
+    try {
+      session = PluginBleSession(
+        transport: createTransport(),
+        authorized: () => registry.isCurrent(driver),
+        runtimeAlive: runtimeAlive,
+        cleanupTimeout: invocationTimeout,
+        eventSink: (event) async {
+          if (event['type'] == 'disconnect') {
+            final domainSession = _domainSession;
+            if (domainSession != null) {
+              device.reportDisconnected(session: domainSession);
+            }
+          }
+          await eventSink(event);
+        },
+      );
+    } catch (_) {
+      registry.release(claim);
+      rethrow;
+    }
+    _session = session;
+    _domainSession = payload['session'] as String;
+    unawaited(session.closed.then((_) => registry.release(claim)));
+    await session.connect();
+    try {
+      return await invokeHandler(operation, {
+        ...payload,
+        'gattSession': session.id,
+      });
+    } catch (_) {
+      await session.retire();
+      rethrow;
+    }
+  }
+
+  Future<Object?> call(
+    String authority,
+    String operation,
+    Map<String, dynamic> args,
+  ) {
+    final session = _session;
+    if (session == null) {
+      throw const PluginBleException('stale_session', 'Unknown BLE session');
+    }
+    return session.call(authority, operation, args);
+  }
+
+  void publish(Map<String, dynamic> snapshot, String? domainSession) {
+    _checkPublication(domainSession);
+    device.publish(snapshot, session: domainSession);
+  }
+
+  void reportDisconnected(String? domainSession) {
+    _checkPublication(domainSession);
+    device.reportDisconnected(session: domainSession);
+  }
+
+  void _checkPublication(String? domainSession) {
+    if (domainSession == null ||
+        domainSession != _domainSession ||
+        _session?.acceptsPublications != true) {
+      throw const PluginBleException(
+        'stale_session',
+        'BLE publication retired',
+      );
+    }
+  }
+
+  Future<void> dispose() => _disposal ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    try {
+      await device.disconnect();
+    } finally {
+      await device.dispose();
+    }
+  }
+}

--- a/lib/src/plugins/plugin_ble_bridge.dart
+++ b/lib/src/plugins/plugin_ble_bridge.dart
@@ -1,0 +1,124 @@
+const pluginBleBridgeJs = r'''
+const __bindBleDriver = (driverId, factory) => {
+  if (!factory || typeof factory.create !== 'function') {
+    return Promise.reject(new Error('bindDriver requires create(device)'));
+  }
+  const factoryHandle = 'factory_' + pluginGeneration + '_' + __deviceNonce + '_' + (++__deviceSeq);
+  const create = payload => {
+    const metadata = payload.device;
+    if (metadata.advertisement.serviceUuids) Object.freeze(metadata.advertisement.serviceUuids);
+    Object.freeze(metadata.advertisement);
+    Object.freeze(metadata);
+    const handlers = factory.create(metadata);
+    if (!handlers || typeof handlers !== 'object' || typeof handlers.then === 'function') {
+      throw new Error('BLE create must return handlers synchronously, without hardware initialization');
+    }
+    if (typeof handlers.connect !== 'function' || typeof handlers.disconnect !== 'function') {
+      throw new Error('BLE connect and disconnect handlers are required');
+    }
+    const handle = payload.registrationHandle;
+    const sessions = new Map();
+    const cleanups = new Set();
+    const stale = () => Object.assign(new Error('BLE session retired'), {code: 'stale_session'});
+    const context = (payload, cleanup) => {
+      const authority = payload.gattSession;
+      const callbacks = new Map();
+      const record = { callbacks, disconnected: false, delivered: false, onDisconnect: null };
+      if (!cleanup) sessions.set(authority, record);
+      else cleanups.add(record);
+      const call = (operation, args = {}) => record.disconnected
+        ? Promise.reject(stale()) : __deviceCall('gatt', {
+        registrationHandle: handle, authority, operation, args
+      }).then(result => result.value);
+      const gatt = Object.freeze({
+        discoverServices: () => call('discoverServices'),
+        read: (service, characteristic) => call('read', {service, characteristic}),
+        writeWithResponse: (service, characteristic, data) =>
+          call('write', {service, characteristic, data, withResponse: true}),
+        writeWithoutResponse: (service, characteristic, data) =>
+          call('write', {service, characteristic, data, withResponse: false}),
+        async subscribe(service, characteristic, callback) {
+          if (typeof callback !== 'function') throw new Error('subscribe requires a callback');
+          const listener = 'listener_' + (++__deviceSeq);
+          callbacks.set(listener, callback);
+          try {
+            const result = await call('subscribe', {service, characteristic, listener});
+            if (result.replacedListener) callbacks.delete(result.replacedListener);
+            return Object.freeze({
+              async unsubscribe() {
+                await call('unsubscribe', {subscription: result.subscription});
+                callbacks.delete(listener);
+              }
+            });
+          } catch (error) {
+            callbacks.delete(listener);
+            throw error;
+          }
+        },
+        onDisconnect(callback) {
+          if (cleanup || typeof callback !== 'function') throw new Error('Invalid disconnect listener');
+          if (record.disconnected) {
+            if (!record.delivered) { record.delivered = true; callback(); }
+            return;
+          }
+          record.onDisconnect = callback;
+        }
+      });
+      if (cleanup) return Object.freeze({gatt});
+      return Object.freeze({
+        gatt,
+        publish: snapshot => record.disconnected ? Promise.reject(stale()) : __deviceCall('blePublish', {
+          registrationHandle: handle, session: payload.session, snapshot
+        }),
+        reportDisconnected: () => record.disconnected ? Promise.reject(stale()) : __deviceCall('bleDisconnected', {
+          registrationHandle: handle, session: payload.session
+        })
+      });
+    };
+    const boundHandlers = {...handlers};
+    boundHandlers.disconnect = payload => handlers.disconnect(context(payload, true));
+    boundHandlers.bleEvent = async event => {
+      const record = sessions.get(event.session);
+      if (!record) return;
+      if (event.type === 'disconnect') {
+        if (record.disconnected) return;
+        record.disconnected = true;
+        record.callbacks.clear();
+        for (const cleanup of cleanups) cleanup.disconnected = true;
+        cleanups.clear();
+        sessions.delete(event.session);
+        const callback = record.onDisconnect;
+        record.onDisconnect = null;
+        if (callback) { record.delivered = true; await callback(); }
+        return;
+      }
+      const callback = record.callbacks.get(event.listener);
+      if (callback && !record.disconnected) await callback(event.data);
+    };
+    __deviceSetHandlers(handle, {
+      pluginId, generation: pluginGeneration, bridgeToken: pluginBridgeToken,
+      handlers: boundHandlers,
+      connectTransport: (_, payload) => context(payload, false),
+      dispose: () => {
+        for (const record of sessions.values()) {
+          record.disconnected = true;
+          record.callbacks.clear();
+          record.onDisconnect = null;
+        }
+        for (const cleanup of cleanups) cleanup.disconnected = true;
+        cleanups.clear();
+        sessions.clear();
+      }
+    });
+    return {vendor: handlers.vendor, dataChannels: handlers.dataChannels, commands: handlers.commands};
+  };
+  __deviceSetHandlers(factoryHandle, {
+    pluginId, generation: pluginGeneration, bridgeToken: pluginBridgeToken,
+    handlers: {create}
+  });
+  return __deviceCall('bindDriver', {registrationHandle: factoryHandle, driverId}).then(
+    () => undefined,
+    error => { __deviceRemoveHandlers(factoryHandle); throw error; }
+  );
+};
+''';

--- a/lib/src/plugins/plugin_ble_registry.dart
+++ b/lib/src/plugins/plugin_ble_registry.dart
@@ -105,12 +105,41 @@ class PluginBleRegistry {
   final int activeBindingLimit;
   final Map<String, PluginBleDriver> _drivers = {};
   final Map<String, PluginBleClaim> _claims = {};
+  final Map<String, Object> _nativeClaims = {};
+  final Completer<void> _ready = Completer<void>();
   final StreamController<int> _changes = StreamController.broadcast();
   int _revision = 0;
   bool _closed = false;
+  bool _acceptingConnections = true;
 
-  PluginBleRegistry({this.activeBindingLimit = 1}) {
+  PluginBleRegistry({this.activeBindingLimit = 1, bool initiallyReady = true}) {
     if (activeBindingLimit < 1) throw ArgumentError.value(activeBindingLimit);
+    if (initiallyReady) _ready.complete();
+  }
+
+  Future<void> get ready => _ready.future;
+  bool get acceptingConnections => !_closed && _acceptingConnections;
+  void stopConnections() => _acceptingConnections = false;
+  void finishInitialLoading() {
+    if (!_ready.isCompleted) _ready.complete();
+  }
+
+  bool isClaimed(String physicalId) =>
+      _claims.containsKey(normalizeBleDeviceId(physicalId)) ||
+      _nativeClaims.containsKey(normalizeBleDeviceId(physicalId));
+
+  Object reserveNative(String physicalId) {
+    if (!acceptingConnections || isClaimed(physicalId)) {
+      throw StateError('Physical BLE device is owned or registry closed');
+    }
+    final claim = Object();
+    _nativeClaims[normalizeBleDeviceId(physicalId)] = claim;
+    return claim;
+  }
+
+  void releaseNative(String physicalId, Object claim) {
+    final id = normalizeBleDeviceId(physicalId);
+    if (identical(_nativeClaims[id], claim)) _nativeClaims.remove(id);
   }
 
   Stream<int> get changes => _changes.stream;
@@ -184,8 +213,10 @@ class PluginBleRegistry {
 
   PluginBleClaim reserve(PluginBleDriver driver, String physicalId) {
     final key = normalizeBleDeviceId(physicalId);
-    if (!isCurrent(driver)) throw StateError('Stale BLE driver');
-    if (_claims.containsKey(key)) {
+    if (!acceptingConnections || !isCurrent(driver)) {
+      throw StateError('Stale BLE driver');
+    }
+    if (isClaimed(key)) {
       throw StateError('Physical BLE device is owned');
     }
     if (_claims.values
@@ -217,6 +248,7 @@ class PluginBleRegistry {
   Future<void> dispose() async {
     if (_closed) return;
     _closed = true;
+    finishInitialLoading();
     _drivers.clear();
     await _changes.close();
   }

--- a/lib/src/plugins/plugin_ble_service.dart
+++ b/lib/src/plugins/plugin_ble_service.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/services/ble/ble_lifecycle_gate.dart';
+import 'package:uuid/uuid.dart';
+
+import 'plugin_ble_binding.dart';
+import 'plugin_ble_registry.dart';
+import 'plugin_ble_session.dart';
+import 'plugin_device_contract.dart';
+import 'plugin_manifest.dart';
+
+typedef PluginBleInvoker =
+    Future<Map<String, dynamic>> Function(
+      PluginBleDriver driver,
+      String handle,
+      PluginDeviceOperation operation,
+      Map<String, dynamic> payload,
+    );
+
+class PluginBleService {
+  final PluginBleRegistry registry;
+  final PluginBleInvoker invoke;
+  final bool Function(PluginBleDriver) runtimeAlive;
+  final bool Function(PluginBleDriver, String, String) hasHandler;
+  final Future<void> Function(PluginBleDriver, String, Map<String, dynamic>)
+  eventSink;
+  final void Function(String) removeHandlers;
+  final Duration invocationTimeout;
+  final Map<String, PluginBleBinding> _bindings = {};
+  bool _disposed = false;
+
+  PluginBleService({
+    required this.registry,
+    required this.invoke,
+    required this.runtimeAlive,
+    required this.hasHandler,
+    required this.eventSink,
+    required this.removeHandlers,
+    required this.invocationTimeout,
+  });
+
+  int get bindingCount => _bindings.length;
+
+  void revokeSessions() {
+    for (final binding in _bindings.values) {
+      binding.revoke();
+    }
+  }
+
+  bool matchesCandidate(Device device, PluginBleDriver driver) =>
+      _bindings.values.any(
+        (binding) =>
+            identical(binding.device, device) &&
+            identical(binding.driver, driver),
+      );
+
+  Future<Device> createCandidate({
+    required PluginBleDriver driver,
+    required String physicalId,
+    required BleAdvertisementEvidence evidence,
+    required BLETransport Function() createTransport,
+    required bool Function() admit,
+  }) async {
+    if (_disposed || !registry.isCurrent(driver)) {
+      throw const PluginBleException('stale_session', 'BLE driver retired');
+    }
+    final id = normalizeBleDeviceId(physicalId);
+    for (final binding in _bindings.values) {
+      if (identical(binding.driver, driver) && binding.physicalId == id) {
+        return binding.device;
+      }
+    }
+    final handle = 'ble_${const Uuid().v4()}';
+    try {
+      final definition = await invoke(
+        driver,
+        driver.factoryHandle,
+        PluginDeviceOperation.create,
+        {
+          'registrationHandle': handle,
+          'device': {
+            'id': 'plugin:${driver.pluginId}:${driver.declaration.id}:$id',
+            'name': evidence.name ?? driver.declaration.id,
+            'advertisement': {
+              'name': evidence.name,
+              'nameComplete': evidence.nameComplete,
+              'serviceUuids': evidence.serviceUuids,
+              'servicesComplete': evidence.servicesComplete,
+            },
+          },
+        },
+      );
+      if (_disposed || !registry.isCurrent(driver) || !admit()) {
+        throw const PluginBleException(
+          'stale_session',
+          'BLE candidate retired',
+        );
+      }
+      if (utf8.encode(jsonEncode(definition)).length > 64 * 1024) {
+        throw const PluginBleException(
+          'resource_limit',
+          'BLE definition exceeds 64 KiB',
+        );
+      }
+      final required = {
+        'connect',
+        'disconnect',
+        'bleEvent',
+        if (driver.declaration.type == PluginDriverType.sensor) 'execute',
+        if (driver.declaration.capabilities.contains(
+          PluginScaleCapability.tare,
+        ))
+          'tare',
+        if (driver.declaration.capabilities.contains(
+          PluginScaleCapability.timerControl,
+        )) ...[
+          'startTimer',
+          'stopTimer',
+          'resetTimer',
+        ],
+        if (driver.declaration.capabilities.contains(
+          PluginScaleCapability.displayControl,
+        )) ...[
+          'sleepDisplay',
+          'wakeDisplay',
+        ],
+      };
+      for (final operation in PluginDeviceOperation.values) {
+        final name = operation.name;
+        if (hasHandler(driver, handle, name) != required.contains(name)) {
+          throw PluginBleException(
+            'invalid_argument',
+            'BLE $name handler does not match declared capabilities',
+          );
+        }
+      }
+      if (driver.declaration.type == PluginDriverType.sensor) {
+        final vendor = definition['vendor'];
+        if (vendor is! String || vendor.isEmpty || vendor.length > 128) {
+          throw const PluginBleException(
+            'invalid_argument',
+            'Invalid Sensor vendor',
+          );
+        }
+      }
+      final binding = PluginBleBinding(
+        registry: registry,
+        driver: driver,
+        physicalId: id,
+        handle: handle,
+        createTransport: createTransport,
+        admit: admit,
+        runtimeAlive: () => runtimeAlive(driver),
+        invokeHandler: (operation, payload) =>
+            invoke(driver, handle, operation, payload),
+        eventSink: (event) => eventSink(driver, handle, event),
+        invocationTimeout: invocationTimeout,
+        name: evidence.name ?? driver.declaration.id,
+        definition: definition,
+      );
+      _bindings[handle] = binding;
+      return binding.device;
+    } catch (_) {
+      removeHandlers(handle);
+      rethrow;
+    }
+  }
+
+  PluginBleBinding _binding(String pluginId, int generation, String handle) {
+    final binding = _bindings[handle];
+    if (binding == null ||
+        binding.driver.pluginId != pluginId ||
+        binding.driver.generation != generation) {
+      throw const PluginBleException('stale_session', 'Unknown BLE binding');
+    }
+    return binding;
+  }
+
+  Future<Object?> call(
+    String pluginId,
+    int generation,
+    String handle,
+    String authority,
+    String operation,
+    Map<String, dynamic> args,
+  ) => _binding(pluginId, generation, handle).call(authority, operation, args);
+
+  void publish(
+    String pluginId,
+    int generation,
+    String handle,
+    Map<String, dynamic> snapshot,
+    String? session,
+  ) => _binding(pluginId, generation, handle).publish(snapshot, session);
+
+  void reportDisconnected(
+    String pluginId,
+    int generation,
+    String handle,
+    String? session,
+  ) => _binding(pluginId, generation, handle).reportDisconnected(session);
+
+  Future<void> discardInactive(Device device) async {
+    for (final binding in _bindings.values) {
+      if (!identical(binding.device, device)) continue;
+      if (binding.occupied || registry.isClaimed(binding.physicalId)) return;
+      await discard(device);
+      return;
+    }
+  }
+
+  Future<void> discard(Device device) async {
+    final entries = _bindings.entries
+        .where((e) => identical(e.value.device, device))
+        .toList();
+    for (final entry in entries) {
+      try {
+        await entry.value.dispose();
+      } finally {
+        _bindings.remove(entry.key);
+        removeHandlers(entry.key);
+      }
+    }
+  }
+
+  Future<void> removeGeneration(String pluginId, int generation) async {
+    final bindings = _bindings.values
+        .where(
+          (b) =>
+              b.driver.pluginId == pluginId &&
+              b.driver.generation == generation,
+        )
+        .toList();
+    try {
+      await Future.wait(bindings.map((b) => discard(b.device)));
+    } finally {
+      registry.removeGeneration(pluginId, generation);
+    }
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    try {
+      await Future.wait(
+        _bindings.values.toList().map((b) => discard(b.device)),
+      );
+    } finally {
+      await registry.dispose();
+    }
+  }
+}

--- a/lib/src/plugins/plugin_ble_session.dart
+++ b/lib/src/plugins/plugin_ble_session.dart
@@ -31,9 +31,10 @@ class _BleSubscription {
   final String id = const Uuid().v4();
   final String service;
   final String characteristic;
+  final String? listener;
   final Completer<void> settled = Completer<void>();
   Future<void>? removing;
-  _BleSubscription(this.service, this.characteristic);
+  _BleSubscription(this.service, this.characteristic, this.listener);
 }
 
 class PluginBleSession {
@@ -274,7 +275,19 @@ class PluginBleSession {
             'Subscription limit reached',
           );
         }
-        final subscription = _BleSubscription(service, characteristic);
+        final listener = args['listener'];
+        if (listener != null &&
+            (listener is! String || listener.length > 128)) {
+          throw const PluginBleException(
+            'invalid_argument',
+            'Invalid BLE listener',
+          );
+        }
+        final subscription = _BleSubscription(
+          service,
+          characteristic,
+          listener as String?,
+        );
         _subscriptions[key] = subscription;
         try {
           if (previous != null) {
@@ -298,9 +311,14 @@ class PluginBleSession {
                 !acceptsPublications) {
               return;
             }
-            _enqueue(current.id, bytes);
+            _enqueue(current, bytes);
           });
-          return subscription.id;
+          return listener == null
+              ? subscription.id
+              : {
+                  'subscription': subscription.id,
+                  'replacedListener': previous?.listener,
+                };
         } catch (_) {
           if (identical(_subscriptions[key], subscription)) {
             _subscriptions.remove(key);
@@ -331,7 +349,7 @@ class PluginBleSession {
     }
   }
 
-  void _enqueue(String subscription, Uint8List bytes) {
+  void _enqueue(_BleSubscription subscription, Uint8List bytes) {
     if (_notifications.length >= maxQueuedEvents ||
         _queuedBytes + bytes.length > maxQueuedBytes) {
       _log.warning(
@@ -344,7 +362,8 @@ class PluginBleSession {
       {
         'type': 'notification',
         'session': id,
-        'subscription': subscription,
+        'subscription': subscription.id,
+        if (subscription.listener != null) 'listener': subscription.listener,
         'data': base64Encode(bytes),
       },
       bytes.length,

--- a/lib/src/plugins/plugin_bound_sensor.dart
+++ b/lib/src/plugins/plugin_bound_sensor.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+
+import 'plugin_device_service.dart';
+import 'plugin_protocol_device.dart';
+
+class PluginBoundSensor extends PluginProtocolDevice implements Sensor {
+  PluginBoundSensor({
+    required super.deviceId,
+    required super.name,
+    required super.invoke,
+    required super.transportType,
+    required super.onReady,
+    required super.invocationTimeout,
+    required Map<String, dynamic> definition,
+  }) : info = SensorInfo(
+         name: name,
+         vendor: definition['vendor'] is String
+             ? definition['vendor'] as String
+             : '',
+         dataChannels: parsePluginDataChannels(definition['dataChannels']),
+         commands: parsePluginCommands(definition['commands']),
+       );
+
+  final StreamController<Map<String, dynamic>> _data =
+      StreamController.broadcast();
+
+  @override
+  final SensorInfo info;
+  @override
+  DeviceType get type => DeviceType.sensor;
+  @override
+  Stream<Map<String, dynamic>> get data => _data.stream;
+
+  @override
+  void publish(Map<String, dynamic> snapshot, {String? session}) {
+    checkSession(session);
+    validatePluginSensorSnapshot(snapshot, {
+      for (final channel in info.dataChannels) channel.key: channel,
+    });
+    _data.add(Map.unmodifiable(snapshot));
+  }
+
+  @override
+  Future<Map<String, dynamic>> execute(
+    String commandId,
+    Map<String, dynamic>? parameters,
+  ) async {
+    if (info.commands?.any((command) => command.id == commandId) != true) {
+      throw PluginDeviceException('Unknown sensor command: $commandId');
+    }
+    validatePluginDevicePayload(parameters ?? const {}, 'Sensor command');
+    final result = await invoke(PluginDeviceOperation.execute, {
+      'commandId': commandId,
+      'params': parameters,
+    });
+    validatePluginDevicePayload(result, 'Sensor command result');
+    return result;
+  }
+
+  @override
+  Future<void> dispose() async {
+    await super.dispose();
+    if (!_data.isClosed) await _data.close();
+  }
+}

--- a/lib/src/plugins/plugin_device_contract.dart
+++ b/lib/src/plugins/plugin_device_contract.dart
@@ -5,6 +5,7 @@ enum PluginDeviceOperation {
   disconnect,
   execute,
   create,
+  bleEvent,
   tare,
   startTimer,
   stopTimer,

--- a/lib/src/plugins/plugin_device_service.dart
+++ b/lib/src/plugins/plugin_device_service.dart
@@ -444,20 +444,7 @@ class _PluginSensor implements Sensor, PluginDeviceAdapter {
   @override
   void publish(Map<String, dynamic> snapshot, {String? session}) {
     if (_disposed) throw const PluginDeviceException('Plugin device is closed');
-    if (snapshot.length != _dataChannels.length ||
-        !_dataChannels.keys.every(snapshot.containsKey)) {
-      throw const PluginDeviceException(
-        'Plugin device snapshot must contain every declared data channel',
-      );
-    }
-    for (final entry in snapshot.entries) {
-      final channel = _dataChannels[entry.key];
-      if (channel == null || !_matchesType(entry.value, channel.type)) {
-        throw PluginDeviceException(
-          'Invalid value for plugin device channel ${entry.key}',
-        );
-      }
-    }
+    validatePluginSensorSnapshot(snapshot, _dataChannels);
     _data.add(Map.unmodifiable(snapshot));
   }
 
@@ -477,6 +464,30 @@ class _PluginSensor implements Sensor, PluginDeviceAdapter {
     await _connectionState.close();
   }
 }
+
+void validatePluginSensorSnapshot(
+  Map<String, dynamic> snapshot,
+  Map<String, DataChannel> channels,
+) {
+  _checkPayloadSize(snapshot, 'Plugin device snapshot');
+  if (snapshot.length != channels.length ||
+      !channels.keys.every(snapshot.containsKey)) {
+    throw const PluginDeviceException(
+      'Plugin device snapshot must contain every declared data channel',
+    );
+  }
+  for (final entry in snapshot.entries) {
+    final channel = channels[entry.key];
+    if (channel == null || !_matchesType(entry.value, channel.type)) {
+      throw PluginDeviceException(
+        'Invalid value for plugin device channel ${entry.key}',
+      );
+    }
+  }
+}
+
+void validatePluginDevicePayload(Object payload, String name) =>
+    _checkPayloadSize(payload, name);
 
 String _requiredSafeString(Map<String, dynamic> json, String key) {
   final value = _requiredString(json, key);

--- a/lib/src/plugins/plugin_loader_service.dart
+++ b/lib/src/plugins/plugin_loader_service.dart
@@ -10,6 +10,7 @@ import 'package:reaprime/src/services/storage/app_directories.dart';
 import 'package:reaprime/src/services/storage/kv_store_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:reaprime/src/plugins/plugin_device_service.dart';
+import 'plugin_ble_registry.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_package.dart';
@@ -70,6 +71,7 @@ class PluginLoaderService {
          kvStore: kvStore,
          decentProxyService: decentProxyService,
          deviceService: deviceService,
+         bleRegistry: PluginBleRegistry(initiallyReady: false),
        );
 
   bool _initialized = false;
@@ -96,6 +98,8 @@ class PluginLoaderService {
     } catch (_) {
       _initialization = null;
       rethrow;
+    } finally {
+      pluginManager.bleService.registry.finishInitialLoading();
     }
   }
 

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -2100,7 +2100,9 @@ class PluginManager {
         const declaredDrivers = ${jsonEncode(manifest.drivers.map((driver) => driver.toJson()).toList())};
         $pluginBleBridgeJs
         const devices = {
-          bindDriver: __bindBleDriver,
+          bindDriver: ${manifest.permissions.contains(PluginPermissions.transportBle)}
+            ? __bindBleDriver
+            : () => rejectPermission("transport.ble"),
           register(definition, handlers) {
             const driver = definition && declaredDrivers.find((entry) => entry.id === definition.driverId);
             if (!driver || (driver.type !== "sensor" && driver.type !== "scale")) {

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -7,6 +7,10 @@ import 'package:flutter_js/flutter_js.dart';
 import 'package:logging/logging.dart';
 
 import 'plugin_manifest.dart';
+import 'plugin_ble_bridge.dart';
+import 'plugin_ble_registry.dart';
+import 'plugin_ble_service.dart';
+import 'plugin_ble_session.dart';
 import 'plugin_decent_proxy_bridge.dart';
 import 'plugin_device_service.dart';
 import 'plugin_runtime.dart';
@@ -18,6 +22,7 @@ import '../controllers/workflow_controller.dart';
 import '../models/device/de1_interface.dart';
 import '../models/device/machine.dart';
 import '../services/account/decent_proxy_service.dart';
+import '../services/ble/ble_exception_mapper.dart';
 
 enum _PendingOpKind { fetch, pluginHttp, decentProxy }
 
@@ -95,6 +100,7 @@ class PluginManager {
   final Duration transportCloseTimeout;
   final Duration deviceInvocationTimeout;
   final PluginDeviceService deviceService;
+  late final PluginBleService bleService;
 
   De1Controller? _de1controller;
   StreamSubscription<De1Interface?>? _de1Subscription;
@@ -122,6 +128,7 @@ class PluginManager {
   int _deviceInvocationSequence = 0;
 
   final Set<(String, int)> _deviceDisconnectCleanup = {};
+  final Map<String, Set<Future<void>>> _bleRegistrations = {};
 
   De1Controller? get de1Controller => _de1controller;
   PluginManagerLifecycle get lifecycle => _lifecycle;
@@ -151,6 +158,7 @@ class PluginManager {
     this.transportCloseTimeout = const Duration(seconds: 5),
     this.deviceInvocationTimeout = const Duration(seconds: 10),
     PluginDeviceService? deviceService,
+    PluginBleRegistry? bleRegistry,
   }) : js = js ?? getJavascriptRuntime(xhr: false),
        deviceService = deviceService ?? PluginDeviceService() {
     _decentProxyBridge = PluginDecentProxyBridge(
@@ -164,6 +172,44 @@ class PluginManager {
       connectSecureSocket: connectSecureSocket,
       closeTimeout: transportCloseTimeout,
     );
+    bleService = PluginBleService(
+      registry: bleRegistry ?? PluginBleRegistry(),
+      invocationTimeout: deviceInvocationTimeout,
+      invoke: (driver, handle, operation, payload) => _invokeDeviceHandler(
+        driver.pluginId,
+        driver.generation,
+        handle,
+        operation,
+        payload,
+      ),
+      runtimeAlive: (driver) =>
+          (_pluginGenerations[driver.pluginId] == driver.generation &&
+              _plugins[driver.pluginId]?.isAlive == true) ||
+          _isDeviceDisconnectCleanup(driver.pluginId, driver.generation),
+      hasHandler: (driver, handle, operation) =>
+          this.js
+              .evaluate(
+                'globalThis.__deviceHasHandler(${jsonEncode(handle)},'
+                '${jsonEncode(driver.pluginId)},${driver.generation},${jsonEncode(operation)})',
+              )
+              .stringResult ==
+          'true',
+      eventSink: (driver, handle, event) async {
+        await _invokeDeviceHandler(
+          driver.pluginId,
+          driver.generation,
+          handle,
+          PluginDeviceOperation.bleEvent,
+          event,
+        );
+      },
+      removeHandlers: (handle) {
+        if (_lifecycle == PluginManagerLifecycle.disposed) return;
+        this.js.evaluate(
+          'globalThis.__deviceRemoveHandlers(${jsonEncode(handle)});',
+        );
+      },
+    );
     _bootstrapJs();
   }
 
@@ -174,6 +220,7 @@ class PluginManager {
   }
 
   Future<void> dispose() {
+    bleService.registry.stopConnections();
     final existing = _disposeFuture;
     if (existing != null) return existing;
 
@@ -734,6 +781,7 @@ class PluginManager {
           __mapSet(__deviceHandlers, handle, entry);
         });
         __frozenTransportGlobal("__deviceRemoveHandlers", function (handle) {
+          __mapGet(__deviceHandlers, handle)?.dispose?.();
           __mapDelete(__deviceHandlers, handle);
         });
         __frozenTransportGlobal("__deviceHasHandler", function (handle, pluginId, generation, operation) {
@@ -811,10 +859,14 @@ class PluginManager {
         });
         __frozenTransportGlobal("__clearDeviceHandlersForPlugin", function (pluginId) {
           __mapForEach(__deviceHandlers, (entry, handle) => {
-            if (entry.pluginId === pluginId) __mapDelete(__deviceHandlers, handle);
+            if (entry.pluginId === pluginId) {
+              entry.dispose?.();
+              __mapDelete(__deviceHandlers, handle);
+            }
           });
         });
         __frozenTransportGlobal("__clearAllDeviceHandlers", function () {
+          __mapForEach(__deviceHandlers, entry => entry.dispose?.());
           __mapClear(__deviceHandlers);
         });
 
@@ -1023,7 +1075,19 @@ class PluginManager {
         final msg = raw as Map<String, dynamic>;
         final pluginId = _pluginIdForBridgeMessage(msg, 'devices');
         if (pluginId != null) {
-          unawaited(_handleDeviceMessage(pluginId, msg));
+          final operation = _handleDeviceMessage(pluginId, msg);
+          if (msg['type'] == 'bindDriver') {
+            final pending = _bleRegistrations.putIfAbsent(pluginId, () => {});
+            pending.add(operation);
+            unawaited(
+              operation.whenComplete(() {
+                pending.remove(operation);
+                if (pending.isEmpty) _bleRegistrations.remove(pluginId);
+              }),
+            );
+          } else {
+            unawaited(operation);
+          }
         }
       } catch (e, st) {
         _log.warning("Invalid plugin device message", e, st);
@@ -1133,9 +1197,14 @@ class PluginManager {
         type == 'invocationResult' &&
         pending != null &&
         (pending.operation == PluginDeviceOperation.connect ||
-            pending.operation == PluginDeviceOperation.disconnect) &&
+            pending.operation == PluginDeviceOperation.disconnect ||
+            pending.operation == PluginDeviceOperation.bleEvent) &&
         _isDeviceDisconnectCleanup(pluginId, generation);
-    if (_lifecycle != PluginManagerLifecycle.active && !cleanupInvocation) {
+    final cleanupGatt =
+        type == 'gatt' && _isDeviceDisconnectCleanup(pluginId, generation);
+    if (_lifecycle != PluginManagerLifecycle.active &&
+        !cleanupInvocation &&
+        !cleanupGatt) {
       return;
     }
     if (type == 'invocationResult') {
@@ -1164,8 +1233,9 @@ class PluginManager {
       _completeDeviceInvocation(pluginId, generation, data);
       return;
     }
-    if (generation != _pluginGenerations[pluginId] ||
-        _plugins[pluginId]?.isAlive != true) {
+    if ((generation != _pluginGenerations[pluginId] ||
+            _plugins[pluginId]?.isAlive != true) &&
+        !cleanupGatt) {
       return;
     }
     final requestId = msg['requestId'];
@@ -1177,6 +1247,73 @@ class PluginManager {
         throw const PluginDeviceException('Invalid registration handle');
       }
       switch (type) {
+        case 'bindDriver':
+          final declarations = _plugins[pluginId]!.manifest.drivers.where(
+            (driver) => driver.id == data['driverId'],
+          );
+          if (declarations.isEmpty ||
+              !js
+                  .evaluate(
+                    'globalThis.__deviceHasHandler(${jsonEncode(registrationHandle)},'
+                    '${jsonEncode(pluginId)},$generation,"create")',
+                  )
+                  .stringResult
+                  .contains('true')) {
+            throw const PluginDeviceException(
+              'BLE factory must name a declared driver',
+            );
+          }
+          bleService.registry.register(
+            pluginId: pluginId,
+            generation: generation,
+            declaration: declarations.single,
+            factoryHandle: registrationHandle,
+            permissions: _plugins[pluginId]!.manifest.permissions,
+          );
+          _replyDevice(requestId, bridgeToken, result: const {});
+        case 'gatt':
+          final authority = data['authority'];
+          final operation = data['operation'];
+          final args = data['args'];
+          if (authority is! String || operation is! String || args is! Map) {
+            throw const PluginBleException(
+              'invalid_argument',
+              'Invalid GATT request',
+            );
+          }
+          final value = await bleService.call(
+            pluginId,
+            generation,
+            registrationHandle,
+            authority,
+            operation,
+            Map<String, dynamic>.from(args),
+          );
+          _replyDevice(requestId, bridgeToken, result: {'value': value});
+        case 'blePublish':
+          final snapshot = data['snapshot'];
+          if (snapshot is! Map) {
+            throw const PluginBleException(
+              'invalid_argument',
+              'Invalid BLE snapshot',
+            );
+          }
+          bleService.publish(
+            pluginId,
+            generation,
+            registrationHandle,
+            Map<String, dynamic>.from(snapshot),
+            data['session'] as String?,
+          );
+          _replyDevice(requestId, bridgeToken, result: const {});
+        case 'bleDisconnected':
+          bleService.reportDisconnected(
+            pluginId,
+            generation,
+            registrationHandle,
+            data['session'] as String?,
+          );
+          _replyDevice(requestId, bridgeToken, result: const {});
         case 'register':
           final definition = data['definition'];
           if (definition is! Map) {
@@ -1296,6 +1433,13 @@ class PluginManager {
         default:
           throw const PluginDeviceException('Unknown plugin device operation');
       }
+    } on PluginBleException catch (error) {
+      _replyDevice(
+        requestId,
+        bridgeToken,
+        error: error.message,
+        code: error.code,
+      );
     } on PluginDeviceException catch (error) {
       _replyDevice(
         requestId,
@@ -1304,7 +1448,12 @@ class PluginManager {
         code: error.code,
       );
     } catch (error) {
-      _replyDevice(requestId, bridgeToken, error: error.toString());
+      _replyDevice(
+        requestId,
+        bridgeToken,
+        error: error.toString(),
+        code: type == 'gatt' ? bleBridgeErrorCode(error) : null,
+      );
     }
   }
 
@@ -1338,7 +1487,8 @@ class PluginManager {
         generation == _pluginGenerations[pluginId] &&
         _plugins[pluginId]?.isAlive == true;
     final cleanupDisconnect =
-        operation == PluginDeviceOperation.disconnect &&
+        (operation == PluginDeviceOperation.disconnect ||
+            operation == PluginDeviceOperation.bleEvent) &&
         _isDeviceDisconnectCleanup(pluginId, generation);
     if (!isCurrent && !cleanupDisconnect) {
       return Future.error(
@@ -1505,7 +1655,8 @@ class PluginManager {
       pending.completer.completeError(PluginDeviceException(error.toString()));
       return;
     }
-    if (pending.operation != PluginDeviceOperation.execute) {
+    if (pending.operation != PluginDeviceOperation.execute &&
+        pending.operation != PluginDeviceOperation.create) {
       pending.completer.complete(const {});
       return;
     }
@@ -1947,7 +2098,9 @@ class PluginManager {
           });
         };
         const declaredDrivers = ${jsonEncode(manifest.drivers.map((driver) => driver.toJson()).toList())};
+        $pluginBleBridgeJs
         const devices = {
+          bindDriver: __bindBleDriver,
           register(definition, handlers) {
             const driver = definition && declaredDrivers.find((entry) => entry.id === definition.driverId);
             if (!driver || (driver.type !== "sensor" && driver.type !== "scale")) {
@@ -2109,6 +2262,9 @@ class PluginManager {
       while (js.executePendingJob() > 0) {}
 
       runtime.markRunning();
+      while (_bleRegistrations[id]?.isNotEmpty == true) {
+        await Future.wait(_bleRegistrations[id]!.toList());
+      }
       if (identical(_plugins[id], runtime) &&
           generation == _pluginGenerations[id]) {
         final workflowController = _workflowController;
@@ -2252,6 +2408,12 @@ class PluginManager {
     );
     _deviceDisconnectCleanup.add((pluginId, retiringGeneration));
     try {
+      try {
+        await bleService.removeGeneration(pluginId, retiringGeneration);
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
       await deviceService.removeAllForPlugin(
         pluginId,
         retiringGeneration,
@@ -2496,6 +2658,7 @@ class PluginManager {
       firstStackTrace ??= stackTrace;
     }
     try {
+      await bleService.dispose();
       await deviceService.dispose();
     } catch (error, stackTrace) {
       firstError ??= error;

--- a/lib/src/services/ble/ble_admission_transport.dart
+++ b/lib/src/services/ble/ble_admission_transport.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/models/errors.dart';
+
+class BleAdmissionTransport extends BLETransport {
+  final BLETransport transport;
+  final Object Function() reserve;
+  final void Function(Object) release;
+  Object? _claim;
+  StreamSubscription<ConnectionState>? _subscription;
+  Future<void>? _closing;
+  bool _disposed = false;
+
+  BleAdmissionTransport({
+    required this.transport,
+    required this.reserve,
+    required this.release,
+  });
+
+  @override
+  String get id => transport.id;
+  @override
+  String get name => transport.name;
+  @override
+  Stream<ConnectionState> get connectionState => transport.connectionState;
+
+  @override
+  Future<void> connect() async {
+    await _closing;
+    if (_disposed) throw StateError('BLE candidate disposed');
+    _claim ??= reserve();
+    try {
+      await transport.connect();
+      if (_disposed) throw StateError('BLE candidate disposed');
+      _subscription ??= transport.connectionState.listen((state) {
+        if (state == ConnectionState.disconnected && _claim != null) {
+          unawaited(
+            disconnectConfirmed().catchError((Object error) {
+              Logger(
+                'BleAdmissionTransport',
+              ).warning('Native BLE ownership retained: $id', error);
+            }),
+          );
+        }
+      });
+    } catch (_) {
+      unawaited(
+        disconnectConfirmed().catchError((Object error) {
+          Logger(
+            'BleAdmissionTransport',
+          ).warning('Failed connect ownership retained: $id', error);
+        }),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> disconnect() => disconnectConfirmed();
+
+  @override
+  Future<void> disconnectConfirmed() {
+    if (_claim == null) return Future.value();
+    return _closing ??= _close().whenComplete(() => _closing = null);
+  }
+
+  Future<void> _close() async {
+    await transport.disconnectConfirmed();
+    await _subscription?.cancel();
+    _subscription = null;
+    final claim = _claim;
+    _claim = null;
+    if (claim != null) release(claim);
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await disconnectConfirmed();
+    await _subscription?.cancel();
+    _subscription = null;
+    await transport.dispose();
+  }
+
+  @override
+  Future<ConnectionState> getConnectionState() =>
+      transport.getConnectionState();
+  Future<T> _owned<T>(Future<T> Function() operation) async {
+    if (_claim == null || _disposed) {
+      throw const DeviceNotConnectedException.unknown();
+    }
+    return operation();
+  }
+
+  @override
+  Future<List<String>> discoverServices() => _owned(transport.discoverServices);
+  @override
+  Future<Uint8List> read(
+    String serviceUUID,
+    String characteristicUUID, {
+    Duration? timeout,
+  }) => _owned(
+    () => transport.read(serviceUUID, characteristicUUID, timeout: timeout),
+  );
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) => _owned(
+    () => transport.write(
+      serviceUUID,
+      characteristicUUID,
+      data,
+      withResponse: withResponse,
+      timeout: timeout,
+    ),
+  );
+  @override
+  Future<void> subscribe(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) => _owned(
+    () => transport.subscribe(serviceUUID, characteristicUUID, callback),
+  );
+  @override
+  Future<void> resetSubscription(
+    String serviceUUID,
+    String characteristicUUID,
+    void Function(Uint8List) callback,
+  ) => _owned(
+    () =>
+        transport.resetSubscription(serviceUUID, characteristicUUID, callback),
+  );
+  @override
+  Future<void> unsubscribe(String serviceUUID, String characteristicUUID) =>
+      _owned(() => transport.unsubscribe(serviceUUID, characteristicUUID));
+  @override
+  Future<void> setTransportPriority(bool prioritized) =>
+      _owned(() => transport.setTransportPriority(prioritized));
+}

--- a/lib/src/services/ble/ble_exception_mapper.dart
+++ b/lib/src/services/ble/ble_exception_mapper.dart
@@ -1,6 +1,19 @@
+import 'dart:async';
+
+import 'package:reaprime/src/models/errors.dart';
 import 'package:reaprime/src/models/device/transport/ble_connect_exception.dart';
 import 'package:reaprime/src/models/device/transport/ble_timeout_exception.dart';
 import 'package:universal_ble/universal_ble.dart';
+
+String bleBridgeErrorCode(Object error) => switch (error) {
+  GattAttributeUnavailableException() => 'attribute_unavailable',
+  DeviceNotConnectedException() => 'link_lost',
+  PermissionDeniedException() => 'permission_denied',
+  TimeoutException() || BleTimeoutException() => 'timeout',
+  UniversalBleException() => error.code.name,
+  BleConnectException() => error.code ?? 'ble_error',
+  _ => 'ble_error',
+};
 
 Object mapUniversalConnectError(UniversalBleException e) {
   if (e.code == UniversalBleErrorCode.connectionTimeout) {

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -8,6 +8,9 @@ import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/models/device/scan_filter.dart' as domain;
 import 'package:reaprime/src/services/ble/ble_discovery_service.dart';
 import 'package:reaprime/src/services/ble/ble_lifecycle_gate.dart';
+import 'package:reaprime/src/services/ble/ble_admission_transport.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_ble_service.dart';
 import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
 import 'package:reaprime/src/services/device_factory.dart';
 import 'package:reaprime/src/services/device_matcher.dart';
@@ -43,9 +46,12 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     bool Function()? watchSupportGate,
     bool Function()? requestLargeMtuNonAndroid,
     BleTransportFactory? transportFactory,
+    PluginBleService Function()? pluginBleService,
+    this.scanDuration = const Duration(seconds: 15),
   }) : _watchSupportGate = watchSupportGate ?? (() => Platform.isAndroid),
        requestLargeMtuNonAndroid = requestLargeMtuNonAndroid ?? (() => false),
-       _transportFactory = transportFactory ?? _defaultTransportFactory;
+       _transportFactory = transportFactory ?? _defaultTransportFactory,
+       _pluginBleService = pluginBleService;
 
   static BLETransport _defaultTransportFactory({
     required BleDevice device,
@@ -63,7 +69,103 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
 
   final bool Function() _watchSupportGate;
   final BleTransportFactory _transportFactory;
+  final Duration scanDuration;
   final BleLifecycleGate _lifecycleGate = BleLifecycleGate();
+  final PluginBleService Function()? _pluginBleService;
+  PluginBleService? get _plugins => _pluginBleService?.call();
+  final BleAdvertisementCache _bleEvidence = BleAdvertisementCache();
+  final Map<String, BleDevice> _bleObservations = {};
+  final Map<String, PluginBleDecision> _pluginOwnership = {};
+  final Set<String> _dirtyObservations = {};
+  StreamSubscription<int>? _registrySubscription;
+  Future<void> _registryReconciliation = Future.value();
+  bool _watchIncludesPluginDrivers = false;
+
+  void _beginBleEvidence() {
+    _bleEvidence.beginGeneration(_scanGeneration);
+    _bleObservations.clear();
+    _pluginOwnership.clear();
+  }
+
+  bool _nativeEligible(String id) {
+    final plugins = _plugins;
+    if (_adapterStateSubject.value != AdapterState.poweredOn) return false;
+    if (_disposed || plugins?.registry.acceptingConnections == false) {
+      return false;
+    }
+    if (plugins == null) return true;
+    final evidence =
+        _bleEvidence.get(id) ??
+        BleAdvertisementEvidence(source: BleEvidenceSource.system);
+    return plugins.registry.decide(evidence).kind == PluginBleOwnership.native;
+  }
+
+  bool _decisionIsCurrent(
+    String id,
+    PluginBleDecision? decision,
+    int generation,
+  ) {
+    if (_disposed || generation != _scanGeneration) return false;
+    final plugins = _plugins;
+    if (plugins == null) return true;
+    final evidence = _bleEvidence.get(id);
+    if (evidence == null ||
+        decision?.registryRevision != plugins.registry.revision) {
+      return false;
+    }
+    final current = plugins.registry.decide(evidence);
+    return current.kind == decision!.kind &&
+        (current.kind != PluginBleOwnership.plugin ||
+            identical(current.drivers.single, decision.drivers.single));
+  }
+
+  BLETransport _nativeTransport(BleDevice device) {
+    final transport = _createTransport(device);
+    final plugins = _plugins;
+    if (plugins == null) return transport;
+    final revision = plugins.registry.revision;
+    return BleAdmissionTransport(
+      transport: transport,
+      reserve: () {
+        if (revision != plugins.registry.revision ||
+            !_nativeEligible(device.deviceId)) {
+          throw StateError('Native BLE candidate ownership changed');
+        }
+        return plugins.registry.reserveNative(device.deviceId);
+      },
+      release: (claim) =>
+          plugins.registry.releaseNative(device.deviceId, claim),
+    );
+  }
+
+  Future<void> _reconcilePluginCandidates() async {
+    if (_disposed) return;
+    final includePlugins = _plugins?.registry.hasDrivers == true;
+    if (_watchScanActive &&
+        _watchRequested?.namePrefix != null &&
+        _watchIncludesPluginDrivers != includePlugins) {
+      await _deactivateWatchScan(
+        stopOsScan: true,
+        context: 'plugin registry change',
+      );
+      if (_disposed) return;
+      await _restartWatchOrReportFailure('plugin registry change');
+    }
+    for (final entry in _devices.entries.toList()) {
+      if (_bleObservations.containsKey(entry.key)) continue;
+      final state = await _cachedConnectionState(entry.value);
+      if (state == ConnectionState.discovered ||
+          state == ConnectionState.disconnected) {
+        if (_plugins?.registry.isClaimed(entry.key) == true) continue;
+        if (await _evictCachedDevice(entry.key, entry.value)) {
+          await _plugins?.discardInactive(entry.value);
+        }
+      }
+    }
+    for (final entry in _bleObservations.entries.toList()) {
+      await _deviceScanned(entry.value, recordEvidence: false);
+    }
+  }
 
   bool Function() requestLargeMtuNonAndroid;
 
@@ -258,6 +360,8 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   }
 
   Future<void> _runWatchScanStart() async {
+    await _plugins?.registry.ready;
+    if (_disposed || _plugins?.registry.acceptingConnections == false) return;
     final filter = _watchRequested;
     if (filter == null || _watchScanActive) return;
     if (_scanPhase == BleScanPhase.faulted) {
@@ -276,19 +380,21 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     _scanOwner = BleScanOwner.watch;
     _scanPhase = BleScanPhase.starting;
     _scanGeneration++;
+    _beginBleEvidence();
+    final generation = _scanGeneration;
 
     _watchScanSub = UniversalBle.scanStream.listen((result) async {
-      if (_currentlyScanning.contains(normalizeBleDeviceId(result.deviceId))) {
-        return;
-      }
-      await _deviceScanned(result);
+      await _deviceScanned(result, generation: generation);
     });
 
     final namePrefix = filter.namePrefix;
+    _watchIncludesPluginDrivers = _plugins?.registry.hasDrivers == true;
     try {
       await UniversalBle.startScan(
         scanFilter: ScanFilter(
-          withNamePrefix: namePrefix != null ? [namePrefix] : [],
+          withNamePrefix: namePrefix != null && !_watchIncludesPluginDrivers
+              ? [namePrefix]
+              : [],
           withServices: [],
         ),
         platformConfig: PlatformConfig(
@@ -511,6 +617,16 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
             'name': entry.value.name,
           },
       },
+      'pluginOwnership': {
+        for (final entry in _pluginOwnership.entries)
+          entry.key: {
+            'decision': entry.value.kind.name,
+            'registryRevision': entry.value.registryRevision,
+            'drivers': entry.value.drivers
+                .map((driver) => '${driver.pluginId}:${driver.declaration.id}')
+                .toList(),
+          },
+      },
       'scanFailures': {
         'count': _scanFailureCount,
         'latest': _latestScanFailure,
@@ -523,6 +639,14 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   Future<void> initialize() async {
     if (_availabilitySubscription != null) return;
     _disposed = false;
+    _registrySubscription ??= _plugins?.registry.changes.listen((_) {
+      if (_disposed) return;
+      _registryReconciliation = _registryReconciliation
+          .then((_) => _reconcilePluginCandidates())
+          .catchError((Object error, StackTrace stack) {
+            log.warning('BLE candidate reconciliation failed', error, stack);
+          });
+    });
     UniversalBle.queueType = QueueType.perDevice;
 
     var initialState = await UniversalBle.getBluetoothAvailabilityState();
@@ -542,6 +666,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       log.info("BLE Adapter state: ${state.name}");
       final mapped = _mapAvailabilityState(state);
       _adapterStateSubject.add(mapped);
+      if (mapped != AdapterState.poweredOn && mapped != AdapterState.unknown) {
+        _plugins?.revokeSessions();
+      }
       _onAdapterStateForWatch(mapped);
     });
 
@@ -645,6 +772,8 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
 
   @override
   Future<void> scanForDevices({domain.ScanFilter? filter}) async {
+    await _plugins?.registry.ready;
+    if (_disposed || _plugins?.registry.acceptingConnections == false) return;
     final state = _adapterStateSubject.value;
     if (state != AdapterState.poweredOn) {
       log.warning("Cannot scan, adapter state is $state");
@@ -670,6 +799,8 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     _scanOwner = BleScanOwner.burst;
     _scanPhase = BleScanPhase.starting;
     _scanGeneration++;
+    _beginBleEvidence();
+    final generation = _scanGeneration;
     _scanStopError = null;
     StreamSubscription<BleDevice>? sub;
 
@@ -681,12 +812,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
         log.finest(
           "Found: ${result.deviceId}: ${result.name}, adv: ${result.services}",
         );
-        if (_currentlyScanning.contains(
-          normalizeBleDeviceId(result.deviceId),
-        )) {
-          return;
-        }
-        await _deviceScanned(result);
+        await _deviceScanned(result, generation: generation);
       });
 
       final scanFilter = ScanFilter(withServices: []);
@@ -726,16 +852,28 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
           withServices: [],
         );
         for (var d in systemDevices) {
-          await _deviceScanned(d);
+          await _deviceScanned(
+            d,
+            source: BleEvidenceSource.system,
+            generation: generation,
+          );
         }
       } catch (e, st) {
         log.fine('System device check failed', e, st);
       }
 
-      await _waitForScanDuration(const Duration(seconds: 15));
+      await _waitForScanDuration(scanDuration);
     } finally {
       await sub?.cancel();
       _cancelScanDurationWait();
+      for (final entry in _pluginOwnership.entries) {
+        if (entry.value.kind == PluginBleOwnership.pending ||
+            entry.value.kind == PluginBleOwnership.conflict) {
+          log.warning(
+            'BLE ownership ${entry.value.kind.name} at scan deadline: ${entry.key}',
+          );
+        }
+      }
       _deviceStreamController.add(_devices.values.toList());
       final faulted = _scanPhase == BleScanPhase.faulted;
       if (_scanOwner == BleScanOwner.burst) {
@@ -807,25 +945,78 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     });
   }
 
-  Future<void> _deviceScanned(BleDevice device) async {
+  Future<void> _deviceScanned(
+    BleDevice device, {
+    BleEvidenceSource source = BleEvidenceSource.advertisement,
+    int? generation,
+    bool recordEvidence = true,
+  }) async {
+    final observedGeneration = generation ?? _scanGeneration;
+    if (_disposed || observedGeneration != _scanGeneration) return;
     final deviceId = normalizeBleDeviceId(device.deviceId);
-    if (_currentlyScanning.contains(deviceId)) return;
+    _bleObservations[deviceId] = device;
+    if (recordEvidence) {
+      _bleEvidence.record(
+        deviceId,
+        observedGeneration,
+        BleAdvertisementEvidence(
+          name: device.name,
+          serviceUuids: device.services,
+          source: source,
+          servicesComplete: source == BleEvidenceSource.advertisement,
+        ),
+      );
+      _recordAdvertisement(deviceId, device.name);
+    }
+    if (_currentlyScanning.contains(deviceId)) {
+      if (_plugins != null) _dirtyObservations.add(deviceId);
+      return;
+    }
     _currentlyScanning.add(deviceId);
-    _recordAdvertisement(deviceId, device.name);
 
     try {
-      final name = device.name ?? '';
-      if (name.isEmpty) return;
+      do {
+        _dirtyObservations.remove(deviceId);
+        await _processBleObservation(deviceId, observedGeneration);
+      } while (observedGeneration == _scanGeneration &&
+          _dirtyObservations.remove(deviceId));
+    } catch (error, stack) {
+      log.warning('BLE candidate failed for $deviceId', error, stack);
+    } finally {
+      _currentlyScanning.remove(deviceId);
+      if (observedGeneration != _scanGeneration &&
+          _dirtyObservations.remove(deviceId)) {
+        final current = _bleObservations[deviceId];
+        if (current != null) {
+          await _deviceScanned(current, recordEvidence: false);
+        }
+      }
+    }
+  }
+
+  Future<void> _processBleObservation(String deviceId, int generation) async {
+    final device = _bleObservations[deviceId];
+    if (device == null || generation != _scanGeneration || _disposed) return;
+    final evidence = _bleEvidence.get(deviceId)!;
+    final plugins = _plugins;
+    final previousDecision = _pluginOwnership[deviceId];
+    final decision = plugins?.registry.decide(evidence);
+    if (decision != null) _pluginOwnership[deviceId] = decision;
+
+    try {
+      final name = evidence.name ?? '';
 
       final existing = _devices[deviceId];
       if (existing != null) {
         final state = await _cachedConnectionState(existing);
+        if (!identical(_devices[deviceId], existing)) return;
+        if (plugins?.registry.isClaimed(deviceId) == true) return;
         if (state == null ||
             state == ConnectionState.connecting ||
             state == ConnectionState.disconnecting) {
           return;
         }
-        if (state == ConnectionState.discovered) return;
+        if (state == ConnectionState.discovered && plugins == null) return;
         if (state == ConnectionState.connected) {
           var nativeLink = await _nativeLinkState(existing.deviceId);
           if (nativeLink == null ||
@@ -861,23 +1052,73 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
             'native link is ${nativeLink.name}',
           );
         }
+        if (state == ConnectionState.discovered &&
+            decision?.kind == PluginBleOwnership.plugin &&
+            plugins!.matchesCandidate(existing, decision!.drivers.single)) {
+          return;
+        }
+        if (state == ConnectionState.discovered &&
+            decision?.kind == PluginBleOwnership.native &&
+            previousDecision?.registryRevision == decision!.registryRevision &&
+            existing.implementation ==
+                DeviceMatcher.implementationForName(name)) {
+          return;
+        }
+        if (plugins?.registry.isClaimed(deviceId) == true) return;
         if (!await _evictCachedDevice(deviceId, existing)) return;
+        await plugins?.discardInactive(existing);
       }
 
+      if (decision?.kind == PluginBleOwnership.pending ||
+          decision?.kind == PluginBleOwnership.conflict) {
+        return;
+      }
+      if (decision?.kind != PluginBleOwnership.plugin && name.isEmpty) return;
+      if (!_decisionIsCurrent(deviceId, decision, generation)) {
+        _dirtyObservations.add(deviceId);
+        return;
+      }
       final matchedDevice = await _candidate(
         deviceId,
-        () => DeviceMatcher.match(
-          transport: _createTransport(device),
-          advertisedName: name,
-        ),
+        () => decision?.kind == PluginBleOwnership.plugin
+            ? plugins!.createCandidate(
+                driver: decision!.drivers.single,
+                physicalId: deviceId,
+                evidence: evidence,
+                createTransport: () => _createTransport(device),
+                admit: () {
+                  if (_disposed ||
+                      _adapterStateSubject.value != AdapterState.poweredOn) {
+                    return false;
+                  }
+                  final current = _bleEvidence.get(deviceId);
+                  if (current == null) return false;
+                  final owner = plugins.registry.decide(current);
+                  return owner.kind == PluginBleOwnership.plugin &&
+                      identical(owner.drivers.single, decision.drivers.single);
+                },
+              )
+            : DeviceMatcher.match(
+                transport: _nativeTransport(device),
+                advertisedName: name,
+              ),
       );
 
       if (matchedDevice != null && !_devices.containsKey(deviceId)) {
+        if (!_decisionIsCurrent(deviceId, decision, generation)) {
+          _dirtyObservations.add(deviceId);
+          await plugins?.discardInactive(matchedDevice);
+          return;
+        }
         await _adoptCachedDevice(deviceId, matchedDevice);
         log.fine("found new device: ${device.name}");
       }
-    } finally {
-      _currentlyScanning.remove(deviceId);
+    } catch (error, stack) {
+      log.warning(
+        'BLE observation processing failed for $deviceId',
+        error,
+        stack,
+      );
     }
   }
 
@@ -900,6 +1141,10 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
 
   @override
   Future<Device?> tryQuickConnect(RememberedDevice remembered) async {
+    await _plugins?.registry.ready;
+    if (_disposed || remembered.implementation == DeviceImplementation.plugin) {
+      return null;
+    }
     final impl = remembered.implementation;
     final tt = remembered.transportType;
     if (impl == null || tt == null || tt != TransportType.ble) {
@@ -930,7 +1175,11 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       bleDevice = BleDevice(deviceId: deviceId, name: remembered.name);
     }
 
-    final transport = _createTransport(bleDevice);
+    if (!_nativeEligible(deviceId) ||
+        _plugins?.registry.isClaimed(deviceId) == true) {
+      return null;
+    }
+    final transport = _nativeTransport(bleDevice);
     final device = DeviceFactory.createBle(impl, transport);
     if (device == null) {
       log.warning('Quick-connect: DeviceFactory returned null for $impl');
@@ -1010,6 +1259,9 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
+    await _registrySubscription?.cancel();
+    _registrySubscription = null;
+    await _registryReconciliation;
     await _availabilitySubscription?.cancel();
     _availabilitySubscription = null;
     _cancelScanDurationWait();

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -85,10 +85,12 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   Future<void> _registryReconciliation = Future.value();
   bool _watchIncludesPluginDrivers = false;
 
-  void _beginBleEvidence() {
+  void _advanceScanGeneration() {
+    _scanGeneration++;
     _bleEvidence.beginGeneration(_scanGeneration);
     _bleObservations.clear();
     _pluginOwnership.clear();
+    _dirtyObservations.clear();
   }
 
   bool _nativeEligible(String id) {
@@ -311,7 +313,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     _cancelWatchScanSub();
     if (_scanOwner == BleScanOwner.watch) {
       _scanPhase = stopOsScan ? BleScanPhase.stopping : BleScanPhase.idle;
-      _scanGeneration++;
+      _advanceScanGeneration();
     }
     if (stopOsScan) {
       try {
@@ -383,8 +385,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     final adapterGen = _watchAdapterGeneration;
     _scanOwner = BleScanOwner.watch;
     _scanPhase = BleScanPhase.starting;
-    _scanGeneration++;
-    _beginBleEvidence();
+    _advanceScanGeneration();
     final generation = _scanGeneration;
 
     _watchScanSub = UniversalBle.scanStream.listen((result) async {
@@ -516,7 +517,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
       _scanOwner = BleScanOwner.none;
       _scanPhase = BleScanPhase.idle;
       _scanStopError = null;
-      _scanGeneration++;
+      _advanceScanGeneration();
       _setWatchState(
         _watchRequested == null
             ? DeviceWatchState.inactive
@@ -802,8 +803,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
 
     _scanOwner = BleScanOwner.burst;
     _scanPhase = BleScanPhase.starting;
-    _scanGeneration++;
-    _beginBleEvidence();
+    _advanceScanGeneration();
     final generation = _scanGeneration;
     _scanStopError = null;
     StreamSubscription<BleDevice>? sub;

--- a/lib/src/services/universal_ble_discovery_service.dart
+++ b/lib/src/services/universal_ble_discovery_service.dart
@@ -44,11 +44,14 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     implements DeviceWatchCapable {
   UniversalBleDiscoveryService({
     bool Function()? watchSupportGate,
+    bool Function()? requiresSystemDevice,
     bool Function()? requestLargeMtuNonAndroid,
     BleTransportFactory? transportFactory,
     PluginBleService Function()? pluginBleService,
     this.scanDuration = const Duration(seconds: 15),
   }) : _watchSupportGate = watchSupportGate ?? (() => Platform.isAndroid),
+       _requiresSystemDevice =
+           requiresSystemDevice ?? (() => Platform.isIOS || Platform.isMacOS),
        requestLargeMtuNonAndroid = requestLargeMtuNonAndroid ?? (() => false),
        _transportFactory = transportFactory ?? _defaultTransportFactory,
        _pluginBleService = pluginBleService;
@@ -68,6 +71,7 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
   }
 
   final bool Function() _watchSupportGate;
+  final bool Function() _requiresSystemDevice;
   final BleTransportFactory _transportFactory;
   final Duration scanDuration;
   final BleLifecycleGate _lifecycleGate = BleLifecycleGate();
@@ -1165,12 +1169,22 @@ class UniversalBleDiscoveryService extends BleDiscoveryService
     final key = normalizeBleDeviceId(deviceId);
 
     BleDevice? bleDevice;
-    if (Platform.isIOS || Platform.isMacOS) {
+    if (_requiresSystemDevice()) {
       bleDevice = await _findSystemDevice(deviceId);
       if (bleDevice == null) {
         log.info('Quick-connect: device $deviceId not in system cache');
         return null;
       }
+      _bleEvidence.record(
+        deviceId,
+        _scanGeneration,
+        BleAdvertisementEvidence(
+          name: bleDevice.name,
+          serviceUuids: bleDevice.services,
+          source: BleEvidenceSource.system,
+          servicesComplete: false,
+        ),
+      );
     } else {
       bleDevice = BleDevice(deviceId: deviceId, name: remembered.name);
     }

--- a/test/helpers/plugin_ble_fixture.dart
+++ b/test/helpers/plugin_ble_fixture.dart
@@ -1,0 +1,188 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import 'fake_ble_transport.dart';
+
+class PluginBleFixtureTransport extends FakeBleTransport {
+  PluginBleFixtureTransport(this.physicalId);
+
+  final String physicalId;
+  final states = BehaviorSubject.seeded(ConnectionState.discovered);
+  final operations = <String>[];
+  Completer<void>? teardown;
+  int connectCalls = 0;
+  int disposeCalls = 0;
+  final disposed = Completer<void>();
+
+  @override
+  String get id => physicalId;
+  @override
+  Stream<ConnectionState> get connectionState => states.stream;
+  @override
+  Future<ConnectionState> getConnectionState() async => states.value;
+
+  @override
+  Future<void> connect() async {
+    connectCalls++;
+    states.add(ConnectionState.connected);
+  }
+
+  @override
+  Future<List<String>> discoverServices() async => ['180f'];
+
+  @override
+  Future<void> subscribe(
+    String service,
+    String characteristic,
+    void Function(Uint8List) callback,
+  ) async {
+    operations.add('subscribe:$service:$characteristic');
+    await super.subscribe(service, characteristic, callback);
+    callback(Uint8List.fromList([52]));
+  }
+
+  @override
+  Future<void> unsubscribe(String service, String characteristic) async {
+    operations.add('unsubscribe:$service:$characteristic');
+    subscribers.remove(characteristic);
+  }
+
+  @override
+  Future<void> resetSubscription(
+    String service,
+    String characteristic,
+    void Function(Uint8List) callback,
+  ) async {
+    await unsubscribe(service, characteristic);
+    await subscribe(service, characteristic, callback);
+  }
+
+  @override
+  Future<void> disconnect() => disconnectConfirmed();
+
+  @override
+  Future<void> disconnectConfirmed() async {
+    await teardown?.future;
+    if (!states.isClosed) states.add(ConnectionState.disconnected);
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (disposeCalls++ != 0) return;
+    subscribers.clear();
+    await states.close();
+    await super.dispose();
+    disposed.complete();
+  }
+}
+
+class PluginBleFixturePlatform extends UniversalBlePlatform {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+
+  final systemDevices = <BleDevice>[];
+  bool scanning = false;
+  final started = Completer<void>();
+  final connectionStates = <String, BleConnectionState>{};
+  final notificationProperties = <BleInputProperty>[];
+  final writeProperties = <BleOutputProperty>[];
+  final scanFilters = <ScanFilter?>[];
+  Object? readError;
+  Object? writeError;
+  BleDevice? firstAdvertisement;
+
+  @override
+  Future<void> connect(
+    String deviceId, {
+    Duration? connectionTimeout,
+    bool autoConnect = false,
+    ConnectionPlatformConfig? platformConfig,
+  }) async {
+    connectionStates[deviceId] = BleConnectionState.connected;
+    updateConnection(deviceId, true);
+  }
+
+  @override
+  Future<void> disconnect(String deviceId) async {
+    connectionStates[deviceId] = BleConnectionState.disconnected;
+    updateConnection(deviceId, false);
+  }
+
+  @override
+  Future<List<BleService>> discoverServices(
+    String deviceId,
+    bool withDescriptors,
+  ) async => [BleService('0000180f-0000-1000-8000-00805f9b34fb', [])];
+  @override
+  Future<void> setNotifiable(
+    String deviceId,
+    String service,
+    String characteristic,
+    BleInputProperty bleInputProperty,
+  ) async {
+    notificationProperties.add(bleInputProperty);
+    if (bleInputProperty == BleInputProperty.notification) {
+      updateCharacteristicValue(
+        deviceId,
+        characteristic,
+        Uint8List.fromList([52]),
+        null,
+      );
+    }
+  }
+
+  @override
+  Future<Uint8List> readValue(
+    String deviceId,
+    String service,
+    String characteristic, {
+    Duration? timeout,
+  }) async {
+    if (readError case final error?) throw error;
+    return Uint8List.fromList([52]);
+  }
+
+  @override
+  Future<void> writeValue(
+    String deviceId,
+    String service,
+    String characteristic,
+    Uint8List value,
+    BleOutputProperty bleOutputProperty,
+  ) async {
+    writeProperties.add(bleOutputProperty);
+    if (writeError case final error?) throw error;
+  }
+
+  @override
+  Future<AvailabilityState> getBluetoothAvailabilityState() async =>
+      AvailabilityState.poweredOn;
+  @override
+  Future<void> startScan({
+    ScanFilter? scanFilter,
+    PlatformConfig? platformConfig,
+  }) async {
+    scanFilters.add(scanFilter);
+    scanning = true;
+    if (!started.isCompleted) started.complete();
+    if (firstAdvertisement case final device?) updateScanResult(device);
+  }
+
+  @override
+  Future<void> stopScan() async {
+    scanning = false;
+  }
+
+  @override
+  Future<bool> isScanning() async => scanning;
+  @override
+  Future<List<BleDevice>> getSystemDevices(List<String>? withServices) async =>
+      systemDevices;
+  @override
+  Future<BleConnectionState> getConnectionState(String deviceId) async =>
+      connectionStates[deviceId] ?? BleConnectionState.disconnected;
+}

--- a/test/helpers/plugin_ble_fixture.dart
+++ b/test/helpers/plugin_ble_fixture.dart
@@ -15,6 +15,7 @@ class PluginBleFixtureTransport extends FakeBleTransport {
   final operations = <String>[];
   Completer<void>? teardown;
   int connectCalls = 0;
+  int disconnectCalls = 0;
   int disposeCalls = 0;
   final disposed = Completer<void>();
 
@@ -66,6 +67,7 @@ class PluginBleFixtureTransport extends FakeBleTransport {
 
   @override
   Future<void> disconnectConfirmed() async {
+    disconnectCalls++;
     await teardown?.future;
     if (!states.isClosed) states.add(ConnectionState.disconnected);
   }

--- a/test/helpers/plugin_ble_fixture.dart
+++ b/test/helpers/plugin_ble_fixture.dart
@@ -8,9 +8,10 @@ import 'package:universal_ble/universal_ble.dart';
 import 'fake_ble_transport.dart';
 
 class PluginBleFixtureTransport extends FakeBleTransport {
-  PluginBleFixtureTransport(this.physicalId);
+  PluginBleFixtureTransport(this.physicalId, {this.services = const ['180f']});
 
   final String physicalId;
+  final List<String> services;
   final states = BehaviorSubject.seeded(ConnectionState.discovered);
   final operations = <String>[];
   Completer<void>? teardown;
@@ -33,7 +34,7 @@ class PluginBleFixtureTransport extends FakeBleTransport {
   }
 
   @override
-  Future<List<String>> discoverServices() async => ['180f'];
+  Future<List<String>> discoverServices() async => services;
 
   @override
   Future<void> subscribe(

--- a/test/plugin_loader_service_watchdog_test.dart
+++ b/test/plugin_loader_service_watchdog_test.dart
@@ -150,6 +150,26 @@ void main() {
     expect(await service.shouldAutoLoad(pluginId), isFalse);
   });
 
+  test(
+    'initial BLE readiness settles even when an auto-loaded plugin fails',
+    () async {
+      final restarted = PluginLoaderService(kvStore: _FakeKvStore());
+      addTearDown(restarted.dispose);
+      var ready = false;
+      final readiness = restarted.pluginManager.bleService.registry.ready.then((
+        _,
+      ) {
+        ready = true;
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(ready, isFalse);
+      await restarted.initialize();
+      await readiness.timeout(const Duration(seconds: 2));
+      expect(restarted.isPluginLoaded(pluginId), isFalse);
+      expect(restarted.pluginManager.bleService.registry.hasDrivers, isFalse);
+    },
+  );
+
   test('missing plugin code also counts as a load failure', () async {
     File('${tempDir.path}/plugins/$pluginId/plugin.js').deleteSync();
 

--- a/test/plugins/plugin_ble_discovery_policy_test.dart
+++ b/test/plugins/plugin_ble_discovery_policy_test.dart
@@ -1,0 +1,294 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart' as domain;
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/watch_filter.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_ble_matcher.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import '../helpers/plugin_ble_fixture.dart';
+import 'plugin_manager_ble_test.dart' show bleSensorSource, bleSensorManifest;
+import 'plugin_test_helpers.dart';
+
+class _Fixture {
+  _Fixture({
+    bool ready = true,
+    Duration scanDuration = const Duration(seconds: 15),
+  }) : manager = PluginManager(
+         kvStore: FakeKeyValueStoreService(),
+         bleRegistry: PluginBleRegistry(initiallyReady: ready),
+       ) {
+    UniversalBle.setInstance(platform);
+    discovery = UniversalBleDiscoveryService(
+      watchSupportGate: () => true,
+      pluginBleService: () => manager.bleService,
+      scanDuration: scanDuration,
+      transportFactory:
+          ({
+            required device,
+            required stopScan,
+            required requestLargeMtuNonAndroid,
+            required lifecycleGate,
+          }) {
+            final transport = PluginBleFixtureTransport(device.deviceId);
+            transports.add(transport);
+            return transport;
+          },
+    );
+    subscription = discovery.devices.listen(devices.add);
+  }
+  final PluginManager manager;
+  final platform = PluginBleFixturePlatform();
+  final transports = <PluginBleFixtureTransport>[];
+  final devices = <List<domain.Device>>[];
+  late final UniversalBleDiscoveryService discovery;
+  late final StreamSubscription<List<domain.Device>> subscription;
+
+  Future<void> load([String id = 'ble.sensor']) => manager.loadPlugin(
+    id: id,
+    manifest: bleSensorManifest(id: id),
+    settings: {},
+    jsCode: bleSensorSource.replaceAll('ble.sensor', id),
+  );
+  Future<void> start() async {
+    await discovery.initialize();
+    await discovery.startDeviceWatch(const DeviceWatchFilter());
+  }
+
+  void advertise({List<String> services = const ['180f']}) =>
+      platform.updateScanResult(
+        BleDevice(deviceId: 'AA:BB', name: 'Bookoo', services: services),
+      );
+  Future<domain.Device> get next => discovery.devices
+      .firstWhere((d) => d.isNotEmpty)
+      .then((d) => d.single)
+      .timeout(const Duration(seconds: 2));
+  Future<void> dispose() async {
+    await subscription.cancel();
+    await discovery.dispose();
+    await manager.dispose();
+  }
+}
+
+void main() {
+  for (final advertisementFirst in [false, true]) {
+    test(
+      'system/advertisement ownership with advertisementFirst=$advertisementFirst',
+      () async {
+        final fixture = _Fixture(
+          scanDuration: const Duration(milliseconds: 60),
+        );
+        addTearDown(fixture.dispose);
+        await fixture.discovery.initialize();
+        await fixture.load();
+        await fixture.manager.loadPlugin(
+          id: 'competitor',
+          settings: {},
+          manifest: testManifest(
+            'competitor',
+            permissions: {
+              PluginPermissions.emit,
+              PluginPermissions.transportBle,
+            },
+            drivers: [
+              PluginDriverDeclaration(
+                id: 'humidity',
+                type: PluginDriverType.sensor,
+                ble: PluginBleMatcher.fromJson({
+                  'serviceUuids': ['180a'],
+                }),
+              ),
+            ],
+          ),
+          jsCode: bleSensorSource.replaceAll('ble.sensor', 'competitor'),
+        );
+        fixture.platform.systemDevices.add(
+          BleDevice(deviceId: 'AA:BB', name: 'Bookoo', services: ['180f']),
+        );
+        if (advertisementFirst) {
+          fixture.platform.firstAdvertisement = BleDevice(
+            deviceId: 'AA:BB',
+            name: 'Bookoo',
+            services: ['180f'],
+          );
+        }
+        final candidate = fixture.next;
+        final scan = fixture.discovery.scanForDevices();
+        await fixture.platform.started.future;
+        if (!advertisementFirst) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          final diagnostics = await fixture.discovery.diagnostics();
+          expect(
+            (diagnostics['pluginOwnership'] as Map)['aa:bb']['decision'],
+            'pending',
+          );
+          expect(fixture.devices.expand((list) => list), isEmpty);
+          fixture.advertise();
+        }
+        expect((await candidate).deviceId, 'plugin:ble.sensor:humidity:aa:bb');
+        await scan.timeout(const Duration(seconds: 2));
+        expect(
+          fixture.devices.last.single.implementation,
+          DeviceImplementation.plugin,
+        );
+        expect(fixture.manager.bleService.bindingCount, 1);
+      },
+    );
+  }
+
+  test(
+    'loading a driver widens a filtered watch through existing scan ownership',
+    () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.dispose);
+      await fixture.discovery.initialize();
+      await fixture.discovery.startDeviceWatch(
+        const DeviceWatchFilter(namePrefix: 'Decent Scale'),
+      );
+      expect(fixture.platform.scanFilters.last?.withNamePrefix, [
+        'Decent Scale',
+      ]);
+      await fixture.load();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(fixture.platform.scanFilters.last?.withNamePrefix, isEmpty);
+      final candidate = fixture.next;
+      fixture.platform.updateScanResult(
+        BleDevice(deviceId: 'AA:BB', name: null, services: ['180f']),
+      );
+      expect((await candidate).implementation, DeviceImplementation.plugin);
+    },
+  );
+
+  test(
+    'startup waits for registry, not factory hardware initialization',
+    () async {
+      final fixture = _Fixture(ready: false);
+      addTearDown(fixture.dispose);
+      await fixture.discovery.initialize();
+      final watch = fixture.discovery.startDeviceWatch(
+        const DeviceWatchFilter(),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(fixture.platform.scanning, isFalse);
+      await fixture.load();
+      expect(fixture.transports, isEmpty);
+      fixture.manager.bleService.registry.finishInitialLoading();
+      await watch;
+      final candidate = fixture.next;
+      fixture.advertise();
+      expect((await candidate).implementation, DeviceImplementation.plugin);
+    },
+  );
+
+  test(
+    'plugin-first ownership fences old native candidate and unload restores native',
+    () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.dispose);
+      await fixture.start();
+      final native = fixture.next;
+      fixture.advertise();
+      final oldNative = await native;
+      expect(oldNative.implementation, DeviceImplementation.bookooScale);
+      final replacement = fixture.next;
+      await fixture.load();
+      expect((await replacement).implementation, DeviceImplementation.plugin);
+      await oldNative.onConnect();
+      expect(fixture.transports.every((t) => t.connectCalls == 0), isTrue);
+      final fallback = fixture.next;
+      await fixture.manager.unloadPlugin('ble.sensor');
+      expect((await fallback).implementation, DeviceImplementation.bookooScale);
+      expect(fixture.devices.every((list) => list.length <= 1), isTrue);
+    },
+  );
+
+  test(
+    'failed plugin handshake does not fall back to native ownership',
+    () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.dispose);
+      await fixture.start();
+      await fixture.manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: bleSensorManifest(),
+        settings: {},
+        jsCode: bleSensorSource.replaceFirst(
+          'context = session;',
+          "throw Error('handshake failed');",
+        ),
+      );
+      final candidate = fixture.next;
+      fixture.advertise();
+      final sensor = await candidate;
+      await expectLater(sensor.onConnect(), throwsA(anything));
+      await fixture.transports.single.disposed.future.timeout(
+        const Duration(seconds: 2),
+      );
+      expect(fixture.transports.single.disposeCalls, 1);
+      expect(
+        fixture.devices
+            .expand((list) => list)
+            .every(
+              (device) => device.implementation == DeviceImplementation.plugin,
+            ),
+        isTrue,
+      );
+      final diagnostics = await fixture.discovery.diagnostics();
+      expect(
+        (diagnostics['pluginOwnership'] as Map)['aa:bb']['decision'],
+        'plugin',
+      );
+    },
+  );
+
+  test(
+    'two definite matches conflict and unloading a competitor resolves ownership',
+    () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.dispose);
+      await fixture.start();
+      await fixture.load();
+      await fixture.load('competitor');
+      fixture.advertise();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(fixture.devices.expand((list) => list), isEmpty);
+      final diagnostics = await fixture.discovery.diagnostics();
+      expect(
+        (diagnostics['pluginOwnership'] as Map)['aa:bb']['decision'],
+        'conflict',
+      );
+      final candidate = fixture.next;
+      await fixture.manager.unloadPlugin('competitor');
+      expect((await candidate).deviceId, 'plugin:ble.sensor:humidity:aa:bb');
+    },
+  );
+
+  test(
+    'pending system evidence reaches normal scan deadline without native fallback',
+    () async {
+      final fixture = _Fixture(scanDuration: const Duration(milliseconds: 30));
+      addTearDown(fixture.dispose);
+      await fixture.discovery.initialize();
+      await fixture.load();
+      fixture.platform.systemDevices.add(
+        BleDevice(deviceId: 'AA:BB', name: 'Bookoo'),
+      );
+      await fixture.discovery.scanForDevices().timeout(
+        const Duration(seconds: 2),
+      );
+      expect(fixture.platform.scanning, isFalse);
+      expect(fixture.transports, isEmpty);
+      expect(fixture.devices.expand((list) => list), isEmpty);
+      final diagnostics = await fixture.discovery.diagnostics();
+      expect(
+        (diagnostics['pluginOwnership'] as Map)['aa:bb']['decision'],
+        'pending',
+      );
+    },
+  );
+}

--- a/test/plugins/plugin_ble_discovery_policy_test.dart
+++ b/test/plugins/plugin_ble_discovery_policy_test.dart
@@ -198,6 +198,7 @@ void main() {
       final replacement = fixture.next;
       await fixture.load();
       expect((await replacement).implementation, DeviceImplementation.plugin);
+      expect(fixture.transports.every((t) => t.disconnectCalls == 0), isTrue);
       await oldNative.onConnect();
       expect(fixture.transports.every((t) => t.connectCalls == 0), isTrue);
       final fallback = fixture.next;

--- a/test/plugins/plugin_ble_discovery_policy_test.dart
+++ b/test/plugins/plugin_ble_discovery_policy_test.dart
@@ -35,7 +35,10 @@ class _Fixture {
             required requestLargeMtuNonAndroid,
             required lifecycleGate,
           }) {
-            final transport = PluginBleFixtureTransport(device.deviceId);
+            final transport = PluginBleFixtureTransport(
+              device.deviceId,
+              services: const ['180f', '0ffe'],
+            );
             transports.add(transport);
             return transport;
           },
@@ -205,6 +208,80 @@ void main() {
       await fixture.manager.unloadPlugin('ble.sensor');
       expect((await fallback).implementation, DeviceImplementation.bookooScale);
       expect(fixture.devices.every((list) => list.length <= 1), isTrue);
+    },
+  );
+
+  test(
+    'connected native owner survives driver binding until normal teardown',
+    () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.dispose);
+      await fixture.start();
+      final candidate = fixture.next;
+      fixture.advertise();
+      final native = await candidate;
+      await native.onConnect();
+      expect(
+        await native.connectionState.first,
+        domain.ConnectionState.connected,
+      );
+      expect(fixture.manager.bleService.registry.isClaimed('AA:BB'), isTrue);
+      final transport = fixture.transports.single;
+
+      await fixture.load();
+      fixture.advertise();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(fixture.devices.last.single, same(native));
+      expect(
+        await native.connectionState.first,
+        domain.ConnectionState.connected,
+      );
+      expect(fixture.manager.bleService.bindingCount, 0);
+      expect(fixture.transports, [same(transport)]);
+      expect(transport.connectCalls, 1);
+      expect(transport.disconnectCalls, 0);
+      expect(transport.disposeCalls, 0);
+
+      await native.disconnect();
+      expect(fixture.manager.bleService.registry.isClaimed('AA:BB'), isFalse);
+      final replacement = fixture.next;
+      fixture.advertise();
+      final plugin = await replacement;
+      expect(plugin.implementation, DeviceImplementation.plugin);
+      await plugin.onConnect();
+      expect(fixture.transports, hasLength(2));
+      expect(fixture.transports.last.connectCalls, 1);
+      expect(transport.disconnectCalls, 1);
+      await plugin.disconnect();
+    },
+  );
+
+  test(
+    'loaded declaration without runtime binding retains native selection',
+    () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.dispose);
+      await fixture.start();
+      await fixture.manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: bleSensorManifest(),
+        settings: {},
+        jsCode: "function createPlugin(host) { return {id: 'ble.sensor'}; }",
+      );
+      expect(fixture.manager.loadedPlugins, hasLength(1));
+      expect(fixture.manager.bleService.registry.hasDrivers, isFalse);
+      final candidate = fixture.next;
+      fixture.advertise();
+      final native = await candidate;
+      expect(native.implementation, DeviceImplementation.bookooScale);
+      await native.onConnect();
+      expect(
+        await native.connectionState.first,
+        domain.ConnectionState.connected,
+      );
+      expect(fixture.manager.bleService.bindingCount, 0);
+      expect(fixture.transports.single.connectCalls, 1);
+      await native.disconnect();
     },
   );
 

--- a/test/plugins/plugin_ble_discovery_test.dart
+++ b/test/plugins/plugin_ble_discovery_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart' as domain;
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/remembered_device.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/models/device/watch_filter.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import '../helpers/plugin_ble_fixture.dart';
+import 'plugin_manager_ble_test.dart' show bleSensorSource, bleSensorManifest;
+import 'plugin_test_helpers.dart';
+
+void main() {
+  test(
+    'existing watch emits nameless plugin Sensor once and reconciles unload',
+    () async {
+      final platform = PluginBleFixturePlatform();
+      UniversalBle.setInstance(platform);
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      final service = UniversalBleDiscoveryService(
+        watchSupportGate: () => true,
+        pluginBleService: () => manager.bleService,
+        transportFactory:
+            ({
+              required device,
+              required stopScan,
+              required requestLargeMtuNonAndroid,
+              required lifecycleGate,
+            }) => PluginBleFixtureTransport(device.deviceId),
+      );
+      addTearDown(() async {
+        await service.dispose();
+        await manager.dispose();
+      });
+      await service.initialize();
+      await manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: bleSensorManifest(),
+        settings: {},
+        jsCode: bleSensorSource,
+      );
+      final devices = <List<domain.Device>>[];
+      final sub = service.devices.listen(devices.add);
+      addTearDown(sub.cancel);
+      await service.startDeviceWatch(const DeviceWatchFilter());
+      final found = service.devices.firstWhere((d) => d.isNotEmpty);
+      platform.updateScanResult(
+        BleDevice(deviceId: 'AA:BB', name: null, services: ['180f']),
+      );
+      final candidate = (await found.timeout(
+        const Duration(seconds: 2),
+      )).single;
+      expect(candidate.deviceId, 'plugin:ble.sensor:humidity:aa:bb');
+      platform.updateScanResult(
+        BleDevice(deviceId: 'AA:BB', name: null, services: ['180f']),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(devices.last.single, same(candidate));
+      final empty = service.devices.firstWhere((d) => d.isEmpty);
+      await manager.unloadPlugin('ble.sensor');
+      await empty.timeout(const Duration(seconds: 2));
+      await expectLater(candidate.onConnect(), throwsA(anything));
+    },
+  );
+
+  test(
+    'remembered native device cannot bypass incomplete BLE ownership',
+    () async {
+      final platform = PluginBleFixturePlatform();
+      UniversalBle.setInstance(platform);
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      final transports = <PluginBleFixtureTransport>[];
+      final service = UniversalBleDiscoveryService(
+        pluginBleService: () => manager.bleService,
+        transportFactory:
+            ({
+              required device,
+              required stopScan,
+              required requestLargeMtuNonAndroid,
+              required lifecycleGate,
+            }) {
+              final t = PluginBleFixtureTransport(device.deviceId);
+              transports.add(t);
+              return t;
+            },
+      );
+      addTearDown(() async {
+        await service.dispose();
+        await manager.dispose();
+      });
+      await service.initialize();
+      await manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: bleSensorManifest(),
+        settings: {},
+        jsCode: bleSensorSource,
+      );
+      final device = await service.tryQuickConnect(
+        RememberedDevice(
+          id: 'AA:BB',
+          name: 'Bookoo',
+          type: domain.DeviceType.scale,
+          implementation: DeviceImplementation.bookooScale,
+          transportType: TransportType.ble,
+        ),
+      );
+      expect(device, isNull);
+      expect(transports, isEmpty);
+    },
+  );
+}

--- a/test/plugins/plugin_ble_native_bridge_test.dart
+++ b/test/plugins/plugin_ble_native_bridge_test.dart
@@ -1,0 +1,123 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import '../helpers/plugin_ble_fixture.dart';
+import 'plugin_manager_ble_test.dart' show bleSensorSource, bleSensorManifest;
+import 'plugin_test_helpers.dart';
+
+void main() {
+  test(
+    'real bridge resets native CCCD and preserves native error distinctions',
+    () async {
+      final platform = PluginBleFixturePlatform();
+      UniversalBle.setInstance(platform);
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      await manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: bleSensorManifest(),
+        settings: {},
+        jsCode: bleSensorSource.replaceFirst(
+          "const services = await session.gatt.discoverServices();",
+          '''
+          globalThis.checkRead = () => session.gatt.read('180f', '2a19')
+            .then(value => host.emit('read', value), error => host.emit('read', error.code));
+          globalThis.checkWrite = () => session.gatt.writeWithResponse('180f', '2a19', 'AQ==')
+            .then(() => host.emit('write', 'ok'), error => host.emit('write', error.code));
+          globalThis.replaceSubscription = async () => {
+            const old = await session.gatt.subscribe('180f', '2a19', () => {});
+            await session.gatt.subscribe('0000180f-0000-1000-8000-00805f9b34fb', '2a19',
+              data => host.emit('replacement', data));
+            await old.unsubscribe();
+            host.emit('replaced', true);
+          };
+          const services = await session.gatt.discoverServices();
+        ''',
+        ),
+      );
+      final evidence = BleAdvertisementEvidence(serviceUuids: ['180f']);
+      final sensor =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => UniversalBleTransport(
+                  device: BleDevice(deviceId: 'AA:BB', name: 'Fixture'),
+                  isLinuxOverride: false,
+                  isAndroidOverride: false,
+                ),
+              )
+              as Sensor;
+      await sensor.onConnect();
+      final replaced = manager.emitStream.firstWhere(
+        (e) => e['event'] == 'replaced',
+      );
+      manager.js.evaluate('replaceSubscription();');
+      while (manager.js.executePendingJob() > 0) {}
+      await replaced.timeout(const Duration(seconds: 2));
+      expect(platform.notificationProperties, [
+        BleInputProperty.notification,
+        BleInputProperty.disabled,
+        BleInputProperty.notification,
+        BleInputProperty.disabled,
+        BleInputProperty.notification,
+      ]);
+      final replacement = manager.emitStream.firstWhere(
+        (e) => e['event'] == 'replacement',
+      );
+      platform.updateCharacteristicValue(
+        'AA:BB',
+        '00002a19-0000-1000-8000-00805f9b34fb',
+        Uint8List.fromList([53]),
+        null,
+      );
+      expect(
+        (await replacement.timeout(const Duration(seconds: 2)))['payload'],
+        'NQ==',
+      );
+      for (final (code, expected) in [
+        (UniversalBleErrorCode.characteristicNotFound, 'attribute_unavailable'),
+        (UniversalBleErrorCode.operationCancelled, 'operationCancelled'),
+      ]) {
+        platform.readError = UniversalBleException(
+          code: code,
+          message: 'fixture',
+        );
+        final result = manager.emitStream.firstWhere(
+          (e) => e['event'] == 'read',
+        );
+        manager.js.evaluate('checkRead();');
+        expect(
+          (await result.timeout(const Duration(seconds: 2)))['payload'],
+          expected,
+        );
+      }
+      platform.writeError = UniversalBleException(
+        code: UniversalBleErrorCode.characteristicDoesNotSupportWrite,
+        message: 'fixture',
+      );
+      final written = manager.emitStream.firstWhere(
+        (e) => e['event'] == 'write',
+      );
+      manager.js.evaluate('checkWrite();');
+      expect(
+        (await written.timeout(const Duration(seconds: 2)))['payload'],
+        'characteristicDoesNotSupportWrite',
+      );
+      expect(platform.writeProperties, [BleOutputProperty.withResponse]);
+      platform.writeError = null;
+      await sensor.disconnect();
+      expect(manager.bleService.registry.activeBindingCount, 0);
+    },
+  );
+}

--- a/test/plugins/plugin_ble_sensor_api_test.dart
+++ b/test/plugins/plugin_ble_sensor_api_test.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/sensor_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/watch_filter.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_plus/shelf_plus.dart';
+import 'package:universal_ble/universal_ble.dart';
+import 'package:web_socket_channel/io.dart';
+
+import '../helpers/mock_settings_service.dart';
+import '../helpers/plugin_ble_fixture.dart';
+import 'plugin_manager_ble_test.dart' show bleSensorSource, bleSensorManifest;
+import 'plugin_test_helpers.dart';
+
+void main() {
+  test(
+    'advertisement through JS protocol reaches existing Sensor REST and WS',
+    () async {
+      final platform = PluginBleFixturePlatform();
+      UniversalBle.setInstance(platform);
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      final transports = <PluginBleFixtureTransport>[];
+      final discovery = UniversalBleDiscoveryService(
+        watchSupportGate: () => true,
+        pluginBleService: () => manager.bleService,
+        transportFactory:
+            ({
+              required device,
+              required stopScan,
+              required requestLargeMtuNonAndroid,
+              required lifecycleGate,
+            }) {
+              final transport = PluginBleFixtureTransport(device.deviceId);
+              transports.add(transport);
+              return transport;
+            },
+      );
+      final devices = DeviceController([discovery]);
+      await devices.initialize();
+      final sensors = SensorController(controller: devices);
+      final settings = SettingsController(MockSettingsService());
+      await settings.loadSettings();
+      final connections = ConnectionManager(
+        deviceScanner: devices,
+        de1Controller: De1Controller(controller: devices),
+        scaleController: ScaleController(),
+        settingsController: settings,
+      );
+      final router = Router().plus;
+      SensorsHandler(controller: sensors).addRoutes(router);
+      final devicesHandler = DevicesHandler(
+        controller: devices,
+        connectionManager: connections,
+      );
+      devicesHandler.addRoutes(router);
+      final server = await shelf_io.serve(router.call, '127.0.0.1', 0);
+      final client = HttpClient();
+      IOWebSocketChannel? channel;
+      addTearDown(() async {
+        await channel?.sink.close();
+        client.close(force: true);
+        await discovery.dispose();
+        await manager.dispose();
+        devicesHandler.dispose();
+        connections.dispose();
+        sensors.dispose();
+        devices.dispose();
+        await server.close(force: true);
+      });
+      await manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: bleSensorManifest(),
+        settings: {},
+        jsCode: bleSensorSource,
+      );
+      await discovery.startDeviceWatch(const DeviceWatchFilter());
+      final found = sensors.sensorRegistry.firstWhere((s) => s.isNotEmpty);
+      platform.updateScanResult(
+        BleDevice(deviceId: 'AA:BB', name: null, services: ['180f']),
+      );
+      final sensor = (await found.timeout(
+        const Duration(seconds: 2),
+      )).values.single;
+      await sensor.connectionState
+          .firstWhere((s) => s == ConnectionState.connected)
+          .timeout(const Duration(seconds: 2));
+      final origin = 'http://127.0.0.1:${server.port}';
+      Future<dynamic> get(String path) async {
+        final response = await (await client.getUrl(
+          Uri.parse('$origin$path'),
+        )).close();
+        expect(response.statusCode, 200);
+        return jsonDecode(await utf8.decoder.bind(response).join());
+      }
+
+      final inventory = await get('/api/v1/devices') as List;
+      expect(inventory.single['id'], sensor.deviceId);
+      expect(inventory.single['type'], 'sensor');
+      final registry = await get('/api/v1/sensors') as List;
+      expect(registry.single['id'], sensor.deviceId);
+      expect(registry.single['info']['data'].single['key'], 'humidity');
+      channel = IOWebSocketChannel.connect(
+        Uri.parse(
+          'ws://127.0.0.1:${server.port}/ws/v1/sensors/${sensor.deviceId}/snapshot',
+        ),
+      );
+      await channel.ready;
+      final snapshot = channel.stream.first;
+      transports.single.subscribers.values.single(Uint8List.fromList([57]));
+      expect(
+        jsonDecode(
+          await snapshot.timeout(const Duration(seconds: 2)) as String,
+        ),
+        {'humidity': 57},
+      );
+      final request = await client.postUrl(
+        Uri.parse('$origin/api/v1/sensors/${sensor.deviceId}/execute'),
+      );
+      request.headers.contentType = ContentType.json;
+      request.write(jsonEncode({'commandId': 'sample', 'params': null}));
+      final response = await request.close();
+      expect(response.statusCode, 200);
+      expect(jsonDecode(await utf8.decoder.bind(response).join()), {
+        'status': 'ok',
+        'result': {'humidity': 52},
+      });
+      expect(transports.single.writes.single.data, [1]);
+      expect(transports.single.writes.single.withResponse, isTrue);
+    },
+  );
+}

--- a/test/plugins/plugin_manager_ble_test.dart
+++ b/test/plugins/plugin_manager_ble_test.dart
@@ -72,6 +72,43 @@ PluginManifest bleSensorManifest({String id = 'ble.sensor'}) => testManifest(
 );
 
 void main() {
+  test(
+    'bindDriver without transport.ble rejects with PluginPermissionError',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      final event = manager.emitStream.firstWhere(
+        (event) => event['event'] == 'denied',
+      );
+      await manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: testManifest(
+          'ble.sensor',
+          permissions: {PluginPermissions.emit},
+          drivers: bleSensorManifest().drivers,
+        ),
+        settings: {},
+        jsCode: '''
+        function createPlugin(host) {
+          return {id: 'ble.sensor', async onLoad() {
+            try {
+              await host.devices.bindDriver('humidity', {create() { return {}; }});
+            } catch (error) {
+              host.emit('denied', {name: error.name, message: error.message});
+            }
+          }};
+        }
+      ''',
+      );
+      expect((await event.timeout(const Duration(seconds: 2)))['payload'], {
+        'name': 'PluginPermissionError',
+        'message':
+            'Plugin ble.sensor requires manifest permission transport.ble',
+      });
+      expect(manager.bleService.registry.hasDrivers, isFalse);
+    },
+  );
+
   Future<Sensor> candidate(
     PluginManager manager,
     List<PluginBleFixtureTransport> transports, {
@@ -99,6 +136,24 @@ void main() {
         settings: {},
         jsCode: source,
       );
+
+  test('cache retirement preserves an occupied plugin binding', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await load(manager);
+    final transports = <PluginBleFixtureTransport>[];
+    final sensor = await candidate(manager, transports);
+    await sensor.onConnect();
+    await manager.bleService.discardInactive(sensor);
+    expect(manager.bleService.bindingCount, 1);
+    expect(manager.bleService.registry.activeBindingCount, 1);
+    expect(transports.single.disconnectCalls, 0);
+    expect(transports.single.disposeCalls, 0);
+    await sensor.disconnect();
+    await manager.bleService.discardInactive(sensor);
+    expect(manager.bleService.bindingCount, 0);
+    expect(manager.bleService.registry.activeBindingCount, 0);
+  });
 
   for (final cleanup in [
     'throw Error("cleanup");',

--- a/test/plugins/plugin_manager_ble_test.dart
+++ b/test/plugins/plugin_manager_ble_test.dart
@@ -1,0 +1,325 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/models/device/transport/data_transport.dart';
+import 'package:reaprime/src/plugins/plugin_ble_matcher.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_ble_session.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+
+import '../helpers/plugin_ble_fixture.dart';
+import 'plugin_test_helpers.dart';
+
+const bleSensorSource = '''
+function createPlugin(host) {
+  return {
+    id: 'ble.sensor',
+    async onLoad() {
+      await host.devices.bindDriver('humidity', {
+        create(device) {
+          globalThis.factoryDevice = device;
+          let context;
+          return {
+            vendor: 'Fixture',
+            dataChannels: [{key: 'humidity', type: 'number'}],
+            commands: [{id: 'sample'}],
+            async connect(session) {
+              context = session;
+              globalThis.oldContext = globalThis.oldContext || session;
+              globalThis.currentContext = session;
+              host.emit('connecting', true);
+              const services = await session.gatt.discoverServices();
+              host.emit('services', services);
+              await session.gatt.subscribe('180f', '2a19', async data => {
+                const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+                if (data.length !== 4 || data.slice(2) !== '==') throw Error('Invalid humidity frame');
+                const humidity = (alphabet.indexOf(data[0]) << 2) | (alphabet.indexOf(data[1]) >> 4);
+                await session.publish({humidity});
+                host.emit('sample', data);
+              });
+            },
+            async disconnect({gatt}) {
+              if (gatt) await gatt.writeWithResponse('180f', '2a19', 'AA==');
+            },
+            async execute(command) {
+              await context.gatt.writeWithResponse('180f', '2a19', 'AQ==');
+              return {humidity: 52};
+            }
+          };
+        }
+      });
+      host.emit('bound', true);
+    }
+  };
+}
+''';
+
+PluginManifest bleSensorManifest({String id = 'ble.sensor'}) => testManifest(
+  id,
+  permissions: {PluginPermissions.emit, PluginPermissions.transportBle},
+  drivers: [
+    PluginDriverDeclaration(
+      id: 'humidity',
+      type: PluginDriverType.sensor,
+      ble: PluginBleMatcher.fromJson({
+        'serviceUuids': ['180f'],
+      }),
+    ),
+  ],
+);
+
+void main() {
+  Future<Sensor> candidate(
+    PluginManager manager,
+    List<PluginBleFixtureTransport> transports, {
+    String id = 'AA:BB',
+  }) async {
+    final evidence = BleAdvertisementEvidence(serviceUuids: ['180f']);
+    return await manager.bleService.createCandidate(
+          driver: manager.bleService.registry.decide(evidence).drivers.single,
+          physicalId: id,
+          evidence: evidence,
+          admit: () => true,
+          createTransport: () {
+            final transport = PluginBleFixtureTransport(id);
+            transports.add(transport);
+            return transport;
+          },
+        )
+        as Sensor;
+  }
+
+  Future<void> load(PluginManager manager, {String source = bleSensorSource}) =>
+      manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: bleSensorManifest(),
+        settings: {},
+        jsCode: source,
+      );
+
+  for (final cleanup in [
+    'throw Error("cleanup");',
+    'await new Promise(() => {});',
+  ]) {
+    test('repeated permanently suspended initialization with $cleanup', () async {
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceInvocationTimeout: const Duration(milliseconds: 100),
+      );
+      addTearDown(manager.dispose);
+      await load(
+        manager,
+        source: bleSensorSource
+            .replaceFirst(
+              "const services = await session.gatt.discoverServices();",
+              "await new Promise(() => {}); const services = [];",
+            )
+            .replaceFirst(
+              "if (gatt) await gatt.writeWithResponse('180f', '2a19', 'AA==');",
+              cleanup,
+            ),
+      );
+      final transports = <PluginBleFixtureTransport>[];
+      final sensor = await candidate(manager, transports);
+      for (var i = 0; i < 4; i++) {
+        final entered = manager.emitStream.firstWhere(
+          (event) => event['event'] == 'connecting',
+        );
+        final connect = expectLater(sensor.onConnect(), throwsA(anything));
+        await entered.timeout(const Duration(seconds: 2));
+        await sensor.disconnect();
+        await connect;
+        expect(manager.bleService.registry.activeBindingCount, 0);
+        expect(manager.deviceConnectAttemptCount, 0);
+        expect(manager.retiredDeviceConnectCount, 0);
+        expect(transports.last.disposeCalls, 1);
+      }
+    });
+  }
+
+  test(
+    'unconfirmed teardown excludes reuse and unload still removes the driver',
+    () async {
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceInvocationTimeout: const Duration(milliseconds: 100),
+      );
+      addTearDown(manager.dispose);
+      await load(manager);
+      final transports = <PluginBleFixtureTransport>[];
+      final sensor = await candidate(manager, transports);
+      await sensor.onConnect();
+      final release = Completer<void>();
+      transports.single.teardown = release;
+      await expectLater(sensor.disconnect(), throwsA(isA<TimeoutException>()));
+      expect(manager.bleService.registry.isClaimed('AA:BB'), isTrue);
+      await expectLater(sensor.onConnect(), throwsA(anything));
+      expect(transports, hasLength(1));
+      await expectLater(manager.unloadPlugin('ble.sensor'), throwsA(anything));
+      expect(manager.bleService.registry.hasDrivers, isFalse);
+      expect(manager.bleService.bindingCount, 0);
+      expect(manager.bleService.registry.isClaimed('AA:BB'), isTrue);
+      release.complete();
+      await transports.single.disposed.future.timeout(
+        const Duration(seconds: 2),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(manager.bleService.registry.activeBindingCount, 0);
+    },
+  );
+
+  test(
+    'two physical Sensors own independent sessions with injected capacity',
+    () async {
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        bleRegistry: PluginBleRegistry(activeBindingLimit: 2),
+      );
+      addTearDown(manager.dispose);
+      await load(manager);
+      final transports = <PluginBleFixtureTransport>[];
+      final first = await candidate(manager, transports);
+      final second = await candidate(manager, transports, id: 'CC:DD');
+      await first.onConnect();
+      await second.onConnect();
+      expect(manager.bleService.registry.activeBindingCount, 2);
+      await first.disconnect();
+      expect(await second.execute('sample', null), {'humidity': 52});
+      expect(manager.bleService.registry.activeBindingCount, 1);
+      expect(
+        () => manager.bleService.call(
+          'foreign',
+          1,
+          'forged',
+          'forged',
+          'read',
+          {'service': '180f', 'characteristic': '2a19'},
+        ),
+        throwsA(isA<PluginBleException>()),
+      );
+    },
+  );
+
+  test(
+    'default capacity rejects a second Sensor without disturbing the first',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      await load(manager);
+      final transports = <PluginBleFixtureTransport>[];
+      final first = await candidate(manager, transports);
+      final second = await candidate(manager, transports, id: 'CC:DD');
+      await first.onConnect();
+      await expectLater(second.onConnect(), throwsA(isA<PluginBleException>()));
+      expect(transports, hasLength(1));
+      expect(manager.bleService.registry.activeBindingCount, 1);
+      expect(await first.execute('sample', null), {'humidity': 52});
+      await first.disconnect();
+      await second.onConnect();
+      expect(transports, hasLength(2));
+    },
+  );
+
+  for (final linkLost in [false, true]) {
+    test(
+      'revocation skips protocol cleanup and emits one terminal event: linkLost=$linkLost',
+      () async {
+        final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+        addTearDown(manager.dispose);
+        await load(
+          manager,
+          source: bleSensorSource.replaceFirst(
+            'context = session;',
+            "context = session; session.gatt.onDisconnect(() => host.emit('terminal', true));",
+          ),
+        );
+        final events = <Map<String, dynamic>>[];
+        final subscription = manager.emitStream.listen(events.add);
+        addTearDown(subscription.cancel);
+        final transports = <PluginBleFixtureTransport>[];
+        final sensor = await candidate(manager, transports);
+        await sensor.onConnect();
+        if (linkLost) {
+          transports.single.states.add(ConnectionState.disconnected);
+        } else {
+          manager.bleService.revokeSessions();
+        }
+        await transports.single.disposed.future.timeout(
+          const Duration(seconds: 2),
+        );
+        await sensor.disconnect();
+        expect(transports.single.writes, isEmpty);
+        expect(
+          events.where((event) => event['event'] == 'terminal'),
+          hasLength(1),
+        );
+        expect(manager.bleService.registry.activeBindingCount, 0);
+      },
+    );
+  }
+
+  test('real JS factory, GATT, Sensor commands and reconnect fence', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    final bound = manager.emitStream.firstWhere((e) => e['event'] == 'bound');
+    await manager.loadPlugin(
+      id: 'ble.sensor',
+      manifest: bleSensorManifest(),
+      settings: {},
+      jsCode: bleSensorSource,
+    );
+    await bound.timeout(const Duration(seconds: 2));
+    final evidence = BleAdvertisementEvidence(serviceUuids: ['180f']);
+    final driver = manager.bleService.registry.decide(evidence).drivers.single;
+    final transports = <PluginBleFixtureTransport>[];
+    final sensor =
+        await manager.bleService.createCandidate(
+              driver: driver,
+              physicalId: 'AA:BB',
+              evidence: evidence,
+              createTransport: () {
+                final transport = PluginBleFixtureTransport('AA:BB');
+                transports.add(transport);
+                return transport;
+              },
+              admit: () => true,
+            )
+            as Sensor;
+    expect(sensor.deviceId, 'plugin:ble.sensor:humidity:aa:bb');
+    expect(sensor.transportType, TransportType.ble);
+    expect(transports, isEmpty);
+    final sample = sensor.data.first;
+    await sensor.onConnect();
+    expect(await sample.timeout(const Duration(seconds: 2)), {'humidity': 52});
+    expect(await sensor.execute('sample', null), {'humidity': 52});
+    expect(transports.single.writes.single.withResponse, isTrue);
+    await sensor.disconnect();
+    await sensor.onConnect();
+    expect(transports, hasLength(2));
+    expect(transports.first.disposeCalls, 1);
+    manager.js.evaluate('''
+      oldContext.gatt.read('180f', '2a19').then(
+        () => { throw Error('stale read succeeded'); },
+        e => currentContext.publish({humidity: 51}).then(() => {
+          globalThis.staleCode = e.code;
+        })
+      );
+    ''');
+    while (manager.js.executePendingJob() > 0) {}
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(
+      manager.js.evaluate('globalThis.staleCode').stringResult,
+      'stale_session',
+    );
+    final states = <ConnectionState>[];
+    final stateSubscription = sensor.connectionState.listen(states.add);
+    await manager.unloadPlugin('ble.sensor');
+    await stateSubscription.cancel();
+    expect(states.last, ConnectionState.disconnected);
+    expect(manager.bleService.registry.hasDrivers, isFalse);
+    expect(manager.bleService.registry.activeBindingCount, 0);
+  });
+}

--- a/test/services/ble/ble_admission_transport_test.dart
+++ b/test/services/ble/ble_admission_transport_test.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/errors.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/services/ble/ble_admission_transport.dart';
+
+import '../../helpers/plugin_ble_fixture.dart';
+
+void main() {
+  test(
+    'native exclusion lasts until confirmed teardown and stale writes fail',
+    () async {
+      final registry = PluginBleRegistry();
+      final raw = PluginBleFixtureTransport('AA:BB');
+      final transport = BleAdmissionTransport(
+        transport: raw,
+        reserve: () => registry.reserveNative(raw.id),
+        release: (claim) => registry.releaseNative(raw.id, claim),
+      );
+      addTearDown(() async {
+        await transport.dispose();
+        await registry.dispose();
+      });
+      await transport.disconnect();
+      expect(raw.states.value.name, 'discovered');
+      await transport.connect();
+      final confirmation = Completer<void>();
+      raw.teardown = confirmation;
+      final closing = transport.disconnect();
+      await Future<void>.delayed(Duration.zero);
+      expect(registry.isClaimed(raw.id), isTrue);
+      expect(() => registry.reserveNative(raw.id), throwsStateError);
+      confirmation.complete();
+      await closing;
+      expect(registry.isClaimed(raw.id), isFalse);
+      await expectLater(
+        transport.write('180f', '2a19', Uint8List.fromList([1])),
+        throwsA(isA<DeviceNotConnectedException>()),
+      );
+      expect(raw.writes, isEmpty);
+      await transport.connect();
+      expect(raw.connectCalls, 2);
+      expect(registry.isClaimed(raw.id), isTrue);
+    },
+  );
+}

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -917,9 +917,13 @@ void main() {
   });
 
   group('quick-connect identity policy', () {
-    for (final apple in [true, false]) {
+    for (final (apple, stopWatch) in [
+      (true, false),
+      (false, false),
+      (true, true),
+    ]) {
       test(
-        'quick-connect uses only fresh system names with apple=$apple',
+        'quick-connect uses only fresh system names with apple=$apple, stopWatch=$stopWatch',
         () async {
           final manager = PluginManager(kvStore: FakeKeyValueStoreService());
           addTearDown(manager.dispose);
@@ -942,6 +946,7 @@ void main() {
           );
           final transport = transportForModel(129);
           final sut = UniversalBleDiscoveryService(
+            watchSupportGate: () => true,
             requiresSystemDevice: () => apple,
             pluginBleService: () => manager.bleService,
             transportFactory:
@@ -954,6 +959,10 @@ void main() {
           );
           addTearDown(sut.dispose);
           await sut.initialize();
+          if (stopWatch) {
+            await sut.startDeviceWatch(_watchFilter);
+            await sut.stopDeviceWatch();
+          }
           final result = await sut.tryQuickConnect(
             const RememberedDevice(
               id: deviceId,

--- a/test/services/universal_ble_discovery_service_test.dart
+++ b/test/services/universal_ble_discovery_service_test.dart
@@ -18,9 +18,13 @@ import 'package:reaprime/src/models/device/remembered_device.dart';
 import 'package:reaprime/src/models/device/transport/data_transport.dart';
 import 'package:reaprime/src/settings/feature_flags.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_ble_matcher.dart';
 
 import '../helpers/fake_ble_transport.dart';
 import '../helpers/mock_settings_service.dart';
+import '../plugins/plugin_test_helpers.dart';
 
 class _FakeBlePlatform extends UniversalBlePlatform {
   final List<BleDevice> systemDevices = [];
@@ -199,6 +203,9 @@ class _TrackingFakeBleTransport extends FakeBleTransport {
     }
     await super.connect();
   }
+
+  @override
+  Future<void> disconnectConfirmed() => disconnect();
 
   @override
   Future<void> disconnect() async {
@@ -910,6 +917,62 @@ void main() {
   });
 
   group('quick-connect identity policy', () {
+    for (final apple in [true, false]) {
+      test(
+        'quick-connect uses only fresh system names with apple=$apple',
+        () async {
+          final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+          addTearDown(manager.dispose);
+          manager.bleService.registry.register(
+            pluginId: 'bookoo',
+            generation: 1,
+            declaration: PluginDriverDeclaration(
+              id: 'scale',
+              type: PluginDriverType.scale,
+              ble: PluginBleMatcher.fromJson({
+                'name': {'exact': 'Bookoo'},
+              }),
+            ),
+            permissions: {PluginPermissions.transportBle},
+            factoryHandle: 'factory',
+          );
+          const deviceId = 'AA:BB:CC:DD:EE:01';
+          platform.systemDevices.add(
+            BleDevice(deviceId: deviceId, name: 'DE1'),
+          );
+          final transport = transportForModel(129);
+          final sut = UniversalBleDiscoveryService(
+            requiresSystemDevice: () => apple,
+            pluginBleService: () => manager.bleService,
+            transportFactory:
+                ({
+                  required device,
+                  required stopScan,
+                  required requestLargeMtuNonAndroid,
+                  required lifecycleGate,
+                }) => transport,
+          );
+          addTearDown(sut.dispose);
+          await sut.initialize();
+          final result = await sut.tryQuickConnect(
+            const RememberedDevice(
+              id: deviceId,
+              name: 'DE1',
+              type: domain.DeviceType.machine,
+              implementation: DeviceImplementation.unifiedDe1,
+              transportType: TransportType.ble,
+            ),
+          );
+          if (apple) {
+            expect(result, isA<De1Interface>());
+            await (result as De1Interface).dispose();
+          } else {
+            expect(result, isNull);
+          }
+        },
+      );
+    }
+
     test(
       'remembered UnifiedDe1 accepts Bengle wire model in degraded mode',
       () async {


### PR DESCRIPTION
## Summary

- Add `host.devices.bindDriver()` and host-owned BLE bindings with synchronous factories, session-scoped GATT/publication, and bounded teardown.
- Wire plugin-first ownership into the existing scanner, system results, watch, startup readiness, and native connection admission. Pending/conflict cannot select native; unconfirmed teardown retains physical exclusion.
- Prove a BLE Sensor through real JavaScript, existing DeviceController/SensorController selection, HTTP inventory/commands, and WebSocket snapshots with a fake BLE edge. Reuse the Scale adapter without claiming Bookoo or Scale timing acceptance.

This is the review-ready BLE binding and Sensor checkpoint after merged #813, not completion of #809. Its merge boundary is host-owned BLE arbitration/lifecycle and Sensor integration through existing controllers and APIs, verified with a fake BLE edge.

## Linked Issue

Refs #809. Keep the issue open.

## Verification

- Formatter: 818 files, zero changes using the CI-compatible dart_style 3.1.13 formatter.
- `flutter analyze --no-pub`: no issues.
- Full `flutter test --no-pub --machine`: 3,992 passing tests, one skip. The 20-second per-suite active-time gate passes.
- Regression coverage includes failed initial plugin loading, both evidence orders, conflict/pending deadline, native candidate fencing, failed handshake without native fallback, repeated permanently hung connects, throwing/hung cleanup, unconfirmed native teardown, capacity/isolation, stale/foreign authority, and terminal delivery on link loss/revocation.
- Real UniversalBleTransport bridge test verifies notification -> disabled -> notification, UUID aliases, old logical unsubscribe isolation, missing attributes, cancellation, and acknowledged-write errors without downgrade.
- Windows debug build (`lib/main.dart`, simulate=1) passed using CMake 3.28 and Visual Studio 2022 in a separate build directory. Flutter's default VS2019 toolchain failed on native dependencies; no global toolchain settings or dependency sources were changed.
- Desktop runtime smoke: an isolated Flutter entrypoint using the production manager, discovery, controllers, and Sensor routes with fake BLE/in-memory settings passed. HTTP inventory reported the connected Sensor; command returned `{"status":"ok","result":{"humidity":52}}`; a fresh WebSocket notification returned `{"humidity":57}`. Runtime exited after teardown. No real BLE/USB devices or saved user data were used. This is not full application UI/hardware acceptance.
- Deliberately rejected JavaScript promises produce QuickJS rejection diagnostics in failure-path tests; assertions observe the expected errors. No hardware test was performed.

Subsequent #809 checkpoints cover Bookoo protocol, Scale measurement timing, automatic optional Scale operations, and sleep policy. Exhaustive reload/discovery interleavings and physical hardware acceptance remain broader #809 acceptance work; they are not claimed by this checkpoint. #809 remains open.

Latest ownership-contract verification at `75e8ec6e`: all 10 discovery-policy tests pass, including occupied native ownership through plugin load and loaded-but-unbound declaration fallback. Full suite: 3,992 passed, one skipped; analysis clean; formatter and 20-second suite timing gate pass. No production code changed in this follow-up. Native build/runtime smoke above are prior checkpoint evidence, not rerun for this test/doc-only change.

## Impact

- BLE plugin Sensors use existing inventory, command, and snapshot routes; no REST/WebSocket route or payload schema change and no database migration.
- Plugin loading now gates initial BLE selection. A matching runtime-bound plugin takes precedence over unoccupied native candidates; unresolved evidence or conflicting matchers excludes native selection.
- Publication and GATT authority are connection-bound. Native and plugin candidates share physical exclusion until confirmed teardown. No new dependencies, scanner, retry scheduler, or BLE calls outside the transport abstraction.
- Update Plugins, DeviceManagement, and AI_BLE_NOTES; archive this checkpoint's design rationale while the broader #809 design remains active.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
