### PR TITLE
Plugin Scale measurement-timing checkpoint

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -445,6 +445,12 @@ cancellation or fencing.
 
 ## Plugin BLE Binding (#809 Checkpoint)
 
+Notification provenance is captured before JS dispatch. An optional opaque token
+round-trips through the callback and publication; host validation supplies the
+Scale timestamp. Four-event/100 ms trace tests reproduced collapsed timestamps
+without it. Keep the two-second expiry aligned with shot freshness, retain bounded
+session ownership, and measure arrival delay separately from timestamp quality.
+
 `PluginBleBinding` reserves the physical ID before transport creation and owns a
 fresh `PluginBleSession` per connect. Factory metadata has no mutable publication
 target: all publication and GATT closures capture a session capability. Do not

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -1,6 +1,30 @@
 
 # Decaid Plugin Development Guide
 
+## BLE Scale Sample Time
+
+BLE notification callbacks receive `(base64Data, sample)`. The optional opaque
+`sample` token identifies a host-timestamped notification. After decoding, use
+`await session.publish({weight: grams}, sample)` to retain its ingress time even
+when JavaScript dispatch/publication is delayed. No timestamp supplied by JS is
+trusted. Existing one-argument callbacks/publications remain compatible.
+
+Tokens are binding/session-owned, single-use, ordered, and expire after two
+seconds (the existing shot freshness window). At most 256 tokens are retained;
+the oldest token is discarded when that bound is reached, without dropping the
+notification itself. A foreign, duplicate, out-of-order, evicted, or expired token
+returns `stale_sample`. That rejection remains visible to plugin code, but if it
+escapes a notification callback the host drops that sample and continues the
+subscription. Other callback failures remain fatal. Retirement invalidates all
+tokens. A backward clock change retires the BLE session rather than leaving
+publication blocked behind its previous timestamp. Reconnect establishes a fresh
+timestamp sequence and follows normal Scale recovery policy.
+
+Omitting the token retains publication-ingress time for non-BLE or synthetic
+measurements. Do not use that fallback to disguise delayed notification samples.
+Accurate sample timestamps do not reduce delivery latency or recover stop commands
+missed while JavaScript was stalled.
+
 Plugin Scale commands report stable error codes through the existing Scale REST
 routes, including `unsupported_operation` for undeclared tare or timer support.
 Automatic shot timer failures are logged without aborting the shot. A Scale with

--- a/doc/plans/archive/issue-809-scale-timing/timing-gate.md
+++ b/doc/plans/archive/issue-809-scale-timing/timing-gate.md
@@ -1,0 +1,36 @@
+# Scale Timing Gate
+
+Keep the existing ScaleController estimators and tuning unchanged. Use 100 ms
+cadence, as in the native estimator fixtures, with identical 0.1 g increments.
+Require exact sample order and timestamps, and display/control flow equality
+within 1e-9 (identical inputs into the same deterministic estimators).
+
+Exercise immediate delivery, dispatch held for a four-notification burst, and
+publication delayed asynchronously after callback dispatch. Compare every accepted
+sample, not just final flow. Record delivery age separately from sample time;
+correct timestamps do not recover real-time decisions missed during a stall.
+
+The shot sequencer's existing freshness window is two seconds. Provenance must
+expire at that boundary, reject clock rollback/future timestamps, be single-use,
+and reject foreign/session/out-of-order tokens. Bound retained tokens to 256 per
+session. Retirement clears them. Non-BLE/synthetic publications retain host
+publication-ingress time. JS must never supply authoritative timestamps.
+
+Ingress timestamps failed: the first 100 ms sample in a four-event batch was
+published at 400 ms. Added only an optional opaque notification token as
+the second callback argument and second publish argument. Validate it host-side
+before forwarding to the shared Scale adapter. Keep protocol decoding in JS.
+
+The regression now compares the full JS path with native ScaleController output
+for batches of one/four and asynchronous delays of zero/150 ms over four recovery
+cycles. Recorded accepted samples drive the existing ShotSequencer: the stop
+sample agrees, while samples delivered three seconds late cannot trigger SAW.
+This replay proves timestamp/control-input equivalence, not that stalled delivery
+can stop hardware on time. Live device latency remains a hardware gate.
+
+Live QuickJS callbacks also remain suspended while the injected host clock advances
+three seconds. Expired publication rejects with `stale_sample` without retiring
+the subscription; a fresh notification still publishes. Unrelated callback
+failures remain fatal. Clock rollback at either capture or publication retires
+the BLE session, and reconnect accepts the earlier timestamp in a new connection.
+Capture happens before notification encoding.

