### PR TITLE
Plugin Scale API and sleep-policy checkpoint

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -1054,6 +1054,7 @@ paths:
     put:
       summary: Tare Scale
       description: |
+        Unsupported plugin Scale tare returns 500 with `code: unsupported_operation`.
         Tares the connected scale. If `blockTareDuringShot` is enabled and an
         app-tracked espresso shot is actively brewing (not idle/finished), the
         request is rejected with `400` rather than tared — see
@@ -1086,39 +1087,63 @@ paths:
                     type: string
         "404":
           description: Scale not found
+        "500":
+          description: Scale command failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScaleCommandError"
 
   /api/v1/scale/timer/start:
     put:
       summary: Start Scale Timer
-      description: Starts the timer on the connected scale. No-op if the scale doesn't support hardware timers.
+      description: >
+        Starts the timer on the connected scale. Native scales without timers retain their no-op behavior.
+        Unsupported plugin Scale timers return 500 with `code: unsupported_operation`.
       tags: [Scale]
       responses:
         "200":
           description: Timer started
         "500":
           description: No scale connected or error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScaleCommandError"
 
   /api/v1/scale/timer/stop:
     put:
       summary: Stop Scale Timer
-      description: Stops the timer on the connected scale. No-op if the scale doesn't support hardware timers.
+      description: >
+        Stops the timer on the connected scale. Native scales without timers retain their no-op behavior.
+        Unsupported plugin Scale timers return 500 with `code: unsupported_operation`.
       tags: [Scale]
       responses:
         "200":
           description: Timer stopped
         "500":
           description: No scale connected or error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScaleCommandError"
 
   /api/v1/scale/timer/reset:
     put:
       summary: Reset Scale Timer
-      description: Resets the timer on the connected scale. No-op if the scale doesn't support hardware timers.
+      description: >
+        Resets the timer on the connected scale. Native scales without timers retain their no-op behavior.
+        Unsupported plugin Scale timers return 500 with `code: unsupported_operation`.
       tags: [Scale]
       responses:
         "200":
           description: Timer reset
         "500":
           description: No scale connected or error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScaleCommandError"
 
   # Sensors API handling
   /api/v1/sensors:
@@ -5427,6 +5452,15 @@ paths:
 
 components:
   schemas:
+    ScaleCommandError:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+          description: Optional plugin error code, including unsupported_operation.
     BleDiagnosticsSnapshot:
       type: object
       required: [timestamp, ble, connection]

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -1,5 +1,10 @@
 # API Reference
 
+Scale REST command failures preserve the existing HTTP 500 response and `error`
+message. Plugin Scale failures additionally include `code`; unsupported optional
+operations use `unsupported_operation`. Native timer no-op behavior is unchanged.
+The four tare/timer 500 responses share the OpenAPI `ScaleCommandError` schema.
+
 Decaid exposes REST and WebSocket APIs on port 8080. Full OpenAPI specs are in [`assets/api/rest_v1.yml`](../assets/api/rest_v1.yml) and [`assets/api/websocket_v1.yml`](../assets/api/websocket_v1.yml). Interactive docs are available at port 4001 when the app is running.
 
 For skin development, see [`doc/Skins.md`](Skins.md). For plugin development, see [`doc/Plugins.md`](Plugins.md).

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -1647,6 +1647,14 @@ identically.
 
 ## Plugin BLE Ownership
 
+Plugin Scales with `disconnectToSleep` mark deliberate sleep before disconnecting
+in display-off power mode. Host Scale recovery pauses until an awake machine
+snapshot, just as radio-disconnect power management waits for wake. Protocol
+failure outside deliberate sleep still follows normal recovery policy.
+Intermediate `disconnecting` cleanup preserves the previous connected state for
+terminal disconnect classification; an expected sleep consumes its expectation
+without starting recovery.
+
 The existing BLE discovery service arbitrates plugin ownership before native
 matching, including nameless advertisements, system results, background watch,
 and remembered native quick-connect. Initial scanning waits for plugin loading

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -1,6 +1,12 @@
 
 # Decaid Plugin Development Guide
 
+Plugin Scale commands report stable error codes through the existing Scale REST
+routes, including `unsupported_operation` for undeclared tare or timer support.
+Automatic shot timer failures are logged without aborting the shot. A Scale with
+`disconnectToSleep` uses host deliberate-sleep policy: display-off disconnects it
+without recovery until the machine wakes. No plugin reconnect loop is needed.
+
 ## Overview
 
 > **Note on naming:** Plugin JS APIs use `Rea`-prefixed names (`fetchReaSettings`, `updateReaSetting`, `convertReaToVisualizerFormat`) for backwards compatibility with existing plugins. These were not renamed during the app rename from ReaPrime to Decaid.

