### PR TITLE
fix(storage): resume partial v5 migrations and fail startup safely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ All three steps are required, not optional.
 - Never import 3rd-party BLE libraries (e.g. `universal_ble`) outside `lib/src/services/ble/`.
 - All BLE operations use 128-bit UUID format.
 - Scale write paths must catch `DeviceNotConnectedException` at the lowest-level write helper.
+- Every persisted Drift schema change must include a migration test from the previous production schema/version using a real SQLite database or fixture; fresh-database tests alone are not sufficient. When the migration transforms or backfills data, assert representative data preservation/transformation too.
 - Keep Flutter build and run flows non-interactive. Prefer `--dart-define=simulate=1` for smoke tests.
 - Use prefixed imports for domain models that share names with Drift-generated code: `import '...shot_record.dart' as domain;` or `hide Workflow` on the database import.
 - No emojis in comments or documentation.

--- a/doc/AI_STORAGE_NOTES.md
+++ b/doc/AI_STORAGE_NOTES.md
@@ -73,6 +73,13 @@ Persistence uses Drift (SQLite) via `AppDatabase`. DAOs in `lib/src/daos/`, mapp
 
 **Schema v5 (shot revision metadata):** `shot_records.createdAt`/`updatedAt` were added as nullable TEXT and backfilled from `timestamp` during the 4→5 migration, so pre-v5 rows carry a real DB-level revision instead of NULL. `ShotMapper.fromRow` still falls back to `timestamp` for any row with NULL fields (e.g. rows inserted without stamps). The revision contract (bookkeeping extras do not advance `updatedAt`, PUT cannot write the fields) is documented in `doc/Api.md` under Shots → Modification tracking.
 
+**Migration lesson from #811 (0.8.5 startup failures):** Drift only writes `PRAGMA user_version` after `beforeOpen`/`onUpgrade` completes, and the upgrade body is NOT automatically transactional. An interrupted multi-step migration can therefore leave a partially upgraded physical schema (e.g. only `created_at` added) while `user_version` stays at the old value; the next open re-enters the same step and the unconditional `ADD COLUMN` fails with `duplicate column name`. Rules for future migrations:
+
+- Wrap the whole `onUpgrade` body in an explicit Drift `transaction()` so any failed step rolls back atomically and the next open retries from a known state.
+- Make each step resume-safe/idempotent where it can reconcile a partial physical schema: inspect `PRAGMA table_info(...)` and apply only the missing work instead of blind `ADD COLUMN`/`CREATE TABLE`. `shot_records` v5 columns (`created_at`/`updated_at`, nullable TEXT) are validated against `PRAGMA table_info` metadata (TEXT, notnull=0, pk=0, no default or an explicit NULL literal default) before being reused.
+- Test partially-applied states (each column subset present at the old `user_version`, NULL and non-NULL value mixes), not only clean `N -> N+1` fixtures.
+- Unknown/incompatible states fail closed and preserve the DB (no drop/recreate/reset/rename fallback); surface them for assisted recovery instead of silently reshaping user data.
+
 ## Profile Storage
 
 Content-based hash IDs for deduplication. `ProfileController` manages the profile library:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,6 +69,7 @@ import 'package:reaprime/src/services/app_log_upload_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:reaprime/src/services/storage/hive_store_service.dart';
+import 'package:reaprime/src/database_failure_view.dart';
 import 'package:reaprime/src/services/universal_ble_discovery_service.dart';
 import 'package:reaprime/src/services/simulated_device_service.dart';
 import 'package:reaprime/src/services/webserver/data_export/backup_data_sources.dart';
@@ -306,6 +307,16 @@ void main(List<String> args) async {
     log.info("enabling simulated devices from dart-define: $dartDefineDevices");
   }
   final appDatabase = AppDatabase.defaults();
+  final databaseStartupError = await appDatabase.openForStartup(log);
+  if (databaseStartupError != null) {
+    runApp(
+      DatabaseFailureApp(
+        logFilePath: '$logDir/log.txt',
+        detail: databaseStartupError.runtimeType.toString(),
+      ),
+    );
+    return;
+  }
 
   final persistenceController = PersistenceController(
     storageService: DriftStorageService(appDatabase),

--- a/lib/src/database_failure_view.dart
+++ b/lib/src/database_failure_view.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+class DatabaseFailureView extends StatelessWidget {
+  const DatabaseFailureView({
+    super.key,
+    required this.logFilePath,
+    this.detail,
+  });
+
+  final String logFilePath;
+  final String? detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final detail = this.detail;
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 560),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.storage, size: 48, color: theme.colorScheme.error),
+                  const SizedBox(height: 16),
+                  Text(
+                    'The local database could not be safely opened or updated',
+                    style: theme.textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Decaid stopped because its local database could not be '
+                    'opened or updated. Your existing data has been left in '
+                    'place.',
+                    style: theme.textTheme.bodyLarge,
+                  ),
+                  if (detail != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      'Diagnostic: $detail',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  ],
+                  const SizedBox(height: 12),
+                  Text(
+                    'Log file: $logFilePath',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Please preserve your data and share your logs (and a data '
+                    'package if one is available) with Decent support, then '
+                    'use an updated Decaid build or assisted repair before '
+                    'trying again.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class DatabaseFailureApp extends StatelessWidget {
+  const DatabaseFailureApp({super.key, required this.logFilePath, this.detail});
+
+  final String logFilePath;
+  final String? detail;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Decaid',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+      ),
+      home: DatabaseFailureView(logFilePath: logFilePath, detail: detail),
+    );
+  }
+}

--- a/lib/src/services/database/database.dart
+++ b/lib/src/services/database/database.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
+import 'package:logging/logging.dart';
 import 'package:reaprime/src/services/database/converters/json_converters.dart';
 import 'package:reaprime/src/services/database/daos/bean_dao.dart';
 import 'package:reaprime/src/services/database/daos/grinder_dao.dart';
@@ -30,6 +31,8 @@ part 'database.g.dart';
   daos: [BeanDao, GrinderDao, ShotDao, SteamDao, WorkflowDao, ProfileDao],
 )
 class AppDatabase extends _$AppDatabase {
+  static final Logger _log = Logger('AppDatabase');
+
   AppDatabase(super.e);
 
   factory AppDatabase.defaults() {
@@ -41,6 +44,33 @@ class AppDatabase extends _$AppDatabase {
         ),
       ),
     );
