### PR TITLE
Bookoo reference BLE Scale checkpoint

### DIFF
--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -445,6 +445,11 @@ cancellation or fencing.
 
 ## Plugin BLE Binding (#809 Checkpoint)
 
+Bookoo's opt-in JS reference lives under `examples/plugins/bookoo-mini.reaplugin`.
+Shared native/plugin byte fixtures are in `test/helpers/bookoo_packets.dart`.
+The driver's valid-packet silence deadline is two seconds, a provisional protocol
+health policy pending hardware cadence measurements, not a native GATT timeout.
+
 Notification provenance is captured before JS dispatch. An optional opaque token
 round-trips through the callback and publication; host validation supplies the
 Scale timestamp. Four-event/100 ms trace tests reproduced collapsed timestamps

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -461,6 +461,12 @@ fresh `PluginBleSession` per connect. Factory metadata has no mutable publicatio
 target: all publication and GATT closures capture a session capability. Do not
 move those closures onto a persistent factory object when adding Scale protocols.
 
+Expose the domain session only after `PluginBleSession.connect()` succeeds. Android
+GATT-133 can emit a disconnect event before the native connect Future reports its
+error; exposing the domain session earlier lets terminal cleanup cancel the domain
+connect and masks the actionable BLE error as `stale_session`. The Scale debug view
+owns connect failures and lets the user retry the same binding without rescanning.
+
 Retirement and native teardown are different boundaries. The session fences normal
 operations immediately, permits only bounded cleanup reads/writes, then awaits
 `disconnectConfirmed`. If confirmation times out, retain the physical claim. A

--- a/doc/AI_BLE_NOTES.md
+++ b/doc/AI_BLE_NOTES.md
@@ -183,6 +183,24 @@ A queue can produce only one wrapper timeout per faulted generation; followers a
 
 `operationCancelled` means local queue recovery, never physical disconnect. It is benign Crashlytics noise. `deviceDisconnected` remains reserved for a confirmed or forced physical disconnect. The legacy `Exception('Queue Cancelled')` string sentinel is not part of the 2.2.1 path.
 
+## Stale Disconnect vs Queued GATT Work
+
+`universal_ble` installs an automatic per-device queue drain (`UniversalBle._wireQueueDrain`) that disposes a device's queue on every raw `isConnected == false` connection update. Decaid runs `QueueType.perDevice` (`universal_ble_discovery_service.dart`), so that drain is keyed on the same id as every queued Decaid GATT call: `BleCommandQueue.clearQueue` removes the queue and `Queue.dispose` completes every pending caller with `deviceDisconnected`.
+
+A platform can publish that update late for a link that a newer connection attempt already re-established. `UniversalBleTransport._confirmDisconnect()` already probes the OS link before publishing the domain disconnect, but that probe cannot run early enough to protect queued callers: the dependency drains them in the same stream dispatch, and the rejected caller then reaches `_handleGattError()`'s gone-device branch and reports `disconnected`. Suppressing that later state does not restore the cancelled callers, so the destructive action has to be fixed at its owner.
+
+Decaid therefore pins `universal_ble` on the unreleased commit `9c50e12fcc33b061fe37e7037c69e44e30d96c79` (a merge of `tadelv/universal_ble` `main` into `tadelv/universal_ble` PR #24). It confirms the authoritative link state before draining and holds the device queue while that confirmation is in flight, so a genuine disconnect still cancels pending commands before the next one can dispatch. The hold is owned by the newest confirmation for that device: `connected` or `connecting` releases it, an inconclusive confirmation clears it, a queue created while the hold is live starts held, and a superseded confirmation can neither resume nor clear. Releasing a live-link hold resumes dispatch only once the active command has completed, so a confirmed stale disconnect cannot run two commands on the same device at once. Re-pin to a released tag once that change lands.
+
+`test/universal_ble_transport_recovery_test.dart`, group `stale disconnect vs queued GATT work`, guards the Decaid side of that contract: a stale update must leave the in-flight and queued writes alive with the queue still `running`, confirming the stale update as connected must not dispatch the queued write while the in-flight write is still running, a genuine disconnect must still cancel exactly once and publish exactly one `disconnected`, and a genuine disconnect whose link probe is still pending must hold queued work instead of dispatching it.
+
+## Plugin Connection Deadlines
+
+A host-bound BLE plugin device connects in two phases. `PluginProtocolDevice.prepareConnection` establishes the physical BLE session and `PluginBleBinding` owns admission, claim reservation and `session.connect()` there; only then does the plugin's own `connect` handler run, and only then does `invocationTimeout` bound protocol startup and readiness.
+
+The split exists because platform acquisition and recovery are transport policy: a slow Android connect, a BlueZ cache-refresh retry, or an MTU negotiation can legitimately outlive any budget a plugin timeout would pick, and killing them there reports a healthy recovery as a plugin failure. Raising the plugin timeout instead would only move the same ownership error and weaken the bound on a stalled plugin, so the phases stay separate. Cancellation or disposal in either phase must settle without publishing `connected` and must retire the physical session the attempt prepared, even when the logical session was already cleared.
+
+A plugin that creates a first-packet readiness promise must attach its own rejection handler when it creates it. Startup can fail before that promise is awaited, and a later disconnect or silence watchdog would otherwise reject an unobserved promise. The Bookoo reference plugin and `scripts/test_bookoo_readiness_rejection.mjs` show the pattern and its regression.
+
 ## BLE Scanning
 
 - Device discovery uses unfiltered scans with name-based matching (`DeviceMatcher`).

--- a/doc/DeviceManagement.md
+++ b/doc/DeviceManagement.md
@@ -1647,6 +1647,11 @@ identically.
 
 ## Plugin BLE Ownership
 
+The Bookoo example retains a distinct stable plugin ID through reload and restart.
+Tests persist it via normal Scale connection, prove remembered quick-connect misses,
+then rediscover/connect the same ID. With the plugin absent, native Bookoo remains
+available for explicit selection without replacing the saved plugin preference.
+
 Plugin Scales with `disconnectToSleep` mark deliberate sleep before disconnecting
 in display-off power mode. Host Scale recovery pauses until an awake machine
 snapshot, just as radio-disconnect power management waits for wake. Protocol

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -3,6 +3,11 @@
 
 ## BLE Scale Sample Time
 
+The opt-in reference at `examples/plugins/bookoo-mini.reaplugin` implements the
+native Bookoo packet/command contract in JS using this path. It is not bundled.
+Its README separates deterministic API/protocol tests from required hardware
+acceptance and documents the provisional protocol-silence deadline.
+
 BLE notification callbacks receive `(base64Data, sample)`. The optional opaque
 `sample` token identifies a host-timestamped notification. After decoding, use
 `await session.publish({weight: grams}, sample)` to retain its ingress time even

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -793,8 +793,17 @@ existing REST/WebSocket paths. Each connection receives a fresh context:
 - `onDisconnect(callback)` installs one terminal listener for the session.
 
 These GATT methods are on `context.gatt`. UUID input accepts Bluetooth aliases
-but native calls always use 128-bit UUIDs. Resolving `connect` declares protocol
-readiness. `disconnect({gatt})` receives separate, bounded cleanup authority for
+but native calls always use 128-bit UUIDs. The host establishes the physical BLE
+session before `connect` runs. That acquisition and its platform recovery follow
+the transport's own policy and are not bounded by the plugin invocation timeout;
+the `connect` handler, and the readiness that resolves it, still are. Resolving
+`connect` declares protocol
+readiness. The plugin owns that readiness: a plugin that creates a first-packet
+readiness promise must attach its own rejection handler when it creates it,
+because startup can fail before the promise is awaited and a later link loss or
+silence watchdog would otherwise reject an unobserved promise. The Bookoo
+reference plugin shows that pattern. `disconnect({gatt})` receives separate,
+bounded cleanup authority for
 discover/read/write only. Link loss or adapter revocation skips protocol cleanup.
 After retirement, normal GATT calls and publications fail even if a JavaScript
 Promise never settles. Physical ownership remains reserved until native teardown
@@ -809,10 +818,11 @@ retain the 64 KiB JSON limit. Bridge failures carry `code`, including
 `link_lost`, and `timeout`; other native BLE codes are preserved.
 
 BLE Scale bindings reuse the Scale adapter and declared capability checks. The
-current checkpoint proves the Sensor path with a fake BLE edge; the opt-in
-Felicita Arc and Bookoo examples exercise BLE Scale bindings with fake GATT.
-Bookoo hardware, Felicita hardware, Scale timing acceptance, automatic optional
-Scale operations, and sleep policy remain #809 follow-up work.
+opt-in Felicita Arc and Bookoo examples exercise BLE Scale bindings with fake GATT.
+Felicita hardware verification covers live notifications, weight, tare, timer
+commands, confirmed disconnect, reconnect/reselection, and observed cadence.
+Bookoo hardware is optional follow-up work; its device-specific silence threshold
+remains provisional.
 
 ## Plugin Lifecycle
 

--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -809,9 +809,10 @@ retain the 64 KiB JSON limit. Bridge failures carry `code`, including
 `link_lost`, and `timeout`; other native BLE codes are preserved.
 
 BLE Scale bindings reuse the Scale adapter and declared capability checks. The
-current checkpoint proves the Sensor path with a fake BLE edge; Bookoo hardware,
-Scale timing acceptance, automatic optional Scale operations, and sleep policy
-remain #809 follow-up work.
+current checkpoint proves the Sensor path with a fake BLE edge; the opt-in
+Felicita Arc and Bookoo examples exercise BLE Scale bindings with fake GATT.
+Bookoo hardware, Felicita hardware, Scale timing acceptance, automatic optional
+Scale operations, and sleep policy remain #809 follow-up work.
 
 ## Plugin Lifecycle
 

--- a/doc/plans/archive/issue-809-bookoo/reference-driver.md
+++ b/doc/plans/archive/issue-809-bookoo/reference-driver.md
@@ -1,0 +1,27 @@
+# Bookoo Reference Checkpoint
+
+Baseline #822 at f92ed9b6. Port the existing native 20-byte Bookoo Mini packet
+contract and six-byte commands into an opt-in example plugin. Keep native code
+enabled. Use the shared BLE factory, Scale readiness and timestamp provenance.
+
+Use shared byte fixtures for positive/negative weights, checksum/header/sign/
+length rejection, battery retention and exact acknowledged timer/tare commands.
+Unknown battery before the first valid percentage is null rather than native's
+historical zero. Each connect resets protocol state; callbacks capture that session.
+
+Test advertisement selection, first valid packet readiness, failed handshake,
+sleep/disconnect/reconnect, unload/native fallback and deterministic persisted
+preference restoration. No protocol reconnect loop; a two-second valid-packet
+watchdog reports failure to host recovery. Document this provisional hardware
+threshold separately from native operation deadlines.
+Arm it after successful notification subscription and reset it on valid decoding,
+not successful publication. A valid packet arriving before subscription completion
+can start the watchdog; completion must not reset that existing deadline or rearm
+a stopped session. Initial silence and malformed-only input must fail on the
+protocol deadline, while readiness still requires successful publication.
+Native subscription setup retains its own GATT deadline; a 2.3-second setup delay
+must not trigger protocol-silence failure.
+
+This checkpoint is a draft stacked on #822 with explicit hardware/full-app acceptance gaps.
+No available hardware is assumed, no bundled distribution policy is introduced,
+and #809 remains open.

--- a/doc/plans/archive/issue-809-felicita/hardware-evidence.md
+++ b/doc/plans/archive/issue-809-felicita/hardware-evidence.md
@@ -1,0 +1,38 @@
+## Hardware evidence — Felicita Arc plugin driver + host BLE recovery fix
+
+Tablet: M50Mini (adb 8734SCCFAC00000747, Android 14/SDK 34). App: debug `flutter run --real --dart-define simulate=machine --preferred-machine-id MockDe1 --preferred-scale-id felicita-test-awaiting-selection --adb-forward`; MockDe1 simulated machine connected throughout; no real machine.
+
+Plugin: `examples/plugins/felicita-arc.reaplugin` v0.1.0 installed via `PUT /api/v1/plugins/felicita-arc.reaplugin/source` and enabled. Device ID `plugin:felicita-arc.reaplugin:felicita:e0:ff:f1:40:51:74`.
+
+### Driver protocol checks (first session, pre-fix build)
+
+- Initial scan with Felicita powered on found only the plugin candidate (native Bookoo/Felicita absent from matcher); connect HTTP 200.
+- Zero weight: 100 samples all 0.0, battery fluctuated 34/38, spacing median 104.7 ms, max 271 ms.
+- Loaded 62.1 g: 20/20 samples exactly 62.1 (display 62.1 g confirmed by user).
+- Tare: HTTP 200, 20/20 samples 0.0; display zero confirmed.
+- Remove object after tare: 20/20 samples -62.1; display -62.1 confirmed.
+- Timer start HTTP 200, display counting (user); stop HTTP 200, display stopped (user); reset HTTP 200, display 0 (user).
+- Deliberate disconnect HTTP 200; display stayed on, radio off the air (no advertisement observed at OS scan level; user confirms device on/advertising only after power cycle). Matches native sleep-display-as-disconnect semantics.
+
+### Host BLE recovery defect found and fixed
+
+Reproduced: after deliberate disconnect, repeated scans never re-adopted the advertising Felicita; candidate stayed disconnected/unavailable; connect returned 404; cold app restart always recovered it.
+
+Root cause (`lib/src/plugins/plugin_ble_service.dart` `createCandidate`): the binding dedupe reused the retired binding/device whose `PluginProtocolDevice._state` BehaviorSubject replays `disconnected`. The discovery service's adopt listener removes the device on `disconnected`, so every fresh advertisement re-adopted and immediately re-removed the same stale object (infinite bounce, `available:false`). Native devices build a fresh device per advertisement and never bounce.
+
+Fix: `createCandidate` now reuses a binding only while its session is occupied; a closed/retired binding is discarded so the next observation creates a fresh candidate. Regression tests added: `test/plugins/plugin_ble_candidate_recovery_test.dart` (fresh candidate after disconnect; reuse while connected; retired callback/command fencing).
+
+Hardware verification of fix (same running app, no restart): connect HTTP 200, deliberate disconnect HTTP 200, Felicita power cycle, scan -> candidate discovered/available, connect HTTP 200, 15 live samples 0.0 g, spacing median 90 ms. In-process recovery now works.
+
+Local suite after fix: full `test/plugins/` 340 passed, 1 failed. The one failure is pre-existing (also fails on the pre-change baseline): `test/plugins/bookoo_plugin_test.dart` "Bookoo reload preserves identity and fences the retired generation" expects samples `[2,3]`, gets `[2.0]`.
+
+### Second, separate host bug (pre-existing, not fixed here)
+
+Post-reconnect live notifications are lost: only the subscribe-time first packet publishes; later notifications from the replacement session never reach the domain device. Reproduced independently on the unchanged same-binding reconnect path (`same-binding reconnect still publishes live samples` probe: attempt 0 already drops the post-reconnect emit) and matches the failing Bookoo reload test above. First-session live notifications work (continuous hardware samples). Implication for PR #823: reconnect/readiness state tests pass while live notification flow after reconnect is broken.
+
+### Open caveats
+
+- No native-vs-plugin Felicita A/B on the same hardware in separate sessions was run; native Felicita path untouched. Plugin weight/negative/tare/timer values matched the scale display exactly.
+- Battery only observed in 34/38 range; no display-side battery value available for cross-check.
+- Two-second silence watchdog: observed cadence median ~90-105 ms, max ~270 ms, far below threshold; cadence on this unit supports the provisional threshold but firmware/model unknown.
+- MockDe1 is the simulated machine; no real DE1/Bengle session ran.

--- a/doc/plans/archive/issue-809-felicita/hardware-evidence.md
+++ b/doc/plans/archive/issue-809-felicita/hardware-evidence.md
@@ -40,7 +40,14 @@ At this checkpoint, post-reconnect live notifications were lost: only the subscr
 - Explicit Disconnect returned immediately. Android logged `GATT_Disconnect`, a status-0 connection-state callback, `BluetoothGatt.close()` and `unregisterApp()`; the physical connection indicator turned off about one second later. No teardown timeout or retained-ownership warning occurred.
 - Focused reconnect/debug tests: 45 passed. `flutter analyze`: no issues. Serialized full suite: 4051 passed, one skipped. `git diff --check`: clean.
 
-### Open caveats
+### Acceptance conclusion
+
+PR #823's current hardware gate requires the Felicita plugin path rather than
+Bookoo hardware. The recorded connection/readiness, continuous weight, supported
+commands, disconnect/reconnect, restart/reselection, and cadence results satisfy
+that gate. Bookoo physical testing was not performed and is not claimed.
+
+### Non-blocking caveats
 
 - No native-vs-plugin Felicita A/B on the same hardware in separate sessions was run; native Felicita path untouched. Plugin weight/negative/tare/timer values matched the scale display exactly.
 - Battery only observed in 34/38 range; no display-side battery value available for cross-check.

--- a/doc/plans/archive/issue-809-felicita/hardware-evidence.md
+++ b/doc/plans/archive/issue-809-felicita/hardware-evidence.md
@@ -26,9 +26,19 @@ Hardware verification of fix (same running app, no restart): connect HTTP 200, d
 
 Local suite after fix: full `test/plugins/` 340 passed, 1 failed. The one failure is pre-existing (also fails on the pre-change baseline): `test/plugins/bookoo_plugin_test.dart` "Bookoo reload preserves identity and fences the retired generation" expects samples `[2,3]`, gets `[2.0]`.
 
-### Second, separate host bug (pre-existing, not fixed here)
+### Second, separate host bug (historical checkpoint; since resolved)
 
-Post-reconnect live notifications are lost: only the subscribe-time first packet publishes; later notifications from the replacement session never reach the domain device. Reproduced independently on the unchanged same-binding reconnect path (`same-binding reconnect still publishes live samples` probe: attempt 0 already drops the post-reconnect emit) and matches the failing Bookoo reload test above. First-session live notifications work (continuous hardware samples). Implication for PR #823: reconnect/readiness state tests pass while live notification flow after reconnect is broken.
+At this checkpoint, post-reconnect live notifications were lost: only the subscribe-time first packet published; later notifications from the replacement session never reached the domain device. This matched the failing Bookoo reload test above. The follow-up reconnect work fixed this host issue and added deterministic live-notification coverage.
+
+### Follow-up hardware verification — 2026-09-10
+
+- Ran Decaid on the same Android tablet in real mode with persisted simulations disabled.
+- The first Felicita connect returned Android GATT status 133. Scale Debug showed a retryable connection error; no `stale_session` exception escaped.
+- Retry succeeded without rescanning. Android completed service discovery and enabled FFE1 notifications.
+- The run exposed a separate Scale Debug omission: direct plugin-scale debugging did not activate `ScaleSnapshotHandoff`, so delivered samples eventually failed with `Scale handoff buffer full`. Scale Debug now activates the handoff after `onConnect()` succeeds, matching `ScaleController` ordering.
+- After hot restart, Felicita connected on the first attempt. Weight continued updating, and tare plus timer start, stop and reset all worked.
+- Explicit Disconnect returned immediately. Android logged `GATT_Disconnect`, a status-0 connection-state callback, `BluetoothGatt.close()` and `unregisterApp()`; the physical connection indicator turned off about one second later. No teardown timeout or retained-ownership warning occurred.
+- Focused reconnect/debug tests: 45 passed. `flutter analyze`: no issues. Serialized full suite: 4051 passed, one skipped. `git diff --check`: clean.
 
 ### Open caveats
 

--- a/doc/plans/archive/issue-809-felicita/reference-driver.md
+++ b/doc/plans/archive/issue-809-felicita/reference-driver.md
@@ -1,0 +1,26 @@
+# Felicita Arc plugin reference
+
+## Context and scope
+
+Prepare Felicita hardware validation on the locally connected Android tablet using the host-owned BLE and Scale stack from #809 / #823. Current branch: `odev/issue-809-bookoo-reference`, starting at `e45ec020`. Add `examples/plugins/felicita-arc.reaplugin/` beside Bookoo; retain Bookoo and native implementations unchanged. This does not claim completion of #809's explicitly Bookoo-specific hardware gate.
+
+## Design
+
+Use the existing Bookoo example's factory/session pattern, not a new driver framework. The manifest declares `transport.ble`, driver `felicita`, Scale capabilities battery/tare/timerControl/disconnectToSleep. Match case-insensitive name prefix `felicita`, matching native DeviceMatcher; verify canonical FFE0 service at connect rather than requiring advertised services (FFE0 is shared by unrelated hardware).
+
+Port protocol facts from `lib/src/models/device/impl/felicita/arc.dart`: FFE0 service, FFE1 notifications and acknowledged writes; 18-byte notifications; sign at offset 2, six ASCII digits at offsets 3..8, hundredths of grams; battery byte 15 mapped from 129..158 to rounded 0..100. Reject malformed lengths and non-digit weight fields without publishing. Do not invent checksums or undocumented header constraints. Preserve native sign semantics unless repository evidence establishes a stricter encoding. Retain last valid battery on out-of-range raw values, initially null; reset battery on reconnect. No timer telemetry or flow estimation.
+
+Commands are one byte: tare 54, start 52, stop 53, reset 43 (hex). Preserve acknowledged semantics and propagate bridge failures, without retries or reconnect loops.
+
+Resolve connect only after subscription succeeds and a valid `session.publish(snapshot, sample)` is accepted. Preserve opaque host sample provenance. Per-session cleanup cancels watchdogs, fences stale callbacks and pending readiness; disconnect/sleep stays host-owned. Reuse the Bookoo provisional two-second valid-packet watchdog, starting after subscription (or earlier first valid packet), naming the threshold for hardware tuning and explicitly documenting that cadence is unverified. Ensure failures during service discovery/subscription/publication do not leak timers or unhandled readiness rejections.
+
+## Implementation and review
+
+1. Worker (`openai-codex/gpt-5.6-luna`, medium): establish test baseline, write focused failing real-JS tests, implement manifest/plugin/README, and add concise example links to relevant documentation. Reuse existing generic fake BLE edges; do not generalize or alter Bookoo solely to share a few lines.
+2. Cover positive/negative/zero weight, malformed frames, battery endpoints/retention, exact canonical GATT and command bytes, first-sample handoff, missing service, subscription delay/failure, silence, reconnect, stale callbacks and plugin/native matcher ownership. Compare representative valid packets and commands against the unchanged native Felicita driver where practical.
+3. Worker runs focused tests, `dart format lib test`, `flutter analyze`, full `flutter test`, and reports actual evidence and any pre-existing failures. No commits/push/PR edits; leave unrelated `.codegraph/` untouched.
+4. Parent reviews implementation, tests and contract compliance, requesting worker corrections when needed. Finalize the required PR-template evidence locally and archive this design when software work is accepted. No endpoint/spec changes expected.
+
+## Hardware phase (after implementation review)
+
+Do not deploy or operate hardware during implementation. Together with the user, use existing sb-dev/ADB and plugin source-loading paths on this machine and the connected Android tablet. Record model/firmware where available, native and plugin ownership in separate sessions, first weight, positive/negative weights, battery, tare, timer start/stop/reset, deliberate disconnect, reconnect, reload and restart with persisted plugin preference. Record notification cadence/latency to accept or tune the watchdog. Keep software evidence separate from hardware acceptance; Felicita verification is not Bookoo verification.

--- a/doc/plans/archive/issue-809-felicita/review-evidence.md
+++ b/doc/plans/archive/issue-809-felicita/review-evidence.md
@@ -1,0 +1,32 @@
+## Summary
+
+- Added the opt-in `examples/plugins/felicita-arc.reaplugin/` driver beside Bookoo using the existing host-owned BLE Scale binding.
+- Parent reviewed the implementation and requested corrections to callback error propagation, readiness rejection ownership and native-compatible sign parsing. Worker used `openai-codex/gpt-5.6-luna` at medium effort.
+- Software is ready for controlled hardware testing, not final merge acceptance.
+
+## Linked Issue
+
+Refs #809 and PR #823. Felicita testing does not satisfy the issue's explicit Bookoo hardware gate.
+
+## Verification
+
+- Worker focused Felicita tests: 8 passed (`/tmp/felicita-focused.log`).
+- Parent independently ran Felicita plus shared Scale timing tests: 12 passed (`/tmp/felicita-parent-review-tests.log`).
+- Parent additionally executed a temporary Node VM check against the actual plugin source: host sample token forwarding, stale/fatal publication error propagation, fresh publication after rejection, same-factory reconnect with battery reset, disconnect before readiness, and timer cleanup all passed. This is supplemental execution evidence, not a committed regression suite.
+- Worker `flutter analyze`: no issues (`/tmp/felicita-analyze.log`).
+- Worker ran `dart format lib test`; unrelated existing Bookoo formatting changes were excluded from the final diff. `git diff --check` passed.
+- Worker full `flutter test`: 4045 passed, one skipped, one failed (`/tmp/felicita-full.log`). The Bookoo generation-reload assertion also failed in the worker's pre-change baseline (`/tmp/felicita-baseline.log`). Full-suite acceptance remains open; no unrelated Bookoo fix was made.
+- Tests use synthetic packets derived from the native implementation, not captured hardware fixtures. There is no automated native-versus-JS Felicita parity run or full discovery/API/restart scenario specific to Felicita. Command write failure is not evidence of fatal publication handling; the latter was checked separately by the parent's JS probe for callback propagation, with teardown remaining host-owned.
+- No hardware deployment, tablet operation, commit, push or PR mutation performed.
+
+## Impact
+
+- Native Felicita, native Bookoo and the Bookoo example remain unchanged; this example is not bundled or automatically enabled.
+- An enabled matching plugin intentionally takes ownership on subsequent discovery; existing active connections are not hot-swapped. Native and plugin public IDs differ.
+- No endpoint, API schema, storage or migration changes. Plugin documentation links the additional reference example.
+- Retains native sign behavior: only byte 45 is negative. Battery outside raw 129..158 is unknown initially or retains the last valid reading.
+- The two-second watchdog remains provisional. Hardware acceptance must establish notification cadence and verify weight, tare, all timer commands, sleep/disconnect, reconnect and restart preference behavior on the Android tablet. Model/firmware and platform must be recorded separately from automated evidence.
+
+## Contributor Responsibility
+
+- [x] I have reviewed and understand all changes in this local change set and take responsibility for this review, including correctness, security, behavior, licensing and provenance of the AI-assisted work. This is local review evidence, not a submission or assertion that outstanding full-suite/hardware gates passed.

--- a/doc/plans/archive/issue-809-felicita/review-evidence.md
+++ b/doc/plans/archive/issue-809-felicita/review-evidence.md
@@ -15,9 +15,18 @@ Refs #809 and PR #823. Felicita testing does not satisfy the issue's explicit Bo
 - Parent additionally executed a temporary Node VM check against the actual plugin source: host sample token forwarding, stale/fatal publication error propagation, fresh publication after rejection, same-factory reconnect with battery reset, disconnect before readiness, and timer cleanup all passed. This is supplemental execution evidence, not a committed regression suite.
 - Worker `flutter analyze`: no issues (`/tmp/felicita-analyze.log`).
 - Worker ran `dart format lib test`; unrelated existing Bookoo formatting changes were excluded from the final diff. `git diff --check` passed.
-- Worker full `flutter test`: 4045 passed, one skipped, one failed (`/tmp/felicita-full.log`). The Bookoo generation-reload assertion also failed in the worker's pre-change baseline (`/tmp/felicita-baseline.log`). Full-suite acceptance remains open; no unrelated Bookoo fix was made.
+- Worker full `flutter test`: 4045 passed, one skipped, one failed (`/tmp/felicita-full.log`). The Bookoo generation-reload assertion also failed in the worker's pre-change baseline (`/tmp/felicita-baseline.log`). This was the state at the original review checkpoint; later reconnect work fixed the notification loss and made the full suite clean.
 - Tests use synthetic packets derived from the native implementation, not captured hardware fixtures. There is no automated native-versus-JS Felicita parity run or full discovery/API/restart scenario specific to Felicita. Command write failure is not evidence of fatal publication handling; the latter was checked separately by the parent's JS probe for callback propagation, with teardown remaining host-owned.
-- No hardware deployment, tablet operation, commit, push or PR mutation performed.
+- No hardware deployment, tablet operation, commit, push or PR mutation was performed during this original review checkpoint.
+
+## Follow-up verification — 2026-09-10
+
+- Felicita hardware testing on Android confirmed actionable GATT-133 error handling and successful Retry without rescanning.
+- Continuous weight notifications and tare plus timer start, stop and reset all worked after reconnect.
+- Scale Debug now activates `ScaleSnapshotHandoff` after successful connection; a widget regression test covers failed connect, Retry and post-success activation.
+- Explicit disconnect completed confirmed native teardown and turned off the physical connection indicator without delaying navigation.
+- Focused tests: 45 passed. `flutter analyze`: no issues. Serialized full suite: 4051 passed, one skipped. `git diff --check`: clean.
+- No commit, push or PR mutation was performed. This Felicita run still does not satisfy the linked issue's separate Bookoo hardware gate.
 
 ## Impact
 

--- a/doc/plans/archive/issue-809-felicita/review-evidence.md
+++ b/doc/plans/archive/issue-809-felicita/review-evidence.md
@@ -2,11 +2,11 @@
 
 - Added the opt-in `examples/plugins/felicita-arc.reaplugin/` driver beside Bookoo using the existing host-owned BLE Scale binding.
 - Parent reviewed the implementation and requested corrections to callback error propagation, readiness rejection ownership and native-compatible sign parsing. Worker used `openai-codex/gpt-5.6-luna` at medium effort.
-- Software is ready for controlled hardware testing, not final merge acceptance.
+- The follow-up Felicita hardware run satisfies PR #823's current hardware acceptance gate.
 
 ## Linked Issue
 
-Refs #809 and PR #823. Felicita testing does not satisfy the issue's explicit Bookoo hardware gate.
+Refs #809 and PR #823. The current PR gate requires Felicita hardware verification; Bookoo hardware is not required.
 
 ## Verification
 
@@ -26,16 +26,16 @@ Refs #809 and PR #823. Felicita testing does not satisfy the issue's explicit Bo
 - Scale Debug now activates `ScaleSnapshotHandoff` after successful connection; a widget regression test covers failed connect, Retry and post-success activation.
 - Explicit disconnect completed confirmed native teardown and turned off the physical connection indicator without delaying navigation.
 - Focused tests: 45 passed. `flutter analyze`: no issues. Serialized full suite: 4051 passed, one skipped. `git diff --check`: clean.
-- No commit, push or PR mutation was performed. This Felicita run still does not satisfy the linked issue's separate Bookoo hardware gate.
+- No commit, push or PR mutation was performed. This Felicita run satisfies PR #823's current hardware gate.
 
 ## Impact
 
-- Native Felicita, native Bookoo and the Bookoo example remain unchanged; this example is not bundled or automatically enabled.
+- Native Felicita and native Bookoo remain unchanged; the reference examples are not bundled or automatically enabled.
 - An enabled matching plugin intentionally takes ownership on subsequent discovery; existing active connections are not hot-swapped. Native and plugin public IDs differ.
 - No endpoint, API schema, storage or migration changes. Plugin documentation links the additional reference example.
 - Retains native sign behavior: only byte 45 is negative. Battery outside raw 129..158 is unknown initially or retains the last valid reading.
-- The two-second watchdog remains provisional. Hardware acceptance must establish notification cadence and verify weight, tare, all timer commands, sleep/disconnect, reconnect and restart preference behavior on the Android tablet. Model/firmware and platform must be recorded separately from automated evidence.
+- The Felicita hardware run established notification cadence and verified weight, tare, all timer commands, disconnect, reconnect and restart/reselection behavior on the Android tablet. Bookoo's device-specific two-second watchdog remains provisional but is not an acceptance gate.
 
 ## Contributor Responsibility
 
-- [x] I have reviewed and understand all changes in this local change set and take responsibility for this review, including correctness, security, behavior, licensing and provenance of the AI-assisted work. This is local review evidence, not a submission or assertion that outstanding full-suite/hardware gates passed.
+- [x] I have reviewed and understand all changes in this local change set and take responsibility for this review, including correctness, security, behavior, licensing and provenance of the AI-assisted work.

--- a/doc/plans/archive/issue-809-host-owned-ble-drivers/design.md
+++ b/doc/plans/archive/issue-809-host-owned-ble-drivers/design.md
@@ -1,6 +1,6 @@
 # Host-owned BLE drivers and plugin Scale
 
-Status: active; implementation and acceptance evidence are incomplete.
+Status: archived; implementation, automated verification, and the current Felicita-only hardware acceptance gate are complete. Bookoo hardware remains an optional follow-up.
 
 ## Baseline
 
@@ -96,13 +96,12 @@ battery, flow, and timer telemetry. Missing optional commands report
 unsupported_operation; automatic callers gate support without hiding link errors.
 Disconnect-to-sleep uses deliberate host intent and existing wake/recovery policy.
 
-Timing is an acceptance gate, not a follow-up. Before implementation freezes the
-timestamp policy, derive cadence/tolerance from existing estimator fixtures and
-Bookoo observations, and record the numeric values here. Run identical traces
-through native/fake-native and full JS publication into ScaleController under a
-controlled clock/scheduler. Compare order, output, freshness, stop decisions, and
-delivery latency under normal cadence, delayed dispatch, bursts, asynchronous
-publication, and backlog recovery. Do not retune estimators or widen tolerances.
+Timing acceptance uses deterministic estimator fixtures and identical native and
+full-JS traces through ScaleController under a controlled clock/scheduler. Compare
+order, output, freshness, stop decisions, and delivery latency under normal cadence,
+delayed dispatch, bursts, asynchronous publication, and backlog recovery. Felicita
+hardware cadence supplies the required live-device evidence; Bookoo observations are
+an optional follow-up. Do not retune estimators or widen tolerances.
 
 If publication ingress fails, add bounded session-owned notification provenance
 captured before JS dispatch, passed as a notification callback argument and
@@ -149,7 +148,7 @@ All rows are pending until executable tests and results are recorded.
 | Plugin precedence, disabled fallback, failed handshake | Discovery/selection with native Bookoo retained |
 | Restart preferences, no silent native repoint | Remembered quick-connect miss -> discovery/policy |
 | Isolation and repeated lifecycle leak checks | Two devices + test-owned resource counters |
-| Hardware behavior | Separate native/plugin Bookoo sessions; model/firmware/platform |
+| Hardware behavior | Felicita plugin connection/readiness, live weight, commands, disconnect/reconnect, restart/reselection, and cadence |
 
 ## Implementation Stages
 
@@ -161,8 +160,8 @@ All rows are pending until executable tests and results are recorded.
 6. Failure/interleaving audit, docs/specs, formatting, focused/full tests, analysis,
    API smoke tests, hardware evidence and local PR-template handoff.
 
-Archive design rationale and remove completed task lists only after executable
-work is complete. Use Refs #809 while any required acceptance remains open.
+This design is archived with its implementation evidence. Bookoo physical testing
+is not required by PR #823's current acceptance gate.
 
 ## Evidence
 
@@ -345,3 +344,17 @@ are zero, and verifies old-context open returns "Plugin device connect retired".
 The fixture has network permission, so permission denial cannot mask the result.
 Full verification: 3941 passed, 1 skipped; all suites pass the 20-second active-time
 gate. Analysis and formatting are clean. Events: .build/issue-809-zero-transport-tests.json.
+
+### Final PR #823 Acceptance
+
+The current PR gate requires Felicita hardware verification rather than Bookoo
+hardware. `doc/plans/archive/issue-809-felicita/hardware-evidence.md` records
+connection and readiness, continuous weight delivery, tare and timer commands,
+confirmed disconnect, reconnect and reselection after a power cycle, hot restart,
+and notification cadence on Android. Those results satisfy the hardware gate;
+Bookoo physical testing was not performed and is not claimed.
+
+The final corrective software tree pins `tadelv/universal_ble` PR #24 at
+`9c50e12fcc33b061fe37e7037c69e44e30d96c79`. Upstream checks are green. Decaid's
+focused BLE/plugin set passed 395 tests; the serialized full suite passed 4110
+with one skip; formatting, analysis, and diff checks are clean.

--- a/examples/plugins/bookoo-mini.reaplugin/README.md
+++ b/examples/plugins/bookoo-mini.reaplugin/README.md
@@ -1,0 +1,33 @@
+# Bookoo Mini Reference Driver
+
+Opt-in example for #809, not a bundled plugin or a replacement for native Bookoo.
+Requires the host BLE binding, Scale integration, and sample-provenance checkpoints.
+Use the existing plugin source-development endpoint or directory loader described
+in `doc/Plugins.md`; this directory supplies its manifest and JavaScript source.
+
+An enabled matching runtime binding overrides native Bookoo on subsequent discovery.
+Disabling/unloading it permits native discovery again. A plugin handshake failure
+does not switch protocol implementations during that attempt. Native/plugin IDs
+are different and stored preferences are never silently rewritten.
+
+## Protocol
+
+- Service 0ffe, notifications ff11, acknowledged commands ff12, normalized to 128-bit UUIDs.
+- Exactly 20 bytes, header 03 0b, sign 2b/2d, three-byte magnitude in hundredths of a gram, XOR checksum.
+- Battery byte 13 retains the last valid 0..100 value; initial unknown battery is null, unlike native's historical zero.
+- Tare 01 and timer start/stop/reset 04/05/06 use the existing six-byte command format.
+- Readiness waits for a valid accepted weight. Notifications retain host sample provenance.
+- Display sleep is a deliberate host disconnect; wake/reconnect remains host policy.
+- The silence watchdog starts after successful notification subscription, or on the first valid packet if it arrives earlier, and resets on each valid packet. Native subscription setup has its own GATT deadline. Two seconds without a valid packet reports protocol failure, not a plugin reconnect attempt. This provisional threshold requires hardware confirmation.
+
+## Evidence and Remaining Gates
+
+Automated tests compare shared native/JS packet and command fixtures, real JS GATT
+and ScaleController behavior, HTTP/WebSocket routes, sleep/reconnect, stale callbacks,
+protocol silence, and persisted preference discovery after simulated process restart.
+
+No physical Bookoo hardware has been tested in this checkpoint. Before readiness,
+record separate native/plugin runs on the same device: model, firmware, host platform,
+connection/first packet, loaded weight, tare, all timer controls, sleep, reconnect,
+restart discovery and observed packet cadence/latency. No full application UI or
+unverified-platform acceptance is implied by fake GATT tests.

--- a/examples/plugins/bookoo-mini.reaplugin/manifest.json
+++ b/examples/plugins/bookoo-mini.reaplugin/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "bookoo-mini.reaplugin",
+  "name": "Bookoo Mini Scale (Reference)",
+  "author": "Decaid contributors",
+  "description": "Opt-in Bookoo Mini protocol reference using host-owned BLE.",
+  "version": "0.1.0",
+  "apiVersion": 1,
+  "permissions": ["transport.ble"],
+  "drivers": [{
+    "id": "bookoo",
+    "type": "scale",
+    "capabilities": ["battery", "tare", "timerControl", "disconnectToSleep"],
+    "ble": {"match": {"name": {"contains": "bookoo"}, "serviceUuids": ["0ffe"]}}
+  }],
+  "settings": {},
+  "api": []
+}

