### PR TITLE
feat(api): read the firmware stop-at-weight target

### DIFF
--- a/assets/api/rest_v1.yml
+++ b/assets/api/rest_v1.yml
@@ -538,6 +538,39 @@ paths:
           description: Machine write queue is full
         "500":
           description: No machine was connected, the machine changed during the write, or the write failed
+  /api/v1/machine/stopAtWeight:
+    get:
+      summary: Get the firmware stop-at-weight target
+      description: |
+        Read the stop-at-weight target the machine currently holds, in grams.
+        The app writes this target from `WorkflowContext.targetYield`, which is
+        its single source of truth, so this endpoint reports what the firmware
+        actually has rather than what the app last sent. `0` means
+        stop-at-weight is off. Returns 404 when the connected machine is not a
+        Bengle. The `stopAtWeight` capability on
+        `GET /api/v1/machine/capabilities` reports whether this endpoint is
+        available.
+      tags: [Machine]
+      responses:
+        "200":
+          description: Current stop-at-weight target
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [grams]
+                properties:
+                  grams:
+                    type: number
+                    format: double
+                    minimum: 0
+                    description: |
+                      Target beverage weight in grams. `0` means stop-at-weight
+                      is off.
+                    example: 36.0
+        "404":
+          description: Machine connected but does not support stop-at-weight
+
   /api/v1/machine/ledStrip:
     get:
       summary: Get LED strip configuration