+  }
+
+  Future<void> initialize() async {
+    await customSelect('PRAGMA user_version').get();
+  }
+
+  Future<Object?> openForStartup(Logger log) async {
+    try {
+      await initialize();
+      return null;
+    } catch (error, stackTrace) {
+      log.severe(
+        'Local database could not be safely opened or updated',
+        error,
+        stackTrace,
+      );
+      try {
+        await close();
+      } catch (closeError, closeStackTrace) {
+        log.warning(
+          'Failed to close database after startup failure',
+          closeError,
+          closeStackTrace,
+        );
+      }
+      return error;
+    }
   }
 
   @override
@@ -55,29 +85,96 @@ class AppDatabase extends _$AppDatabase {
         await _createIndices();
       },
       onUpgrade: (Migrator m, int from, int to) async {
-        if (from < 2) {
-          await _createIndices();
-        }
-        if (from < 3) {
-          await m.createTable(steamRecords);
-          await _createSteamIndices();
-        }
-        if (from < 4) {
-          await m.addColumn(shotRecords, shotRecords.stopReason);
-        }
-        if (from < 5) {
-          await m.addColumn(shotRecords, shotRecords.createdAt);
-          await m.addColumn(shotRecords, shotRecords.updatedAt);
-          await customStatement(
-            'UPDATE shot_records SET created_at = timestamp, '
-            'updated_at = timestamp',
-          );
-        }
+        _log.info(
+          'db migration $from -> $to starting; '
+          'user_version=${await _userVersion()}',
+        );
+        await transaction(() async {
+          if (from < 2) {
+            await _createIndices();
+          }
+          if (from < 3) {
+            await m.createTable(steamRecords);
+            await _createSteamIndices();
+          }
+          if (from < 4) {
+            await m.addColumn(shotRecords, shotRecords.stopReason);
+          }
+          if (from < 5) {
+            await _upgradeToSchema5(m);
+          }
+        });
+        _log.info('db migration $from -> $to completed');
       },
       beforeOpen: (details) async {
         await customStatement('PRAGMA foreign_keys = ON');
       },
     );
+  }
+
+  Future<int> _userVersion() async {
+    final result = await customSelect('PRAGMA user_version').getSingle();
+    return result.data['user_version'] as int;
+  }
+
+  Future<void> _upgradeToSchema5(Migrator m) async {
+    final columns = await _shotRecordColumnInfo();
+    _log.info(
+      'db migration to 5; shot_records columns: ${columns.keys.join(', ')}; '
+      'created_at=${_columnSummary(columns['created_at'])}, '
+      'updated_at=${_columnSummary(columns['updated_at'])}',
+    );
+    for (final column in <String>['created_at', 'updated_at']) {
+      if (columns.containsKey(column)) {
+        _validateExistingV5Column(column, columns[column]!);
+      }
+    }
+    if (!columns.containsKey('created_at')) {
+      await m.addColumn(shotRecords, shotRecords.createdAt);
+    }
+    if (!columns.containsKey('updated_at')) {
+      await m.addColumn(shotRecords, shotRecords.updatedAt);
+    }
+    await customStatement(
+      'UPDATE shot_records '
+      'SET created_at = COALESCE(created_at, timestamp), '
+      'updated_at = COALESCE(updated_at, timestamp) '
+      'WHERE created_at IS NULL OR updated_at IS NULL',
+    );
+  }
+
+  static void _validateExistingV5Column(
+    String name,
+    Map<String, Object?> column,
+  ) {
+    final type = column['type'] as String?;
+    final defaultValue = column['dflt_value'];
+    final nullLiteral =
+        defaultValue == null ||
+        (defaultValue is String && defaultValue.trim().toUpperCase() == 'NULL');
+    final reusable =
+        type?.toUpperCase() == 'TEXT' &&
+        column['notnull'] == 0 &&
+        column['pk'] == 0 &&
+        nullLiteral;
+    if (!reusable) {
+      throw StateError(
+        'shot_records.$name already exists with an incompatible definition '
+        '(${_columnSummary(column)}); refusing to reshape it. '
+        'Preserve the database for assisted recovery.',
+      );
+    }
+  }
+
+  static String _columnSummary(Map<String, Object?>? column) {
+    if (column == null) return 'absent';
+    return 'type=${column['type']}, notNull=${column['notnull']}, '
+        'dflt=${column['dflt_value']}, pk=${column['pk']}';
+  }
+
+  Future<Map<String, Map<String, Object?>>> _shotRecordColumnInfo() async {
+    final rows = await customSelect('PRAGMA table_info(shot_records)').get();
+    return {for (final row in rows) row.data['name'] as String: row.data};
   }
 
   Future<void> _createIndices() async {

--- a/test/database/database_startup_test.dart
+++ b/test/database/database_startup_test.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logging/logging.dart';
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+class _ThrowingCloseInterceptor extends QueryInterceptor {
+  int closeCalls = 0;
+
+  @override
+  Future<void> close(QueryExecutor inner) async {
+    closeCalls++;
+    throw StateError('close failed');
+  }
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('reaprime_db_startup');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  File incompatibleLegacyFile() {
+    final file = File(
+      '${tempDir.path}/incompatible_${DateTime.now().microsecondsSinceEpoch}.db',
+    );
+    final legacy = sqlite3.sqlite3.open(file.path);
+    try {
+      legacy.execute(
+        'CREATE TABLE shot_records (id TEXT NOT NULL PRIMARY KEY, '
+        'updated_at TEXT NOT NULL)',
+      );
+      legacy.execute('PRAGMA user_version = 4');
+      legacy.execute(
+        'INSERT INTO shot_records (id, updated_at) VALUES (?, ?)',
+        ['legacy-1', '2025-02-01T00:00:00.000Z'],
+      );
+    } finally {
+      legacy.close();
+    }
+    return file;
+  }
+
+  group('AppDatabase.openForStartup', () {
+    test('returns null on a fresh database and opens at schema 5', () async {
+      final db = AppDatabase(NativeDatabase.memory());
+      addTearDown(db.close);
+      final startupError = await db.openForStartup(Logger('StartupTest'));
+      expect(startupError, isNull);
+      final version = await db.customSelect('PRAGMA user_version').getSingle();
+      expect(version.data['user_version'], 5);
+    });
+
+    test(
+      'returns the error, logs once with stack, and closes the executor after '
+      'migration failure',
+      () async {
+        final executor = NativeDatabase(incompatibleLegacyFile());
+        addTearDown(executor.close);
+        final db = AppDatabase(executor);
+        final log = Logger('StartupFailureTest');
+        final severe = <LogRecord>[];
+        final subscription = log.onRecord.listen((r) {
+          if (r.level >= Level.SEVERE) severe.add(r);
+        });
+        addTearDown(subscription.cancel);
+
+        final startupError = await db.openForStartup(log);
+        expect(startupError, isNotNull);
+        expect(severe, hasLength(1));
+        expect(severe.single.error, same(startupError));
+        expect(severe.single.stackTrace, isNotNull);
+
+        await expectLater(
+          db.customSelect('SELECT 1').get(),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains("Can't re-open a database after closing it"),
+            ),
+          ),
+        );
+      },
+    );
+
+    test('a failing close does not mask the original startup error', () async {
+      final executor = NativeDatabase(incompatibleLegacyFile());
+      addTearDown(executor.close);
+      final interceptor = _ThrowingCloseInterceptor();
+      final db = AppDatabase(executor.interceptWith(interceptor));
+      final log = Logger('CloseFailureTest');
+      final records = <LogRecord>[];
+      final subscription = log.onRecord.listen(records.add);
+      addTearDown(subscription.cancel);
+
+      final startupError = await db.openForStartup(log);
+      expect(startupError, isNotNull);
+      expect(interceptor.closeCalls, 1);
+      final severe = records.where((r) => r.level >= Level.SEVERE).toList();
+      final warnings = records.where((r) => r.level == Level.WARNING).toList();
+      expect(severe, hasLength(1));
+      expect(severe.single.error, same(startupError));
+      expect(
+        warnings.map((r) => r.message).join('\n'),
+        contains('Failed to close database after startup failure'),
+      );
+      expect(warnings.single.error, isA<StateError>());
+      expect(warnings.single.stackTrace, isNotNull);
+    });
+  });
+}