--- a/examples/plugins/bookoo-mini.reaplugin/plugin.js
+++ b/examples/plugins/bookoo-mini.reaplugin/plugin.js
@@ -45,35 +45,54 @@ function createPlugin(host) {
               const state = {session, stopped: false, timer: null};
               active = state;
               let battery = null;
-              const services = await session.gatt.discoverServices();
-              if (!services.includes(service)) throw new Error("Bookoo service unavailable");
               let ready;
               let failed;
+              let settled = false;
               const firstPacket = new Promise((resolve, reject) => {ready = resolve; failed = reject;});
+              firstPacket.catch(() => {});
+              function succeed() {
+                if (!settled) {
+                  settled = true;
+                  ready();
+                }
+              }
+              function fail(error) {
+                if (!settled) {
+                  settled = true;
+                  failed(error);
+                }
+              }
               function watchPackets() {
                 clearTimeout(state.timer);
                 state.timer = setTimeout(() => {
                   stop(state);
-                  failed(new Error("Bookoo protocol silence"));
+                  fail(new Error("Bookoo protocol silence"));
                   session.reportDisconnected().catch(() => {});
                 }, 2000);
               }
-              session.gatt.onDisconnect(() => {
+              try {
+                const services = await session.gatt.discoverServices();
+                if (!services.includes(service)) throw new Error("Bookoo service unavailable");
+                session.gatt.onDisconnect(() => {
+                  stop(state);
+                  fail(new Error("Bookoo disconnected before readiness"));
+                });
+                await session.gatt.subscribe(service, dataCharacteristic, async (data, sample) => {
+                  if (state.stopped) return;
+                  const decoded = decode(data);
+                  if (!decoded) return;
+                  watchPackets();
+                  if (decoded.battery <= 100) battery = decoded.battery;
+                  await session.publish({weight: decoded.weight, battery}, sample);
+                  if (!state.stopped) succeed();
+                });
+                if (!state.stopped && state.timer === null) watchPackets();
+                await firstPacket;
+              } catch (error) {
                 stop(state);
-                failed(new Error("Bookoo disconnected before readiness"));
-              });
-              await session.gatt.subscribe(service, dataCharacteristic, async (data, sample) => {
-                if (state.stopped) return;
-                const decoded = decode(data);
-                if (!decoded) return;
-                watchPackets();
-                if (decoded.battery <= 100) battery = decoded.battery;
-                await session.publish({weight: decoded.weight, battery}, sample);
-                if (state.stopped) return;
-                ready();
-              });
-              if (!state.stopped && state.timer === null) watchPackets();
-              await firstPacket;
+                fail(error);
+                throw error;
+              }
             },
             disconnect() { stop(active); },
             tare() { return command(1); },