--- a/doc/Api.md
+++ b/doc/Api.md
@@ -90,6 +90,7 @@ For browser clients on a different origin, `ETag` is exposed via `Access-Control
 | PUT | `/api/v1/machine/cupWarmer` | Set setpoint (whole °C, 0–80) and/or `enabled`; temperature-only requests also enable manual heating (back-compat), `enabled:false` keeps the setpoint — Bengle only | |
 | GET | `/api/v1/machine/cupWarmer/preheat` | Read scheduled pre-warm `enabled`/`leadMinutes`/`active` (firmware-owned timing) — Bengle only, 404 elsewhere | |
 | PUT | `/api/v1/machine/cupWarmer/preheat` | Set pre-warm `enabled` and/or `leadMinutes` (0–120, persisted in firmware) — Bengle only | |
+| GET | `/api/v1/machine/stopAtWeight` | Read the firmware stop-at-weight target in grams (`0` means off); the app writes it from `WorkflowContext.targetYield` — Bengle only | |
 | GET | `/api/v1/machine/ledStrip` | Read LED strip palette (3 zones × 2 modes, 16-bit RGB; `frontSwitch` derived, not a hardware control); 503 until firmware hydration succeeds — Bengle only | |
 | PUT | `/api/v1/machine/ledStrip` | Write palette write-through to FW registers (persisted immediately; `frontSwitch` ignored) — Bengle only | |
 | POST | `/api/v1/machine/ledStrip/commit` | Compatibility no-op (palette writes are already persisted) — Bengle only | |

--- a/lib/src/services/webserver/de1handler.dart
+++ b/lib/src/services/webserver/de1handler.dart
@@ -205,6 +205,14 @@ class De1Handler {
       admittedWebSocketHandler(_handleShotState),
     );
 
+    app.get('/api/v1/machine/stopAtWeight', (Request _) async {
+      return withDe1((de1) async {
+        final gate = _bengleFirmwareGate(de1, 'stopAtWeight');
+        if (gate != null) return gate;
+        final grams = await (de1 as BengleInterface).getStopAtWeightTarget();
+        return jsonOk({'grams': grams});
+      });
+    });
     app.get('/api/v1/machine/ledStrip', (Request _) async {
       return withDe1((de1) async {
         final gate = _bengleFirmwareGate(de1, 'ledStrip');

--- a/test/services/webserver/de1handler_stop_at_weight_test.dart
+++ b/test/services/webserver/de1handler_stop_at_weight_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reaprime/src/controllers/de1_controller.dart';
+import 'package:reaprime/src/controllers/device_controller.dart';
+import 'package:reaprime/src/controllers/workflow_controller.dart';
+import 'package:reaprime/src/settings/settings_controller.dart';
+import 'package:reaprime/src/models/device/de1_interface.dart';
+import 'package:reaprime/src/models/device/impl/bengle/mock_bengle.dart';
+import 'package:reaprime/src/models/device/impl/mock_de1/mock_de1.dart';
+import 'package:reaprime/src/services/webserver_service.dart';
+import 'package:shelf_plus/shelf_plus.dart';
+import 'package:yaml/yaml.dart';
+
+import '../../helpers/mock_device_discovery_service.dart';
+import '../../helpers/mock_settings_service.dart';
+import '../../helpers/test_scale.dart';
+import '../../helpers/test_scale_controller.dart';
+
+void main() {
+  late Handler handler;
+  late De1Controller controller;
+  late SettingsController settingsController;
+  late TestScaleController scaleController;
+
+  Future<void> wireWith(De1Interface? device) async {
+    final deviceController = DeviceController([MockDeviceDiscoveryService()]);
+    await deviceController.initialize();
+    controller = De1Controller(controller: deviceController);
+    if (device != null) {
+      await controller.connectToDe1(device);
+    }
+
+    final mockSettings = MockSettingsService();
+    settingsController = SettingsController(mockSettings);
+    await settingsController.loadSettings();
+
+    final testScale = TestScale();
+    scaleController = TestScaleController(testScale);
+    final de1Handler = De1Handler(
+      controller: controller,
+      settingsController: settingsController,
+      scaleController: scaleController,
+      workflowController: WorkflowController(),
+    );
+    final app = Router().plus;
+    de1Handler.addRoutes(app);
+    handler = app.call;
+  }
+
+  Future<Response> get(String path) async =>
+      await handler(Request('GET', Uri.parse('http://localhost$path')));
+
+  group('GET /api/v1/machine/stopAtWeight', () {
+    test('200 + the firmware target in grams', () async {
+      final bengle = MockBengle();
+      await wireWith(bengle);
+      await bengle.setStopAtWeightTarget(42.5);
+
+      final res = await get('/api/v1/machine/stopAtWeight');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['grams'], 42.5);
+    });
+
+    test('reports 0 when stop-at-weight is disabled in firmware', () async {
+      final bengle = MockBengle();
+      await wireWith(bengle);
+
+      final res = await get('/api/v1/machine/stopAtWeight');
+      expect(res.statusCode, 200);
+      final body = jsonDecode(await res.readAsString());
+      expect(body['grams'], 0.0);
+    });
+
+    test('404 on plain DE1', () async {
+      await wireWith(MockDe1());
+      final res = await get('/api/v1/machine/stopAtWeight');
+      expect(res.statusCode, 404);
+    });
+
+    test('rest_v1.yml documents the route and its grams response', () {
+      final spec =
+          loadYaml(File('assets/api/rest_v1.yml').readAsStringSync())
+              as YamlMap;
+      final route =
+          (spec['paths'] as YamlMap)['/api/v1/machine/stopAtWeight']
+              as YamlMap?;
+      expect(route, isNotNull, reason: 'the endpoint must be in the spec');
+
+      final ok =
+          ((route!['get'] as YamlMap)['responses'] as YamlMap)['200']
+              as YamlMap;
+      final schema =
+          ((ok['content'] as YamlMap)['application/json'] as YamlMap)['schema']
+              as YamlMap;
+      expect((schema['properties'] as YamlMap).containsKey('grams'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`GET /api/v1/machine/capabilities` already reports `stopAtWeight`, but no
endpoint let a client read what the machine actually holds. The app writes that
target from `WorkflowContext.targetYield`, its single source of truth, so until
now a client could only infer the firmware value from the workflow it last sent.

`GET /api/v1/machine/stopAtWeight` returns `{"grams": n}`. `0` means
stop-at-weight is off. It sits behind the existing `_bengleFirmwareGate` and
answers `404` on a plain DE1.

`getStopAtWeightTarget` already exists on `BengleInterface`, and so does the
gate, so the handler is eight lines.

### History

This started inside #791, which is about a different question — whether an
absent `targetYield` should write `0` — and it had no spec entry there. It is
split out and specified.

## Linked Issue

N/A

## Verification

- `flutter analyze` — clean.
- `flutter test` — full suite **3968 passed / 1 skipped / 0 failed**.
- `flutter test test/services/webserver/de1handler_stop_at_weight_test.dart` —
  4 passed: the target in grams, `0` when the feature is off, `404` on a plain
  DE1, and a check that the spec documents the route.
- `dart format --output=none --set-exit-if-changed` — clean on both changed
  files, run with Dart 3.13.3, the version CI resolves on `stable`.

## Impact

- **User-visible**: none. The endpoint is read-only and additive.
- **API**: adds `GET /api/v1/machine/stopAtWeight`. `assets/api/rest_v1.yml` and
  `doc/Api.md` both carry it. One of the tests reads the spec and fails if the
  route or its `grams` response is ever dropped, so the pair cannot drift.
- **Compatibility**: additive. Nothing existing changes.
- **Security**: none. It reads one firmware register behind the existing Bengle
  gate.

## Contributor Responsibility

AI-assisted development is allowed. The submitter remains responsible for the submitted work.

- [ ] I have reviewed and understand all changes in this PR and take responsibility for their correctness, security, behavior, licensing, and provenance, including any AI-assisted or AI-generated work. <!-- contributor-responsibility -->