--- a/doc/plans/archive/issue-809-scale-integration/scale-policy.md
+++ b/doc/plans/archive/issue-809-scale-integration/scale-policy.md
@@ -1,0 +1,28 @@
+# Scale Integration Checkpoint
+
+Builds on merged #820 at c957e2b1. The existing adapter and public registration
+remain transport-independent. A real QuickJS in-memory protocol exercises inventory,
+connection selection/preference, first-sample handoff, Scale REST commands,
+WebSocket weights, unknown battery, unsupported timer errors, and unload/reload
+without BLE permission.
+
+Automatic timer calls follow the existing automatic tare error-handling pattern:
+observe the future and log failure without aborting shot sequencing. Explicit
+REST commands still fail, and plugin errors expose their stable code alongside
+the existing message through a Scale-domain operation error. Native no-op timer
+behavior is unchanged.
+
+Disconnect-to-sleep is a domain capability, not a dependency from host controllers
+onto the plugin implementation. Before display sleep disconnects the Scale, the
+host marks deliberate sleep and pauses normal Scale reacquisition. An observed
+awake machine state releases this pause. Display-control devices retain their
+existing independent sleep/wake commands.
+
+Disconnect classification retains connection history across `disconnecting`,
+so protocol cleanup cannot suppress unexpected-failure recovery. Terminal sleep
+disconnects consume the existing expectation instead. Tare and timer failures
+share an OpenAPI error schema, including the optional operation error code.
+
+Measurement timing and the Bookoo protocol remain separate checkpoints.
+HTTP/WebSocket and controller tests use test-owned servers and fake devices;
+they do not claim full application UI or hardware acceptance.