--- a/examples/plugins/bookoo-mini.reaplugin/plugin.js
+++ b/examples/plugins/bookoo-mini.reaplugin/plugin.js
@@ -1,0 +1,88 @@
+function createPlugin(host) {
+  const service = "00000ffe-0000-1000-8000-00805f9b34fb";
+  const dataCharacteristic = "0000ff11-0000-1000-8000-00805f9b34fb";
+  const commandCharacteristic = "0000ff12-0000-1000-8000-00805f9b34fb";
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  function decode(data) {
+    if (typeof data !== "string" || data.length !== 28 || data[27] !== "=") return null;
+    const bytes = [];
+    for (let i = 0; i < data.length; i += 4) {
+      const a = alphabet.indexOf(data[i]);
+      const b = alphabet.indexOf(data[i + 1]);
+      const c = alphabet.indexOf(data[i + 2]);
+      const d = data[i + 3] === "=" ? 0 : alphabet.indexOf(data[i + 3]);
+      if (a < 0 || b < 0 || c < 0 || d < 0) return null;
+      bytes.push((a << 2) | (b >> 4), ((b & 15) << 4) | (c >> 2));
+      if (data[i + 3] !== "=") bytes.push(((c & 3) << 6) | d);
+    }
+    if (bytes[0] !== 3 || bytes[1] !== 11 || (bytes[6] !== 43 && bytes[6] !== 45)) return null;
+    if (bytes.slice(0, 19).reduce((checksum, byte) => checksum ^ byte, 0) !== bytes[19]) return null;
+    const magnitude = (bytes[7] << 16) | (bytes[8] << 8) | bytes[9];
+    return {weight: (bytes[6] === 45 ? -magnitude : magnitude) / 100, battery: bytes[13]};
+  }
+
+  return {
+    id: "bookoo-mini.reaplugin",
+    onLoad() {
+      return host.devices.bindDriver("bookoo", {
+        create() {
+          let active;
+          function stop(state) {
+            if (!state || state.stopped) return;
+            state.stopped = true;
+            clearTimeout(state.timer);
+          }
+          function command(opcode) {
+            if (!active || active.stopped) return Promise.reject(new Error("Bookoo session is not connected"));
+            const bytes = [3, 10, opcode, 0, 0];
+            bytes.push(bytes.reduce((checksum, byte) => checksum ^ byte, 0));
+            return active.session.gatt.writeWithResponse(service, commandCharacteristic,
+              btoa(String.fromCharCode(...bytes)));
+          }
+          return {
+            async connect(session) {
+              const state = {session, stopped: false, timer: null};
+              active = state;
+              let battery = null;
+              const services = await session.gatt.discoverServices();
+              if (!services.includes(service)) throw new Error("Bookoo service unavailable");
+              let ready;
+              let failed;
+              const firstPacket = new Promise((resolve, reject) => {ready = resolve; failed = reject;});
+              function watchPackets() {
+                clearTimeout(state.timer);
+                state.timer = setTimeout(() => {
+                  stop(state);
+                  failed(new Error("Bookoo protocol silence"));
+                  session.reportDisconnected().catch(() => {});
+                }, 2000);
+              }
+              session.gatt.onDisconnect(() => {
+                stop(state);
+                failed(new Error("Bookoo disconnected before readiness"));
+              });
+              await session.gatt.subscribe(service, dataCharacteristic, async (data, sample) => {
+                if (state.stopped) return;
+                const decoded = decode(data);
+                if (!decoded) return;
+                watchPackets();
+                if (decoded.battery <= 100) battery = decoded.battery;
+                await session.publish({weight: decoded.weight, battery}, sample);
+                if (state.stopped) return;
+                ready();
+              });
+              if (!state.stopped && state.timer === null) watchPackets();
+              await firstPacket;
+            },
+            disconnect() { stop(active); },
+            tare() { return command(1); },
+            startTimer() { return command(4); },
+            stopTimer() { return command(5); },
+            resetTimer() { return command(6); }
+          };
+        }
+      });
+    }
+  };
+}

--- a/examples/plugins/felicita-arc.reaplugin/README.md
+++ b/examples/plugins/felicita-arc.reaplugin/README.md
@@ -1,0 +1,20 @@
+# Felicita Arc Reference Driver
+
+Opt-in example for #809, beside the Bookoo reference plugin. It is not bundled
+or enabled automatically; load it through the plugin source-development path.
+
+The driver matches a case-insensitive `Felicita` name prefix. It verifies the
+shared FFE0 service after connection, subscribes to FFE1, and uses acknowledged
+writes to FFE1. A valid notification is exactly 18 bytes: the sign is byte 2,
+bytes 3–8 are six ASCII weight digits in hundredths of a gram, and byte 15 is
+the battery encoding. Raw battery values 129–158 map to 0–100; other values
+retain the last valid battery value, with unknown initially represented as
+null. Invalid frames are ignored.
+
+Commands are one-byte acknowledged writes: tare `54`, timer start `52`, stop
+`53`, and reset `43` (hex). Readiness waits for the first valid accepted weight;
+connection and protocol failure remain host-owned. Display sleep deliberately
+disconnects, and wake/reconnect remains host policy. The two-second valid-packet
+silence watchdog is provisional and requires hardware cadence measurements.
+
+No Felicita hardware verification is included in this example checkpoint.

--- a/examples/plugins/felicita-arc.reaplugin/manifest.json
+++ b/examples/plugins/felicita-arc.reaplugin/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "felicita-arc.reaplugin",
+  "name": "Felicita Arc Scale (Reference)",
+  "author": "Decaid contributors",
+  "description": "Opt-in Felicita Arc protocol reference using host-owned BLE.",
+  "version": "0.1.0",
+  "apiVersion": 1,
+  "permissions": ["transport.ble"],
+  "drivers": [{
+    "id": "felicita",
+    "type": "scale",
+    "capabilities": ["battery", "tare", "timerControl", "disconnectToSleep"],
+    "ble": {"match": {"name": {"prefix": "felicita"}}}
+  }],
+  "settings": {},
+  "api": []
+}

--- a/examples/plugins/felicita-arc.reaplugin/plugin.js
+++ b/examples/plugins/felicita-arc.reaplugin/plugin.js
@@ -1,0 +1,135 @@
+function createPlugin(host) {
+  const service = "0000ffe0-0000-1000-8000-00805f9b34fb";
+  const characteristic = "0000ffe1-0000-1000-8000-00805f9b34fb";
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  function decodeBase64(data) {
+    if (typeof data !== "string" || data.length % 4 !== 0) return null;
+    const bytes = [];
+    for (let i = 0; i < data.length; i += 4) {
+      const a = alphabet.indexOf(data[i]);
+      const b = alphabet.indexOf(data[i + 1]);
+      const c = data[i + 2] === "=" ? 0 : alphabet.indexOf(data[i + 2]);
+      const d = data[i + 3] === "=" ? 0 : alphabet.indexOf(data[i + 3]);
+      if (a < 0 || b < 0 || c < 0 || d < 0) return null;
+      bytes.push((a << 2) | (b >> 4));
+      if (data[i + 2] !== "=") bytes.push(((b & 15) << 4) | (c >> 2));
+      if (data[i + 3] !== "=") bytes.push(((c & 3) << 6) | d);
+    }
+    return bytes;
+  }
+
+  function decode(data) {
+    const bytes = decodeBase64(data);
+    if (!bytes || bytes.length !== 18) return null;
+    const sign = bytes[2];
+    let digits = "";
+    for (let i = 3; i <= 8; i++) {
+      if (bytes[i] < 48 || bytes[i] > 57) return null;
+      digits += String.fromCharCode(bytes[i]);
+    }
+    const magnitude = Number(digits);
+    const rawBattery = bytes[15];
+    const battery = rawBattery >= 129 && rawBattery <= 158
+      ? Math.round((rawBattery - 129) * 100 / 29)
+      : null;
+    return {weight: (sign === 45 ? -magnitude : magnitude) / 100, battery};
+  }
+
+  return {
+    id: "felicita-arc.reaplugin",
+    onLoad() {
+      return host.devices.bindDriver("felicita", {
+        create() {
+          let active = null;
+          let battery = null;
+
+          function stop(state) {
+            if (!state || state.stopped) return;
+            state.stopped = true;
+            clearTimeout(state.timer);
+          }
+
+          function command(opcode) {
+            if (!active || active.stopped) {
+              return Promise.reject(new Error("Felicita session is not connected"));
+            }
+            return active.session.gatt.writeWithResponse(
+              service,
+              characteristic,
+              btoa(String.fromCharCode(opcode)),
+            );
+          }
+
+          return {
+            async connect(session) {
+              const state = {session, stopped: false, timer: null};
+              active = state;
+              battery = null;
+              let ready;
+              let failed;
+              let settled = false;
+              const firstPacket = new Promise((resolve, reject) => {
+                ready = resolve;
+                failed = reject;
+              });
+              firstPacket.catch(() => {});
+              function succeed() {
+                if (!settled) {
+                  settled = true;
+                  ready();
+                }
+              }
+              function fail(error) {
+                if (!settled) {
+                  settled = true;
+                  failed(error);
+                }
+              }
+              function watchPackets() {
+                clearTimeout(state.timer);
+                state.timer = setTimeout(() => {
+                  stop(state);
+                  fail(new Error("Felicita protocol silence"));
+                  session.reportDisconnected().catch(() => {});
+                }, 2000);
+              }
+              try {
+                const services = await session.gatt.discoverServices();
+                if (!services.includes(service)) {
+                  throw new Error("Felicita service unavailable");
+                }
+                session.gatt.onDisconnect(() => {
+                  stop(state);
+                  fail(new Error("Felicita disconnected before readiness"));
+                });
+                await session.gatt.subscribe(service, characteristic, async (data, sample) => {
+                  if (state.stopped) return;
+                  const decoded = decode(data);
+                  if (!decoded) return;
+                  watchPackets();
+                  if (decoded.battery !== null) battery = decoded.battery;
+                  await session.publish({weight: decoded.weight, battery}, sample);
+                  if (!state.stopped) succeed();
+                });
+                if (!state.stopped && state.timer === null) watchPackets();
+                await firstPacket;
+              } catch (error) {
+                stop(state);
+                fail(error);
+                throw error;
+              }
+            },
+            disconnect() {
+              stop(active);
+            },
+            tare() { return command(0x54); },
+            startTimer() { return command(0x52); },
+            stopTimer() { return command(0x53); },
+            resetTimer() { return command(0x43); }
+          };
+        }
+      });
+    }
+  };
+}

--- a/lib/src/debug_feature/scale_debug_view.dart
+++ b/lib/src/debug_feature/scale_debug_view.dart
@@ -13,11 +13,24 @@ class ScaleDebugView extends StatefulWidget {
 
 class _ScaleDebugViewState extends State<ScaleDebugView> {
   var _lastDate = DateTime.now();
+  Object? _connectError;
 
   @override
   void initState() {
     super.initState();
-    widget.scale.onConnect();
+    _connect();
+  }
+
+  Future<void> _connect() async {
+    if (mounted) setState(() => _connectError = null);
+    try {
+      await widget.scale.onConnect();
+      if (widget.scale case final ScaleSnapshotHandoff handoff) {
+        handoff.activateSnapshots();
+      }
+    } catch (error) {
+      if (mounted) setState(() => _connectError = error);
+    }
   }
 
   @override
@@ -43,35 +56,48 @@ class _ScaleDebugViewState extends State<ScaleDebugView> {
           ),
         ],
       ),
-      body: StreamBuilder<ScaleSnapshot>(
-        stream: widget.scale.currentSnapshot,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.active) {
-            final diff =
-                snapshot.data?.timestamp.difference(_lastDate) ?? Duration.zero;
-            _lastDate = snapshot.data?.timestamp ?? DateTime.now();
-            return _buildActiveView(theme, snapshot.data!, diff);
-          } else if (snapshot.connectionState == ConnectionState.waiting) {
-            return Center(
-              child: Row(
+      body: _connectError == null
+          ? StreamBuilder<ScaleSnapshot>(
+              stream: widget.scale.currentSnapshot,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.active) {
+                  final diff =
+                      snapshot.data?.timestamp.difference(_lastDate) ??
+                      Duration.zero;
+                  _lastDate = snapshot.data?.timestamp ?? DateTime.now();
+                  return _buildActiveView(theme, snapshot.data!, diff);
+                } else if (snapshot.connectionState ==
+                    ConnectionState.waiting) {
+                  return Center(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                        const SizedBox(width: 8),
+                        Text('Connecting…', style: theme.textTheme.muted),
+                      ],
+                    ),
+                  );
+                }
+                return Center(
+                  child: Text('Waiting for data', style: theme.textTheme.muted),
+                );
+              },
+            )
+          : Center(
+              child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                  const SizedBox(width: 8),
-                  Text('Connecting…', style: theme.textTheme.muted),
+                  const Text('Unable to connect to scale'),
+                  const SizedBox(height: 12),
+                  ShadButton(onPressed: _connect, child: const Text('Retry')),
                 ],
               ),
-            );
-          }
-          return Center(
-            child: Text('Waiting for data', style: theme.textTheme.muted),
-          );
-        },
-      ),
+            ),
     );
   }
 

--- a/lib/src/plugins/plugin_ble_binding.dart
+++ b/lib/src/plugins/plugin_ble_binding.dart
@@ -140,9 +140,9 @@ class PluginBleBinding {
       rethrow;
     }
     _session = session;
-    _domainSession = payload['session'] as String;
     unawaited(session.closed.then((_) => registry.release(claim)));
     await session.connect();