--- a/test/database/schema_migration_parity_test.dart
+++ b/test/database/schema_migration_parity_test.dart
@@ -31,9 +31,7 @@ List<Map<String, Object?>> _shotSchema(File file) {
           },
         )
         .toList();
-    schema.sort(
-      (a, b) => (a['name'] as String).compareTo(b['name'] as String),
-    );
+    schema.sort((a, b) => (a['name'] as String).compareTo(b['name'] as String));
     return schema;
   } finally {
     db.close();

--- a/test/database/schema_migration_parity_test.dart
+++ b/test/database/schema_migration_parity_test.dart
@@ -16,81 +16,25 @@ Future<File> _createCurrentDatabase(Directory tempDir, String name) async {
   return file;
 }
 
-String _quoteIdentifier(String identifier) =>
-    '"${identifier.replaceAll('"', '""')}"';
-
-Map<String, Object?> _schemaSnapshot(File file) {
+List<Map<String, Object?>> _shotSchema(File file) {
   final db = sqlite3.sqlite3.open(file.path);
   try {
-    final tableNames = db
-        .select(
-          "SELECT name FROM sqlite_schema "
-          "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' "
-          'ORDER BY name',
-        )
-        .map((row) => row['name'] as String)
-        .toList();
-
-    final tables = <String, Object?>{};
-    for (final table in tableNames) {
-      final quoted = _quoteIdentifier(table);
-      final columns = db
-          .select('PRAGMA table_info($quoted)')
-          .map(
-            (row) => <String, Object?>{
-              'name': row['name'],
-              'type': (row['type'] as String).toUpperCase(),
-              'notnull': row['notnull'],
-              'default': row['dflt_value'],
-              'pk': row['pk'],
-            },
-          )
-          .toList()
-        ..sort(
-          (a, b) => (a['name'] as String).compareTo(b['name'] as String),
-        );
-
-      final foreignKeys = db
-          .select('PRAGMA foreign_key_list($quoted)')
-          .map(
-            (row) => <String, Object?>{
-              'table': row['table'],
-              'from': row['from'],
-              'to': row['to'],
-              'on_update': row['on_update'],
-              'on_delete': row['on_delete'],
-              'match': row['match'],
-            },
-          )
-          .toList()
-        ..sort((a, b) {
-          final byTable = (a['table'] as String).compareTo(b['table'] as String);
-          if (byTable != 0) return byTable;
-          return (a['from'] as String).compareTo(b['from'] as String);
-        });
-
-      tables[table] = {'columns': columns, 'foreignKeys': foreignKeys};
-    }
-
-    final schemaObjects = db
-        .select(
-          "SELECT type, name, tbl_name, sql FROM sqlite_schema "
-          "WHERE type IN ('index', 'trigger') AND sql IS NOT NULL "
-          'ORDER BY type, name',
-        )
+    final schema = db
+        .select('PRAGMA table_info(shot_records)')
         .map(
           (row) => <String, Object?>{
-            'type': row['type'],
             'name': row['name'],
-            'table': row['tbl_name'],
-            'sql': (row['sql'] as String)
-                .replaceAll(RegExp(r'\s+'), ' ')
-                .trim(),
+            'type': (row['type'] as String).toUpperCase(),
+            'notnull': row['notnull'],
+            'default': row['dflt_value'],
+            'pk': row['pk'],
           },
         )
         .toList();
-
-    return {'tables': tables, 'schemaObjects': schemaObjects};
+    schema.sort(
+      (a, b) => (a['name'] as String).compareTo(b['name'] as String),
+    );
+    return schema;
   } finally {
     db.close();
   }
@@ -107,7 +51,7 @@ void main() {
     if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
   });
 
-  test('v4 to v5 migration matches a freshly-created current schema', () async {
+  test('v4 to v5 migration matches the current shot schema', () async {
     final migratedFile = await _createCurrentDatabase(tempDir, 'migrated');
     final legacy = sqlite3.sqlite3.open(migratedFile.path);
     try {
@@ -126,17 +70,14 @@ void main() {
     }
 
     final referenceFile = await _createCurrentDatabase(tempDir, 'reference');
-
-    final migratedRaw = sqlite3.sqlite3.open(migratedFile.path);
+    final raw = sqlite3.sqlite3.open(migratedFile.path);
     try {
-      expect(
-        migratedRaw.select('PRAGMA user_version').single.values.single,
-        5,
-      );
+      final version = raw.select('PRAGMA user_version').first.values.first;
+      expect(version, 5);
     } finally {
-      migratedRaw.close();
+      raw.close();
     }
 
-    expect(_schemaSnapshot(migratedFile), _schemaSnapshot(referenceFile));
+    expect(_shotSchema(migratedFile), _shotSchema(referenceFile));
   });
 }

--- a/test/database/schema_migration_parity_test.dart
+++ b/test/database/schema_migration_parity_test.dart
@@ -1,0 +1,142 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/services/database/database.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+Future<File> _createCurrentDatabase(Directory tempDir, String name) async {
+  final file = File('${tempDir.path}/$name.db');
+  final db = AppDatabase(NativeDatabase(file));
+  try {
+    await db.initialize();
+  } finally {
+    await db.close();
+  }
+  return file;
+}
+
+String _quoteIdentifier(String identifier) =>
+    '"${identifier.replaceAll('"', '""')}"';
+
+Map<String, Object?> _schemaSnapshot(File file) {
+  final db = sqlite3.sqlite3.open(file.path);
+  try {
+    final tableNames = db
+        .select(
+          "SELECT name FROM sqlite_schema "
+          "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' "
+          'ORDER BY name',
+        )
+        .map((row) => row['name'] as String)
+        .toList();
+
+    final tables = <String, Object?>{};
+    for (final table in tableNames) {
+      final quoted = _quoteIdentifier(table);
+      final columns = db
+          .select('PRAGMA table_info($quoted)')
+          .map(
+            (row) => <String, Object?>{
+              'name': row['name'],
+              'type': (row['type'] as String).toUpperCase(),
+              'notnull': row['notnull'],
+              'default': row['dflt_value'],
+              'pk': row['pk'],
+            },
+          )
+          .toList()
+        ..sort(
+          (a, b) => (a['name'] as String).compareTo(b['name'] as String),
+        );
+
+      final foreignKeys = db
+          .select('PRAGMA foreign_key_list($quoted)')
+          .map(
+            (row) => <String, Object?>{
+              'table': row['table'],
+              'from': row['from'],
+              'to': row['to'],
+              'on_update': row['on_update'],
+              'on_delete': row['on_delete'],
+              'match': row['match'],
+            },
+          )
+          .toList()
+        ..sort((a, b) {
+          final byTable = (a['table'] as String).compareTo(b['table'] as String);
+          if (byTable != 0) return byTable;
+          return (a['from'] as String).compareTo(b['from'] as String);
+        });
+
+      tables[table] = {'columns': columns, 'foreignKeys': foreignKeys};
+    }
+
+    final schemaObjects = db
+        .select(
+          "SELECT type, name, tbl_name, sql FROM sqlite_schema "
+          "WHERE type IN ('index', 'trigger') AND sql IS NOT NULL "
+          'ORDER BY type, name',
+        )
+        .map(
+          (row) => <String, Object?>{
+            'type': row['type'],
+            'name': row['name'],
+            'table': row['tbl_name'],
+            'sql': (row['sql'] as String)
+                .replaceAll(RegExp(r'\s+'), ' ')
+                .trim(),
+          },
+        )
+        .toList();
+
+    return {'tables': tables, 'schemaObjects': schemaObjects};
+  } finally {
+    db.close();
+  }
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('reaprime_schema_parity');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('v4 to v5 migration matches a freshly-created current schema', () async {
+    final migratedFile = await _createCurrentDatabase(tempDir, 'migrated');
+    final legacy = sqlite3.sqlite3.open(migratedFile.path);
+    try {
+      legacy.execute('ALTER TABLE shot_records DROP COLUMN created_at');
+      legacy.execute('ALTER TABLE shot_records DROP COLUMN updated_at');
+      legacy.execute('PRAGMA user_version = 4');
+    } finally {
+      legacy.close();
+    }
+
+    final migrated = AppDatabase(NativeDatabase(migratedFile));
+    try {
+      await migrated.initialize();
+    } finally {
+      await migrated.close();
+    }
+
+    final referenceFile = await _createCurrentDatabase(tempDir, 'reference');
+
+    final migratedRaw = sqlite3.sqlite3.open(migratedFile.path);
+    try {
+      expect(
+        migratedRaw.select('PRAGMA user_version').single.values.single,
+        5,
+      );
+    } finally {
+      migratedRaw.close();
+    }
+
+    expect(_schemaSnapshot(migratedFile), _schemaSnapshot(referenceFile));
+  });
+}

--- a/test/database/shot_schema_migration_test.dart
+++ b/test/database/shot_schema_migration_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaprime/src/controllers/workflow_controller.dart';
@@ -11,77 +10,574 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
 // v4 shot_records DDL: the v5 CREATE TABLE minus the created_at/updated_at
 // columns added by the from<5 migration step.
-const _v4ShotTableDdl =
-    'CREATE TABLE "shot_records" ("id" TEXT NOT NULL, "timestamp" TEXT NOT '
-    'NULL, "profile_title" TEXT NULL, "grinder_id" TEXT NULL, '
-    '"grinder_model" TEXT NULL, "grinder_setting" TEXT NULL, '
-    '"bean_batch_id" TEXT NULL, "coffee_name" TEXT NULL, "coffee_roaster" '
-    'TEXT NULL, "target_dose_weight" REAL NULL, "target_yield" REAL NULL, '
-    '"enjoyment" REAL NULL, "espresso_notes" TEXT NULL, "stop_reason" TEXT '
-    'NULL, "workflow_json" TEXT NOT NULL, "annotations_json" TEXT NULL, '
-    '"measurements_json" TEXT NOT NULL, PRIMARY KEY ("id"))';
+const _v4Columns = [
+  '"id" TEXT NOT NULL',
+  '"timestamp" TEXT NOT NULL',
+  '"profile_title" TEXT NULL',
+  '"grinder_id" TEXT NULL',
+  '"grinder_model" TEXT NULL',
+  '"grinder_setting" TEXT NULL',
+  '"bean_batch_id" TEXT NULL',
+  '"coffee_name" TEXT NULL',
+  '"coffee_roaster" TEXT NULL',
+  '"target_dose_weight" REAL NULL',
+  '"target_yield" REAL NULL',
+  '"enjoyment" REAL NULL',
+  '"espresso_notes" TEXT NULL',
+  '"stop_reason" TEXT NULL',
+  '"workflow_json" TEXT NOT NULL',
+  '"annotations_json" TEXT NULL',
+  '"measurements_json" TEXT NOT NULL',
+];
+
+const _createdAtColumn = '"created_at" TEXT NULL';
+const _updatedAtColumn = '"updated_at" TEXT NULL';
+
+Map<String, Object?> _row({
+  required String id,
+  required String timestamp,
+  Object? createdAt,
+  Object? updatedAt,
+}) {
+  return {
+    'id': id,
+    'timestamp': timestamp,
+    'created_at': createdAt,
+    'updated_at': updatedAt,
+    'workflow_json': jsonEncode(WorkflowController().currentWorkflow.toJson()),
+    'measurements_json': '[]',
+  };
+}
 
 void main() {
   late Directory tempDir;
 
   setUp(() {
-    tempDir = Directory.systemTemp.createTempSync('reaprime_v4_migration');
+    tempDir = Directory.systemTemp.createTempSync('reaprime_v5_migration');
   });
 
   tearDown(() {
     if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
   });
 
-  test(
-    'migration from schema 4 backfills createdAt and updatedAt from timestamp',
-    () async {
-      final dbFile = File('${tempDir.path}/legacy.db');
-      final legacy = sqlite3.sqlite3.open(dbFile.path);
-      try {
-        legacy.execute(_v4ShotTableDdl);
-        legacy.execute('PRAGMA user_version = 4');
-        legacy.execute(
-          'INSERT INTO shot_records '
-          '(id, timestamp, workflow_json, measurements_json) '
-          'VALUES (?, ?, ?, ?)',
-          [
-            'legacy-1',
-            '2025-03-01T12:00:00.000Z',
-            jsonEncode(WorkflowController().currentWorkflow.toJson()),
-            '[]',
-          ],
-        );
-      } finally {
-        legacy.close();
+  String createLegacyDb({
+    int userVersion = 4,
+    List<String> baseColumns = _v4Columns,
+    List<String> extraColumns = const [],
+    List<Map<String, Object?>> rows = const [],
+    String? extraDdl,
+    String primaryKey = '"id"',
+  }) {
+    final dbFile = File(
+      '${tempDir.path}/legacy_${DateTime.now().microsecondsSinceEpoch}.db',
+    );
+    final legacy = sqlite3.sqlite3.open(dbFile.path);
+    try {
+      legacy.execute(
+        'CREATE TABLE "shot_records" ('
+        '${[...baseColumns, ...extraColumns].join(', ')}, '
+        'PRIMARY KEY ($primaryKey))',
+      );
+      legacy.execute('PRAGMA user_version = $userVersion');
+      final columnNames = {'id', 'timestamp'};
+      for (final def in baseColumns) {
+        columnNames.add(RegExp(r'^"(\w+)"').firstMatch(def)!.group(1)!);
       }
-
-      final db = AppDatabase(NativeDatabase(dbFile));
-      try {
-        final version = (await db.customSelect('PRAGMA user_version').get())
-            .single
-            .data['user_version'];
-        expect(version, 5);
-
-        final raw =
-            (await db
-                    .customSelect(
-                      'SELECT created_at, updated_at FROM shot_records WHERE id = ?',
-                      variables: [const Variable('legacy-1')],
-                    )
-                    .get())
-                .single
-                .data;
-        expect(raw['created_at'], '2025-03-01T12:00:00.000Z');
-        expect(raw['updated_at'], '2025-03-01T12:00:00.000Z');
-
-        final shot = ShotMapper.fromRow(
-          (await db.shotDao.getShotById('legacy-1'))!,
+      for (final def in extraColumns) {
+        columnNames.add(RegExp(r'^"(\w+)"').firstMatch(def)!.group(1)!);
+      }
+      for (final row in rows) {
+        final columns = row.keys.where(columnNames.contains).toList();
+        final placeholders = List.filled(columns.length, '?').join(', ');
+        legacy.execute(
+          'INSERT INTO shot_records (${columns.join(', ')}) '
+          'VALUES ($placeholders)',
+          [for (final c in columns) row[c]],
         );
-        expect(shot.createdAt, DateTime.utc(2025, 3, 1, 12));
-        expect(shot.updatedAt, DateTime.utc(2025, 3, 1, 12));
+      }
+      if (extraDdl != null) {
+        legacy.execute(extraDdl);
+      }
+    } finally {
+      legacy.close();
+    }
+    return dbFile.path;
+  }
+
+  Future<void> expectUserVersion(AppDatabase db, int expected) async {
+    final result = await db.customSelect('PRAGMA user_version').get();
+    expect(result.single.data['user_version'], expected);
+  }
+
+  Future<List<Map<String, Object?>>> shotColumnInfo(AppDatabase db) async {
+    final rows = await db.customSelect('PRAGMA table_info(shot_records)').get();
+    return rows.map((r) => r.data).toList();
+  }
+
+  Future<void> expectV5ColumnsExactlyOnce(AppDatabase db) async {
+    final info = await shotColumnInfo(db);
+    final names = info.map((c) => c['name']).toList();
+    expect(names.where((n) => n == 'created_at').length, 1, reason: '$names');
+    expect(names.where((n) => n == 'updated_at').length, 1, reason: '$names');
+  }
+
+  Future<Map<String, Map<String, Object?>>> readRevisionColumns(
+    AppDatabase db,
+  ) async {
+    final rows = await db
+        .customSelect(
+          'SELECT id, created_at, updated_at FROM shot_records ORDER BY id',
+        )
+        .get();
+    return {
+      for (final r in rows)
+        r.data['id'] as String: {
+          'created_at': r.data['created_at'],
+          'updated_at': r.data['updated_at'],
+        },
+    };
+  }
+
+  Future<void> expectRecoveredV5(
+    String dbPath, {
+    required Map<String, Map<String, Object?>> expectedRevisions,
+    required String mapperId,
+    required DateTime mapperCreatedAt,
+    required DateTime mapperUpdatedAt,
+  }) async {
+    final db = AppDatabase(NativeDatabase(File(dbPath)));
+    try {
+      await db.initialize();
+      await expectUserVersion(db, 5);
+      await expectV5ColumnsExactlyOnce(db);
+      expect(await readRevisionColumns(db), expectedRevisions);
+      final shot = ShotMapper.fromRow(
+        (await db.shotDao.getShotById(mapperId))!,
+      );
+      expect(shot.createdAt, mapperCreatedAt);
+      expect(shot.updatedAt, mapperUpdatedAt);
+    } finally {
+      await db.close();
+    }
+  }
+
+  group('v4 -> v5 migration', () {
+    final cases =
+        <
+          ({
+            String name,
+            List<String> extraColumns,
+            List<Map<String, Object?>> rows,
+            Map<String, Map<String, Object?>> expectedRevisions,
+            String mapperId,
+            DateTime mapperCreatedAt,
+            DateTime mapperUpdatedAt,
+          })
+        >[
+          (
+            name:
+                'clean v4: neither v5 column exists, both added and backfilled',
+            extraColumns: const [],
+            rows: [
+              _row(id: 'legacy-1', timestamp: '2025-03-01T12:00:00.000Z'),
+              _row(id: 'legacy-2', timestamp: '2025-03-02T08:30:00.000Z'),
+            ],
+            expectedRevisions: {
+              'legacy-1': {
+                'created_at': '2025-03-01T12:00:00.000Z',
+                'updated_at': '2025-03-01T12:00:00.000Z',
+              },
+              'legacy-2': {
+                'created_at': '2025-03-02T08:30:00.000Z',
+                'updated_at': '2025-03-02T08:30:00.000Z',
+              },
+            },
+            mapperId: 'legacy-1',
+            mapperCreatedAt: DateTime.utc(2025, 3, 1, 12),
+            mapperUpdatedAt: DateTime.utc(2025, 3, 1, 12),
+          ),
+          (
+            name:
+                'partial v5 (created only): existing created_at kept, updated_at added',
+            extraColumns: const [_createdAtColumn],
+            rows: [
+              _row(
+                id: 'legacy-1',
+                timestamp: '2025-03-01T12:00:00.000Z',
+                createdAt: '2025-02-01T00:00:00.000Z',
+              ),
+              _row(
+                id: 'legacy-2',
+                timestamp: '2025-03-02T08:30:00.000Z',
+                createdAt: '2025-02-02T00:00:00.000Z',
+              ),
+            ],
+            expectedRevisions: {
+              'legacy-1': {
+                'created_at': '2025-02-01T00:00:00.000Z',
+                'updated_at': '2025-03-01T12:00:00.000Z',
+              },
+              'legacy-2': {
+                'created_at': '2025-02-02T00:00:00.000Z',
+                'updated_at': '2025-03-02T08:30:00.000Z',
+              },
+            },
+            mapperId: 'legacy-1',
+            mapperCreatedAt: DateTime.utc(2025, 2, 1),
+            mapperUpdatedAt: DateTime.utc(2025, 3, 1, 12),
+          ),
+          (
+            name:
+                'partial v5 (updated only): existing updated_at kept, created_at added',
+            extraColumns: const [_updatedAtColumn],
+            rows: [
+              _row(
+                id: 'legacy-1',
+                timestamp: '2025-03-01T12:00:00.000Z',
+                updatedAt: '2025-02-10T00:00:00.000Z',
+              ),
+            ],
+            expectedRevisions: {
+              'legacy-1': {
+                'created_at': '2025-03-01T12:00:00.000Z',
+                'updated_at': '2025-02-10T00:00:00.000Z',
+              },
+            },
+            mapperId: 'legacy-1',
+            mapperCreatedAt: DateTime.utc(2025, 3, 1, 12),
+            mapperUpdatedAt: DateTime.utc(2025, 2, 10),
+          ),
+          (
+            name:
+                'partial v5 (both columns present at user_version 4) completes',
+            extraColumns: const [_createdAtColumn, _updatedAtColumn],
+            rows: [
+              _row(
+                id: 'legacy-1',
+                timestamp: '2025-03-01T12:00:00.000Z',
+                createdAt: '2025-01-01T00:00:00.000Z',
+                updatedAt: '2025-01-02T00:00:00.000Z',
+              ),
+            ],
+            expectedRevisions: {
+              'legacy-1': {
+                'created_at': '2025-01-01T00:00:00.000Z',
+                'updated_at': '2025-01-02T00:00:00.000Z',
+              },
+            },
+            mapperId: 'legacy-1',
+            mapperCreatedAt: DateTime.utc(2025, 1, 1),
+            mapperUpdatedAt: DateTime.utc(2025, 1, 2),
+          ),
+          (
+            name:
+                'partial backfill: NULL revision values filled from timestamp',
+            extraColumns: const [_createdAtColumn, _updatedAtColumn],
+            rows: [
+              _row(id: 'legacy-1', timestamp: '2025-03-01T12:00:00.000Z'),
+              _row(
+                id: 'legacy-2',
+                timestamp: '2025-03-02T08:30:00.000Z',
+                createdAt: null,
+                updatedAt: '2025-02-02T00:00:00.000Z',
+              ),
+              _row(
+                id: 'legacy-3',
+                timestamp: '2025-03-03T10:00:00.000Z',
+                createdAt: '2025-01-03T00:00:00.000Z',
+              ),
+            ],
+            expectedRevisions: {
+              'legacy-1': {
+                'created_at': '2025-03-01T12:00:00.000Z',
+                'updated_at': '2025-03-01T12:00:00.000Z',
+              },
+              'legacy-2': {
+                'created_at': '2025-03-02T08:30:00.000Z',
+                'updated_at': '2025-02-02T00:00:00.000Z',
+              },
+              'legacy-3': {
+                'created_at': '2025-01-03T00:00:00.000Z',
+                'updated_at': '2025-03-03T10:00:00.000Z',
+              },
+            },
+            mapperId: 'legacy-1',
+            mapperCreatedAt: DateTime.utc(2025, 3, 1, 12),
+            mapperUpdatedAt: DateTime.utc(2025, 3, 1, 12),
+          ),
+          (
+            name:
+                'preserve completed work: non-NULL revisions survive, NULLs filled',
+            extraColumns: const [_createdAtColumn, _updatedAtColumn],
+            rows: [
+              _row(
+                id: 'legacy-1',
+                timestamp: '2025-03-01T12:00:00.000Z',
+                createdAt: '2025-01-01T00:00:00.000Z',
+                updatedAt: '2025-01-02T00:00:00.000Z',
+              ),
+              _row(
+                id: 'legacy-2',
+                timestamp: '2025-03-02T08:30:00.000Z',
+                createdAt: '2025-02-01T00:00:00.000Z',
+              ),
+              _row(id: 'legacy-3', timestamp: '2025-03-03T10:00:00.000Z'),
+            ],
+            expectedRevisions: {
+              'legacy-1': {
+                'created_at': '2025-01-01T00:00:00.000Z',
+                'updated_at': '2025-01-02T00:00:00.000Z',
+              },
+              'legacy-2': {
+                'created_at': '2025-02-01T00:00:00.000Z',
+                'updated_at': '2025-03-02T08:30:00.000Z',
+              },
+              'legacy-3': {
+                'created_at': '2025-03-03T10:00:00.000Z',
+                'updated_at': '2025-03-03T10:00:00.000Z',
+              },
+            },
+            mapperId: 'legacy-1',
+            mapperCreatedAt: DateTime.utc(2025, 1, 1),
+            mapperUpdatedAt: DateTime.utc(2025, 1, 2),
+          ),
+          (
+            name: 'compatible existing nullable TEXT DEFAULT NULL is reused',
+            extraColumns: const ['"created_at" TEXT DEFAULT NULL'],
+            rows: [
+              _row(id: 'legacy-1', timestamp: '2025-03-01T12:00:00.000Z'),
+              _row(
+                id: 'legacy-2',
+                timestamp: '2025-03-02T08:30:00.000Z',
+                createdAt: '2025-02-02T00:00:00.000Z',
+              ),
+            ],
+            expectedRevisions: {
+              'legacy-1': {
+                'created_at': '2025-03-01T12:00:00.000Z',
+                'updated_at': '2025-03-01T12:00:00.000Z',
+              },
+              'legacy-2': {
+                'created_at': '2025-02-02T00:00:00.000Z',
+                'updated_at': '2025-03-02T08:30:00.000Z',
+              },
+            },
+            mapperId: 'legacy-1',
+            mapperCreatedAt: DateTime.utc(2025, 3, 1, 12),
+            mapperUpdatedAt: DateTime.utc(2025, 3, 1, 12),
+          ),
+        ];
+
+    for (final testCase in cases) {
+      test(testCase.name, () async {
+        await expectRecoveredV5(
+          createLegacyDb(
+            extraColumns: testCase.extraColumns,
+            rows: testCase.rows,
+          ),
+          expectedRevisions: testCase.expectedRevisions,
+          mapperId: testCase.mapperId,
+          mapperCreatedAt: testCase.mapperCreatedAt,
+          mapperUpdatedAt: testCase.mapperUpdatedAt,
+        );
+      });
+    }
+  });
+
+  group('legacy schema upgrades through v5', () {
+    test(
+      'v3 shot_records (no stop_reason) upgrades through v4 to v5',
+      () async {
+        final v3Columns = _v4Columns
+            .where((c) => !c.contains('"stop_reason"'))
+            .toList();
+        final dbPath = createLegacyDb(
+          userVersion: 3,
+          baseColumns: v3Columns,
+          rows: [_row(id: 'legacy-1', timestamp: '2025-03-01T12:00:00.000Z')],
+        );
+
+        final db = AppDatabase(NativeDatabase(File(dbPath)));
+        try {
+          await db.initialize();
+          await expectUserVersion(db, 5);
+          await expectV5ColumnsExactlyOnce(db);
+
+          final info = await shotColumnInfo(db);
+          expect(info.map((c) => c['name']), contains('stop_reason'));
+
+          final shot = ShotMapper.fromRow(
+            (await db.shotDao.getShotById('legacy-1'))!,
+          );
+          expect(shot.createdAt, DateTime.utc(2025, 3, 1, 12));
+          expect(shot.stopReason, isNull);
+        } finally {
+          await db.close();
+        }
+      },
+    );
+  });
+
+  group('v5 migration failure modes', () {
+    (List<Map<String, Object?>>, List<Map<String, Object?>>) snapshotDb(
+      String dbPath,
+    ) {
+      final raw = sqlite3.sqlite3.open(dbPath);
+      try {
+        final schema = raw
+            .select('PRAGMA table_info(shot_records)')
+            .map((r) => Map<String, Object?>.from(r))
+            .toList();
+        final data = raw
+            .select('SELECT * FROM shot_records ORDER BY id')
+            .map((r) => Map<String, Object?>.from(r))
+            .toList();
+        return (schema, data);
+      } finally {
+        raw.close();
+      }
+    }
+
+    final incompatibleCases =
+        <
+          ({
+            String name,
+            List<String> extraColumns,
+            String? primaryKey,
+            List<Map<String, Object?>> rows,
+            String incompatibleColumn,
+          })
+        >[
+          (
+            name: 'NOT NULL column',
+            extraColumns: const ['"updated_at" TEXT NOT NULL'],
+            primaryKey: null,
+            rows: [
+              _row(
+                id: 'legacy-1',
+                timestamp: '2025-03-01T12:00:00.000Z',
+                updatedAt: '2025-02-01T00:00:00.000Z',
+              ),
+            ],
+            incompatibleColumn: 'updated_at',
+          ),
+          (
+            name: 'wrong column type',
+            extraColumns: const ['"created_at" INTEGER'],
+            primaryKey: null,
+            rows: [_row(id: 'legacy-1', timestamp: '2025-03-01T12:00:00.000Z')],
+            incompatibleColumn: 'created_at',
+          ),
+          (
+            name: 'non-null default',
+            extraColumns: const ['"created_at" TEXT DEFAULT CURRENT_TIMESTAMP'],
+            primaryKey: null,
+            rows: [_row(id: 'legacy-1', timestamp: '2025-03-01T12:00:00.000Z')],
+            incompatibleColumn: 'created_at',
+          ),
+          (
+            name: 'column in the primary key',
+            extraColumns: const ['"created_at" TEXT'],
+            primaryKey: '"id", "created_at"',
+            rows: [
+              _row(
+                id: 'legacy-1',
+                timestamp: '2025-03-01T12:00:00.000Z',
+                createdAt: '2025-02-01T00:00:00.000Z',
+              ),
+            ],
+            incompatibleColumn: 'created_at',
+          ),
+        ];
+
+    for (final testCase in incompatibleCases) {
+      test(
+        'rejects incompatible ${testCase.name} and leaves the DB untouched',
+        () async {
+          final dbPath = createLegacyDb(
+            extraColumns: testCase.extraColumns,
+            primaryKey: testCase.primaryKey ?? '"id"',
+            rows: testCase.rows,
+          );
+          final before = snapshotDb(dbPath);
+
+          final db = AppDatabase(NativeDatabase(File(dbPath)));
+          try {
+            await expectLater(
+              db.initialize(),
+              throwsA(
+                isA<StateError>().having(
+                  (e) => e.message,
+                  'message',
+                  contains('incompatible definition'),
+                ),
+              ),
+            );
+          } finally {
+            await db.close();
+          }
+
+          final raw = sqlite3.sqlite3.open(dbPath);
+          try {
+            final version =
+                raw.select('PRAGMA user_version').first.values.first as int;
+            expect(version, 4);
+
+            final after = snapshotDb(dbPath);
+            expect(after.$1, before.$1);
+            expect(after.$2, before.$2);
+            final names = after.$1.map((c) => c['name']).toList();
+            expect(names, contains(testCase.incompatibleColumn));
+          } finally {
+            raw.close();
+          }
+        },
+      );
+    }
+
+    test('failed migration rolls back partial ALTER work', () async {
+      final dbPath = createLegacyDb(
+        rows: [_row(id: 'legacy-1', timestamp: '2025-03-01T12:00:00.000Z')],
+        extraDdl:
+            'CREATE TRIGGER abort_backfill BEFORE UPDATE ON shot_records '
+            'BEGIN SELECT RAISE(ABORT, "intentional"); END',
+      );
+      final before = snapshotDb(dbPath);
+
+      final db = AppDatabase(NativeDatabase(File(dbPath)));
+      try {
+        await expectLater(
+          db.initialize(),
+          throwsA(
+            isA<sqlite3.SqliteException>().having(
+              (e) => e.message,
+              'message',
+              contains('intentional'),
+            ),
+          ),
+        );
       } finally {
         await db.close();
       }
-    },
-  );
+
+      final raw = sqlite3.sqlite3.open(dbPath);
+      try {
+        final version =
+            raw.select('PRAGMA user_version').first.values.first as int;
+        expect(version, 4);
+
+        final columns = raw
+            .select('PRAGMA table_info(shot_records)')
+            .map((r) => r['name'] as String);
+        expect(columns, isNot(contains('created_at')));
+        expect(columns, isNot(contains('updated_at')));
+
+        final after = snapshotDb(dbPath);
+        expect(after.$1, before.$1);
+        expect(after.$2, before.$2);
+      } finally {
+        raw.close();
+      }
+    });
+  });
 }

--- a/test/database_failure_view_test.dart
+++ b/test/database_failure_view_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/database_failure_view.dart';
+
+Widget host(Widget child) => MaterialApp(home: child);
+
+void main() {
+  testWidgets('explains the database could not be opened and data was kept', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        const DatabaseFailureView(
+          logFilePath: '/tmp/support/log.txt',
+          detail: 'StateError: incompatible column',
+        ),
+      ),
+    );
+
+    expect(find.textContaining('could not be safely opened'), findsOneWidget);
+    expect(find.textContaining('left in place'), findsOneWidget);
+    expect(
+      find.textContaining('StateError: incompatible column'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('/tmp/support/log.txt'), findsOneWidget);
+  });
+
+  testWidgets('offers no destructive reset or retry action', (tester) async {
+    await tester.pumpWidget(
+      host(const DatabaseFailureView(logFilePath: '/tmp/support/log.txt')),
+    );
+
+    expect(find.byType(TextButton), findsNothing);
+    expect(find.byType(FilledButton), findsNothing);
+    expect(find.byType(OutlinedButton), findsNothing);
+    expect(find.textContaining('reset'), findsNothing);
+    expect(find.textContaining('delete'), findsNothing);
+    expect(find.textContaining('retry'), findsNothing);
+  });
+
+  testWidgets('DatabaseFailureApp renders a database-independent home', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const DatabaseFailureApp(logFilePath: '/tmp/support/log.txt'),
+    );
+
+    expect(find.textContaining('could not be safely opened'), findsOneWidget);
+    expect(find.textContaining('left in place'), findsOneWidget);
+  });
+
+  testWidgets('all content is reachable on a compact screen with large text', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    const textScaler = TextScaler.linear(2);
+    const viewPadding = EdgeInsets.all(24);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            textScaler: textScaler,
+            padding: viewPadding,
+          ),
+          child: const DatabaseFailureView(
+            logFilePath: '/data/user/0/net.tadel.reaprime/files/logs/log.txt',
+            detail: 'StateError',
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.textContaining('could not be safely opened'), findsOneWidget);
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.textContaining('assisted repair'),
+      200,
+      scrollable: find.descendant(
+        of: find.byType(SingleChildScrollView),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    expect(find.textContaining('assisted repair'), findsOneWidget);
+    expect(find.textContaining('left in place'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

- Make the existing v5 Drift migration resumable: inspect physical column metadata, add only missing revision columns, and backfill NULL values without overwriting completed work. Keep schema version 5 and wrap the upgrade body in a transaction.
- Explicitly open the database before constructing database-backed services. On failure, log the original error/stack once, close the failed connection, stop normal startup, and show a database-independent fatal screen with diagnostics and preservation-first recovery guidance.
- Reject incompatible column definitions without reset, deletion, recreation, rename, downgrade, or blank-database fallback.

## Linked Issue

Fixes #811

## Verification

- Test-first real SQLite fixtures cover clean v4, created-only, updated-only, both columns, partial backfill, non-NULL preservation, and compatible explicit NULL defaults. Successful cases verify version 5, column uniqueness, revisions, and DAO/mapper access.
- Incompatible type, nullability, default, and primary-key fixtures fail closed with full schema/row snapshots unchanged. An aborting trigger verifies rollback after ALTER work.
- Startup tests verify single error logging with stack, connection closure, and retaining the original error if close fails. Widget tests verify independent fatal rendering, no destructive actions, and scrollable recovery instructions on compact screens with large text.
- `dart format lib test`: 809 files, 0 changed.
- Focused migration/startup/widget tests: **20 passed**.
- `flutter analyze`: **No issues found**.
- `flutter test`: **3983 passed, 1 skipped** on final parent rerun; worker final full run also passed. The first parent full run encountered an unrelated teardown race in `de1_controller_shotsettings_stall_test.dart:165` (queued serial callback adds to a closed stream). That unchanged test passed in isolation (5 tests), and the unchanged full suite passed on rerun. No unrelated test or transport code changed.
- `./scripts/fetch_dye2_plugin.sh`: passed. `git diff --check`: clean.
- Parent personally reviewed the complete diff with Karpathy guidelines and Ponytail Review, requested fixes, then re-reviewed and independently ran final gates.
- No reporter database package was available at final issue recheck. No real-hardware or installed-app smoke test performed; database verification uses temporary SQLite files and UI verification uses Flutter widget tests.

## Impact

- Compatible partially applied v5 upgrades recover automatically. Unknown states preserve the database and show a native fatal screen rather than repeated workflow/profile startup failures.
- No schema v6, new dependencies, general recovery framework, or destructive recovery action.
- Migration diagnostics contain schema metadata, not shot contents. The fatal screen exposes only an error type and log location, not row data.
- Updated `doc/AI_STORAGE_NOTES.md`. Completed implementation checklist removed; rationale retained in storage notes. No REST/WS, plugin, skin, profile-handling, or device-flow contract changes; corresponding API specs and domain docs do not need updates.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [x] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