--- a/lib/src/controllers/connection/disconnect_supervisor.dart
+++ b/lib/src/controllers/connection/disconnect_supervisor.dart
@@ -29,6 +29,7 @@ class DisconnectSupervisor {
   De1Interface? _latestDe1;
   device.ConnectionState _latestScaleState = device.ConnectionState.discovered;
   String? _lastKnownMachineId;
+  bool _scaleHadConnection = false;
 
   Completer<void>? _machineSeenCompleter;
   String? _awaitedMachineId;
@@ -119,11 +120,15 @@ class DisconnectSupervisor {
       final wasConnected =
           _latestScaleState == device.ConnectionState.connected;
       _latestScaleState = state;
+      final hadConnection = _scaleHadConnection;
+      if (state != device.ConnectionState.disconnecting) {
+        _scaleHadConnection = state == device.ConnectionState.connected;
+      }
       _log.fine('scale connection update: ${state.name}');
       if (!wasConnected && state == device.ConnectionState.connected) {
         _onScaleConnected?.call();
       }
-      if (wasConnected &&
+      if (hadConnection &&
           state == device.ConnectionState.disconnected &&
           !_isConnectingScale()) {
         final id = _scaleLastConnectedId() ?? _preferredScaleId();

--- a/lib/src/controllers/connection_manager.dart
+++ b/lib/src/controllers/connection_manager.dart
@@ -151,9 +151,17 @@ class ConnectionManager {
 
   bool get _machineConnected => _disconnectSupervisor.isMachineConnected;
   bool get _scaleConnected => _disconnectSupervisor.isScaleConnected;
+  bool _scaleSleepRequested = false;
   bool get _scaleReconnectBlockedByPowerMode =>
-      settingsController.scalePowerMode == ScalePowerMode.disconnect &&
-      _latestMachineState == MachineState.sleeping;
+      _scaleSleepRequested ||
+      (settingsController.scalePowerMode == ScalePowerMode.disconnect &&
+          _latestMachineState == MachineState.sleeping);
+
+  void markScaleSleeping(String deviceId) {
+    _scaleSleepRequested = true;
+    markExpectingDisconnect(deviceId);
+    _pauseScaleReconnectForPowerMode();
+  }
 
   late final DisconnectSupervisor _disconnectSupervisor;
   late final ScanOrchestrator _scanOrchestrator;
@@ -1478,6 +1486,7 @@ class ConnectionManager {
         final state = snapshot.state.state;
         if (_latestMachineState == state) return;
         _latestMachineState = state;
+        if (state != MachineState.sleeping) _scaleSleepRequested = false;
         if (_scaleReconnectBlockedByPowerMode) {
           _log.fine(
             'Machine is sleeping and scale power mode is disconnect; '

--- a/lib/src/controllers/de1_state_manager.dart
+++ b/lib/src/controllers/de1_state_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:async';
+import 'package:reaprime/src/models/device/scale.dart';
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
@@ -586,6 +587,10 @@ class De1StateManager with WidgetsBindingObserver {
         final scale = _scaleController.connectedScale();
 
         if (scalePowerMode == ScalePowerMode.displayOff) {
+          if (scale is DisconnectToSleepScale &&
+              (scale as DisconnectToSleepScale).disconnectsToSleep) {
+            _connectionManager.markScaleSleeping(scale.deviceId);
+          }
           scale.sleepDisplay().catchError((e) {
             _logger.warning('Failed to sleep scale display: $e');
           });

--- a/lib/src/controllers/shot_sequencer.dart
+++ b/lib/src/controllers/shot_sequencer.dart
@@ -386,7 +386,9 @@ class ShotSequencer {
             scaleController.tare().catchError(
               (e) => _log.warning("Failed to tare scale at shot start", e),
             );
-            scaleController.connectedScale().resetTimer();
+            scaleController.connectedScale().resetTimer().catchError(
+              (e) => _log.warning('Failed to reset scale timer', e),
+            );
           }
           _state = ShotState.preheating;
           _stateStream.add(_state);
@@ -414,7 +416,9 @@ class ShotSequencer {
             scaleController.tare().catchError(
               (e) => _log.warning("Failed to tare scale for pour", e),
             );
-            scaleController.connectedScale().startTimer();
+            scaleController.connectedScale().startTimer().catchError(
+              (e) => _log.warning('Failed to start scale timer', e),
+            );
             _scaleTared = true;
           }
 
@@ -504,7 +508,9 @@ class ShotSequencer {
       case ShotState.stopping:
         _volumeCountingActive = false;
         if (_bypassSAW == false && scale != null && !_scaleLost) {
-          scaleController.connectedScale().stopTimer();
+          scaleController.connectedScale().stopTimer().catchError(
+            (e) => _log.warning('Failed to stop scale timer', e),
+          );
         }
 
         _refineStoppingYield(scale);

--- a/lib/src/models/device/scale.dart
+++ b/lib/src/models/device/scale.dart
@@ -14,12 +14,26 @@ abstract class Scale extends Device {
   Future<void> resetTimer() async {}
 }
 
+class ScaleOperationException implements Exception {
+  final String message;
+  final String code;
+
+  const ScaleOperationException(this.message, {required this.code});
+
+  @override
+  String toString() => message;
+}
+
 abstract interface class TransportHandoffScale {
   Future<void> disconnectForHandoff();
 }
 
 abstract interface class ScaleSnapshotHandoff {
   void activateSnapshots();
+}
+
+abstract interface class DisconnectToSleepScale {
+  bool get disconnectsToSleep;
 }
 
 class ScaleSnapshot {

--- a/lib/src/plugins/plugin_scale.dart
+++ b/lib/src/plugins/plugin_scale.dart
@@ -9,7 +9,7 @@ import 'plugin_manifest.dart';
 import 'plugin_protocol_device.dart';
 
 class PluginScale extends PluginProtocolDevice
-    implements Scale, ScaleSnapshotHandoff {
+    implements Scale, ScaleSnapshotHandoff, DisconnectToSleepScale {
   final Set<PluginScaleCapability> capabilities;
   final StreamController<ScaleSnapshot> _snapshots =
       StreamController.broadcast();
@@ -29,6 +29,9 @@ class PluginScale extends PluginProtocolDevice
 
   @override
   DeviceType get type => DeviceType.scale;
+  @override
+  bool get disconnectsToSleep =>
+      capabilities.contains(PluginScaleCapability.disconnectToSleep);
   @override
   Stream<ScaleSnapshot> get currentSnapshot => _snapshots.stream;
   @override
@@ -109,16 +112,18 @@ class PluginScale extends PluginProtocolDevice
   Future<void> _optional(
     PluginScaleCapability capability,
     PluginDeviceOperation operation,
-  ) {
+  ) async {
     if (!capabilities.contains(capability)) {
-      return Future.error(
-        PluginDeviceException(
-          '${operation.name} is unsupported',
-          code: 'unsupported_operation',
-        ),
+      throw ScaleOperationException(
+        '${operation.name} is unsupported',
+        code: 'unsupported_operation',
       );
     }
-    return command(operation);
+    try {
+      await command(operation);
+    } on PluginDeviceException catch (error) {
+      throw ScaleOperationException(error.message, code: error.code);
+    }
   }
 
   @override
@@ -140,8 +145,7 @@ class PluginScale extends PluginProtocolDevice
     PluginDeviceOperation.resetTimer,
   );
   @override
-  Future<void> sleepDisplay() =>
-      capabilities.contains(PluginScaleCapability.disconnectToSleep)
+  Future<void> sleepDisplay() => disconnectsToSleep
       ? disconnect()
       : _optional(
           PluginScaleCapability.displayControl,

--- a/lib/src/services/webserver/scale_handler.dart
+++ b/lib/src/services/webserver/scale_handler.dart
@@ -40,7 +40,10 @@ class ScaleHandler {
             await _controller.tare();
           } catch (e) {
             _log.warning('tare command failed', e);
-            return jsonError({'error': e.toString()});
+            return jsonError({
+              'error': e.toString(),
+              if (e is ScaleOperationException) 'code': e.code,
+            });
           }
           return jsonOk(null);
         default:
@@ -68,7 +71,10 @@ class ScaleHandler {
         }
       } catch (e) {
         _log.warning('timer $command command failed', e);
-        return jsonError({'error': e.toString()});
+        return jsonError({
+          'error': e.toString(),
+          if (e is ScaleOperationException) 'code': e.code,
+        });
       }
     });
     app.get('/ws/v1/scale/snapshot', admittedWebSocketHandler(_handleSnapshot));

--- a/test/controllers/connection/disconnect_supervisor_test.dart
+++ b/test/controllers/connection/disconnect_supervisor_test.dart
@@ -5,6 +5,7 @@ import 'package:reaprime/src/controllers/connection/disconnect_expectations.dart
 import 'package:reaprime/src/controllers/connection/disconnect_supervisor.dart';
 import 'package:reaprime/src/controllers/connection/status_publisher.dart';
 import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/device.dart';
 
 class _FakeDe1 implements De1Interface {
   @override
@@ -32,6 +33,41 @@ DisconnectSupervisor _buildSupervisor(
 }
 
 void main() {
+  for (final expected in [false, true]) {
+    test(
+      'Scale cleanup retains disconnect classification expected=$expected',
+      () async {
+        final states = StreamController<ConnectionState>();
+        final expectations = DisconnectExpectations();
+        final publisher = StatusPublisher();
+        var recoveries = 0;
+        final supervisor = DisconnectSupervisor(
+          machineStream: const Stream.empty(),
+          scaleStream: states.stream,
+          statusPublisher: publisher,
+          expectations: expectations,
+          isConnectingMachine: () => false,
+          isConnectingScale: () => false,
+          scaleLastConnectedId: () => 'scale',
+          preferredScaleId: () => 'scale',
+          onScaleDisconnected: () => recoveries++,
+        );
+        states.add(ConnectionState.connected);
+        await Future<void>.delayed(Duration.zero);
+        if (expected) expectations.mark('scale');
+        states.add(ConnectionState.disconnecting);
+        states.add(ConnectionState.disconnected);
+        states.add(ConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+        expect(recoveries, expected ? 0 : 1);
+        expect(expectations.consume('scale'), isFalse);
+        supervisor.dispose();
+        expectations.dispose();
+        publisher.dispose();
+        await states.close();
+      },
+    );
+  }
   group('DisconnectSupervisor.waitForMachine', () {
     late StreamController<De1Interface?> machineController;
     late DisconnectSupervisor supervisor;

--- a/test/controllers/connection_manager_test.dart
+++ b/test/controllers/connection_manager_test.dart
@@ -2224,6 +2224,9 @@ void main() {
 
           mockScanner.scanCompleter = Completer<void>();
           mockScaleController.mockEmitConnectionState(
+            ConnectionState.disconnecting,
+          );
+          mockScaleController.mockEmitConnectionState(
             ConnectionState.disconnected,
           );
           await mockScanner.scanningStream.firstWhere((s) => s);
@@ -2239,55 +2242,69 @@ void main() {
         },
       );
 
-      test(
-        'scale power disconnect pauses while sleeping and resumes when awake',
-        () async {
-          await settingsController.setPreferredScaleId('pref-scale');
-          await settingsController.setScalePowerMode(ScalePowerMode.disconnect);
-          connectionManager.scaleReconnectBaseDelay = Duration.zero;
+      for (final powerMode in [
+        ScalePowerMode.disconnect,
+        ScalePowerMode.displayOff,
+      ]) {
+        test(
+          'scale sleep pauses recovery and resumes when awake with $powerMode',
+          () async {
+            await settingsController.setPreferredScaleId('pref-scale');
+            await settingsController.setScalePowerMode(powerMode);
+            connectionManager.scaleReconnectBaseDelay = Duration.zero;
 
-          final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.connected,
-          );
-          mockScaleController.debugSetLastConnectedId('pref-scale');
-          mockDe1Controller.de1Subject.add(fakeDe1);
-          await Future<void>.delayed(Duration.zero);
-          fakeDe1.emitState(MachineState.idle);
-          await Future<void>.delayed(Duration.zero);
+            final fakeDe1 = _FakeDe1(deviceId: 'connected-de1');
+            mockScaleController.mockEmitConnectionState(
+              ConnectionState.connected,
+            );
+            mockScaleController.debugSetLastConnectedId('pref-scale');
+            mockDe1Controller.de1Subject.add(fakeDe1);
+            await Future<void>.delayed(Duration.zero);
+            fakeDe1.emitState(MachineState.idle);
+            await Future<void>.delayed(Duration.zero);
 
-          final scanningEvents = <bool>[];
-          final sub = mockScanner.scanningStream.listen(scanningEvents.add);
+            final scanningEvents = <bool>[];
+            final sub = mockScanner.scanningStream.listen(scanningEvents.add);
 
-          fakeDe1.emitState(MachineState.sleeping);
-          connectionManager.markExpectingDisconnect('pref-scale');
-          mockScaleController.mockEmitConnectionState(
-            ConnectionState.disconnected,
-          );
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
+            fakeDe1.emitState(MachineState.sleeping);
+            if (powerMode == ScalePowerMode.displayOff) {
+              connectionManager.markScaleSleeping('pref-scale');
+            }
+            connectionManager.markExpectingDisconnect('pref-scale');
+            mockScaleController.mockEmitConnectionState(
+              ConnectionState.disconnecting,
+            );
+            mockScaleController.mockEmitConnectionState(
+              ConnectionState.disconnected,
+            );
+            await Future<void>.delayed(Duration.zero);
+            await Future<void>.delayed(Duration.zero);
 
-          expect(
-            scanningEvents,
-            isNot(contains(true)),
-            reason: 'sleeping + ScalePowerMode.disconnect must not scan',
-          );
+            expect(
+              scanningEvents,
+              isNot(contains(true)),
+              reason: 'sleeping + ScalePowerMode.disconnect must not scan',
+            );
 
-          mockScanner.scanCompleter = Completer<void>();
-          fakeDe1.emitState(MachineState.idle);
-          await mockScanner.scanningStream.firstWhere((s) => s);
+            mockScanner.scanCompleter = Completer<void>();
+            fakeDe1.emitState(MachineState.idle);
+            await mockScanner.scanningStream.firstWhere((s) => s);
 
-          mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
-          mockScanner.completeScan();
-          await Future<void>.delayed(Duration.zero);
+            mockScanner.addDevice(TestScale(deviceId: 'pref-scale'));
+            await Future<void>.delayed(Duration.zero);
+            await Future<void>.delayed(Duration.zero);
+            mockScanner.completeScan();
+            await Future<void>.delayed(Duration.zero);
 
-          expect(mockScaleController.connectCalls, hasLength(1));
-          expect(mockScaleController.connectCalls.first.deviceId, 'pref-scale');
-          await sub.cancel();
-        },
-      );
+            expect(mockScaleController.connectCalls, hasLength(1));
+            expect(
+              mockScaleController.connectCalls.first.deviceId,
+              'pref-scale',
+            );
+            await sub.cancel();
+          },
+        );
+      }
 
       test(
         'sleeping during an active scale scan stops it and blocks reconnect',

--- a/test/controllers/de1_state_manager_wake_scan_test.dart
+++ b/test/controllers/de1_state_manager_wake_scan_test.dart
@@ -13,7 +13,11 @@ import 'package:reaprime/src/models/device/de1_interface.dart';
 import 'package:reaprime/src/models/device/machine.dart';
 import 'package:reaprime/src/services/storage/storage_service.dart';
 import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/settings/scale_power_mode.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:reaprime/src/plugins/plugin_scale.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_device_contract.dart';
 
 import '../helpers/mock_device_discovery_service.dart';
 import '../helpers/mock_device_scanner.dart';
@@ -114,6 +118,42 @@ void main() {
     testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
     await pump(6);
   }
+
+  test('plugin display-off disconnect sleeps until machine wake', () async {
+    mockScanner.supportsWatch = true;
+    await settingsController.setPreferredScaleId('plugin-scale');
+    await settingsController.setScalePowerMode(ScalePowerMode.displayOff);
+    final operations = <PluginDeviceOperation>[];
+    late PluginScale scale;
+    scale = PluginScale(
+      deviceId: 'plugin-scale',
+      name: 'Scale',
+      capabilities: {PluginScaleCapability.disconnectToSleep},
+      invoke: (operation, payload) async {
+        operations.add(operation);
+        if (operation == PluginDeviceOperation.connect) {
+          scale.publish({'weight': 1}, session: payload['session'] as String);
+        }
+        return {};
+      },
+    );
+    addTearDown(scale.dispose);
+    await scaleController.connectToScale(scale);
+    de1Controller.connect(testDe1);
+    await pump();
+    testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
+    await pump();
+    testDe1.emitStateAndSubstate(MachineState.sleeping, MachineSubstate.idle);
+    await pump(6);
+    expect(operations, contains(PluginDeviceOperation.disconnect));
+    expect(mockScanner.scanCallCount, 0);
+    final watchStarts = mockScanner.startWatchCallCount;
+    await pump(6);
+    expect(mockScanner.startWatchCallCount, watchStarts);
+    testDe1.emitStateAndSubstate(MachineState.idle, MachineSubstate.idle);
+    await pump(6);
+    expect(mockScanner.startWatchCallCount, greaterThan(watchStarts));
+  });
 
   test('wake with watch support and a preferred scale skips the '
       'scale-only burst scan', () async {

--- a/test/controllers/shot_sequencer_test.dart
+++ b/test/controllers/shot_sequencer_test.dart
@@ -59,6 +59,22 @@ class _TestDe1Controller extends De1Controller {
   }
 }
 
+class _FailingTimerScale extends TestScale {
+  final calls = <String>[];
+
+  Future<void> fail(String operation) async {
+    calls.add(operation);
+    throw StateError('unsupported_operation');
+  }
+
+  @override
+  Future<void> startTimer() => fail('start');
+  @override
+  Future<void> stopTimer() => fail('stop');
+  @override
+  Future<void> resetTimer() => fail('reset');
+}
+
 class _TestScaleController extends ScaleController {
   final TestScale testScale;
   final BehaviorSubject<ConnectionState> _connectionState;
@@ -789,6 +805,41 @@ void main() {
         );
 
         shotSequencer.dispose();
+      });
+    });
+
+    test('automatic timer failures do not escape shot sequencing', () {
+      fakeAsync((async) {
+        final optionalScale = _FailingTimerScale();
+        scaleController.dispose();
+        scaleController = _TestScaleController(optionalScale);
+        scaleController.emitWeight(0);
+        final sequencer = ShotSequencer(
+          scaleController: scaleController,
+          de1controller: de1Controller,
+          persistenceController: persistenceController,
+          targetProfile: profile,
+          targetYield: 36,
+          bypassSAW: false,
+          blockOnNoScale: false,
+          weightFlowMultiplier: 0,
+          volumeFlowMultiplier: 0,
+          stepExitArbiterEnabled: true,
+        );
+        async.elapse(const Duration(milliseconds: 10));
+        driveToPouring(sequencer);
+        async.elapse(const Duration(milliseconds: 10));
+        for (var i = 0; i < 2; i++) {
+          scaleController.emitWeight(i + 1.0);
+          testDe1.emitStateAndSubstate(
+            MachineState.espresso,
+            MachineSubstate.pouringDone,
+          );
+          async.elapse(const Duration(milliseconds: 100));
+        }
+        expect(optionalScale.calls, containsAll(['reset', 'start', 'stop']));
+        sequencer.dispose();
+        optionalScale.dispose();
       });
     });
 

--- a/test/plugins/plugin_manager_scale_test.dart
+++ b/test/plugins/plugin_manager_scale_test.dart
@@ -418,7 +418,13 @@ void main() {
       expect((await tareSample).weight, 0);
       await expectLater(
         scale.startTimer(),
-        throwsA(isA<PluginDeviceException>()),
+        throwsA(
+          isA<ScaleOperationException>().having(
+            (e) => e.code,
+            'code',
+            'unsupported_operation',
+          ),
+        ),
       );
       await scale.disconnect();
       await controller.connectToScale(scale);

--- a/test/plugins/plugin_scale_api_test.dart
+++ b/test/plugins/plugin_scale_api_test.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_plus/shelf_plus.dart';
+import 'package:web_socket_channel/io.dart';
+
+import '../helpers/mock_settings_service.dart';
+import 'plugin_test_helpers.dart';
+
+void main() {
+  for (final timers in [true, false]) {
+    test(
+      'public non-BLE Scale REST/WS and reload with timers=$timers',
+      () async {
+        final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+        final devices = DeviceController([manager.deviceService]);
+        await devices.initialize();
+        final scales = ScaleController();
+        final de1 = De1Controller(controller: devices);
+        final settings = SettingsController(MockSettingsService());
+        await settings.loadSettings();
+        final connections = ConnectionManager(
+          deviceScanner: devices,
+          de1Controller: de1,
+          scaleController: scales,
+          settingsController: settings,
+        );
+        final router = Router().plus;
+        ScaleHandler(
+          controller: scales,
+          de1Controller: de1,
+          settingsController: settings,
+        ).addRoutes(router);
+        final inventory = DevicesHandler(
+          controller: devices,
+          connectionManager: connections,
+        );
+        inventory.addRoutes(router);
+        final server = await shelf_io.serve(router.call, '127.0.0.1', 0);
+        final client = HttpClient();
+        final channel = IOWebSocketChannel.connect(
+          Uri.parse('ws://127.0.0.1:${server.port}/ws/v1/scale/snapshot'),
+        );
+        final messages = <Map<String, dynamic>>[];
+        final subscription = channel.stream.listen(
+          (data) => messages.add(jsonDecode(data as String)),
+        );
+        addTearDown(() async {
+          await channel.sink.close();
+          await subscription.cancel();
+          client.close(force: true);
+          await manager.dispose();
+          inventory.dispose();
+          connections.dispose();
+          scales.dispose();
+          devices.dispose();
+          await server.close(force: true);
+        });
+        await channel.ready;
+        Future<dynamic> request(
+          String method,
+          String path, {
+          int status = 200,
+        }) async {
+          final response = await (await client.openUrl(
+            method,
+            Uri.parse('http://127.0.0.1:${server.port}$path'),
+          )).close();
+          expect(response.statusCode, status);
+          return jsonDecode(await utf8.decoder.bind(response).join());
+        }
+
+        Future<void> load() => manager.loadPlugin(
+          id: 'api.scale',
+          manifest: testManifest(
+            'api.scale',
+            permissions: {PluginPermissions.emit},
+            drivers: [
+              PluginDriverDeclaration(
+                id: 'scale',
+                type: PluginDriverType.scale,
+                capabilities: {
+                  if (timers) PluginScaleCapability.tare,
+                  if (timers) PluginScaleCapability.timerControl,
+                },
+              ),
+            ],
+          ),
+          settings: {},
+          jsCode:
+              '''
+          function createPlugin(host) {
+            let context;
+            return {id: 'api.scale', async onLoad() {
+              await host.devices.register({driverId:'scale', instanceId:'one', name:'API Scale'}, {
+                async connect(session) { context = session; await session.publish({weight:12.5}); },
+                disconnect() {},
+                ${timers ? 'async tare() { await context.publish({weight:0}); },' : ''}
+                ${timers ? "startTimer() {host.emit('timer','start');}, stopTimer() {host.emit('timer','stop');}, resetTimer() {host.emit('timer','reset');}," : ''}
+              });
+            }};
+          }
+        ''',
+        );
+        String? publicId;
+        for (var generation = 0; generation < 2; generation++) {
+          await load();
+          final scale =
+              (await manager.deviceService.devices.firstWhere(
+                    (list) => list.isNotEmpty,
+                  )).single
+                  as Scale;
+          publicId ??= scale.deviceId;
+          expect(scale.deviceId, publicId);
+          final first = scales.weightSnapshot.first;
+          await connections.connect(scaleOnly: true);
+          expect((await first).weight, 12.5);
+          expect(scales.lastConnectedDeviceId, publicId);
+          expect(settings.preferredScaleId, publicId);
+          final listed = await request('GET', '/api/v1/devices') as List;
+          expect(listed.single['id'], publicId);
+          expect(listed.single['type'], 'scale');
+          final tare = await request(
+            'PUT',
+            '/api/v1/scale/tare',
+            status: timers ? 200 : 500,
+          );
+          if (!timers) expect(tare['code'], 'unsupported_operation');
+          for (final operation in ['start', 'stop', 'reset']) {
+            final event = timers
+                ? manager.emitStream.firstWhere((e) => e['event'] == 'timer')
+                : null;
+            final result = await request(
+              'PUT',
+              '/api/v1/scale/timer/$operation',
+              status: timers ? 200 : 500,
+            );
+            if (timers) {
+              expect((await event!)['payload'], operation);
+            } else {
+              expect(result['code'], 'unsupported_operation');
+            }
+          }
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          if (timers) {
+            expect(
+              messages.any((m) => m['weight'] == 0 && m['battery'] == null),
+              isTrue,
+            );
+          }
+          await manager.unloadPlugin('api.scale');
+        }
+      },
+    );
+  }
+}

--- a/test/plugins/plugin_scale_test.dart
+++ b/test/plugins/plugin_scale_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/plugins/plugin_device_service.dart';
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_scale.dart';
@@ -105,7 +106,16 @@ void main() {
       expect(weights, [-1.25]);
       expect(controller.currentWeightSnapshot!.battery, isNull);
       await scale.disconnect();
-      await expectLater(scale.tare(), throwsA(isA<PluginDeviceException>()));
+      await expectLater(
+        scale.tare(),
+        throwsA(
+          isA<ScaleOperationException>().having(
+            (e) => e.code,
+            'code',
+            'unsupported_operation',
+          ),
+        ),
+      );
       expect(
         () => scale.publish({'weight': 2}, session: firstSession),
         throwsA(isA<PluginDeviceException>()),
@@ -140,7 +150,7 @@ void main() {
       await expectLater(
         scale.startTimer(),
         throwsA(
-          isA<PluginDeviceException>().having(
+          isA<ScaleOperationException>().having(
             (e) => e.code,
             'code',
             'unsupported_operation',
@@ -159,6 +169,35 @@ void main() {
       await scale.dispose();
     },
   );
+
+  test('plugin command failures become Scale operation errors', () async {
+    late PluginScale scale;
+    scale = PluginScale(
+      deviceId: 'scale',
+      name: 'Scale',
+      capabilities: {PluginScaleCapability.tare},
+      invoke: (operation, payload) async {
+        if (operation == PluginDeviceOperation.connect) {
+          scale.publish({'weight': 1}, session: payload['session'] as String);
+        }
+        if (operation == PluginDeviceOperation.tare) {
+          throw const PluginDeviceException('busy', code: 'device_busy');
+        }
+        return {};
+      },
+    );
+    await scale.onConnect();
+    await expectLater(
+      scale.tare(),
+      throwsA(
+        isA<ScaleOperationException>()
+            .having((e) => e.code, 'code', 'device_busy')
+            .having((e) => e.message, 'message', 'busy'),
+      ),
+    );
+    await scale.disconnect();
+    await scale.dispose();
+  });
 
   test(
     'invalid weights and undeclared telemetry cannot satisfy readiness',


### PR DESCRIPTION
## Summary

- Complete the next Scale integration checkpoint on top of merged #820. The branch now contains current `main` (`c957e2b1`) and this PR targets `main`, so the review diff is limited to the #821 checkpoint.
- Observe automatic timer failures, preserve explicit Scale command error codes through a domain-facing error contract, and pause host recovery for disconnect-to-sleep until machine wake.
- Add real QuickJS non-BLE Scale inventory/selection/HTTP/WebSocket/reload coverage and host sleep-policy regressions. No BLE permission is needed for the fixture.

## Linked Issue

Refs #809. Builds on merged #820. Does not close the issue.

## Verification

- Previous full `flutter test --no-pub --machine`: 3,995 passed, one skipped. CI active-time gate passed. Local evidence: `.build/scale-integration-full.json`.
- Previous `flutter analyze --no-pub`: no issues. CI-compatible formatting and `git diff --check` passed.
- Final-head CI is rerunning after the restack and review fixes.
- Real HTTP/WebSocket clients exercise production handlers with a real JS registration and test-owned in-memory device. The Scale is now selected through `ConnectionManager`, reaches `ScaleController`, and persists its stable public ID through normal preference policy. This is not a full application UI or hardware run.
- Test-first regressions reproduced unhandled automatic timer failures and missing REST permission-independent optional-operation codes.

## Impact

- Existing Scale routes expose stable operation `code` values through a Scale-domain exception contract; `PluginScale` adapts plugin failures into that contract, including `unsupported_operation`. Existing HTTP status/message and native timer behavior are preserved.
- Display-off sleep of a plugin with `disconnectToSleep` pauses recovery until machine wake. Protocol failures outside deliberate sleep retain normal recovery.
- Documentation/spec updated. Measurement timing, Bookoo protocol/persistence proof, full-app smoke and hardware acceptance remain later work. Keep draft.

## Contributor Responsibility

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