+    _domainSession = payload['session'] as String;
     try {
       return await invokeHandler(operation, {
         ...payload,

--- a/lib/src/plugins/plugin_ble_binding.dart
+++ b/lib/src/plugins/plugin_ble_binding.dart
@@ -24,6 +24,7 @@ class PluginBleBinding {
   late final PluginDeviceAdapter device;
   PluginBleSession? _session;
   String? _domainSession;
+  String? _preparedDomainSession;
   bool _disposed = false;
   Future<void>? _disposal;
 
@@ -49,6 +50,7 @@ class PluginBleBinding {
             name: name,
             invoke: invoke,
             transportType: TransportType.ble,
+            prepareConnection: prepareConnection,
             onReady: () => _session!.markReady(),
             invocationTimeout: invocationTimeout,
             definition: definition,
@@ -58,6 +60,7 @@ class PluginBleBinding {
             name: name,
             invoke: invoke,
             transportType: TransportType.ble,
+            prepareConnection: prepareConnection,
             onReady: () => _session!.markReady(),
             invocationTimeout: invocationTimeout,
             capabilities: driver.declaration.capabilities,
@@ -67,41 +70,9 @@ class PluginBleBinding {
   bool get occupied =>
       _session != null && _session!.state != PluginBleSessionState.closed;
 
-  void revoke() => _session?.revoke();
-
-  Future<Map<String, dynamic>> invoke(
-    PluginDeviceOperation operation,
-    Map<String, dynamic> payload,
-  ) async {
-    if (operation == PluginDeviceOperation.disconnect) {
-      final session = _session;
-      _domainSession = null;
-      if (session != null) {
-        await session.retire(
-          cleanup: (authority) async {
-            await invokeHandler(operation, {'gattSession': authority});
-          },
-        );
-        await session.closed.timeout(invocationTimeout);
-      }
-      return const {};
-    }
+  Future<void> prepareConnection(String domainSession) async {
     if (_disposed || !registry.isCurrent(driver) || !runtimeAlive()) {
       throw const PluginBleException('stale_session', 'BLE binding retired');
-    }
-    if (operation != PluginDeviceOperation.connect) {
-      final session = _session;
-      if (session == null || session.state != PluginBleSessionState.ready) {
-        throw const PluginBleException(
-          'stale_session',
-          'BLE device is not ready',
-        );
-      }
-      final result = await invokeHandler(operation, payload);
-      if (!identical(_session, session) || !session.acceptsPublications) {
-        throw const PluginBleException('stale_session', 'BLE command retired');
-      }
-      return result;
     }
     if (occupied) {
       throw const PluginBleException(
@@ -140,18 +111,68 @@ class PluginBleBinding {
       rethrow;
     }
     _session = session;
+    _preparedDomainSession = domainSession;
     unawaited(session.closed.then((_) => registry.release(claim)));
     await session.connect();
-    _domainSession = payload['session'] as String;
-    try {
-      return await invokeHandler(operation, {
-        ...payload,
-        'gattSession': session.id,
-      });
-    } catch (_) {
-      await session.retire();
-      rethrow;
+  }
+
+  void revoke() => _session?.revoke();
+
+  Future<Map<String, dynamic>> invoke(
+    PluginDeviceOperation operation,
+    Map<String, dynamic> payload,
+  ) async {
+    if (operation == PluginDeviceOperation.disconnect) {
+      final session = _session;
+      _domainSession = null;
+      _preparedDomainSession = null;
+      if (session != null) {
+        await session.retire(
+          cleanup: (authority) async {
+            await invokeHandler(operation, {'gattSession': authority});
+          },
+        );
+        await session.closed.timeout(invocationTimeout);
+      }
+      return const {};
     }
+    if (_disposed || !registry.isCurrent(driver) || !runtimeAlive()) {
+      throw const PluginBleException('stale_session', 'BLE binding retired');
+    }
+    if (operation == PluginDeviceOperation.connect) {
+      final session = _session;
+      if (session == null ||
+          session.state != PluginBleSessionState.initializing ||
+          _preparedDomainSession != payload['session']) {
+        throw const PluginBleException(
+          'stale_session',
+          'BLE session was not prepared',
+        );
+      }
+      _preparedDomainSession = null;
+      _domainSession = payload['session'] as String;
+      try {
+        return await invokeHandler(operation, {
+          ...payload,
+          'gattSession': session.id,
+        });
+      } catch (_) {
+        await session.retire();
+        rethrow;
+      }
+    }
+    final session = _session;
+    if (session == null || session.state != PluginBleSessionState.ready) {
+      throw const PluginBleException(
+        'stale_session',
+        'BLE device is not ready',
+      );
+    }
+    final result = await invokeHandler(operation, payload);
+    if (!identical(_session, session) || !session.acceptsPublications) {
+      throw const PluginBleException('stale_session', 'BLE command retired');
+    }
+    return result;
   }
 
   Future<Object?> call(

--- a/lib/src/plugins/plugin_ble_service.dart
+++ b/lib/src/plugins/plugin_ble_service.dart
@@ -68,10 +68,24 @@ class PluginBleService {
       throw const PluginBleException('stale_session', 'BLE driver retired');
     }
     final id = normalizeBleDeviceId(physicalId);
-    for (final binding in _bindings.values) {
-      if (identical(binding.driver, driver) && binding.physicalId == id) {
+    final candidates = _bindings.values
+        .where(
+          (binding) =>
+              identical(binding.driver, driver) && binding.physicalId == id,
+        )
+        .toList();
+    for (final binding in candidates) {
+      if (binding.occupied) {
+        // An active session owns this physical device: reuse it so concurrent
+        // advertisements cannot create a duplicate candidate or connection.
         return binding.device;
       }
+      // The session is closed (deliberate disconnect or link loss) and the
+      // discovery inventory has already dropped this device. Reusing the
+      // retired device replays `disconnected`, so the discovery service can
+      // never re-adopt it from a fresh advertisement. Discard the stale
+      // binding so the next observation creates a fresh candidate.
+      await discard(binding.device);
     }
     final handle = 'ble_${const Uuid().v4()}';
     try {

--- a/lib/src/plugins/plugin_bound_sensor.dart
+++ b/lib/src/plugins/plugin_bound_sensor.dart
@@ -12,6 +12,7 @@ class PluginBoundSensor extends PluginProtocolDevice implements Sensor {
     required super.name,
     required super.invoke,
     required super.transportType,
+    super.prepareConnection,
     required super.onReady,
     required super.invocationTimeout,
     required Map<String, dynamic> definition,

--- a/lib/src/plugins/plugin_manager.dart
+++ b/lib/src/plugins/plugin_manager.dart
@@ -63,7 +63,7 @@ class _PendingDeviceInvocation {
   final String registrationHandle;
   final PluginDeviceOperation operation;
   final Completer<Map<String, dynamic>> completer;
-  final Timer timer;
+  final Timer? timer;
 }
 
 class PluginHttpError implements Exception {
@@ -181,6 +181,8 @@ class PluginManager {
         handle,
         operation,
         payload,
+        protocolBoundsConnectStartup:
+            operation == PluginDeviceOperation.connect,
       ),
       runtimeAlive: (driver) =>
           (_pluginGenerations[driver.pluginId] == driver.generation &&
@@ -290,7 +292,7 @@ class PluginManager {
       _pluginBridgeTokens.clear();
       _pluginIdsByBridgeToken.clear();
       for (final pending in _pendingDeviceInvocations.values) {
-        pending.timer.cancel();
+        pending.timer?.cancel();
         if (!pending.completer.isCompleted) {
           pending.completer.completeError(
             const PluginDeviceException('Plugin manager disposed'),
@@ -1482,8 +1484,9 @@ class PluginManager {
     int generation,
     String registrationHandle,
     PluginDeviceOperation operation,
-    Map<String, dynamic> payload,
-  ) {
+    Map<String, dynamic> payload, {
+    bool protocolBoundsConnectStartup = false,
+  }) {
     final isCurrent =
         _lifecycle == PluginManagerLifecycle.active &&
         generation == _pluginGenerations[pluginId] &&
@@ -1523,7 +1526,7 @@ class PluginManager {
           connectInvocationId,
         );
         final pending = _pendingDeviceInvocations.remove(connectInvocationId);
-        pending?.timer.cancel();
+        pending?.timer?.cancel();
         pending?.completer.completeError(
           const PluginDeviceException(
             'Plugin device connect retired',
@@ -1535,28 +1538,33 @@ class PluginManager {
     final invocationId =
         '${pluginId}_${generation}_device_${++_deviceInvocationSequence}';
     final completer = Completer<Map<String, dynamic>>();
-    final timer = Timer(deviceInvocationTimeout, () {
-      final pending = _pendingDeviceInvocations.remove(invocationId);
-      if (pending?.operation == PluginDeviceOperation.connect) {
-        final key = (
-          pending!.pluginId,
-          pending.generation,
-          pending.registrationHandle,
-        );
-        _timedOutDeviceConnects
-            .putIfAbsent(key, () => <String>{})
-            .add(invocationId);
-        _transportService.retireDeviceConnect(
-          pending.pluginId,
-          pending.generation,
-          pending.registrationHandle,
-          invocationId,
-        );
-      }
-      pending?.completer.completeError(
-        const PluginDeviceException('Plugin device invocation timed out'),
-      );
-    });
+    final protocolOwnsStartup =
+        protocolBoundsConnectStartup &&
+        operation == PluginDeviceOperation.connect;
+    final timer = protocolOwnsStartup
+        ? null
+        : Timer(deviceInvocationTimeout, () {
+            final pending = _pendingDeviceInvocations.remove(invocationId);
+            if (pending?.operation == PluginDeviceOperation.connect) {
+              final key = (
+                pending!.pluginId,
+                pending.generation,
+                pending.registrationHandle,
+              );
+              _timedOutDeviceConnects
+                  .putIfAbsent(key, () => <String>{})
+                  .add(invocationId);
+              _transportService.retireDeviceConnect(
+                pending.pluginId,
+                pending.generation,
+                pending.registrationHandle,
+                invocationId,
+              );
+            }
+            pending?.completer.completeError(
+              const PluginDeviceException('Plugin device invocation timed out'),
+            );
+          });
     _pendingDeviceInvocations[invocationId] = _PendingDeviceInvocation(
       pluginId: pluginId,
       generation: generation,
@@ -1582,7 +1590,7 @@ class PluginManager {
       while (js.executePendingJob() > 0) {}
     } catch (error) {
       final pending = _pendingDeviceInvocations.remove(invocationId);
-      pending?.timer.cancel();
+      pending?.timer?.cancel();
       if (operation == PluginDeviceOperation.connect) {
         _deviceConnectAttempts.remove(invocationId);
       }
@@ -1651,7 +1659,7 @@ class PluginManager {
       return;
     }
     _pendingDeviceInvocations.remove(invocationId);
-    pending.timer.cancel();
+    pending.timer?.cancel();
     final error = payload['error'];
     if (error != null) {
       pending.completer.completeError(PluginDeviceException(error.toString()));
@@ -1695,7 +1703,7 @@ class PluginManager {
         .toList();
     for (final id in ids) {
       final pending = _pendingDeviceInvocations.remove(id)!;
-      pending.timer.cancel();
+      pending.timer?.cancel();
       if (!pending.completer.isCompleted) {
         pending.completer.completeError(PluginDeviceException(reason));
       }

--- a/lib/src/plugins/plugin_protocol_device.dart
+++ b/lib/src/plugins/plugin_protocol_device.dart
@@ -17,6 +17,7 @@ abstract class PluginProtocolDevice extends PluginDeviceAdapter {
   @override
   final TransportType transportType;
   final PluginDeviceInvoker invoke;
+  final Future<void> Function(String session)? prepareConnection;
   final void Function()? onReady;
   final Duration invocationTimeout;
   final BehaviorSubject<ConnectionState> _state = BehaviorSubject.seeded(
@@ -34,6 +35,7 @@ abstract class PluginProtocolDevice extends PluginDeviceAdapter {
     required this.name,
     required this.invoke,
     this.transportType = TransportType.unknown,
+    this.prepareConnection,
     this.onReady,
     this.invocationTimeout = const Duration(seconds: 5),
   });
@@ -87,7 +89,14 @@ abstract class PluginProtocolDevice extends PluginDeviceAdapter {
     beginSamples();
     final readiness = waitForReadiness();
     _state.add(ConnectionState.connecting);
+    var prepared = false;
     try {
+      final prepare = prepareConnection;
+      if (prepare != null) {
+        await prepare(session);
+        prepared = true;
+        checkSession(session);
+      }
       final initialization = () async {
         await invoke(PluginDeviceOperation.connect, {'session': session});
         await readiness;
@@ -103,6 +112,10 @@ abstract class PluginProtocolDevice extends PluginDeviceAdapter {
       if (_session == session) {
         try {
           await disconnect();
+        } catch (_) {}
+      } else if (prepared) {
+        try {
+          await invoke(PluginDeviceOperation.disconnect, {'session': session});
         } catch (_) {}
       }
       Error.throwWithStackTrace(error, stackTrace);

--- a/lib/src/plugins/plugin_protocol_device.dart
+++ b/lib/src/plugins/plugin_protocol_device.dart
@@ -101,10 +101,16 @@ abstract class PluginProtocolDevice extends PluginDeviceAdapter {
         await invoke(PluginDeviceOperation.connect, {'session': session});
         await readiness;
       }();
-      await Future.any([
-        initialization,
-        cancelled.future,
+      final cancelledDuringStartup = await Future.any<bool>([
+        initialization.then((_) => false),
+        cancelled.future.then((_) => true),
       ]).timeout(invocationTimeout);
+      if (cancelledDuringStartup) {
+        throw const PluginDeviceException(
+          'Plugin device connect cancelled',
+          code: 'stale_session',
+        );
+      }
       checkSession(session);
       onReady?.call();
       _state.add(ConnectionState.connected);

--- a/lib/src/plugins/plugin_scale.dart
+++ b/lib/src/plugins/plugin_scale.dart
@@ -24,6 +24,7 @@ class PluginScale extends PluginProtocolDevice
     required super.invoke,
     required Set<PluginScaleCapability> capabilities,
     super.transportType,
+    super.prepareConnection,
     super.onReady,
     super.invocationTimeout,
   }) : capabilities = Set.unmodifiable(capabilities);

--- a/lib/src/services/ble/universal_ble_transport.dart
+++ b/lib/src/services/ble/universal_ble_transport.dart
@@ -169,13 +169,32 @@ class UniversalBleTransport extends BLETransport {
           if (update.isConnected) {
             _connectionStateSubject.add(device.ConnectionState.connected);
           } else {
-            if (_maintenanceGeneration == generation) return;
-            _recoveringQueueGeneration = null;
-            final reason = update.error ?? 'unknown';
-            _log.warning('Transport disconnected: $reason');
-            _publishDisconnected();
+            final maintenance = _maintenanceGeneration == generation;
+            if (maintenance) return;
+            unawaited(_confirmDisconnect(generation, update.error));
           }
         });
+  }
+
+  Future<void> _confirmDisconnect(int generation, String? error) async {
+    BleConnectionState state;
+    try {
+      state = await UniversalBle.getConnectionState(
+        _device.deviceId,
+        timeout: _linkProbeTimeout,
+      );
+    } catch (_) {
+      state = BleConnectionState.disconnected;
+    }
+    if (_connectionGeneration != generation || _disposed) return;
+    if (state == BleConnectionState.connected ||
+        state == BleConnectionState.connecting) {
+      return;
+    }
+    if (_maintenanceGeneration == generation) return;
+    _recoveringQueueGeneration = null;
+    _log.warning('Transport disconnected: ${error ?? 'unknown'}');
+    _publishDisconnected();
   }
 
   Future<void> _doConnectBlueZ([int? maintenanceGeneration]) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1698,8 +1698,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2.2.6"
-      resolved-ref: "6116abba1d1c00fb66ecce1d14cc5314d7c184f1"
+      ref: "9c50e12fcc33b061fe37e7037c69e44e30d96c79"
+      resolved-ref: "9c50e12fcc33b061fe37e7037c69e44e30d96c79"
       url: "https://github.com/tadelv/universal_ble.git"
     source: git
     version: "2.2.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,10 @@ dependencies:
   universal_ble:
     git:
       url: https://github.com/tadelv/universal_ble.git
-      ref: 2.2.6
+      # Held on this commit (unreleased): confirms link state before the
+      # automatic queue drain, so a stale disconnect update cannot cancel the
+      # current connection's queued GATT work. Re-pin once it is released.
+      ref: 9c50e12fcc33b061fe37e7037c69e44e30d96c79
   shared_preferences: ^2.5.3
   # share_plus HELD at 12.x — 13.x requires win32 ^6, which conflicts with
   # file_picker 11's win32 ^5.9 pin. 13.x is only SDK-floor bumps, no API gain.

--- a/scripts/test_bookoo_readiness_rejection.mjs
+++ b/scripts/test_bookoo_readiness_rejection.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// Readiness-rejection lifecycle check for the Bookoo reference plugin.
+//
+// The Decaid plugin runtime does not expose unhandled-promise tracking, so this
+// script drives the real plugin source through the scenarios that matter and
+// reports unhandled rejections itself. It supplements the Dart runtime tests;
+// it is not a substitute for them.
+//
+// Run: node scripts/test_bookoo_readiness_rejection.mjs
+
+import { readFileSync } from 'node:fs';
+
+const pluginPath = new URL(
+  '../examples/plugins/bookoo-mini.reaplugin/plugin.js',
+  import.meta.url,
+);
+
+const source = readFileSync(pluginPath, 'utf8');
+const createPlugin = new Function('host', `${source}\nreturn createPlugin(host);`);
+
+const failures = [];
+const unhandled = [];
+
+process.on('unhandledRejection', (reason) => {
+  unhandled.push(reason);
+});
+
+/// One event-loop turn, so anything scheduled by the plugin (microtasks and
+/// immediate callbacks) has run before a result is inspected. No timed waits:
+/// the scenarios advance on observed plugin activity instead.
+const turn = () => new Promise((resolve) => setImmediate(resolve));
+
+function check(name, condition, detail) {
+  if (!condition) failures.push(`${name}: ${detail}`);
+}
+
+function loadDriver() {
+  let binding;
+  const host = {
+    log() {},
+    devices: {
+      bindDriver(id, implementation) {
+        binding = implementation;
+      },
+    },
+  };
+  const plugin = createPlugin(host);
+  plugin.onLoad();
+  return binding;
+}
+
+function bookooPacket(grams, battery = 50) {
+  const magnitude = Math.round(Math.abs(grams) * 100);
+  const packet = new Array(20).fill(0);
+  packet[0] = 0x03;
+  packet[1] = 0x0b;
+  packet[6] = grams < 0 ? 0x2d : 0x2b;
+  packet[7] = (magnitude >> 16) & 0xff;
+  packet[8] = (magnitude >> 8) & 0xff;
+  packet[9] = magnitude & 0xff;
+  packet[13] = battery;
+  packet[19] = packet.slice(0, 19).reduce((sum, byte) => sum ^ byte, 0);
+  return Buffer.from(packet).toString('base64');
+}
+
+function makeSession({ subscribeError } = {}) {
+  let subscriber;
+  let onDisconnect;
+  const published = [];
+  const publishWaiters = [];
+  let markSubscribed;
+  const subscribed = new Promise((resolve) => {
+    markSubscribed = resolve;
+  });
+  return {
+    published,
+    subscribed: () => subscribed,
+    async waitForPublishes(count) {
+      while (published.length < count) {
+        await new Promise((resolve) => publishWaiters.push(resolve));
+      }
+    },
+    gatt: {
+      async discoverServices() {
+        return ['00000ffe-0000-1000-8000-00805f9b34fb'];
+      },
+      async subscribe(service, characteristic, callback) {
+        if (subscribeError) throw subscribeError;
+        subscriber = callback;
+        markSubscribed();
+      },
+      onDisconnect(callback) {
+        onDisconnect = callback;
+      },
+    },
+    async publish(snapshot) {
+      published.push(snapshot);
+      publishWaiters.splice(0).forEach((resolve) => resolve());
+    },
+    async reportDisconnected() {},
+    emit(packet) {
+      subscriber?.(packet, undefined);
+    },
+    disconnect() {
+      onDisconnect?.();
+    },
+  };
+}
+
+async function scenarioSubscribeFailureThenDisconnect() {
+  // Each scenario reports only its own rejections.
+  unhandled.length = 0;
+
+  const driver = loadDriver();
+  const instance = driver.create({});
+  const subscribeError = new Error('Bookoo subscription failed');
+  const session = makeSession({ subscribeError });
+
+  let connectError;
+  try {
+    await instance.connect(session);
+  } catch (error) {
+    connectError = error;
+  }
+  check(
+    'subscribe failure is preserved',
+    connectError === subscribeError,
+    `connect rejected with ${connectError}`,
+  );
+
+  session.disconnect();
+  await turn();
+
+  check(
+    'subscribe failure followed by disconnect leaves no unhandled rejection',
+    unhandled.length === 0,
+    `${unhandled.length} unhandled rejection(s): ${unhandled[0]}`,
+  );
+}
+
+async function scenarioDisconnectBeforeFirstPacket() {
+  // Each scenario reports only its own rejections.
+  unhandled.length = 0;
+
+  const driver = loadDriver();
+  const instance = driver.create({});
+  const session = makeSession();
+
+  // Observe the outcome from the start: the rejection arrives while readiness
+  // is still awaited, and an unobserved rejection would be reported as unhandled.
+  const connecting = instance.connect(session).then(
+    () => undefined,
+    (error) => error,
+  );
+  await session.subscribed();
+  session.disconnect();
+  await turn();
+
+  const connectError = await connecting;
+  check(
+    'disconnect before readiness is reported',
+    connectError instanceof Error &&
+      /disconnected before readiness/.test(connectError.message),
+    `connect rejected with ${connectError}`,
+  );
+  check(
+    'disconnect before readiness leaves no unhandled rejection',
+    unhandled.length === 0,
+    `${unhandled.length} unhandled rejection(s): ${unhandled[0]}`,
+  );
+}
+
+async function scenarioSuccessfulFirstPacket() {
+  // Each scenario reports only its own rejections.
+  unhandled.length = 0;
+
+  const driver = loadDriver();
+  const instance = driver.create({});
+  const session = makeSession();
+
+  const connecting = instance.connect(session);
+  await session.subscribed();
+  session.emit(bookooPacket(12.34));
+  await connecting;
+  await session.waitForPublishes(1);
+
+  check(
+    'first packet publishes weight',
+    session.published.length === 1 && session.published[0].weight === 12.34,
+    JSON.stringify(session.published),
+  );
+
+  session.emit(bookooPacket(20));
+  await session.waitForPublishes(2);
+  check(
+    'processing continues after readiness',
+    session.published.length === 2 && session.published[1].weight === 20,
+    JSON.stringify(session.published),
+  );
+  check(
+    'successful startup leaves no unhandled rejection',
+    unhandled.length === 0,
+    `${unhandled.length} unhandled rejection(s): ${unhandled[0]}`,
+  );
+}
+
+const scenarios = {
+  subscribe: scenarioSubscribeFailureThenDisconnect,
+  disconnect: scenarioDisconnectBeforeFirstPacket,
+  ready: scenarioSuccessfulFirstPacket,
+};
+const selected = process.argv[2] ? [process.argv[2]] : Object.keys(scenarios);
+for (const name of selected) {
+  await scenarios[name]();
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) console.error(`FAIL ${failure}`);
+  process.exit(1);
+}
+console.log('Bookoo readiness rejection lifecycle: OK');

--- a/test/debug_feature/scale_debug_view_test.dart
+++ b/test/debug_feature/scale_debug_view_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/debug_feature/scale_debug_view.dart';
+import 'package:reaprime/src/models/device/device.dart' as device;
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:shadcn_ui/shadcn_ui.dart' hide Scale;
+
+import '../helpers/test_scale.dart';
+
+class _FailingScale extends TestScale implements ScaleSnapshotHandoff {
+  _FailingScale() : super(initialState: device.ConnectionState.discovered);
+
+  var connectCalls = 0;
+  var snapshotsActive = false;
+
+  @override
+  Future<void> onConnect() async {
+    connectCalls++;
+    if (connectCalls == 1) throw StateError('gatt status 133');
+  }
+
+  @override
+  void activateSnapshots() => snapshotsActive = true;
+}
+
+void main() {
+  testWidgets('failed connect is shown as a retryable state', (tester) async {
+    final scale = _FailingScale();
+    addTearDown(scale.dispose);
+    final errors = <FlutterErrorDetails>[];
+    final previous = FlutterError.onError;
+    FlutterError.onError = errors.add;
+    addTearDown(() => FlutterError.onError = previous);
+
+    await tester.pumpWidget(ShadApp(home: ScaleDebugView(scale: scale)));
+    await tester.pump();
+
+    expect(errors, isEmpty);
+    expect(find.text('Unable to connect to scale'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pump();
+
+    expect(errors, isEmpty);
+    expect(scale.connectCalls, 2);
+    expect(scale.snapshotsActive, isTrue);
+    expect(find.text('Unable to connect to scale'), findsNothing);
+  });
+}

--- a/test/helpers/bookoo_packets.dart
+++ b/test/helpers/bookoo_packets.dart
@@ -1,0 +1,35 @@
+List<int> bookooPacket(double grams, {int? battery = 50}) {
+  final magnitude = (grams.abs() * 100).round();
+  final packet = List<int>.filled(20, 0);
+  packet[0] = 0x03;
+  packet[1] = 0x0B;
+  packet[6] = grams < 0 ? 0x2D : 0x2B;
+  packet[7] = (magnitude >> 16) & 0xff;
+  packet[8] = (magnitude >> 8) & 0xff;
+  packet[9] = magnitude & 0xff;
+  if (battery != null) packet[13] = battery;
+  packet[19] = packet.take(19).fold(0, (sum, byte) => sum ^ byte);
+  return packet;
+}
+
+const bookooCommands = [
+  [0x03, 0x0A, 0x01, 0, 0, 0x08],
+  [0x03, 0x0A, 0x04, 0, 0, 0x0D],
+  [0x03, 0x0A, 0x05, 0, 0, 0x0C],
+  [0x03, 0x0A, 0x06, 0, 0, 0x0F],
+];
+
+List<List<int>> invalidBookooPackets() {
+  final valid = bookooPacket(10);
+  final sign = [...valid];
+  sign[6] = 0;
+  sign[19] = sign.take(19).fold(0, (sum, byte) => sum ^ byte);
+  return [
+    for (final length in [0, 9, 10, 11, 19]) valid.sublist(0, length),
+    [...valid, 0],
+    [0x04, ...valid.sublist(1)],
+    [0x03, 0x0A, ...valid.sublist(2)],
+    [...valid.take(19), valid.last ^ 1],
+    sign,
+  ];
+}

--- a/test/helpers/bookoo_plugin_fixture.dart
+++ b/test/helpers/bookoo_plugin_fixture.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+
+import 'plugin_ble_fixture.dart';
+
+const bookooPluginPath = 'examples/plugins/bookoo-mini.reaplugin';
+const bookooServiceUuid = '00000ffe-0000-1000-8000-00805f9b34fb';
+const bookooDataCharacteristicUuid = '0000ff11-0000-1000-8000-00805f9b34fb';
+const bookooCommandCharacteristicUuid =
+    '0000ff12-0000-1000-8000-00805f9b34fb';
+
+PluginManifest bookooManifest() => PluginManifest.fromJson(
+  jsonDecode(File('$bookooPluginPath/manifest.json').readAsStringSync()),
+);
+Future<void> loadBookooPlugin(PluginManager manager) => manager.loadPlugin(
+  id: bookooManifest().id,
+  manifest: bookooManifest(),
+  settings: {},
+  jsCode: File('$bookooPluginPath/plugin.js').readAsStringSync(),
+);
+
+class BookooPluginTransport extends PluginBleFixtureTransport {
+  BookooPluginTransport(
+    super.physicalId, {
+    this.firstPacket,
+    this.servicePresent = true,
+    this.subscriptionDelay = Duration.zero,
+  });
+  final List<int>? firstPacket;
+  final bool servicePresent;
+  final Duration subscriptionDelay;
+  final subscribed = Completer<void>();
+  @override
+  Future<List<String>> discoverServices() async =>
+      servicePresent ? [bookooServiceUuid] : [];
+
+  @override
+  Future<void> subscribe(
+    String service,
+    String characteristic,
+    void Function(Uint8List) callback,
+  ) async {
+    if (service != bookooServiceUuid ||
+        characteristic != bookooDataCharacteristicUuid) {
+      throw StateError(
+        'Unexpected Bookoo subscription $service/$characteristic',
+      );
+    }
+    if (subscriptionDelay != Duration.zero) {
+      await Future<void>.delayed(subscriptionDelay);
+    }
+    subscribers[characteristic] = callback;
+    if (firstPacket != null) callback(Uint8List.fromList(firstPacket!));
+    if (!subscribed.isCompleted) subscribed.complete();
+  }
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {
+    if (serviceUUID != bookooServiceUuid ||
+        characteristicUUID != bookooCommandCharacteristicUuid) {
+      throw StateError(
+        'Unexpected Bookoo write $serviceUUID/$characteristicUUID',
+      );
+    }
+    await super.write(
+      serviceUUID,
+      characteristicUUID,
+      data,
+      withResponse: withResponse,
+      timeout: timeout,
+    );
+  }
+
+  void emit(List<int> packet) =>
+      subscribers[bookooDataCharacteristicUuid]!(Uint8List.fromList(packet));
+}

--- a/test/helpers/bookoo_plugin_fixture.dart
+++ b/test/helpers/bookoo_plugin_fixture.dart
@@ -11,8 +11,7 @@ import 'plugin_ble_fixture.dart';
 const bookooPluginPath = 'examples/plugins/bookoo-mini.reaplugin';
 const bookooServiceUuid = '00000ffe-0000-1000-8000-00805f9b34fb';
 const bookooDataCharacteristicUuid = '0000ff11-0000-1000-8000-00805f9b34fb';
-const bookooCommandCharacteristicUuid =
-    '0000ff12-0000-1000-8000-00805f9b34fb';
+const bookooCommandCharacteristicUuid = '0000ff12-0000-1000-8000-00805f9b34fb';
 
 PluginManifest bookooManifest() => PluginManifest.fromJson(
   jsonDecode(File('$bookooPluginPath/manifest.json').readAsStringSync()),

--- a/test/helpers/bookoo_plugin_fixture.dart
+++ b/test/helpers/bookoo_plugin_fixture.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 
@@ -29,11 +30,22 @@ class BookooPluginTransport extends PluginBleFixtureTransport {
     this.firstPacket,
     this.servicePresent = true,
     this.subscriptionDelay = Duration.zero,
+    this.subscriptionFailure,
   });
   final List<int>? firstPacket;
   final bool servicePresent;
   final Duration subscriptionDelay;
+  final Object? subscriptionFailure;
   final subscribed = Completer<void>();
+
+  /// Fires the platform's connection update for this device, standing in for a
+  /// device-initiated or lost link. A link that is already torn down has
+  /// nothing left to drop.
+  void dropLink() {
+    if (states.isClosed) return;
+    states.add(device.ConnectionState.disconnected);
+  }
+
   @override
   Future<List<String>> discoverServices() async =>
       servicePresent ? [bookooServiceUuid] : [];
@@ -53,6 +65,7 @@ class BookooPluginTransport extends PluginBleFixtureTransport {
     if (subscriptionDelay != Duration.zero) {
       await Future<void>.delayed(subscriptionDelay);
     }
+    if (subscriptionFailure != null) throw subscriptionFailure!;
     subscribers[characteristic] = callback;
     if (firstPacket != null) callback(Uint8List.fromList(firstPacket!));
     if (!subscribed.isCompleted) subscribed.complete();

--- a/test/helpers/felicita_plugin_fixture.dart
+++ b/test/helpers/felicita_plugin_fixture.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+
+import 'plugin_ble_fixture.dart';
+
+const felicitaPluginPath = 'examples/plugins/felicita-arc.reaplugin';
+const felicitaServiceUuid = '0000ffe0-0000-1000-8000-00805f9b34fb';
+const felicitaCharacteristicUuid = '0000ffe1-0000-1000-8000-00805f9b34fb';
+
+PluginManifest felicitaManifest() => PluginManifest.fromJson(
+  jsonDecode(File('$felicitaPluginPath/manifest.json').readAsStringSync()),
+);
+
+Future<void> loadFelicitaPlugin(PluginManager manager) => manager.loadPlugin(
+  id: felicitaManifest().id,
+  manifest: felicitaManifest(),
+  settings: {},
+  jsCode: File('$felicitaPluginPath/plugin.js').readAsStringSync(),
+);
+
+List<int> felicitaPacket(double grams, {int battery = 143, int? sign}) {
+  final magnitude = (grams.abs() * 100).round().toString().padLeft(6, '0');
+  return [
+    0,
+    0,
+    sign ?? (grams < 0 ? 45 : 43),
+    ...magnitude.codeUnits,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    battery,
+    0,
+    0,
+  ];
+}
+
+class FelicitaPluginTransport extends PluginBleFixtureTransport {
+  FelicitaPluginTransport(
+    super.physicalId, {
+    this.firstPacket,
+    this.servicePresent = true,
+    this.subscriptionDelay = Duration.zero,
+    this.subscriptionFailure,
+    this.writeFailure,
+  });
+
+  final List<int>? firstPacket;
+  final bool servicePresent;
+  final Duration subscriptionDelay;
+  final Object? subscriptionFailure;
+  final Object? writeFailure;
+  final subscribed = Completer<void>();
+
+  @override
+  Future<List<String>> discoverServices() async =>
+      servicePresent ? [felicitaServiceUuid] : [];
+
+  @override
+  Future<void> subscribe(
+    String service,
+    String characteristic,
+    void Function(Uint8List) callback,
+  ) async {
+    if (service != felicitaServiceUuid ||
+        characteristic != felicitaCharacteristicUuid) {
+      throw StateError(
+        'Unexpected Felicita subscription $service/$characteristic',
+      );
+    }
+    if (subscriptionDelay != Duration.zero) {
+      await Future<void>.delayed(subscriptionDelay);
+    }
+    if (subscriptionFailure != null) throw subscriptionFailure!;
+    subscribers[characteristic] = callback;
+    if (firstPacket != null) callback(Uint8List.fromList(firstPacket!));
+    if (!subscribed.isCompleted) subscribed.complete();
+  }
+
+  @override
+  Future<void> write(
+    String serviceUUID,
+    String characteristicUUID,
+    Uint8List data, {
+    bool withResponse = true,
+    Duration? timeout,
+  }) async {
+    if (serviceUUID != felicitaServiceUuid ||
+        characteristicUUID != felicitaCharacteristicUuid) {
+      throw StateError(
+        'Unexpected Felicita write $serviceUUID/$characteristicUUID',
+      );
+    }
+    if (writeFailure != null) throw writeFailure!;
+    await super.write(
+      serviceUUID,
+      characteristicUUID,
+      data,
+      withResponse: withResponse,
+      timeout: timeout,
+    );
+  }
+
+  void emit(List<int> packet) =>
+      subscribers[felicitaCharacteristicUuid]!(Uint8List.fromList(packet));
+}

--- a/test/helpers/felicita_plugin_fixture.dart
+++ b/test/helpers/felicita_plugin_fixture.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:reaprime/src/models/device/device.dart' as device;
 import 'package:reaprime/src/plugins/plugin_manifest.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 
@@ -50,6 +51,7 @@ class FelicitaPluginTransport extends PluginBleFixtureTransport {
     this.subscriptionDelay = Duration.zero,
     this.subscriptionFailure,
     this.writeFailure,
+    this.connectFailure,
   });
 
   final List<int>? firstPacket;
@@ -57,7 +59,18 @@ class FelicitaPluginTransport extends PluginBleFixtureTransport {
   final Duration subscriptionDelay;
   final Object? subscriptionFailure;
   final Object? writeFailure;
+  final Object? connectFailure;
   final subscribed = Completer<void>();
+
+  @override
+  Future<void> connect() async {
+    connectCalls++;
+    if (connectFailure != null) {
+      states.add(device.ConnectionState.disconnected);
+      throw connectFailure!;
+    }
+    states.add(device.ConnectionState.connected);
+  }
 
   @override
   Future<List<String>> discoverServices() async =>

--- a/test/helpers/felicita_plugin_fixture.dart
+++ b/test/helpers/felicita_plugin_fixture.dart
@@ -52,6 +52,7 @@ class FelicitaPluginTransport extends PluginBleFixtureTransport {
     this.subscriptionFailure,
     this.writeFailure,
     this.connectFailure,
+    this.connectBlocker,
   });
 
   final List<int>? firstPacket;
@@ -60,11 +61,24 @@ class FelicitaPluginTransport extends PluginBleFixtureTransport {
   final Object? subscriptionFailure;
   final Object? writeFailure;
   final Object? connectFailure;
+
+  /// Holds physical acquisition open so a test can decide when it lands.
+  final Completer<void>? connectBlocker;
+
+  /// Completes when physical acquisition starts, so a test never has to sleep
+  /// to know which phase it is in.
+  final acquisitionStarted = Completer<void>();
+
+  /// Completes when the plugin's first protocol call lands.
+  final servicesRequested = Completer<void>();
   final subscribed = Completer<void>();
+  int discoverServicesCalls = 0;
 
   @override
   Future<void> connect() async {
     connectCalls++;
+    if (!acquisitionStarted.isCompleted) acquisitionStarted.complete();
+    await connectBlocker?.future;
     if (connectFailure != null) {
       states.add(device.ConnectionState.disconnected);
       throw connectFailure!;
@@ -73,8 +87,11 @@ class FelicitaPluginTransport extends PluginBleFixtureTransport {
   }
 
   @override
-  Future<List<String>> discoverServices() async =>
-      servicePresent ? [felicitaServiceUuid] : [];
+  Future<List<String>> discoverServices() async {
+    discoverServicesCalls++;
+    if (!servicesRequested.isCompleted) servicesRequested.complete();
+    return servicePresent ? [felicitaServiceUuid] : [];
+  }
 
   @override
   Future<void> subscribe(

--- a/test/helpers/plugin_ble_fixture.dart
+++ b/test/helpers/plugin_ble_fixture.dart
@@ -98,6 +98,13 @@ class PluginBleFixturePlatform extends UniversalBlePlatform {
   Object? writeError;
   BleDevice? firstAdvertisement;
 
+  /// Leading connect calls that fail, to exercise transport recovery.
+  int connectFailures = 0;
+  int connectCalls = 0;
+
+  /// Native operations in order, so a test can assert a recovery sequence.
+  final operations = <String>[];
+
   @override
   Future<void> connect(
     String deviceId, {
@@ -105,6 +112,15 @@ class PluginBleFixturePlatform extends UniversalBlePlatform {
     bool autoConnect = false,
     ConnectionPlatformConfig? platformConfig,
   }) async {
+    connectCalls++;
+    operations.add('connect');
+    if (connectFailures > 0) {
+      connectFailures--;
+      throw UniversalBleException(
+        code: UniversalBleErrorCode.failed,
+        message: 'simulated native connect failure',
+      );
+    }
     connectionStates[deviceId] = BleConnectionState.connected;
     updateConnection(deviceId, true);
   }
@@ -119,7 +135,11 @@ class PluginBleFixturePlatform extends UniversalBlePlatform {
   Future<List<BleService>> discoverServices(
     String deviceId,
     bool withDescriptors,
-  ) async => [BleService('0000180f-0000-1000-8000-00805f9b34fb', [])];
+  ) async {
+    operations.add('discoverServices');
+    return [BleService('0000180f-0000-1000-8000-00805f9b34fb', [])];
+  }
+
   @override
   Future<void> setNotifiable(
     String deviceId,
@@ -149,6 +169,10 @@ class PluginBleFixturePlatform extends UniversalBlePlatform {
     return Uint8List.fromList([52]);
   }
 
+  /// Holds native writes open so a test can keep the device queue occupied.
+  bool hangWrites = false;
+  Completer<void>? writeBlocker;
+
   @override
   Future<void> writeValue(
     String deviceId,
@@ -159,6 +183,7 @@ class PluginBleFixturePlatform extends UniversalBlePlatform {
   ) async {
     writeProperties.add(bleOutputProperty);
     if (writeError case final error?) throw error;
+    if (hangWrites) await (writeBlocker ?? Completer<void>()).future;
   }
 
   @override
@@ -170,6 +195,7 @@ class PluginBleFixturePlatform extends UniversalBlePlatform {
     PlatformConfig? platformConfig,
   }) async {
     scanFilters.add(scanFilter);
+    operations.add('startScan');
     scanning = true;
     if (!started.isCompleted) started.complete();
     if (firstAdvertisement case final device?) updateScanResult(device);
@@ -177,6 +203,7 @@ class PluginBleFixturePlatform extends UniversalBlePlatform {
 
   @override
   Future<void> stopScan() async {
+    operations.add('stopScan');
     scanning = false;
   }
 

--- a/test/plugins/bookoo_discovery_test.dart
+++ b/test/plugins/bookoo_discovery_test.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/connection_manager.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/device_implementation.dart';
+import 'package:reaprime/src/models/device/remembered_device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_plus/shelf_plus.dart';
+import 'package:universal_ble/universal_ble.dart';
+import 'package:web_socket_channel/io.dart';
+
+import '../helpers/bookoo_packets.dart';
+import '../helpers/bookoo_plugin_fixture.dart';
+import '../helpers/mock_settings_service.dart';
+import '../helpers/plugin_ble_fixture.dart';
+import 'plugin_test_helpers.dart';
+
+class _Fixture {
+  final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+  final platform = PluginBleFixturePlatform();
+  final transports = <BookooPluginTransport>[];
+  final scales = ScaleController();
+  late final UniversalBleDiscoveryService discovery;
+  late final DeviceController devices;
+  late final De1Controller de1;
+  late final SettingsController settings;
+  late final ConnectionManager connections;
+
+  Future<void> initialize(
+    MockSettingsService store, {
+    bool plugin = true,
+    bool compatible = true,
+  }) async {
+    UniversalBle.setInstance(platform);
+    discovery = UniversalBleDiscoveryService(
+      pluginBleService: () => manager.bleService,
+      scanDuration: const Duration(milliseconds: 40),
+      transportFactory:
+          ({
+            required device,
+            required stopScan,
+            required requestLargeMtuNonAndroid,
+            required lifecycleGate,
+          }) {
+            final transport = BookooPluginTransport(
+              device.deviceId,
+              firstPacket: bookooPacket(1),
+              servicePresent: compatible,
+            );
+            transports.add(transport);
+            return transport;
+          },
+    );
+    devices = DeviceController([discovery]);
+    await devices.initialize();
+    settings = SettingsController(store);
+    await settings.loadSettings();
+    de1 = De1Controller(controller: devices);
+    connections = ConnectionManager(
+      deviceScanner: devices,
+      de1Controller: de1,
+      scaleController: scales,
+      settingsController: settings,
+    );
+    if (plugin) await loadBookooPlugin(manager);
+    platform.firstAdvertisement = BleDevice(
+      deviceId: 'AA:BB',
+      name: 'Bookoo Mini',
+      services: ['0ffe'],
+    );
+  }
+
+  Future<void> dispose() async {
+    await connections.dispose();
+    scales.dispose();
+    await discovery.dispose();
+    await manager.dispose();
+    await de1.dispose();
+    devices.dispose();
+  }
+}
+
+void main() {
+  test(
+    'Bookoo handshake failure never selects native in the same attempt',
+    () async {
+      final fixture = _Fixture();
+      await fixture.initialize(MockSettingsService(), compatible: false);
+      addTearDown(fixture.dispose);
+      await fixture.connections.connect(scaleOnly: true);
+      expect(
+        fixture.scales.currentConnectionState,
+        isNot(ConnectionState.connected),
+      );
+      expect(fixture.transports, hasLength(1));
+      await fixture.transports.single.disposed.future.timeout(
+        const Duration(seconds: 2),
+      );
+      expect(fixture.transports.single.disposeCalls, 1);
+      expect(
+        fixture.devices.devices.whereType<Scale>().every(
+          (s) => s.implementation == DeviceImplementation.plugin,
+        ),
+        isTrue,
+      );
+      expect(fixture.settings.preferredScaleId, isNull);
+    },
+  );
+
+  test(
+    'persisted Bookoo plugin preference survives reconstruction and never repoints to native',
+    () async {
+      final store = MockSettingsService();
+      RememberedDevice? remembered;
+      String? preferred;
+      for (final enabled in [true, true, false]) {
+        final fixture = _Fixture();
+        await fixture.initialize(store, plugin: enabled);
+        try {
+          if (remembered != null) {
+            expect(fixture.settings.preferredScaleId, preferred);
+            expect(await fixture.devices.tryQuickConnect(remembered), isNull);
+            expect(fixture.transports, isEmpty);
+          }
+          await fixture.connections
+              .connect(scaleOnly: true)
+              .timeout(const Duration(seconds: 3));
+          if (enabled) {
+            final scale = fixture.scales.connectedScale();
+            expect(scale.implementation, DeviceImplementation.plugin);
+            preferred ??= scale.deviceId;
+            expect(scale.deviceId, preferred);
+            expect(fixture.settings.preferredScaleId, preferred);
+            remembered = RememberedDevice.fromDevice(scale)!;
+            expect(fixture.transports.single.connectCalls, 1);
+          } else {
+            expect(
+              fixture.devices.devices.whereType<Scale>().single.implementation,
+              DeviceImplementation.bookooScale,
+            );
+            expect(fixture.settings.preferredScaleId, preferred);
+            expect(
+              fixture.scales.currentConnectionState,
+              isNot(ConnectionState.connected),
+            );
+            expect(
+              fixture.transports.every((t) => t.connectCalls == 0),
+              isTrue,
+            );
+            expect(
+              fixture.connections.currentStatus.pendingAmbiguity,
+              isNotNull,
+            );
+          }
+        } finally {
+          await fixture.dispose();
+        }
+      }
+    },
+  );
+
+  test(
+    'Bookoo discovery reaches existing Scale HTTP commands and WS snapshots',
+    () async {
+      final fixture = _Fixture();
+      await fixture.initialize(MockSettingsService());
+      addTearDown(fixture.dispose);
+      await fixture.connections.connect(scaleOnly: true);
+      final router = Router().plus;
+      ScaleHandler(
+        controller: fixture.scales,
+        de1Controller: fixture.de1,
+        settingsController: fixture.settings,
+      ).addRoutes(router);
+      final server = await shelf_io.serve(router.call, '127.0.0.1', 0);
+      final client = HttpClient();
+      final channel = IOWebSocketChannel.connect(
+        Uri.parse('ws://127.0.0.1:${server.port}/ws/v1/scale/snapshot'),
+      );
+      final frames = StreamIterator(channel.stream);
+      addTearDown(() async {
+        await frames.cancel();
+        await channel.sink.close();
+        client.close(force: true);
+        await server.close(force: true);
+      });
+      await channel.ready;
+      expect(await frames.moveNext(), isTrue);
+      expect(jsonDecode(frames.current as String)['status'], 'connected');
+      fixture.transports.single.emit(bookooPacket(-4.5, battery: 80));
+      expect(await frames.moveNext(), isTrue);
+      final sample = jsonDecode(frames.current as String);
+      expect(sample['weight'], -4.5);
+      expect(sample['battery'], 80);
+      for (final path in ['tare', 'timer/start', 'timer/stop', 'timer/reset']) {
+        final response = await (await client.putUrl(
+          Uri.parse('http://127.0.0.1:${server.port}/api/v1/scale/$path'),
+        )).close();
+        expect(response.statusCode, 200);
+        await response.drain<void>();
+      }
+      expect(
+        fixture.transports.single.writes.map((w) => w.data.toList()),
+        bookooCommands,
+      );
+    },
+  );
+}

--- a/test/plugins/bookoo_plugin_test.dart
+++ b/test/plugins/bookoo_plugin_test.dart
@@ -108,6 +108,135 @@ void main() {
     );
   }
 
+  Future<Scale> bookooCandidate(
+    PluginManager manager,
+    BookooPluginTransport transport,
+  ) async {
+    final evidence = BleAdvertisementEvidence(
+      name: 'BOOKOO',
+      serviceUuids: ['0ffe'],
+    );
+    return await manager.bleService.createCandidate(
+          driver: manager.bleService.registry.decide(evidence).drivers.single,
+          physicalId: 'AA:BB',
+          evidence: evidence,
+          admit: () => true,
+          createTransport: () => transport,
+        )
+        as Scale;
+  }
+
+  test(
+    'Bookoo refused subscription fails the attempt without leftovers',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      await loadBookooPlugin(manager);
+      final transport = BookooPluginTransport(
+        'AA:BB',
+        subscriptionFailure: StateError('Bookoo subscription refused'),
+      );
+      final scale = await bookooCandidate(manager, transport);
+      final states = <ConnectionState>[];
+      final subscription = scale.connectionState.listen(states.add);
+      addTearDown(subscription.cancel);
+
+      final outcome = await scale.onConnect().then<Object?>(
+        (_) => null,
+        onError: (Object error) => error,
+      );
+      expect(
+        outcome,
+        isNotNull,
+        reason: 'a refused subscription must fail the attempt',
+      );
+
+      // Startup teardown already retired the session here, so a late link drop
+      // cannot be delivered through this seam: the abandoned readiness promise
+      // and its later disconnect rejection are asserted by the plugin-runtime
+      // harness in scripts/test_bookoo_readiness_rejection.mjs. This test covers
+      // the observable leftovers instead.
+      transport.dropLink();
+      await pumpEventQueue();
+
+      expect(states, isNot(contains(ConnectionState.connected)));
+      expect(manager.activeTimerCount, 0);
+      expect(manager.bleService.registry.activeBindingCount, 0);
+    },
+  );
+
+  test(
+    'Bookoo disconnect before the first packet reports the disconnect',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      await loadBookooPlugin(manager);
+      final transport = BookooPluginTransport('AA:BB');
+      final scale = await bookooCandidate(manager, transport);
+
+      final connecting = scale.onConnect().then<Object?>(
+        (_) => null,
+        onError: (Object error) => error,
+      );
+      await transport.subscribed.future;
+      transport.dropLink();
+
+      final outcome = await connecting;
+      expect(
+        outcome,
+        isNotNull,
+        reason: 'a link loss before readiness must fail the attempt',
+      );
+      expect(await scale.connectionState.first, ConnectionState.disconnected);
+      expect(manager.activeTimerCount, 0);
+      expect(manager.bleService.registry.activeBindingCount, 0);
+    },
+  );
+
+  test('Bookoo keeps publishing after readiness', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    final controller = ScaleController();
+    addTearDown(() async {
+      controller.dispose();
+      await manager.dispose();
+    });
+    await loadBookooPlugin(manager);
+    final transport = BookooPluginTransport(
+      'AA:BB',
+      firstPacket: bookooPacket(1),
+    );
+    final scale = await bookooCandidate(manager, transport);
+    final samples = <WeightSnapshot>[];
+    final subscription = controller.weightSnapshot.listen(samples.add);
+    addTearDown(subscription.cancel);
+
+    await controller.connectToScale(scale);
+    expect(await scale.connectionState.first, ConnectionState.connected);
+
+    transport.emit(bookooPacket(-12.5));
+    await pumpEventQueue();
+
+    expect(
+      samples,
+      isNotEmpty,
+      reason: 'a successful start must not stop the live session',
+    );
+    expect(samples.last.weight, closeTo(-12.5, 1e-9));
+    expect(
+      manager.activeTimerCount,
+      1,
+      reason: 'the live session keeps exactly one silence watchdog armed',
+    );
+
+    await scale.disconnect();
+    await pumpEventQueue();
+    expect(
+      manager.activeTimerCount,
+      0,
+      reason: 'teardown must not leave a watchdog armed',
+    );
+  });
+
   test(
     'Bookoo JS validates native fixtures, readiness, commands and reconnect',
     () async {
@@ -150,7 +279,7 @@ void main() {
         for (final invalid in invalidBookooPackets()) {
           transport.emit(invalid);
         }
-        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await pumpEventQueue();
         expect(await scale.connectionState.first, ConnectionState.connecting);
         expect(samples, isEmpty);
         final firstSample = controller.weightSnapshot.first;

--- a/test/plugins/bookoo_plugin_test.dart
+++ b/test/plugins/bookoo_plugin_test.dart
@@ -45,10 +45,7 @@ void main() {
       await controller.connectToScale(scale);
       expect(await scale.connectionState.first, ConnectionState.connected);
       expect(transport.disconnectCalls, 0);
-      expect(
-        transport.subscribers.keys.single,
-        bookooDataCharacteristicUuid,
-      );
+      expect(transport.subscribers.keys.single, bookooDataCharacteristicUuid);
       await scale.disconnect();
       expect(manager.activeTimerCount, 0);
     },
@@ -149,10 +146,7 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         final transport = transports.last;
         await transport.subscribed.future;
-        expect(
-          transport.subscribers.keys.single,
-          bookooDataCharacteristicUuid,
-        );
+        expect(transport.subscribers.keys.single, bookooDataCharacteristicUuid);
         for (final invalid in invalidBookooPackets()) {
           transport.emit(invalid);
         }
@@ -270,8 +264,11 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       expect(samples.map((sample) => sample.weight), [2]);
 
+      final weightThree = newScale.currentSnapshot.firstWhere(
+        (sample) => sample.weight == 3,
+      );
       newTransport.emit(bookooPacket(3));
-      await Future<void>.delayed(Duration.zero);
+      await weightThree.timeout(const Duration(seconds: 1));
       expect(samples.map((sample) => sample.weight), [2, 3]);
       await newScale.disconnect();
     },

--- a/test/plugins/bookoo_plugin_test.dart
+++ b/test/plugins/bookoo_plugin_test.dart
@@ -1,0 +1,279 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+
+import '../helpers/bookoo_packets.dart';
+import '../helpers/bookoo_plugin_fixture.dart';
+import 'plugin_test_helpers.dart';
+
+void main() {
+  test(
+    'Bookoo subscription setup does not consume the packet deadline',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      final controller = ScaleController();
+      addTearDown(() async {
+        controller.dispose();
+        await manager.dispose();
+      });
+      await loadBookooPlugin(manager);
+      final transport = BookooPluginTransport(
+        'AA:BB',
+        firstPacket: bookooPacket(1),
+        subscriptionDelay: const Duration(milliseconds: 2300),
+      );
+      final evidence = BleAdvertisementEvidence(
+        name: 'Bookoo',
+        serviceUuids: ['0ffe'],
+      );
+      final scale =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => transport,
+              )
+              as Scale;
+      await controller.connectToScale(scale);
+      expect(await scale.connectionState.first, ConnectionState.connected);
+      expect(transport.disconnectCalls, 0);
+      expect(
+        transport.subscribers.keys.single,
+        bookooDataCharacteristicUuid,
+      );
+      await scale.disconnect();
+      expect(manager.activeTimerCount, 0);
+    },
+  );
+
+  for (final (label, firstPacket, ready) in [
+    ('no packets', null, false),
+    ('malformed packet', <int>[0], false),
+    ('valid packet', bookooPacket(1), true),
+  ]) {
+    test(
+      'Bookoo protocol silence after $label reports host failure without a reconnect loop',
+      () async {
+        final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+        final controller = ScaleController();
+        addTearDown(() async {
+          controller.dispose();
+          await manager.dispose();
+        });
+        await loadBookooPlugin(manager);
+        final transport = BookooPluginTransport(
+          'AA:BB',
+          firstPacket: firstPacket,
+        );
+        final evidence = BleAdvertisementEvidence(
+          name: 'Bookoo',
+          serviceUuids: ['0ffe'],
+        );
+        final scale =
+            await manager.bleService.createCandidate(
+                  driver: manager.bleService.registry
+                      .decide(evidence)
+                      .drivers
+                      .single,
+                  physicalId: 'AA:BB',
+                  evidence: evidence,
+                  admit: () => true,
+                  createTransport: () => transport,
+                )
+                as Scale;
+        final elapsed = Stopwatch()..start();
+        final connect = controller.connectToScale(scale);
+        final completion = ready
+            ? connect
+            : expectLater(connect, throwsA(anything));
+        await transport.subscribed.future;
+        await scale.connectionState
+            .firstWhere((state) => state == ConnectionState.disconnected)
+            .timeout(const Duration(seconds: 4));
+        await completion;
+        expect(
+          elapsed.elapsed,
+          greaterThanOrEqualTo(const Duration(milliseconds: 1800)),
+        );
+        await transport.disposed.future.timeout(const Duration(seconds: 2));
+        expect(transport.connectCalls, 1);
+        expect(manager.bleService.registry.activeBindingCount, 0);
+        expect(manager.activeTimerCount, 0);
+      },
+    );
+  }
+
+  test(
+    'Bookoo JS validates native fixtures, readiness, commands and reconnect',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      final controller = ScaleController();
+      final transports = <BookooPluginTransport>[];
+      addTearDown(() async {
+        controller.dispose();
+        await manager.dispose();
+      });
+      await loadBookooPlugin(manager);
+      final evidence = BleAdvertisementEvidence(
+        name: 'BOOKOO',
+        serviceUuids: ['0ffe'],
+      );
+      final scale =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () {
+                  final t = BookooPluginTransport('AA:BB');
+                  transports.add(t);
+                  return t;
+                },
+              )
+              as Scale;
+      for (var attempt = 0; attempt < 2; attempt++) {
+        final samples = <WeightSnapshot>[];
+        final subscription = controller.weightSnapshot.listen(samples.add);
+        final connect = controller.connectToScale(scale);
+        await Future<void>.delayed(Duration.zero);
+        final transport = transports.last;
+        await transport.subscribed.future;
+        expect(
+          transport.subscribers.keys.single,
+          bookooDataCharacteristicUuid,
+        );
+        for (final invalid in invalidBookooPackets()) {
+          transport.emit(invalid);
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(await scale.connectionState.first, ConnectionState.connecting);
+        expect(samples, isEmpty);
+        final firstSample = controller.weightSnapshot.first;
+        transport.emit(bookooPacket(123.45, battery: 101));
+        await connect;
+        expect((await firstSample).battery, isNull);
+        final battery = controller.weightSnapshot.firstWhere(
+          (s) => s.battery == 72,
+        );
+        transport.emit(bookooPacket(123.45, battery: 72));
+        await battery;
+        final negative = controller.weightSnapshot.firstWhere(
+          (s) => s.weight == -12.34,
+        );
+        transport.emit(bookooPacket(-12.34, battery: 101));
+        expect((await negative).battery, 72);
+        expect(samples.map((s) => s.weight), [123.45, 123.45, -12.34]);
+        await scale.tare();
+        await scale.startTimer();
+        await scale.stopTimer();
+        await scale.resetTimer();
+        expect(transport.writes.map((w) => w.data.toList()), bookooCommands);
+        expect(transport.writes.every((w) => w.withResponse), isTrue);
+        expect(
+          transport.writes.every(
+            (w) => w.characteristicUUID == bookooCommandCharacteristicUuid,
+          ),
+          isTrue,
+        );
+        final oldNotification =
+            transport.subscribers[bookooDataCharacteristicUuid]!;
+        await scale.sleepDisplay();
+        oldNotification(Uint8List.fromList(bookooPacket(99)));
+        await Future<void>.delayed(Duration.zero);
+        expect(samples.last.weight, -12.34);
+        expect(manager.bleService.registry.activeBindingCount, 0);
+        await subscription.cancel();
+      }
+      expect(scale.deviceId, 'plugin:bookoo-mini.reaplugin:bookoo:aa:bb');
+    },
+  );
+
+  test(
+    'Bookoo reload preserves identity and fences the retired generation',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      final manifest = bookooManifest();
+      await loadBookooPlugin(manager);
+      final evidence = BleAdvertisementEvidence(
+        name: 'Bookoo Mini',
+        serviceUuids: ['0ffe'],
+      );
+
+      Future<Scale> createScale(BookooPluginTransport transport) async =>
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => transport,
+              )
+              as Scale;
+
+      final firstGeneration = manager.pluginGeneration(manifest.id);
+      final oldTransport = BookooPluginTransport(
+        'AA:BB',
+        firstPacket: bookooPacket(1),
+      );
+      final oldScale = await createScale(oldTransport);
+      await oldScale.onConnect();
+      expect(await oldScale.connectionState.first, ConnectionState.connected);
+      final stableId = oldScale.deviceId;
+      final oldNotification =
+          oldTransport.subscribers[bookooDataCharacteristicUuid]!;
+
+      await manager.unloadPlugin(manifest.id);
+      await loadBookooPlugin(manager);
+      expect(manager.pluginGeneration(manifest.id), isNot(firstGeneration));
+
+      final newTransport = BookooPluginTransport(
+        'AA:BB',
+        firstPacket: bookooPacket(2),
+      );
+      final newScale = await createScale(newTransport);
+      expect(newScale.deviceId, stableId);
+      expect(identical(newScale, oldScale), isFalse);
+
+      final samples = <ScaleSnapshot>[];
+      final snapshotSubscription = newScale.currentSnapshot.listen(samples.add);
+      addTearDown(snapshotSubscription.cancel);
+      await newScale.onConnect();
+      (newScale as ScaleSnapshotHandoff).activateSnapshots();
+      await Future<void>.delayed(Duration.zero);
+      expect(samples.map((sample) => sample.weight), [2]);
+
+      await expectLater(
+        oldScale.tare(),
+        throwsA(
+          isA<ScaleOperationException>().having(
+            (error) => error.code,
+            'code',
+            'stale_session',
+          ),
+        ),
+      );
+      oldNotification(Uint8List.fromList(bookooPacket(99)));
+      await Future<void>.delayed(Duration.zero);
+      expect(samples.map((sample) => sample.weight), [2]);
+
+      newTransport.emit(bookooPacket(3));
+      await Future<void>.delayed(Duration.zero);
+      expect(samples.map((sample) => sample.weight), [2, 3]);
+      await newScale.disconnect();
+    },
+  );
+}

--- a/test/plugins/felicita_plugin_test.dart
+++ b/test/plugins/felicita_plugin_test.dart
@@ -1,0 +1,338 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+
+import '../helpers/felicita_plugin_fixture.dart';
+import 'plugin_test_helpers.dart';
+
+void main() {
+  test(
+    'Felicita JS waits for a valid first packet and maps native protocol',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      final controller = ScaleController();
+      addTearDown(() async {
+        controller.dispose();
+        await manager.dispose();
+      });
+      await loadFelicitaPlugin(manager);
+      final evidence = BleAdvertisementEvidence(name: 'FELICITA ARC');
+      final transport = FelicitaPluginTransport('AA:BB');
+      final scale =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => transport,
+              )
+              as Scale;
+      final samples = <WeightSnapshot>[];
+      final sampleSubscription = controller.weightSnapshot.listen(samples.add);
+      addTearDown(sampleSubscription.cancel);
+      final connect = controller.connectToScale(scale);
+      await transport.subscribed.future;
+      expect(await scale.connectionState.first, ConnectionState.connecting);
+      transport.emit(felicitaPacket(-12.34, battery: 143));
+      await connect;
+      final first = await controller.weightSnapshot.first;
+      expect(first.weight, -12.34);
+      expect(first.battery, 48);
+      final positive = controller.weightSnapshot.first;
+      transport.emit(felicitaPacket(0, battery: 129, sign: 32));
+      expect((await positive).weight, 0);
+      expect(samples.last.battery, 0);
+      final fullBattery = controller.weightSnapshot.first;
+      transport.emit(felicitaPacket(1.23, battery: 158));
+      expect((await fullBattery).weight, 1.23);
+      expect(samples.last.battery, 100);
+      final retainedBattery = controller.weightSnapshot.first;
+      transport.emit(felicitaPacket(2.34, battery: 200));
+      expect((await retainedBattery).weight, 2.34);
+      expect(samples.last.battery, 100);
+      await scale.tare();
+      await scale.startTimer();
+      await scale.stopTimer();
+      await scale.resetTimer();
+      expect(transport.writes.map((write) => write.data.single), [
+        0x54,
+        0x52,
+        0x53,
+        0x43,
+      ]);
+      expect(transport.writes.every((write) => write.withResponse), isTrue);
+      await scale.disconnect();
+    },
+  );
+
+  test(
+    'Felicita invalid packets do not satisfy readiness or publish',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      await loadFelicitaPlugin(manager);
+      final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+      final transport = FelicitaPluginTransport('AA:BB');
+      final scale =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => transport,
+              )
+              as Scale;
+      final snapshots = <ScaleSnapshot>[];
+      final snapshotSubscription = scale.currentSnapshot.listen(snapshots.add);
+      addTearDown(snapshotSubscription.cancel);
+      final connect = expectLater(scale.onConnect(), throwsA(anything));
+      await transport.subscribed.future;
+      final invalidLength = [...felicitaPacket(1), 0];
+      final invalidDigit = felicitaPacket(1)..[3] = 65;
+      transport.emit(invalidLength);
+      transport.emit(invalidDigit);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(snapshots, isEmpty);
+      await connect;
+    },
+  );
+
+  test('Felicita battery starts unknown and resets between sessions', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    final transports = <FelicitaPluginTransport>[];
+    Future<Scale> createScale({List<int>? firstPacket}) async {
+      final transport = FelicitaPluginTransport(
+        'AA:BB',
+        firstPacket: firstPacket,
+      );
+      transports.add(transport);
+      return await manager.bleService.createCandidate(
+            driver: manager.bleService.registry.decide(evidence).drivers.single,
+            physicalId: 'AA:BB',
+            evidence: evidence,
+            admit: () => true,
+            createTransport: () => transport,
+          )
+          as Scale;
+    }
+
+    final first = await createScale(
+      firstPacket: felicitaPacket(1, battery: 200),
+    );
+    final firstConnect = first.onConnect();
+    await transports[0].subscribed.future;
+    (first as ScaleSnapshotHandoff).activateSnapshots();
+    final firstSnapshot = first.currentSnapshot.first;
+    transports[0].emit(felicitaPacket(1, battery: 200));
+    expect((await firstSnapshot).batteryLevel, isNull);
+    await firstConnect;
+    await first.disconnect();
+    await transports[0].disposed.future;
+    await manager.unloadPlugin(felicitaManifest().id);
+    await loadFelicitaPlugin(manager);
+    final second = await createScale(
+      firstPacket: felicitaPacket(2, battery: 158),
+    );
+    final secondSnapshot = second.currentSnapshot.first;
+    final secondConnect = second.onConnect();
+    await transports[1].subscribed.future;
+    (second as ScaleSnapshotHandoff).activateSnapshots();
+    await secondConnect;
+    expect((await secondSnapshot).batteryLevel, 100);
+    await second.disconnect();
+  });
+
+  test('Felicita service and subscription failures reject cleanly', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    Future<Scale> create(FelicitaPluginTransport transport) async =>
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: transport.physicalId,
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () => transport,
+            )
+            as Scale;
+    final missing = await create(
+      FelicitaPluginTransport('missing', servicePresent: false),
+    );
+    await expectLater(missing.onConnect(), throwsA(isA<Exception>()));
+    final failed = await create(
+      FelicitaPluginTransport(
+        'failed',
+        subscriptionFailure: StateError('subscribe'),
+      ),
+    );
+    await expectLater(failed.onConnect(), throwsA(anything));
+  });
+
+  test('Felicita delayed subscription and silence are host-owned', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    final delayedTransport = FelicitaPluginTransport(
+      'delayed',
+      firstPacket: felicitaPacket(1),
+      subscriptionDelay: const Duration(milliseconds: 2300),
+    );
+    final delayed =
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'delayed',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () => delayedTransport,
+            )
+            as Scale;
+    await delayed.onConnect();
+    expect(await delayed.connectionState.first, ConnectionState.connected);
+    await delayed.disconnect();
+    final silentTransport = FelicitaPluginTransport(
+      'silent',
+      firstPacket: felicitaPacket(1),
+    );
+    final silent =
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'silent',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () => silentTransport,
+            )
+            as Scale;
+    await silent.onConnect();
+    await expectLater(
+      silent.connectionState.firstWhere(
+        (s) => s == ConnectionState.disconnected,
+      ),
+      completes,
+    );
+  });
+
+  test('Felicita matcher unload removes plugin ownership', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final matching = BleAdvertisementEvidence(name: 'FELICITA ARC');
+    expect(manager.bleService.registry.decide(matching).drivers, hasLength(1));
+    expect(
+      manager.bleService.registry
+          .decide(BleAdvertisementEvidence(name: 'Bookoo'))
+          .drivers,
+      isEmpty,
+    );
+    await manager.unloadPlugin(felicitaManifest().id);
+    expect(manager.bleService.registry.decide(matching).drivers, isEmpty);
+  });
+
+  test('Felicita reload fences old callbacks and preserves identity', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    final firstTransport = FelicitaPluginTransport(
+      'AA:BB',
+      firstPacket: felicitaPacket(1),
+    );
+    final first =
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'AA:BB',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () => firstTransport,
+            )
+            as Scale;
+    final firstConnect = first.onConnect();
+    await firstTransport.subscribed.future;
+    final oldCallback = firstTransport.subscribers[felicitaCharacteristicUuid]!;
+    await firstConnect;
+    final stableId = first.deviceId;
+    await manager.unloadPlugin(felicitaManifest().id);
+    await loadFelicitaPlugin(manager);
+    final secondTransport = FelicitaPluginTransport(
+      'AA:BB',
+      firstPacket: felicitaPacket(2),
+    );
+    final second =
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'AA:BB',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () => secondTransport,
+            )
+            as Scale;
+    final snapshots = <ScaleSnapshot>[];
+    final subscription = second.currentSnapshot.listen(snapshots.add);
+    addTearDown(subscription.cancel);
+    final secondConnect = second.onConnect();
+    await secondTransport.subscribed.future;
+    (second as ScaleSnapshotHandoff).activateSnapshots();
+    await secondConnect;
+    expect(second.deviceId, stableId);
+    oldCallback(Uint8List.fromList(felicitaPacket(99)));
+    await Future<void>.delayed(Duration.zero);
+    expect(snapshots.map((sample) => sample.weight), [2]);
+    await second.disconnect();
+  });
+
+  test('Felicita command write failures remain visible', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    final transport = FelicitaPluginTransport(
+      'AA:BB',
+      firstPacket: felicitaPacket(1),
+      writeFailure: StateError('write'),
+    );
+    final scale =
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'AA:BB',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () => transport,
+            )
+            as Scale;
+    await scale.onConnect();
+    await expectLater(scale.tare(), throwsA(isA<ScaleOperationException>()));
+  });
+}

--- a/test/plugins/plugin_ble_bluez_recovery_test.dart
+++ b/test/plugins/plugin_ble_bluez_recovery_test.dart
@@ -1,0 +1,139 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import '../helpers/plugin_ble_fixture.dart';
+import 'plugin_manager_ble_test.dart' show bleSensorManifest, bleSensorSource;
+import 'plugin_test_helpers.dart';
+
+/// Platform recovery is owned by the transport, not by the plugin host.
+///
+/// The configured BlueZ recovery sequence - first connect fails, device cache
+/// refresh with its own scan, retry, post-connect settle - is longer than the
+/// plugin invocation timeout here, so a plugin-imposed deadline would kill a
+/// recovery the transport considers healthy. Fake time advances the whole
+/// sequence and the native operation log proves the order it ran in.
+void main() {
+  const pluginTimeout = Duration(milliseconds: 200);
+
+  test('BlueZ recovery may exceed the plugin invocation timeout', () {
+    final platform = PluginBleFixturePlatform()..connectFailures = 1;
+    UniversalBle.setInstance(platform);
+    UniversalBle.queueType = QueueType.perDevice;
+    addTearDown(() {
+      UniversalBle.clearQueue();
+      UniversalBle.queueType = QueueType.global;
+    });
+
+    fakeAsync((async) {
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceInvocationTimeout: pluginTimeout,
+      );
+      Object? loadError;
+      manager
+          .loadPlugin(
+            id: 'ble.sensor',
+            manifest: bleSensorManifest(),
+            settings: {},
+            jsCode: bleSensorSource,
+          )
+          .then(
+            (_) {},
+            onError: (Object error) {
+              loadError = error;
+            },
+          );
+      async.elapse(const Duration(seconds: 1));
+      expect(loadError, isNull, reason: 'the sensor fixture must load');
+
+      final evidence = BleAdvertisementEvidence(serviceUuids: ['180f']);
+      Sensor? sensor;
+      var settled = false;
+      Object? outcome;
+      manager.bleService
+          .createCandidate(
+            driver: manager.bleService.registry.decide(evidence).drivers.single,
+            physicalId: 'AA:BB',
+            evidence: evidence,
+            admit: () => true,
+            createTransport: () => UniversalBleTransport(
+              device: BleDevice(deviceId: 'AA:BB', name: 'Fixture'),
+              isAndroidOverride: false,
+              isLinuxOverride: true,
+              bluezScanSettleDelay: const Duration(milliseconds: 60),
+              bluezCacheRefreshScan: const Duration(milliseconds: 90),
+              bluezPostConnectDelay: const Duration(milliseconds: 60),
+            ),
+          )
+          .then((device) {
+            sensor = device as Sensor;
+            return sensor!.onConnect();
+          })
+          .then(
+            (_) {
+              settled = true;
+            },
+            onError: (Object error) {
+              settled = true;
+              outcome = error;
+            },
+          );
+
+      async.elapse(const Duration(seconds: 30));
+
+      expect(
+        settled,
+        isTrue,
+        reason:
+            'the recovery must complete inside the transport policy even '
+            'though it outlives the plugin invocation timeout',
+      );
+      expect(outcome, isNull);
+      expect(
+        async.elapsed,
+        greaterThan(pluginTimeout),
+        reason: 'the exercised recovery is longer than the plugin budget',
+      );
+      expect(
+        platform.connectCalls,
+        2,
+        reason: 'the first acquisition fails and the retry is the second one',
+      );
+
+      final operations = platform.operations;
+      final firstConnect = operations.indexOf('connect');
+      final refreshScan = operations.indexOf('startScan', firstConnect + 1);
+      final retry = operations.indexOf('connect', firstConnect + 1);
+      final pluginRan = operations.indexOf('discoverServices');
+      expect(firstConnect, greaterThanOrEqualTo(0));
+      expect(
+        refreshScan,
+        greaterThan(firstConnect),
+        reason: 'the device cache refresh scans before the retry',
+      );
+      expect(
+        retry,
+        greaterThan(refreshScan),
+        reason: 'the retry follows the cache-refresh scan',
+      );
+      expect(
+        pluginRan,
+        greaterThan(retry),
+        reason: 'the plugin protocol starts only after recovery connects',
+      );
+      expect(
+        platform.scanFilters.length,
+        greaterThanOrEqualTo(1),
+        reason: 'the device cache refresh ran its own scan',
+      );
+
+      manager.dispose().ignore();
+      async.elapse(const Duration(seconds: 2));
+    });
+  });
+}

--- a/test/plugins/plugin_ble_candidate_recovery_test.dart
+++ b/test/plugins/plugin_ble_candidate_recovery_test.dart
@@ -1,0 +1,141 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+
+import '../helpers/felicita_plugin_fixture.dart';
+import 'plugin_test_helpers.dart';
+
+/// Host BLE candidate recovery after an in-process disconnect (#809).
+///
+/// A deliberate disconnect closes the binding session and the discovery
+/// inventory drops the device. A subsequent advertisement must create a fresh
+/// candidate, not reuse the retired device whose replayed `disconnected` state
+/// can never be re-adopted (observed on hardware: device stuck unavailable
+/// until an app restart).
+void main() {
+  test('a retired binding is discarded so a new advertisement creates a fresh '
+      'reconnectable candidate', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    final transports = <FelicitaPluginTransport>[];
+
+    Future<Scale> createCandidate() async =>
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'AA:BB',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () {
+                final transport = FelicitaPluginTransport(
+                  'AA:BB',
+                  firstPacket: felicitaPacket(1),
+                );
+                transports.add(transport);
+                return transport;
+              },
+            )
+            as Scale;
+
+    final first = await createCandidate();
+    expect(manager.bleService.registry.activeBindingCount, 0);
+    await first.onConnect();
+    expect(await first.connectionState.first, ConnectionState.connected);
+    expect(manager.bleService.registry.activeBindingCount, 1);
+
+    // Concurrent advertisements while connected must not duplicate.
+    final concurrent = await createCandidate();
+    expect(identical(concurrent, first), isTrue);
+
+    await first.disconnect();
+    expect(await first.connectionState.first, ConnectionState.disconnected);
+    expect(manager.bleService.registry.activeBindingCount, 0);
+
+    // The retired binding must not be reused: a fresh advertisement yields a
+    // new device in the discovered state that can connect again.
+    final second = await createCandidate();
+    expect(identical(second, first), isFalse);
+    expect(await second.connectionState.first, ConnectionState.discovered);
+    await second.onConnect();
+    expect(await second.connectionState.first, ConnectionState.connected);
+    expect(transports, hasLength(2));
+    expect(transports[1].connectCalls, 1);
+    expect(manager.bleService.registry.activeBindingCount, 1);
+    await second.disconnect();
+    expect(manager.bleService.registry.activeBindingCount, 0);
+  });
+
+  test(
+    'stale callbacks from the retired binding cannot publish or reconnect',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      await loadFelicitaPlugin(manager);
+      final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+      final transports = <FelicitaPluginTransport>[];
+
+      Future<Scale> createCandidate() async =>
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () {
+                  final transport = FelicitaPluginTransport(
+                    'AA:BB',
+                    firstPacket: felicitaPacket(1),
+                  );
+                  transports.add(transport);
+                  return transport;
+                },
+              )
+              as Scale;
+
+      final first = await createCandidate();
+      await first.onConnect();
+      final stale = transports[0].subscribers[felicitaCharacteristicUuid]!;
+      await first.disconnect();
+
+      final second = await createCandidate();
+      expect(identical(second, first), isFalse);
+      final samples = <ScaleSnapshot>[];
+      final subscription = second.currentSnapshot.listen(samples.add);
+      addTearDown(subscription.cancel);
+      final secondConnect = second.onConnect();
+      await transports[1].subscribed.future;
+      (second as ScaleSnapshotHandoff).activateSnapshots();
+      await secondConnect;
+      await Future<void>.delayed(Duration.zero);
+      expect(samples.map((sample) => sample.weight), [1]);
+
+      // The retired transport callback cannot publish into the new session.
+      stale(Uint8List.fromList(felicitaPacket(99)));
+      await Future<void>.delayed(Duration.zero);
+      expect(samples.map((sample) => sample.weight), [1]);
+
+      // The retired device object cannot command the replacement session.
+      await expectLater(
+        first.tare(),
+        throwsA(
+          isA<ScaleOperationException>().having(
+            (error) => error.code,
+            'code',
+            'stale_session',
+          ),
+        ),
+      );
+      await second.disconnect();
+    },
+  );
+}

--- a/test/plugins/plugin_ble_candidate_recovery_test.dart
+++ b/test/plugins/plugin_ble_candidate_recovery_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/models/device/device.dart';
 import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/transport/ble_connect_exception.dart';
 import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
 import 'package:reaprime/src/plugins/plugin_manager.dart';
 
@@ -74,7 +75,7 @@ void main() {
   });
 
   test(
-    'stale callbacks from the retired binding cannot publish or reconnect',
+    'failed transport connect preserves its native error and releases ownership',
     () async {
       final manager = PluginManager(kvStore: FakeKeyValueStoreService());
       addTearDown(manager.dispose);
@@ -95,6 +96,9 @@ void main() {
                   final transport = FelicitaPluginTransport(
                     'AA:BB',
                     firstPacket: felicitaPacket(1),
+                    connectFailure: transports.isEmpty
+                        ? BleConnectException(code: '133')
+                        : null,
                   );
                   transports.add(transport);
                   return transport;
@@ -103,12 +107,76 @@ void main() {
               as Scale;
 
       final first = await createCandidate();
+      await expectLater(
+        first.onConnect(),
+        throwsA(
+          isA<BleConnectException>().having(
+            (error) => error.code,
+            'code',
+            '133',
+          ),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(manager.bleService.registry.activeBindingCount, 0);
+
       await first.onConnect();
+      expect(first.connectionState, emits(ConnectionState.connected));
+      expect(transports, hasLength(2));
+      await first.disconnect();
+
+      final second = await createCandidate();
+      expect(identical(second, first), isFalse);
+      await second.onConnect();
+      expect(second.connectionState, emits(ConnectionState.connected));
+      expect(transports, hasLength(3));
+      await second.disconnect();
+    },
+  );
+
+  test(
+    'stale callbacks from the retired binding cannot publish or reconnect',
+    () async {
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      await loadFelicitaPlugin(manager);
+      final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+      final transports = <FelicitaPluginTransport>[];
+
+      Future<Scale> createCandidate() async =>
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () {
+                  final transport = FelicitaPluginTransport(
+                    'AA:BB',
+                    firstPacket: felicitaPacket(transports.isEmpty ? 1 : 2),
+                  );
+                  transports.add(transport);
+                  return transport;
+                },
+              )
+              as Scale;
+
+      final first = await createCandidate();
+      final firstSamples = <ScaleSnapshot>[];
+      final firstSubscription = first.currentSnapshot.listen(firstSamples.add);
+      addTearDown(firstSubscription.cancel);
+      await first.onConnect();
+      (first as ScaleSnapshotHandoff).activateSnapshots();
+      await Future<void>.delayed(Duration.zero);
+      expect(firstSamples.map((sample) => sample.weight), [1]);
       final stale = transports[0].subscribers[felicitaCharacteristicUuid]!;
       await first.disconnect();
 
       final second = await createCandidate();
       expect(identical(second, first), isFalse);
+      expect(second.deviceId, first.deviceId);
       final samples = <ScaleSnapshot>[];
       final subscription = second.currentSnapshot.listen(samples.add);
       addTearDown(subscription.cancel);
@@ -117,12 +185,19 @@ void main() {
       (second as ScaleSnapshotHandoff).activateSnapshots();
       await secondConnect;
       await Future<void>.delayed(Duration.zero);
-      expect(samples.map((sample) => sample.weight), [1]);
+      expect(samples.map((sample) => sample.weight), [2]);
+      final weightFour = second.currentSnapshot.firstWhere(
+        (sample) => sample.weight == 4,
+      );
+      transports[1].emit(felicitaPacket(3));
+      transports[1].emit(felicitaPacket(4));
+      await weightFour.timeout(const Duration(seconds: 1));
+      expect(samples.map((sample) => sample.weight), [2, 3, 4]);
 
       // The retired transport callback cannot publish into the new session.
       stale(Uint8List.fromList(felicitaPacket(99)));
       await Future<void>.delayed(Duration.zero);
-      expect(samples.map((sample) => sample.weight), [1]);
+      expect(samples.map((sample) => sample.weight), [2, 3, 4]);
 
       // The retired device object cannot command the replacement session.
       await expectLater(

--- a/test/plugins/plugin_ble_connect_phases_test.dart
+++ b/test/plugins/plugin_ble_connect_phases_test.dart
@@ -345,6 +345,11 @@ void main() {
       expect(transport.disconnectCalls, greaterThanOrEqualTo(1));
       await Future<void>.delayed(Duration.zero);
       expect(manager.bleService.registry.activeBindingCount, 0);
+      expect(
+        manager.deviceConnectAttemptCount,
+        0,
+        reason: 'cleanup must not leave a pending BLE connect attempt',
+      );
     },
   );
 

--- a/test/plugins/plugin_ble_connect_phases_test.dart
+++ b/test/plugins/plugin_ble_connect_phases_test.dart
@@ -1,0 +1,529 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/transport/ble_connect_exception.dart';
+import 'package:reaprime/src/models/device/transport/ble_transport.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_device_contract.dart';
+import 'package:reaprime/src/plugins/plugin_manifest.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+
+import '../helpers/felicita_plugin_fixture.dart';
+import 'plugin_test_helpers.dart';
+
+/// Connection phase ownership for host-bound BLE plugin devices (#809).
+///
+/// Physical acquisition and platform recovery follow the transport's policy, so
+/// they are not bounded by the plugin invocation timeout. The plugin's own
+/// `connect` handler and protocol readiness still are.
+///
+/// The manager, the plugin runtime and the transport all live inside the
+/// `fakeAsync` zone, so every deadline in the path is advanced by fake time and
+/// no test sleeps. A manager built outside the zone cannot be driven this way:
+/// its invocation deadlines are real timers that fake time never advances.
+const _pluginTimeout = Duration(milliseconds: 200);
+const _pastEveryDeadline = Duration(seconds: 30);
+
+const _stallPluginId = 'phase-stall.reaplugin';
+
+const _stallJs = '''
+function createPlugin(host) {
+  return {
+    id: "phase-stall.reaplugin",
+    onLoad() {
+      return host.devices.bindDriver("stall", {
+        create() {
+          return {
+            async connect(session) {
+              await session.gatt.discoverServices();
+              await new Promise(function () {});
+            },
+            disconnect() {}
+          };
+        }
+      });
+    }
+  };
+}
+''';
+
+PluginManifest _stallManifest() => PluginManifest.fromJson({
+  'id': _stallPluginId,
+  'name': 'Phase stall',
+  'author': 'test',
+  'description': 'Connection phase fixture',
+  'version': '0.1.0',
+  'apiVersion': 1,
+  'permissions': ['transport.ble'],
+  'drivers': [
+    {
+      'id': 'stall',
+      'type': 'scale',
+      'ble': {
+        'match': {
+          'name': {'contains': 'stall'},
+        },
+      },
+    },
+  ],
+  'settings': {},
+  'api': [],
+});
+
+class _Attempt {
+  Device? device;
+  StreamSubscription<ConnectionState>? subscription;
+  final seen = <ConnectionState>[];
+  bool settled = false;
+  Object? outcome;
+}
+
+void main() {
+  /// Creates a manager inside [async] and loads the Felicita reference plugin.
+  PluginManager felicitaManager(FakeAsync async) {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceInvocationTimeout: _pluginTimeout,
+    );
+    Object? loadError;
+    loadFelicitaPlugin(manager).then(
+      (_) {},
+      onError: (Object error) {
+        loadError = error;
+      },
+    );
+    async.elapse(const Duration(seconds: 1));
+    expect(loadError, isNull, reason: 'the plugin fixture must load');
+    return manager;
+  }
+
+  PluginManager stallManager(FakeAsync async) {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceInvocationTimeout: _pluginTimeout,
+    );
+    Object? loadError;
+    manager
+        .loadPlugin(
+          id: _stallPluginId,
+          manifest: _stallManifest(),
+          settings: {},
+          jsCode: _stallJs,
+        )
+        .then(
+          (_) {},
+          onError: (Object error) {
+            loadError = error;
+          },
+        );
+    async.elapse(const Duration(seconds: 1));
+    expect(loadError, isNull, reason: 'the stall fixture must load');
+    return manager;
+  }
+
+  /// Disposes [manager] inside the fixture's fake zone.
+  ///
+  /// The plugin host cannot finish its JavaScript unload under fake time, so a
+  /// residual cleanup failure is discarded rather than failing a phase-ownership
+  /// assertion; the zone teardown releases the rest.
+  void disposeInsideZone(PluginManager manager, FakeAsync async) {
+    manager.dispose().ignore();
+    async.elapse(const Duration(seconds: 2));
+  }
+
+  /// Starts candidate creation and the connection attempt, then advances fake
+  /// time until the candidate exists.
+  _Attempt startAttempt(
+    PluginManager manager,
+    FakeAsync async, {
+    required String evidenceName,
+    required BLETransport Function() createTransport,
+  }) {
+    final attempt = _Attempt();
+    addTearDown(() async => attempt.subscription?.cancel());
+    final evidence = BleAdvertisementEvidence(name: evidenceName);
+    manager.bleService
+        .createCandidate(
+          driver: manager.bleService.registry.decide(evidence).drivers.single,
+          physicalId: 'AA:BB',
+          evidence: evidence,
+          admit: () => true,
+          createTransport: createTransport,
+        )
+        .then((device) {
+          attempt.device = device;
+          attempt.subscription = device.connectionState.listen(
+            attempt.seen.add,
+          );
+          return device.onConnect();
+        })
+        .then(
+          (_) {
+            attempt.settled = true;
+          },
+          onError: (Object error) {
+            attempt.settled = true;
+            attempt.outcome = error;
+          },
+        );
+    async.elapse(const Duration(seconds: 1));
+    return attempt;
+  }
+
+  test('physical acquisition may outlive the plugin invocation timeout', () {
+    fakeAsync((async) {
+      final manager = felicitaManager(async);
+      final acquisition = Completer<void>();
+      final transport = FelicitaPluginTransport(
+        'AA:BB',
+        firstPacket: felicitaPacket(2),
+        connectBlocker: acquisition,
+      );
+      final attempt = startAttempt(
+        manager,
+        async,
+        evidenceName: 'Felicita Arc',
+        createTransport: () => transport,
+      );
+      expect(attempt.device, isNotNull);
+
+      async.elapse(_pastEveryDeadline);
+      expect(
+        attempt.settled,
+        isFalse,
+        reason: 'the plugin deadline must not pre-empt acquisition',
+      );
+      expect(attempt.seen, contains(ConnectionState.connecting));
+      expect(transport.connectCalls, 1);
+      expect(
+        transport.discoverServicesCalls,
+        0,
+        reason: 'the plugin must not start before the session exists',
+      );
+
+      acquisition.complete();
+      async.elapse(_pastEveryDeadline);
+
+      expect(attempt.settled, isTrue);
+      expect(attempt.outcome, isNull);
+      expect(attempt.seen, contains(ConnectionState.connected));
+      expect(transport.discoverServicesCalls, 1);
+      disposeInsideZone(manager, async);
+    });
+  });
+
+  test('a slow acquisition still leaves the plugin handler bounded', () {
+    fakeAsync((async) {
+      final manager = stallManager(async);
+      final acquisition = Completer<void>();
+      final transport = FelicitaPluginTransport(
+        'AA:BB',
+        connectBlocker: acquisition,
+      );
+      final attempt = startAttempt(
+        manager,
+        async,
+        evidenceName: 'stall device',
+        createTransport: () => transport,
+      );
+
+      async.elapse(_pastEveryDeadline);
+      expect(
+        attempt.settled,
+        isFalse,
+        reason: 'acquisition is not bounded by the plugin deadline',
+      );
+
+      acquisition.complete();
+      async.elapse(_pastEveryDeadline);
+
+      expect(
+        attempt.settled,
+        isTrue,
+        reason: 'protocol startup is still bounded after acquisition',
+      );
+      expect(attempt.outcome, isNotNull);
+      expect(
+        transport.discoverServicesCalls,
+        1,
+        reason: 'the handler ran only once the session existed',
+      );
+      expect(attempt.seen, isNot(contains(ConnectionState.connected)));
+      disposeInsideZone(manager, async);
+    });
+  });
+
+  test('a stalled plugin connect handler stays bounded', () {
+    fakeAsync((async) {
+      final manager = stallManager(async);
+      final transport = FelicitaPluginTransport('AA:BB');
+      final attempt = startAttempt(
+        manager,
+        async,
+        evidenceName: 'stall device',
+        createTransport: () => transport,
+      );
+
+      async.elapse(_pastEveryDeadline);
+
+      expect(attempt.settled, isTrue);
+      expect(attempt.outcome, isNotNull);
+      expect(transport.connectCalls, 1);
+      expect(attempt.seen, isNot(contains(ConnectionState.connected)));
+      expect(
+        attempt.seen.last,
+        ConnectionState.disconnected,
+        reason: 'a stalled handler must not leave the device half-live',
+      );
+      disposeInsideZone(manager, async);
+    });
+  });
+
+  test('readiness that never arrives stays bounded', () {
+    fakeAsync((async) {
+      final manager = felicitaManager(async);
+      final transport = FelicitaPluginTransport('AA:BB');
+      final attempt = startAttempt(
+        manager,
+        async,
+        evidenceName: 'Felicita Arc',
+        createTransport: () => transport,
+      );
+
+      async.elapse(_pastEveryDeadline);
+
+      expect(attempt.settled, isTrue);
+      expect(
+        attempt.outcome,
+        isNotNull,
+        reason: 'readiness that never arrives must not hang the attempt',
+      );
+      expect(attempt.seen.last, ConnectionState.disconnected);
+      expect(
+        transport.disconnectCalls,
+        greaterThanOrEqualTo(1),
+        reason: 'the physical session is retired with the failed attempt',
+      );
+      disposeInsideZone(manager, async);
+    });
+  });
+
+  test(
+    'stalled readiness rejects with the plugin timeout in real time',
+    () async {
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceInvocationTimeout: _pluginTimeout,
+      );
+      addTearDown(manager.dispose);
+      await loadFelicitaPlugin(manager);
+      final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+      final transport = FelicitaPluginTransport('AA:BB');
+      final scale =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => transport,
+              )
+              as Scale;
+
+      final outcome = await scale.onConnect().then<Object?>(
+        (_) => null,
+        onError: (Object error) => error,
+      );
+
+      expect(outcome, isA<TimeoutException>());
+      expect(await scale.connectionState.first, ConnectionState.disconnected);
+      expect(transport.disconnectCalls, greaterThanOrEqualTo(1));
+      await Future<void>.delayed(Duration.zero);
+      expect(manager.bleService.registry.activeBindingCount, 0);
+    },
+  );
+
+  test(
+    'a stalled plugin handler still releases BLE ownership in real time',
+    () async {
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceInvocationTimeout: _pluginTimeout,
+      );
+      addTearDown(manager.dispose);
+      await manager.loadPlugin(
+        id: _stallPluginId,
+        manifest: _stallManifest(),
+        settings: {},
+        jsCode: _stallJs,
+      );
+      final evidence = BleAdvertisementEvidence(name: 'stall device');
+      final transport = FelicitaPluginTransport('AA:BB');
+      final scale =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => transport,
+              )
+              as Scale;
+
+      final outcome = await scale.onConnect().then<Object?>(
+        (_) => null,
+        onError: (Object error) => error,
+      );
+
+      expect(outcome, isNotNull);
+      expect(await scale.connectionState.first, ConnectionState.disconnected);
+      expect(transport.connectCalls, 1);
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        manager.bleService.registry.activeBindingCount,
+        0,
+        reason: 'failed startup must release BLE ownership',
+      );
+    },
+  );
+
+  test(
+    'a failed acquisition keeps its native error and never starts the plugin',
+    () async {
+      final manager = PluginManager(
+        kvStore: FakeKeyValueStoreService(),
+        deviceInvocationTimeout: _pluginTimeout,
+      );
+      addTearDown(manager.dispose);
+      await loadFelicitaPlugin(manager);
+      final transport = FelicitaPluginTransport(
+        'AA:BB',
+        firstPacket: felicitaPacket(4),
+        connectFailure: BleConnectException(code: '133'),
+      );
+      final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+      final scale =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: 'AA:BB',
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => transport,
+              )
+              as Scale;
+
+      final outcome = await scale.onConnect().then<Object?>(
+        (_) => null,
+        onError: (Object error) => error,
+      );
+
+      expect(
+        outcome,
+        isA<BleConnectException>().having((error) => error.code, 'code', '133'),
+      );
+      expect(
+        transport.discoverServicesCalls,
+        0,
+        reason: 'a failed acquisition must not run the plugin protocol',
+      );
+      expect(await scale.connectionState.first, ConnectionState.disconnected);
+      expect(manager.bleService.registry.activeBindingCount, 0);
+    },
+  );
+
+  test('disposal during acquisition never publishes connected', () async {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceInvocationTimeout: _pluginTimeout,
+    );
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final acquisition = Completer<void>();
+    final transport = FelicitaPluginTransport(
+      'AA:BB',
+      firstPacket: felicitaPacket(5),
+      connectBlocker: acquisition,
+    );
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    final scale =
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'AA:BB',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () => transport,
+            )
+            as Scale;
+    final seen = <ConnectionState>[];
+    final subscription = scale.connectionState.listen(seen.add);
+    addTearDown(subscription.cancel);
+
+    final connecting = scale.onConnect().then<Object?>(
+      (_) => null,
+      onError: (Object error) => error,
+    );
+    await transport.acquisitionStarted.future;
+    await (scale as PluginDeviceAdapter).dispose();
+    acquisition.complete();
+
+    expect(await connecting, isNotNull);
+    expect(seen, isNot(contains(ConnectionState.connected)));
+    expect(transport.discoverServicesCalls, 0);
+    expect(
+      transport.disconnectCalls,
+      greaterThanOrEqualTo(1),
+      reason: 'a prepared physical session must be retired on disposal',
+    );
+    expect(manager.bleService.registry.activeBindingCount, 0);
+  });
+
+  test('disposal during protocol startup never publishes connected', () async {
+    final manager = PluginManager(
+      kvStore: FakeKeyValueStoreService(),
+      deviceInvocationTimeout: _pluginTimeout,
+    );
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final transport = FelicitaPluginTransport('AA:BB');
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    final scale =
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'AA:BB',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () => transport,
+            )
+            as Scale;
+    final seen = <ConnectionState>[];
+    final subscription = scale.connectionState.listen(seen.add);
+    addTearDown(subscription.cancel);
+
+    final connecting = scale.onConnect().then<Object?>(
+      (_) => null,
+      onError: (Object error) => error,
+    );
+    await transport.servicesRequested.future;
+    await (scale as PluginDeviceAdapter).dispose();
+
+    expect(await connecting, isNotNull);
+    expect(seen, isNot(contains(ConnectionState.connected)));
+    expect(manager.bleService.registry.activeBindingCount, 0);
+  });
+}

--- a/test/plugins/plugin_ble_cross_layer_test.dart
+++ b/test/plugins/plugin_ble_cross_layer_test.dart
@@ -1,0 +1,213 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/scale_controller.dart';
+import 'package:reaprime/src/models/device/device.dart';
+import 'package:reaprime/src/models/device/scale.dart';
+import 'package:reaprime/src/models/device/sensor.dart';
+import 'package:reaprime/src/plugins/plugin_ble_registry.dart';
+import 'package:reaprime/src/plugins/plugin_manager.dart';
+import 'package:reaprime/src/services/ble/universal_ble_transport.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import '../helpers/felicita_plugin_fixture.dart';
+import '../helpers/plugin_ble_fixture.dart';
+import 'plugin_manager_ble_test.dart' show bleSensorManifest, bleSensorSource;
+import 'plugin_test_helpers.dart';
+
+/// Cross-layer interactions between the BLE queue, the transport and a live
+/// plugin session (#809).
+///
+/// Stage 1 owns the queue-level behaviour and Stage 2 owns the connection-phase
+/// deadlines; these compose them through a real plugin binding. The slow
+/// recovery cases live in `plugin_ble_connect_phases_test.dart` and
+/// `plugin_ble_bluez_recovery_test.dart`.
+void main() {
+  test(
+    'a stale disconnect with queued GATT work leaves the plugin session live',
+    () async {
+      final platform = PluginBleFixturePlatform();
+      UniversalBle.setInstance(platform);
+      UniversalBle.queueType = QueueType.perDevice;
+      addTearDown(() {
+        UniversalBle.clearQueue();
+        UniversalBle.queueType = QueueType.global;
+      });
+
+      final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+      addTearDown(manager.dispose);
+      await manager.loadPlugin(
+        id: 'ble.sensor',
+        manifest: bleSensorManifest(),
+        settings: {},
+        jsCode: bleSensorSource,
+      );
+
+      const deviceId = 'AA:BB';
+      const serviceUuid = '0000180f-0000-1000-8000-00805f9b34fb';
+      const characteristicUuid = '00002a19-0000-1000-8000-00805f9b34fb';
+      platform.connectionStates[deviceId] = BleConnectionState.connected;
+      final evidence = BleAdvertisementEvidence(serviceUuids: ['180f']);
+      late UniversalBleTransport transport;
+      final sensor =
+          await manager.bleService.createCandidate(
+                driver: manager.bleService.registry
+                    .decide(evidence)
+                    .drivers
+                    .single,
+                physicalId: deviceId,
+                evidence: evidence,
+                admit: () => true,
+                createTransport: () => transport = UniversalBleTransport(
+                  device: BleDevice(deviceId: deviceId, name: 'Fixture'),
+                  isAndroidOverride: false,
+                  isLinuxOverride: false,
+                ),
+              )
+              as Sensor;
+      final states = <ConnectionState>[];
+      final stateSubscription = sensor.connectionState.listen(states.add);
+      addTearDown(stateSubscription.cancel);
+      final samples = <Map<String, dynamic>>[];
+      final dataSubscription = sensor.data.listen(samples.add);
+      addTearDown(dataSubscription.cancel);
+
+      await sensor.onConnect();
+      expect(await sensor.connectionState.first, ConnectionState.connected);
+
+      // Occupy the device queue, then queue a second write behind it.
+      platform.hangWrites = true;
+      final writeBlocker = Completer<void>();
+      platform.writeBlocker = writeBlocker;
+      final inFlight = transport.write(
+        serviceUuid,
+        characteristicUuid,
+        Uint8List.fromList([1]),
+      );
+      final queued = transport.write(
+        serviceUuid,
+        characteristicUuid,
+        Uint8List.fromList([2]),
+      );
+
+      // A late physical disconnect for a link the platform still reports
+      // connected must not disturb the live session or its queued work.
+      platform.connectionStates[deviceId] = BleConnectionState.connected;
+      platform.updateConnection(deviceId, false);
+      await pumpEventQueue();
+
+      expect(
+        states,
+        isNot(contains(ConnectionState.disconnected)),
+        reason: 'a stale disconnect must not retire the live session',
+      );
+      expect(
+        manager.bleService.registry.activeBindingCount,
+        1,
+        reason: 'the session keeps its BLE ownership',
+      );
+
+      writeBlocker.complete();
+      platform.hangWrites = false;
+      await inFlight;
+      await queued;
+
+      platform.updateCharacteristicValue(
+        deviceId,
+        '2a19',
+        Uint8List.fromList([52]),
+        null,
+      );
+      await pumpEventQueue();
+      expect(
+        samples,
+        isNotEmpty,
+        reason: 'subscriptions continue after the stale event',
+      );
+      expect(
+        await sensor.connectionState.first,
+        ConnectionState.connected,
+        reason: 'observed states: $states',
+      );
+    },
+  );
+
+  test('a genuine disconnect then reconnect gives the new session a clean '
+      'start', () async {
+    final manager = PluginManager(kvStore: FakeKeyValueStoreService());
+    addTearDown(manager.dispose);
+    await loadFelicitaPlugin(manager);
+    final evidence = BleAdvertisementEvidence(name: 'Felicita Arc');
+    final transports = <FelicitaPluginTransport>[];
+
+    Future<Scale> candidate() async =>
+        await manager.bleService.createCandidate(
+              driver: manager.bleService.registry
+                  .decide(evidence)
+                  .drivers
+                  .single,
+              physicalId: 'AA:BB',
+              evidence: evidence,
+              admit: () => true,
+              createTransport: () {
+                final transport = FelicitaPluginTransport(
+                  'AA:BB',
+                  firstPacket: felicitaPacket(transports.length + 1),
+                );
+                transports.add(transport);
+                return transport;
+              },
+            )
+            as Scale;
+
+    final first = await candidate();
+    final firstSamples = <ScaleSnapshot>[];
+    final firstSubscription = first.currentSnapshot.listen(firstSamples.add);
+    addTearDown(firstSubscription.cancel);
+    await first.onConnect();
+    expect(await first.connectionState.first, ConnectionState.connected);
+    final retiredSubscriber =
+        transports.first.subscribers[felicitaCharacteristicUuid];
+
+    // Genuine link loss: the retired session must not publish into whatever
+    // replaces it.
+    transports.first.states.add(ConnectionState.disconnected);
+    await first.connectionState
+        .firstWhere((state) => state == ConnectionState.disconnected)
+        .timeout(const Duration(seconds: 2));
+    await pumpEventQueue();
+    expect(manager.bleService.registry.activeBindingCount, 0);
+
+    final second = await candidate();
+    final controller = ScaleController();
+    addTearDown(controller.dispose);
+    final secondSamples = <WeightSnapshot>[];
+    final secondSubscription = controller.weightSnapshot.listen(
+      secondSamples.add,
+    );
+    addTearDown(secondSubscription.cancel);
+    await controller.connectToScale(second);
+    expect(await second.connectionState.first, ConnectionState.connected);
+    expect(transports, hasLength(2));
+    expect(transports.last.connectCalls, 1);
+    expect(manager.bleService.registry.activeBindingCount, 1);
+
+    // The retired session cannot inject its own packets into the replacement.
+    retiredSubscriber?.call(Uint8List.fromList(felicitaPacket(99)));
+    await pumpEventQueue();
+    expect(
+      secondSamples.where((sample) => sample.weight == 99),
+      isEmpty,
+      reason: 'a retired generation must not publish into the new session',
+    );
+
+    transports.last.emit(felicitaPacket(7));
+    await pumpEventQueue();
+    expect(secondSamples.map((sample) => sample.weight), contains(7));
+
+    await second.disconnect();
+    await pumpEventQueue();
+    expect(manager.bleService.registry.activeBindingCount, 0);
+  });
+}

--- a/test/unit/models/bookoo_scale_test.dart
+++ b/test/unit/models/bookoo_scale_test.dart
@@ -7,6 +7,7 @@ import 'package:reaprime/src/models/device/scale.dart';
 import 'package:reaprime/src/models/device/transport/ble_transport.dart';
 import 'package:reaprime/src/models/errors.dart';
 import 'package:rxdart/rxdart.dart';
+import '../../helpers/bookoo_packets.dart';
 
 class _BookooTransport extends BLETransport {
   final BehaviorSubject<ConnectionState> states = BehaviorSubject.seeded(
@@ -78,17 +79,7 @@ class _BookooTransport extends BLETransport {
 }
 
 List<int> _packet(double grams, {int? battery = 50}) {
-  final magnitude = (grams.abs() * 100).round();
-  final packet = List<int>.filled(20, 0);
-  packet[0] = 0x03;
-  packet[1] = 0x0B;
-  packet[6] = grams < 0 ? 0x2D : 0x2B;
-  packet[7] = magnitude >> 16;
-  packet[8] = magnitude >> 8;
-  packet[9] = magnitude;
-  if (battery != null) packet[13] = battery;
-  packet[19] = packet.take(19).fold(0, (sum, byte) => sum ^ byte);
-  return packet;
+  return bookooPacket(grams, battery: battery);
 }
 
 void main() {
@@ -160,12 +151,15 @@ void main() {
     await scale.startTimer();
     await scale.stopTimer();
     await scale.resetTimer();
-    expect(transport.writes, [
-      [0x03, 0x0A, 0x01, 0, 0, 0x08],
-      [0x03, 0x0A, 0x04, 0, 0, 0x0D],
-      [0x03, 0x0A, 0x05, 0, 0, 0x0C],
-      [0x03, 0x0A, 0x06, 0, 0, 0x0F],
-    ]);
+    expect(transport.writes, bookooCommands);
+  });
+
+  test('shared plugin malformed packet fixtures emit nothing', () async {
+    for (final packet in invalidBookooPackets()) {
+      transport.emit(packet);
+    }
+    await Future<void>.delayed(Duration.zero);
+    expect(snapshots, isEmpty);
   });
 
   test('disconnected command failure is ignored', () async {

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -90,9 +90,7 @@ class _FakeBlePlatform extends UniversalBlePlatform {
     if (disconnectRequested?.isCompleted == false) {
       disconnectRequested!.complete();
     }
-    if (updateConnectionStateOnLifecycle) {
-      connectionStateResult = BleConnectionState.disconnected;
-    }
+    connectionStateResult = BleConnectionState.disconnected;
     if (emitDisconnectEvent) updateConnection(deviceId, false);
   }
 
@@ -636,6 +634,7 @@ void main() {
     });
 
     test('advert while transport already disconnected is ignored', () async {
+      platform.connectionStateResult = BleConnectionState.disconnected;
       platform.updateConnection(deviceId, false);
       await pump(10);
       expect(observedStates, contains(device.ConnectionState.disconnected));
@@ -708,6 +707,36 @@ void main() {
   });
 
   group('re-subscribe push channel (universal_ble broadcast controller)', () {
+    test(
+      'stale disconnect update is ignored while native link is connected',
+      () async {
+        final received = <int>[];
+        await transport.subscribe(_serviceUuid, _charUuid, (value) {
+          received.add(value.first);
+        });
+        platform.connectionStateResult = BleConnectionState.connected;
+        platform.updateConnection(deviceId, false);
+        await pump();
+        expect(
+          observedStates,
+          isNot(contains(device.ConnectionState.disconnected)),
+        );
+        platform.updateCharacteristicValue(
+          deviceId,
+          _charUuid,
+          Uint8List.fromList([2]),
+          null,
+        );
+        platform.updateCharacteristicValue(
+          deviceId,
+          _charUuid,
+          Uint8List.fromList([3]),
+          null,
+        );
+        await pump();
+        expect(received, [2, 3]);
+      },
+    );
     test(
       'plugin replacement resets CCCD and fences old logical unsubscribe',
       () async {
@@ -1030,6 +1059,7 @@ void main() {
         ),
       );
 
+      await pump(10);
       expect(
         states.where((state) => state == device.ConnectionState.disconnected),
         hasLength(1),

--- a/test/universal_ble_transport_recovery_test.dart
+++ b/test/universal_ble_transport_recovery_test.dart
@@ -590,6 +590,156 @@ void main() {
     );
   });
 
+  group('stale disconnect vs queued GATT work', () {
+    Future<Object?> startWrite(int byte) => transport
+        .write(_serviceUuid, _charUuid, Uint8List.fromList([byte]))
+        .then<Object?>((_) => null, onError: (Object error) => error);
+
+    test(
+      'stale disconnect update keeps in-flight and queued GATT work alive',
+      () async {
+        final notifications = <int>[];
+        await transport.subscribe(_serviceUuid, _charUuid, (value) {
+          notifications.add(value.first);
+        });
+
+        platform.hangWrites = true;
+        final writeBlocker = Completer<void>();
+        platform.writeBlocker = writeBlocker;
+
+        final inFlight = startWrite(1);
+        await pumpEventQueue();
+        final queued = startWrite(2);
+        await pumpEventQueue();
+        expect(
+          platform.writeCalls,
+          1,
+          reason: 'the second write must stay queued behind the first',
+        );
+
+        // Late physical-id disconnect for a link the OS still reports
+        // connected: the event must not dispose the current queue.
+        platform.connectionStateResult = BleConnectionState.connected;
+        platform.updateConnection(deviceId, false);
+        await pumpEventQueue();
+
+        expect(
+          platform.writeCalls,
+          1,
+          reason:
+              'confirming a live link must not dispatch queued work while the '
+              'in-flight write is still running',
+        );
+
+        writeBlocker.complete();
+        expect(await inFlight, isNull);
+        expect(
+          await queued,
+          isNull,
+          reason: 'a stale disconnect event must not cancel queued work',
+        );
+        await pumpEventQueue();
+
+        expect(platform.writeCalls, 2);
+        expect(
+          UniversalBle.getQueueDiagnostics(deviceId).state,
+          QueueDiagnosticsState.running,
+          reason: 'the device queue must survive a stale event',
+        );
+        expect(
+          observedStates,
+          isNot(contains(device.ConnectionState.disconnected)),
+        );
+
+        platform.updateCharacteristicValue(
+          deviceId,
+          _charUuid,
+          Uint8List.fromList([7]),
+          null,
+        );
+        await pumpEventQueue();
+        expect(notifications, [7]);
+      },
+    );
+
+    test('genuine disconnect cancels queued GATT work exactly once', () async {
+      platform.hangWrites = true;
+      final writeBlocker = Completer<void>();
+      platform.writeBlocker = writeBlocker;
+
+      final inFlight = startWrite(1);
+      await pumpEventQueue();
+      final queued = startWrite(2);
+      await pumpEventQueue();
+
+      platform.connectionStateResult = BleConnectionState.disconnected;
+      platform.updateConnection(deviceId, false);
+      await pumpEventQueue();
+
+      expect(await queued, isA<DeviceNotConnectedException>());
+      expect(
+        platform.writeCalls,
+        1,
+        reason: 'no operation may start against the dead link',
+      );
+      expect(
+        observedStates.where(
+          (state) => state == device.ConnectionState.disconnected,
+        ),
+        hasLength(1),
+      );
+
+      writeBlocker.complete();
+      expect(await inFlight, isNull);
+      await pumpEventQueue();
+      expect(
+        platform.writeCalls,
+        1,
+        reason: 'a failed connection must not dispatch later work',
+      );
+
+      platform.connectionStateResult = BleConnectionState.connected;
+      platform.updateConnection(deviceId, true);
+      await pumpEventQueue();
+      expect(observedStates, contains(device.ConnectionState.connected));
+
+      platform.hangWrites = false;
+      await transport.write(_serviceUuid, _charUuid, Uint8List.fromList([3]));
+      expect(platform.writeCalls, 2);
+    });
+
+    test('genuine disconnect still cancels queued work while the link probe is '
+        'pending', () async {
+      platform.hangWrites = true;
+      final writeBlocker = Completer<void>();
+      platform.writeBlocker = writeBlocker;
+      final probe = Completer<BleConnectionState>();
+      platform.connectionStateBlocker = probe;
+
+      final inFlight = startWrite(1);
+      await pumpEventQueue();
+      final queued = startWrite(2);
+      await pumpEventQueue();
+
+      platform.updateConnection(deviceId, false);
+      await pumpEventQueue();
+
+      writeBlocker.complete();
+      expect(await inFlight, isNull);
+      await pumpEventQueue();
+      expect(
+        platform.writeCalls,
+        1,
+        reason: 'queued work must stay held until the disconnect is confirmed',
+      );
+
+      probe.complete(BleConnectionState.disconnected);
+      await pumpEventQueue();
+      expect(await queued, isA<DeviceNotConnectedException>());
+      expect(platform.writeCalls, 1);
+    });
+  });
+
   group('advertising-while-connected detection (fix 2)', () {
     test(
       'own advert + OS reporting disconnected → emits disconnected',


### PR DESCRIPTION
## Summary

- Add an opt-in Bookoo Mini reference `.reaplugin`, stacked on #822 (`odev/issue-809-scale-timing`). Merge #822 first, then retarget this PR to `main`.
- Keep protocol parsing, service/characteristic selection, acknowledged commands, first-packet readiness and protocol-silence reporting in JS. Retain native Bookoo unchanged and do not bundle/auto-enable the example.
- Share packet/command fixtures with native tests and exercise the real JS binding through discovery, ScaleController, HTTP/WebSocket commands, reconnect, plugin reload and persisted preference reconstruction.
- Restacked on current #822 head `f41b662eb61e17c2017297fb5f65d017d45a805c`; #823 is one focused commit / 12 files, zero commits behind #822, and inherits #822's current provenance fencing and Scale-domain error mapping.

## Linked Issue

Refs #809. Depends on #822, #821 and #820. Does not close the issue.

## Verification

- Current stacked head: `e45ec020e411d61163fe1a831767da1e55181a1a`.
- Previous Bookoo-content head `2442f73e4efc11b48fee980aa167417b59f02d9c` completed local `flutter test --no-pub --machine` with 4,013 passed and one skipped; analysis, CI-compatible formatting and diff checks also passed. That is prior evidence only, not verification of the final retargeted head.
- #822 final-head PR checks are running on `f41b662eb61e17c2017297fb5f65d017d45a805c`; its format and analyze stages are green. After #822 lands, retarget #823 to `main` and use that resulting SHA for final-head PR checks.
- Focused coverage includes shared positive/negative/malformed packet fixtures, battery retention, exact acknowledged tare/timer bytes, invalid-packet readiness rejection, stale callbacks, reconnect/two sessions and protocol-silence cleanup, including initial no-packet and malformed-packet cases.
- The Bookoo fake GATT edge rejects any subscription other than canonical service `0ffe` / characteristic `ff11` and any command write other than service `0ffe` / characteristic `ff12`; the protocol test also explicitly asserts `ff11` and `ff12`.
- A Bookoo-specific same-runtime unload/reload regression proves the plugin generation changes, the reconstructed public device ID remains stable, retained command authority from the retired Scale fails with `stale_session`, a retained old notification cannot publish into the replacement generation, and the replacement session continues publishing normally.
- A native subscription delayed 2.3 seconds still connects successfully. The initial silence watchdog starts after subscription succeeds; valid packets can start/reset it earlier. Subscription completion neither resets an existing packet deadline nor rearms a stopped session.
- Real HTTP/WebSocket clients exercise Bookoo publication and commands through production handlers with fake GATT. Persisted plugin preference survives fresh manager/controller reconstruction and quick-connect miss followed by ordinary discovery; absent plugin produces native selection without preference rewrite. Failed plugin handshake does not select native.

## Impact

- New opt-in example only; native Bookoo stays enabled. Initial unknown plugin battery is null, unlike native's historical zero sentinel.
- The two-second Bookoo valid-packet silence threshold remains provisional, but Bookoo hardware confirmation is no longer an acceptance gate for this PR. Keep deterministic coverage for the watchdog behavior and adjust the device-specific threshold later if Bookoo field evidence demonstrates a concrete need.
- Required real-hardware acceptance uses the maintainer-available Felicita scale, not Bookoo. After the corrective BLE lifecycle work is complete, validate the Felicita plugin path on hardware and record the results in a PR comment. Cover connection/readiness, live weight delivery, supported commands, disconnect/reconnect, restart/reselection behavior, and observed notification cadence/latency. Bookoo physical hardware validation is not required for acceptance.

## Contributor Responsibility

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->