--- a/lib/src/plugins/plugin_ble_binding.dart
+++ b/lib/src/plugins/plugin_ble_binding.dart
@@ -166,9 +166,19 @@ class PluginBleBinding {
     return session.call(authority, operation, args);
   }
 
-  void publish(Map<String, dynamic> snapshot, String? domainSession) {
+  void publish(
+    Map<String, dynamic> snapshot,
+    String? domainSession, {
+    String? sample,
+  }) {
     _checkPublication(domainSession);
-    device.publish(snapshot, session: domainSession);
+    final timestamp = sample == null ? null : _session!.consumeSample(sample);
+    final target = device;
+    if (target is PluginScale) {
+      target.publish(snapshot, session: domainSession, timestamp: timestamp);
+    } else {
+      target.publish(snapshot, session: domainSession);
+    }
   }
 
   void reportDisconnected(String? domainSession) {

--- a/lib/src/plugins/plugin_ble_bridge.dart
+++ b/lib/src/plugins/plugin_ble_bridge.dart
@@ -19,11 +19,19 @@ const __bindBleDriver = (driverId, factory) => {
     const handle = payload.registrationHandle;
     const sessions = new Map();
     const cleanups = new Set();
+    const recoverableSampleErrors = new WeakMap();
     const stale = () => Object.assign(new Error('BLE session retired'), {code: 'stale_session'});
     const context = (payload, cleanup) => {
       const authority = payload.gattSession;
       const callbacks = new Map();
-      const record = { callbacks, disconnected: false, delivered: false, onDisconnect: null };
+      const record = {
+        callbacks,
+        disconnected: false,
+        delivered: false,
+        onDisconnect: null,
+        callbackEpoch: 0,
+        activeCallbackEpoch: 0
+      };
       if (!cleanup) sessions.set(authority, record);
       else cleanups.add(record);
       const call = (operation, args = {}) => record.disconnected
@@ -67,8 +75,18 @@ const __bindBleDriver = (driverId, factory) => {
       if (cleanup) return Object.freeze({gatt});
       return Object.freeze({
         gatt,
-        publish: snapshot => record.disconnected ? Promise.reject(stale()) : __deviceCall('blePublish', {
-          registrationHandle: handle, session: payload.session, snapshot
+        publish: (snapshot, sample) => record.disconnected ? Promise.reject(stale()) : __deviceCall('blePublish', {
+          registrationHandle: handle, session: payload.session, snapshot, sample
+        }).catch(error => {
+          if (sample != null && error && error.code === 'stale_sample' &&
+              (typeof error === 'object' || typeof error === 'function') &&
+              record.activeCallbackEpoch !== 0) {
+            recoverableSampleErrors.set(error, {
+              record,
+              epoch: record.activeCallbackEpoch
+            });
+          }
+          throw error;
         }),
         reportDisconnected: () => record.disconnected ? Promise.reject(stale()) : __deviceCall('bleDisconnected', {
           registrationHandle: handle, session: payload.session
@@ -93,7 +111,23 @@ const __bindBleDriver = (driverId, factory) => {
         return;
       }
       const callback = record.callbacks.get(event.listener);
-      if (callback && !record.disconnected) await callback(event.data);
+      if (callback && !record.disconnected) {
+        const epoch = ++record.callbackEpoch;
+        record.activeCallbackEpoch = epoch;
+        try {
+          await callback(event.data, event.sample);
+        } catch (error) {
+          const provenance = error &&
+            (typeof error === 'object' || typeof error === 'function')
+              ? recoverableSampleErrors.get(error) : null;
+          if (!provenance || provenance.record !== record || provenance.epoch !== epoch) {
+            throw error;
+          }
+          recoverableSampleErrors.delete(error);
+        } finally {
+          if (record.activeCallbackEpoch === epoch) record.activeCallbackEpoch = 0;
+        }
+      }
     };
     __deviceSetHandlers(handle, {
       pluginId, generation: pluginGeneration, bridgeToken: pluginBridgeToken,

--- a/lib/src/plugins/plugin_ble_service.dart
+++ b/lib/src/plugins/plugin_ble_service.dart
@@ -193,8 +193,13 @@ class PluginBleService {
     int generation,
     String handle,
     Map<String, dynamic> snapshot,
-    String? session,
-  ) => _binding(pluginId, generation, handle).publish(snapshot, session);
+    String? session, {
+    String? sample,
+  }) => _binding(
+    pluginId,
+    generation,
+    handle,
+  ).publish(snapshot, session, sample: sample);
 
   void reportDisconnected(
     String pluginId,

--- a/lib/src/plugins/plugin_ble_session.dart
+++ b/lib/src/plugins/plugin_ble_session.dart
@@ -9,6 +9,7 @@ import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:uuid/uuid.dart';
 
 import 'plugin_ble_matcher.dart';
+import 'plugin_sample_provenance.dart';
 
 enum PluginBleSessionState {
   connecting,
@@ -53,6 +54,9 @@ class PluginBleSession {
   final Map<(String, String), _BleSubscription> _subscriptions = {};
   final Set<Completer<Object?>> _pending = {};
   final Queue<(Map<String, dynamic>, int)> _notifications = Queue();
+  late final PluginSampleProvenance _samples = PluginSampleProvenance(
+    onClockRollback: revoke,
+  );
   final Completer<void> _closed = Completer<void>();
   final Completer<void> _cleanupInterrupted = Completer<void>();
   StreamSubscription<ConnectionState>? _connectionSubscription;
@@ -81,6 +85,13 @@ class PluginBleSession {
   int get subscriptionCount => _subscriptions.length;
   int get pendingOperationCount => _pending.length;
   int get queuedEventCount => _notifications.length;
+  DateTime consumeSample(String token) {
+    if (!acceptsPublications) {
+      throw const PluginBleException('stale_session', 'BLE session retired');
+    }
+    return _samples.consume(token);
+  }
+
   bool get acceptsPublications =>
       authorized() &&
       runtimeAlive() &&
@@ -350,6 +361,11 @@ class PluginBleSession {
   }
 
   void _enqueue(_BleSubscription subscription, Uint8List bytes) {
+    final sample = _samples.capture();
+    if (!acceptsPublications) {
+      _samples.clear();
+      return;
+    }
     if (_notifications.length >= maxQueuedEvents ||
         _queuedBytes + bytes.length > maxQueuedBytes) {
       _log.warning(
@@ -365,6 +381,7 @@ class PluginBleSession {
         'subscription': subscription.id,
         if (subscription.listener != null) 'listener': subscription.listener,
         'data': base64Encode(bytes),
+        'sample': sample,
       },
       bytes.length,
     ));
@@ -406,6 +423,7 @@ class PluginBleSession {
         _state == PluginBleSessionState.initializing ||
         _state == PluginBleSessionState.ready;
     _state = PluginBleSessionState.retiring;
+    _samples.clear();
     _notifications.clear();
     _queuedBytes = 0;
     _rejectPending();

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -1292,7 +1292,8 @@ class PluginManager {
           _replyDevice(requestId, bridgeToken, result: {'value': value});
         case 'blePublish':
           final snapshot = data['snapshot'];
-          if (snapshot is! Map) {
+          final sample = data['sample'];
+          if (snapshot is! Map || (sample != null && sample is! String)) {
             throw const PluginBleException(
               'invalid_argument',
               'Invalid BLE snapshot',
@@ -1304,6 +1305,7 @@ class PluginManager {
             registrationHandle,
             Map<String, dynamic>.from(snapshot),
             data['session'] as String?,
+            sample: sample as String?,
           );
           _replyDevice(requestId, bridgeToken, result: const {});
         case 'bleDisconnected':

--- a/lib/src/plugins/plugin_sample_provenance.dart
+++ b/lib/src/plugins/plugin_sample_provenance.dart
@@ -1,0 +1,51 @@
+import 'package:clock/clock.dart';
+import 'package:uuid/uuid.dart';
+
+import 'plugin_device_contract.dart';
+
+class PluginSampleProvenance {
+  final void Function() onClockRollback;
+  PluginSampleProvenance({required this.onClockRollback});
+  static const capacity = 256;
+  static const lifetime = Duration(seconds: 2);
+  final Map<String, (int, DateTime)> _samples = {};
+  int _sequence = 0;
+  int _lastConsumed = 0;
+  DateTime? _lastClock;
+
+  int get count => _samples.length;
+
+  DateTime _now() {
+    final now = clock.now();
+    if (_lastClock != null && now.isBefore(_lastClock!)) {
+      clear();
+      onClockRollback();
+    }
+    _lastClock = now;
+    _samples.removeWhere((_, sample) => now.difference(sample.$2) >= lifetime);
+    return now;
+  }
+
+  String capture() {
+    final now = _now();
+    if (_samples.length == capacity) _samples.remove(_samples.keys.first);
+    final token = const Uuid().v4();
+    _samples[token] = (++_sequence, now);
+    return token;
+  }
+
+  DateTime consume(String token) {
+    _now();
+    final sample = _samples.remove(token);
+    if (sample == null || sample.$1 <= _lastConsumed) {
+      throw const PluginDeviceException(
+        'Invalid or expired sample provenance',
+        code: 'stale_sample',
+      );
+    }
+    _lastConsumed = sample.$1;
+    return sample.$2;
+  }
+
+  void clear() => _samples.clear();
+}

--- a/lib/src/plugins/plugin_scale.dart
+++ b/lib/src/plugins/plugin_scale.dart
@@ -16,6 +16,7 @@ class PluginScale extends PluginProtocolDevice
   final List<ScaleSnapshot> _handoff = [];
   Completer<void> _firstWeight = Completer<void>();
   bool _active = false;
+  DateTime? _lastTimestamp;
 
   PluginScale({
     required super.deviceId,
@@ -39,6 +40,7 @@ class PluginScale extends PluginProtocolDevice
     _firstWeight = Completer<void>();
     _handoff.clear();
     _active = false;
+    _lastTimestamp = null;
   }
 
   @override
@@ -54,7 +56,11 @@ class PluginScale extends PluginProtocolDevice
   }
 
   @override
-  void publish(Map<String, dynamic> snapshot, {String? session}) {
+  void publish(
+    Map<String, dynamic> snapshot, {
+    String? session,
+    DateTime? timestamp,
+  }) {
     checkSession(session);
     final weight = snapshot['weight'];
     final battery = snapshot['battery'];
@@ -94,8 +100,16 @@ class PluginScale extends PluginProtocolDevice
         code: 'resource_limit',
       );
     }
+    final acceptedAt = timestamp ?? clock.now();
+    if (_lastTimestamp != null && acceptedAt.isBefore(_lastTimestamp!)) {
+      throw const PluginDeviceException(
+        'Scale sample precedes the last publication',
+        code: 'stale_sample',
+      );
+    }
+    _lastTimestamp = acceptedAt;
     final sample = ScaleSnapshot(
-      timestamp: clock.now(),
+      timestamp: acceptedAt,
       weight: weight.toDouble(),
       batteryLevel: battery as int?,
       flow: (flow as num?)?.toDouble(),

--- a/test/helpers/scale_timing_shot.dart
+++ b/test/helpers/scale_timing_shot.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/persistence_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/controllers/shot_sequencer.dart';
+import 'package:reaprime/src/models/data/profile.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/machine.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/services/storage/storage_service.dart';
+
+import 'test_de1.dart';
+import 'test_scale.dart';
+
+class _RecordedScaleController extends ScaleController {
+  final samples = StreamController<WeightSnapshot>.broadcast();
+  final scale = TestScale();
+  WeightSnapshot? latest;
+  @override
+  Stream<WeightSnapshot> get weightSnapshot => samples.stream;
+  @override
+  WeightSnapshot? get currentWeightSnapshot => latest;
+  @override
+  ConnectionState get currentConnectionState => ConnectionState.connected;
+  @override
+  Stream<ConnectionState> get connectionState =>
+      Stream.value(ConnectionState.connected);
+  @override
+  Scale connectedScale() => scale;
+  @override
+  int get connectionGeneration => 1;
+}
+
+class _MachineController extends De1Controller {
+  final TestDe1 machine;
+  _MachineController(this.machine) : super(controller: DeviceController([]));
+  @override
+  De1Interface connectedDe1() => machine;
+  @override
+  Future<void> requestMachineState(MachineState state) =>
+      machine.requestState(state);
+}
+
+class _Storage implements StorageService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => Future<dynamic>.value(null);
+}
+
+Future<int?> scaleTimingStopIndex(
+  List<WeightSnapshot> samples, {
+  Duration deliveryAge = Duration.zero,
+}) async {
+  final controller = _RecordedScaleController();
+  final machine = TestDe1();
+  final de1 = _MachineController(machine);
+  final persistence = PersistenceController(storageService: _Storage());
+  controller.latest = samples.first;
+  final sequencer = ShotSequencer(
+    scaleController: controller,
+    de1controller: de1,
+    persistenceController: persistence,
+    targetProfile: Profile(
+      version: '2',
+      title: 'Timing',
+      notes: '',
+      author: 'test',
+      beverageType: BeverageType.espresso,
+      targetVolumeCountStart: 0,
+      tankTemperature: 0,
+      targetWeight: 5.45,
+      steps: [
+        ProfileStepPressure(
+          name: 'pour',
+          transition: TransitionType.fast,
+          volume: 0,
+          seconds: 30,
+          temperature: 93,
+          sensor: TemperatureSensor.coffee,
+          pressure: 9,
+        ),
+      ],
+    ),
+    targetYield: 5.45,
+    bypassSAW: false,
+    blockOnNoScale: false,
+    weightFlowMultiplier: 1,
+    volumeFlowMultiplier: 0,
+    stepExitArbiterEnabled: true,
+  );
+  Future<void> emit(WeightSnapshot sample, MachineSubstate substate) async {
+    controller.latest = sample;
+    controller.samples.add(sample);
+    await Future<void>.delayed(Duration.zero);
+    machine.emitSnapshot(
+      machine.snapshotSubject.value.copyWith(
+        timestamp: sample.timestamp.add(deliveryAge),
+        state: MachineStateSnapshot(
+          state: MachineState.espresso,
+          substate: substate,
+        ),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  try {
+    await emit(samples.first, MachineSubstate.preparingForShot);
+    await emit(samples.first, MachineSubstate.pouring);
+    for (var i = 1; i < samples.length; i++) {
+      await emit(samples[i], MachineSubstate.pouring);
+      if (machine.requestedStates.contains(MachineState.idle)) return i;
+    }
+    return null;
+  } finally {
+    sequencer.dispose();
+    await controller.samples.close();
+    controller.scale.dispose();
+    controller.dispose();
+    await de1.dispose();
+    await machine.dispose();
+    persistence.dispose();
+  }
+}

--- a/test/plugins/plugin_sample_provenance_test.dart
+++ b/test/plugins/plugin_sample_provenance_test.dart
@@ -1,0 +1,67 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/plugins/plugin_device_contract.dart';
+import 'package:reaprime/src/plugins/plugin_sample_provenance.dart';
+
+void main() {
+  test('tokens are host-timed, bounded, single-use and session-local', () {
+    var now = DateTime.utc(2026);
+    withClock(Clock(() => now), () {
+      final samples = PluginSampleProvenance(
+        onClockRollback: () => fail('Unexpected rollback'),
+      );
+      final other = PluginSampleProvenance(
+        onClockRollback: () => fail('Unexpected rollback'),
+      );
+      final first = samples.capture();
+      now = now.add(const Duration(milliseconds: 100));
+      final second = samples.capture();
+      expect(() => other.consume(first), throwsA(isA<PluginDeviceException>()));
+      expect(samples.consume(second), now);
+      expect(
+        () => samples.consume(first),
+        throwsA(isA<PluginDeviceException>()),
+      );
+      expect(
+        () => samples.consume(second),
+        throwsA(isA<PluginDeviceException>()),
+      );
+      final evicted = samples.capture();
+      for (var i = 0; i < PluginSampleProvenance.capacity; i++) {
+        samples.capture();
+      }
+      expect(samples.count, PluginSampleProvenance.capacity);
+      expect(
+        () => samples.consume(evicted),
+        throwsA(isA<PluginDeviceException>()),
+      );
+      samples.clear();
+      expect(samples.count, 0);
+    });
+  });
+
+  test('expiry and backward clock changes invalidate provenance', () {
+    var now = DateTime.utc(2026);
+    withClock(Clock(() => now), () {
+      var rollbacks = 0;
+      final samples = PluginSampleProvenance(
+        onClockRollback: () => rollbacks++,
+      );
+      final expired = samples.capture();
+      now = now.add(PluginSampleProvenance.lifetime);
+      expect(
+        () => samples.consume(expired),
+        throwsA(isA<PluginDeviceException>()),
+      );
+      final future = samples.capture();
+      now = now.subtract(const Duration(seconds: 1));
+      expect(
+        () => samples.consume(future),
+        throwsA(isA<PluginDeviceException>()),
+      );
+      final current = samples.capture();
+      expect(samples.consume(current), now);
+      expect(rollbacks, 1);
+    });
+  });
+}

--- a/test/plugins/plugin_scale_test.dart
+++ b/test/plugins/plugin_scale_test.dart
@@ -8,6 +8,50 @@ import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_scale.dart';
 
 void main() {
+  test(
+    'backward sample time is rejected and reconnect resets ordering',
+    () async {
+      var timestamp = DateTime.utc(2026);
+      late PluginScale scale;
+      late String session;
+      scale = PluginScale(
+        deviceId: 'scale',
+        name: 'Scale',
+        capabilities: {},
+        invoke: (operation, payload) async {
+          if (operation == PluginDeviceOperation.connect) {
+            session = payload['session'] as String;
+            scale.publish(
+              {'weight': 1},
+              session: session,
+              timestamp: timestamp,
+            );
+          }
+          return {};
+        },
+      );
+      addTearDown(scale.dispose);
+      await scale.onConnect();
+      timestamp = timestamp.subtract(const Duration(seconds: 1));
+      expect(
+        () => scale.publish(
+          {'weight': 2},
+          session: session,
+          timestamp: timestamp,
+        ),
+        throwsA(
+          isA<PluginDeviceException>().having(
+            (e) => e.code,
+            'code',
+            'stale_sample',
+          ),
+        ),
+      );
+      await scale.disconnect();
+      await scale.onConnect();
+    },
+  );
+
   for (final hangs in [false, true]) {
     test(
       'reconnect after ${hangs ? "timed-out" : "throwing"} disconnect',

--- a/test/plugins/plugin_scale_timing_test.dart
+++ b/test/plugins/plugin_scale_timing_test.dart
@@ -1,0 +1,258 @@
+import 'dart:typed_data';
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/plugins/plugin_ble_matcher.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import '../helpers/plugin_ble_fixture.dart';
+import '../helpers/test_scale.dart';
+import '../helpers/scale_timing_shot.dart';
+import 'plugin_test_helpers.dart';
+
+void main() {
+  for (final (batchSize, publicationDelay) in [
+    (1, 0),
+    (4, 0),
+    (1, 150),
+    (4, 150),
+  ]) {
+    test(
+      'full JS Scale preserves native timestamps and flow: batch=$batchSize, publicationDelay=$publicationDelay',
+      () async {
+        var now = DateTime.utc(2026, 1, 1);
+        await withClock(Clock(() => now), () async {
+          final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+          var transport = PluginBleFixtureTransport('AA:BB');
+          final nativeScale = TestScale();
+          final native = ScaleController();
+          final plugin = ScaleController();
+          final nativeSamples = <WeightSnapshot>[];
+          final pluginSamples = <WeightSnapshot>[];
+          final deliveryAges = <Duration>[];
+          final nativeSub = native.weightSnapshot.listen(nativeSamples.add);
+          final pluginSub = plugin.weightSnapshot.listen((sample) {
+            pluginSamples.add(sample);
+            deliveryAges.add(now.difference(sample.timestamp));
+          });
+          addTearDown(() async {
+            await nativeSub.cancel();
+            await pluginSub.cancel();
+            native.dispose();
+            plugin.dispose();
+            nativeScale.dispose();
+            await manager.dispose();
+          });
+          await native.connectToScale(nativeScale);
+          await manager.loadPlugin(
+            id: 'timing.scale',
+            settings: {},
+            manifest: testManifest(
+              'timing.scale',
+              permissions: {
+                PluginPermissions.emit,
+                PluginPermissions.transportBle,
+              },
+              drivers: [
+                PluginDriverDeclaration(
+                  id: 'scale',
+                  type: PluginDriverType.scale,
+                  ble: PluginBleMatcher.fromJson({
+                    'serviceUuids': ['180f'],
+                  }),
+                ),
+              ],
+            ),
+            jsCode: '''
+            function createPlugin(host) {
+              return {id:'timing.scale', onLoad() {
+                return host.devices.bindDriver('scale', {create() {
+                  return {async connect(session) {
+                    globalThis.context = session;
+                    globalThis.trySample = sample => session.publish({weight:99}, sample)
+                      .then(() => host.emit('duplicate','accepted'), error => host.emit('duplicate',error.code));
+                    await session.gatt.subscribe('180f','2a19', async (data, sample) => {
+                      try {
+                      if (globalThis.crash) throw Object.assign(new Error('protocol failed'), {code:'stale_sample'});
+                      globalThis.lastSample = sample;
+                      if (globalThis.hold) {
+                        globalThis.hold = false;
+                        await new Promise(resolve => {globalThis.release = resolve; host.emit('held',true);});
+                      }
+                      const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+                      const value = (alphabet.indexOf(data[0]) << 2) | (alphabet.indexOf(data[1]) >> 4);
+                      await session.publish({weight:value / 10}, sample);
+                      host.emit('sample',value);
+                      } catch (error) { host.emit('rejection',error.code); throw error; }
+                      finally { host.emit('settled',true); }
+                    });
+                  }, disconnect() {}};
+                }});
+              }};
+            }
+          ''',
+          );
+          final evidence = BleAdvertisementEvidence(serviceUuids: ['180f']);
+          final scale =
+              await manager.bleService.createCandidate(
+                    driver: manager.bleService.registry
+                        .decide(evidence)
+                        .drivers
+                        .single,
+                    physicalId: 'AA:BB',
+                    evidence: evidence,
+                    admit: () => true,
+                    createTransport: () => transport,
+                  )
+                  as Scale;
+          await plugin.connectToScale(scale);
+          nativeScale.emitSnapshot(
+            ScaleSnapshot(timestamp: now, weight: 5.2, batteryLevel: null),
+          );
+          for (var batch = 0; batch < 4; batch++) {
+            final last = 53 + batch * batchSize + batchSize - 1;
+            final finished = manager.emitStream.firstWhere(
+              (e) => e['event'] == 'sample' && e['payload'] == last,
+            );
+            final held = manager.emitStream.firstWhere(
+              (e) => e['event'] == 'held',
+            );
+            manager.js.evaluate('globalThis.hold = true');
+            for (var offset = 0; offset < batchSize; offset++) {
+              now = now.add(const Duration(milliseconds: 100));
+              final value = 53 + batch * batchSize + offset;
+              nativeScale.emitSnapshot(
+                ScaleSnapshot(
+                  timestamp: now,
+                  weight: value / 10,
+                  batteryLevel: null,
+                ),
+              );
+              transport.subscribers.values.single(Uint8List.fromList([value]));
+              if (offset == 0) await held.timeout(const Duration(seconds: 2));
+            }
+            now = now.add(Duration(milliseconds: publicationDelay));
+            manager.js.evaluate('globalThis.release()');
+            while (manager.js.executePendingJob() > 0) {}
+            await finished.timeout(const Duration(seconds: 2));
+          }
+          expect(pluginSamples.length, nativeSamples.length);
+          expect(
+            deliveryAges
+                .skip(1)
+                .any(
+                  (age) =>
+                      age.inMilliseconds >=
+                      (batchSize - 1) * 100 + publicationDelay,
+                ),
+            isTrue,
+          );
+          for (var i = 0; i < nativeSamples.length; i++) {
+            expect(
+              pluginSamples[i].timestamp,
+              nativeSamples[i].timestamp,
+              reason: 'sample $i',
+            );
+            expect(pluginSamples[i].weight, nativeSamples[i].weight);
+            expect(
+              pluginSamples[i].weightFlow,
+              closeTo(nativeSamples[i].weightFlow, 1e-9),
+            );
+            expect(
+              pluginSamples[i].controlWeightFlow,
+              closeTo(nativeSamples[i].controlWeightFlow, 1e-9),
+            );
+          }
+          final duplicate = manager.emitStream.firstWhere(
+            (e) => e['event'] == 'duplicate',
+          );
+          manager.js.evaluate('globalThis.trySample(globalThis.lastSample)');
+          while (manager.js.executePendingJob() > 0) {}
+          expect(
+            (await duplicate.timeout(const Duration(seconds: 2)))['payload'],
+            'stale_sample',
+          );
+          final nativeStop = await scaleTimingStopIndex(nativeSamples);
+          expect(nativeStop, isNotNull);
+          expect(await scaleTimingStopIndex(pluginSamples), nativeStop);
+          expect(
+            await scaleTimingStopIndex(
+              pluginSamples,
+              deliveryAge: const Duration(seconds: 3),
+            ),
+            isNull,
+          );
+          if (batchSize == 1) {
+            Future<void> holdSample() async {
+              final held = manager.emitStream.firstWhere(
+                (e) => e['event'] == 'held',
+              );
+              manager.js.evaluate('globalThis.hold = true');
+              transport.subscribers.values.single(Uint8List.fromList([80]));
+              await held.timeout(const Duration(seconds: 2));
+            }
+
+            void release() {
+              manager.js.evaluate('globalThis.release()');
+              while (manager.js.executePendingJob() > 0) {}
+            }
+
+            await holdSample();
+            final beforeExpiry = pluginSamples.length;
+            now = now.add(const Duration(seconds: 3));
+            final settled = manager.emitStream.firstWhere(
+              (e) => e['event'] == 'settled',
+            );
+            final rejected = manager.emitStream.firstWhere(
+              (e) => e['event'] == 'rejection',
+            );
+            release();
+            await settled.timeout(const Duration(seconds: 2));
+            expect((await rejected)['payload'], 'stale_sample');
+            expect(pluginSamples.length, beforeExpiry);
+            final fresh = manager.emitStream.firstWhere(
+              (e) => e['event'] == 'sample' && e['payload'] == 81,
+            );
+            transport.subscribers.values.single(Uint8List.fromList([81]));
+            await fresh.timeout(const Duration(seconds: 2));
+            expect(
+              await scale.connectionState.first,
+              ConnectionState.connected,
+            );
+            if (publicationDelay != 0) await holdSample();
+            now = now.subtract(const Duration(seconds: 1));
+            if (publicationDelay == 0) {
+              transport.subscribers.values.single(Uint8List.fromList([82]));
+            } else {
+              release();
+            }
+            await transport.disposed.future.timeout(const Duration(seconds: 2));
+            await scale.connectionState.firstWhere(
+              (s) => s == ConnectionState.disconnected,
+            );
+            transport = PluginBleFixtureTransport('AA:BB');
+            final restarted = plugin.weightSnapshot.first;
+            await plugin.connectToScale(scale);
+            expect((await restarted).timestamp, now);
+            final pluginFailure = manager.emitStream.firstWhere(
+              (e) =>
+                  e['event'] == 'rejection' && e['payload'] == 'stale_sample',
+            );
+            manager.js.evaluate('globalThis.crash = true');
+            transport.subscribers.values.single(Uint8List.fromList([83]));
+            expect(
+              (await pluginFailure.timeout(
+                const Duration(seconds: 2),
+              ))['payload'],
+              'stale_sample',
+            );
+            await transport.disposed.future.timeout(const Duration(seconds: 2));
+          }
+        });
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Add the measurement-timing checkpoint directly on current `main` after merged #821.
- Preserve BLE notification ingress time through optional opaque sample provenance, without accepting JS timestamps or changing estimator tuning.
- Bound/session-fence provenance and reject duplicates, foreign/expired/out-of-order samples; protect Scale timestamp ordering across publications.
- Preserve #821's Scale-domain command error mapping while narrowing recoverable `stale_sample` handling to host-originated provenance failures from the active BLE callback invocation.

## Linked Issue

Refs #809, amendment D of the approved assignment. Builds on merged #821 and #820. Does not close #809.

## Verification

- Test-first full-JS trace reproduced first sample 100 ms becoming 400 ms in a four-notification burst before the fix.
- Native/full-JS ScaleController comparisons cover 100 ms cadence, one/four-event batches, zero/150 ms asynchronous delays, repeated backlog recovery, exact timestamps/order and flow equality within 1e-9. Tolerances were recorded before implementation; estimators are unchanged.
- Recorded accepted controller samples drive the existing ShotSequencer with equal stop sample indices; three-second-old delivery cannot trigger SAW. This replay is not proof of real-time hardware reaction during a JS stall.
- Regression coverage requires expired host provenance to remain recoverable while a plugin-created error that also uses `code: "stale_sample"` remains fatal.
- Previous pre-retarget full suite: 4,002 passed, one skipped; CI active-time gate passed. Evidence: `.build/timing-full.json`. Previous analysis, formatting and diff checks passed.
- Final-head `PR checks` run #1013 passed on `f41b662eb61e17c2017297fb5f65d017d45a805c`: Dart format, Flutter analyze, Flutter test, slow-suite gate, contribution policy, and Linux build smoke are green.
- No physical-device or full application UI run is required in this checkpoint.

## Impact

- BLE callback gains optional second `sample` argument; `publish(snapshot, sample)` resolves its host timestamp. Existing one-argument code remains compatible, with publication-ingress fallback for synthetic/non-BLE samples.
- Tokens expire at two seconds, are limited to 256 per session, and are invalidated on retirement/clock rollback. Invalid tokens produce `stale_sample`; no native/JS timestamps supplied by plugins are trusted.
- Only the host-originated stale provenance rejection from the active callback invocation is treated as a recoverable dropped sample. Arbitrary plugin callback failures, including plugin-created `stale_sample` errors, remain fatal.
- Bookoo reference/persistence proof and hardware/full-app acceptance remain separate later gates.

## Contributor Responsibility

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->